### PR TITLE
Better error messages for when external definitions are missing

### DIFF
--- a/core/src/main/scala/org/bykn/bosatsu/Evaluation.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/Evaluation.scala
@@ -151,7 +151,11 @@ case class Evaluation(pm: PackageMap.Inferred, externals: Externals) {
             // we reset the environment in the other package
             recurse((from, Left(orig), Map.empty))
           case NameKind.ExternalDef(pn, n, scheme) =>
-            (externals.toMap((pn, n)).call(scheme.result), scheme)
+            externals.toMap.get((pn, n)) match {
+              case None =>
+                throw EvaluationException(s"Missing External defintion of '${pn.parts.toList.mkString("/")} $n'. Check that your 'external' parameter is correct.")
+              case Some(ext) => (ext.call(scheme.result), scheme)
+            }
         }
     }
 
@@ -303,3 +307,5 @@ case class Evaluation(pm: PackageMap.Inferred, externals: Externals) {
     loop(a, t)
   }
 }
+
+case class EvaluationException(message: String) extends Exception(message)


### PR DESCRIPTION
Without this change you get the somewhat cryptic

```
[error] (run-main-0) java.util.NoSuchElementException: key not found: (PackageName(NonEmptyList(Foo, S, Example)),fold)
```
instead of
```
[error] (run-main-0) org.bykn.bosatsu.EvaluationException: Missing External defintion of 'Foo/S/Example fold'. Check that your 'external' parameter is correct.
```

I should proooobably add tests