### PR TITLE
Add TypeLambda to the Type AST

### DIFF
--- a/core/src/main/scala/org/bykn/bosatsu/Evaluation.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/Evaluation.scala
@@ -282,6 +282,9 @@ case class Evaluation(pm: PackageMap.Inferred, externals: Externals) {
           Right(applyDT(dt, arg))
         case v@Type.Var(_) =>
           Left(Type.TypeApply(v, arg))
+        case Type.TypeLambda(param, expr) =>
+          // the param == arg in the expr
+          sys.error(s"TODO: let $param = $arg in $expr")
       }
 
     def loop(a: Any, t: Type): Option[T] = {
@@ -302,6 +305,8 @@ case class Evaluation(pm: PackageMap.Inferred, externals: Externals) {
         case Type.Var(_) =>
           // we should have fully resolved the type
           sys.error(s"should have fully resolved the type of: $a: $t")
+        case Type.TypeLambda(_, _) =>
+          sys.error(s"unexepected type lambda: $a has type $t")
       }
     }
     loop(a, t)

--- a/core/src/main/scala/org/bykn/bosatsu/Type.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/Type.scala
@@ -1,28 +1,47 @@
 package org.bykn.bosatsu
 
-import cats.data.NonEmptyList
-import cats.Order
+import cats.data.{NonEmptyList, State}
+import cats.{Monad, Order}
 import cats.implicits._
 
 sealed abstract class Type {
   import Type._
 
-  def varsIn: List[Type.Var] =
-    this match {
-      case v@Var(_) => v :: Nil
-      case Arrow(from, to) =>
-        (from.varsIn ::: to.varsIn).distinct
-      case TypeApply(hk, arg) =>
-        (hk.varsIn ::: arg.varsIn).distinct
-      case _ =>
-        Nil
-    }
+  /**
+   * What are the free variables in a type that are not bound
+   * to a type lambda
+   *
+   * TODO: how exactly is this different from Substitutable[Type].typeVars(this)
+   * I don't think it should be but a scalacheck would be good
+   */
+  def varsIn: List[Type.Var] = {
+    def loop(ts: List[Type], bindings: Set[String], acc: List[Type.Var]): List[Type.Var] =
+      ts match {
+        case Nil => acc.reverse.distinct
+        case Var(nm) :: rest if bindings(nm) =>
+          loop(rest, bindings, acc)
+        case (v@Var(_)) :: rest =>
+          loop(rest, bindings, v :: acc)
+        case Arrow(from, to) :: rest =>
+          loop(from :: to :: rest, bindings, acc)
+        case TypeApply(hk, arg) :: rest =>
+          loop(hk :: arg :: rest, bindings, acc)
+        case TypeLambda(param, expr) :: rest =>
+          // this binding is only in scope in expr
+          val inVars = loop(expr :: Nil, bindings + param, acc)
+          loop(rest, bindings, inVars.reverse_:::(acc))
+        case Declared(_, _) :: rest =>
+          loop(rest, bindings, acc)
+      }
+
+    loop(this :: Nil, Set.empty, Nil)
+  }
 }
 object Type {
   case class Arrow(from: Type, to: Type) extends Type
   case class Declared(packageName: PackageName, name: String) extends Type
   case class TypeApply(hk: Type, arg: Type) extends Type
-  //case class TypeLambda(param: String, in: Type) extends Type
+  case class TypeLambda(param: String, in: Type) extends Type
   case class Var(name: String) extends Type
 
   private def predef(t: String): Type =
@@ -38,6 +57,7 @@ object Type {
         Arrow(transformDeclared(a)(fn), transformDeclared(b)(fn))
       case TypeApply(t, a) =>
         TypeApply(transformDeclared(t)(fn), transformDeclared(a)(fn))
+      case TypeLambda(p, t) => TypeLambda(p, transformDeclared(t)(fn))
       case d@Declared(_, _) => fn(d)
       case v@Var(_) => v
     }
@@ -49,6 +69,94 @@ object Type {
       case TypeApply(left, _) => rootDeclared(left)
       case _ => None
     }
+
+  def simplifyApply(t: Type): Type =
+    t match {
+      case TypeApply(TypeLambda(name, expr), arg) =>
+        Substitutable.forType(Subst.pair(name, arg), expr)
+      case TypeApply(fn, arg) =>
+        TypeApply(simplifyApply(fn), simplifyApply(arg))
+      case Arrow(a, b) =>
+        Arrow(simplifyApply(a), simplifyApply(b))
+      case TypeLambda(p, t) => TypeLambda(p, simplifyApply(t))
+      case d@Declared(_, _) => d
+      case v@Var(_) => v
+    }
+
+  /**
+   * This reassigns lambda variables from a increasing
+   */
+  def normalize(tpe: Type): Type = {
+
+    def iToC(i: Int): Char = ('a'.toInt + i).toChar
+    @annotation.tailrec
+    def idxToLetter(i: Int, acc: List[Char] = Nil): String =
+      if (i < 26 && 0 <= i) (iToC(i) :: acc).mkString
+      else {
+        val rem = i % 26
+        val next = i / 26
+        idxToLetter(next, iToC(rem) :: acc)
+      }
+
+    type NormState = (Int, Map[String, String])
+    val incCounter: State[NormState, Unit] =
+      State.modify[NormState] {
+        case (c, m) => (c + 1, m)
+      }
+    val getMap: State[NormState, Map[String, String]] =
+      State.get[NormState].map(_._2)
+
+    def setMap(m: Map[String, String]): State[NormState, Unit] =
+      State.modify[NormState] { case (c, _) => (c, m) }
+
+    def nextMapping[A](v: String, avoid: Set[String])(recurse: String => State[NormState, A]): State[NormState, A] = {
+
+      lazy val next: State[NormState, String] =
+        for {
+          counterMap <- State.get[NormState]
+          (counter, map) = counterMap
+          newVar0 = idxToLetter(counter)
+          newVar <- if (avoid(newVar0)) incCounter >> next else incCounter.as(newVar0)
+        } yield newVar
+
+      for {
+        initMap <- getMap
+        newVar <- next
+        newMap = initMap.updated(v, newVar)
+        _ <- setMap(newMap)
+        a <- recurse(newVar)
+        _ <- setMap(initMap)
+      } yield a
+    }
+
+
+    def loop(t: Type): State[NormState, Type] =
+      t match {
+        case TypeLambda(p, expr) =>
+          val freeVars = t.varsIn.iterator.map(_.name).toSet
+          nextMapping(p, freeVars) { newVar =>
+            loop(expr).map(TypeLambda(newVar, _))
+          }
+        case v@Var(nm) =>
+          State.get[NormState]
+            .map { case (_, replacements) =>
+              replacements.get(nm).fold(v)(Var(_))
+            }
+        case Arrow(a, b) =>
+          for {
+            la <- loop(a)
+            lb <- loop(b)
+          } yield Arrow(la, lb)
+        case TypeApply(t, a) =>
+          for {
+            lt <- loop(t)
+            la <- loop(a)
+          } yield TypeApply(lt, la)
+        case d@Declared(_, _) => State.pure(d)
+      }
+
+    loop(tpe).run((0, Map.empty)).value._2
+  }
 
   implicit val ordType: Order[Type] =
     new Order[Type] {
@@ -69,15 +177,15 @@ object Type {
             val c = compare(aa, ba)
             if (c == 0) compare(ab, bb)
             else c
-          //case (TypeApply(_, _), TypeLambda(_, _)) => -1
+          case (TypeApply(_, _), TypeLambda(_, _)) => -1
           case (TypeApply(_, _), Var(_)) => -1
           case (TypeApply(_, _), _) => 1
-          // case (TypeLambda(pa, ta), TypeLambda(pb, tb)) =>
-          //   val c = pa.compareTo(pb)
-          //   if (c == 0) compare(ta, tb)
-          //   else c
-          // case (TypeLambda(_, _), Var(_)) => -1
-          // case (TypeLambda(_, _), _) => 1
+          case (TypeLambda(pa, ta), TypeLambda(pb, tb)) =>
+            val c = pa.compareTo(pb)
+            if (c == 0) compare(ta, tb)
+            else c
+          case (TypeLambda(_, _), Var(_)) => -1
+          case (TypeLambda(_, _), _) => 1
           case (Var(na), Var(nb)) => na.compareTo(nb)
           case (Var(_), _) => 1
         }
@@ -88,59 +196,28 @@ object Type {
 case class Scheme(vars: List[String], result: Type) {
   import Type._
 
-  def normalized: Scheme = {
-
-    @annotation.tailrec
-    def inOrd(t: Type, toVisit: List[Type], acc: List[String]): List[String] =
-      t match {
-        case Arrow(a, b) => inOrd(a, b :: toVisit, acc)
-        case Declared(_, _) =>
-          toVisit match {
-            case Nil => acc.reverse
-            case h :: tail => inOrd(h, tail, acc)
-          }
-        case TypeApply(hk, arg) => inOrd(hk, arg :: toVisit, acc)
-        //case TypeLambda(_, t) => inOrd(t, toVisit, acc)
-        case Var(v) => v :: Nil
-          toVisit match {
-            case Nil => (v :: acc).reverse
-            case h :: tail => inOrd(h, tail, v :: acc)
-          }
+  lazy val toType: Type = {
+    def loop(vars: List[String], expr: Type): Type =
+      vars match {
+        case Nil => expr
+        case h :: tail => TypeLambda(h, loop(tail, expr))
       }
-
-    def iToC(i: Int): Char = ('a'.toInt + i).toChar
-    @annotation.tailrec
-    def idxToLetter(i: Int, acc: List[Char] = Nil): String =
-      if (i < 26 && 0 <= i) (iToC(i) :: acc).mkString
-      else {
-        val rem = i % 26
-        val next = i / 26
-        idxToLetter(next, iToC(rem) :: acc)
-      }
-
-    val inOrdDistinct = inOrd(result, Nil, Nil).distinct
-    val mapping: List[(String, String)] =
-      inOrdDistinct.zipWithIndex.map { case (i, idx) =>
-        i -> idxToLetter(idx)
-      }
-
-    val mappingMap = mapping.toMap
-
-    def norm(t: Type): Type =
-      t match {
-        case Arrow(a, b) => Arrow(norm(a), norm(b))
-        case d@Declared(_, _) => d
-        case TypeApply(hk, arg) => TypeApply(norm(hk), norm(arg))
-        //case TypeLambda(v, t) => TypeLambda(v, norm(t))
-        case Var(v) => Var(mappingMap(v))
-      }
-
-    Scheme(mapping.map(_._2), norm(result))
+    loop(vars, result)
   }
+
+  def normalized: Scheme =
+    Scheme.fromType(Type.normalize(toType))
 }
 
 object Scheme {
-  def fromType(t: Type): Scheme = Scheme(Nil, t)
+  def fromType(t: Type): Scheme =
+    t match {
+      case Type.TypeLambda(h, rest) =>
+        val Scheme(vars, expr) = fromType(rest)
+        Scheme(h :: vars, expr)
+      case notLambda =>
+        Scheme(Nil, t)
+    }
 
   def typeConstructor(t: Type): Scheme =
     Scheme(t.varsIn.map(_.name), t).normalized

--- a/core/src/test/scala/org/bykn/bosatsu/TypeTest.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/TypeTest.scala
@@ -1,11 +1,55 @@
 package org.bykn.bosatsu
 
+import cats.data.NonEmptyList
+import org.scalacheck.{Gen, Arbitrary}
 import org.scalatest.FunSuite
+import org.scalatest.prop.PropertyChecks.forAll
+
 
 import Type._
 
-// TODO write property checks for more of these
+object TypeGen {
+  val genRoot: Gen[Type] = {
+    val pn = Gen.choose(1, 5).flatMap { s =>
+      Gen.listOfN(s, Gen.identifier)
+        .map {
+          case (h :: tail) => PackageName(NonEmptyList.of(h, tail :_*))
+          case Nil => sys.error("unreachable")
+        }
+    }
+
+    val decl = pn.flatMap { p => Gen.identifier.map(Type.Declared(p, _)) }
+    val vart = Gen.oneOf('a' to 'z').flatMap { first => Gen.identifier.map { tail => s"$first$tail" } }.map(Type.Var(_))
+    Gen.oneOf(decl, vart)
+  }
+
+  def genDepth(d: Int): Gen[Type] =
+    if (d <= 0) genRoot
+    else {
+      val smaller = Gen.lzy(genDepth(d - 1))
+      val arrow = Gen.zip(smaller, smaller).map { case (a, b) => Type.Arrow(a, b) }
+      val tap = Gen.zip(smaller, smaller).map { case (a, b) => Type.TypeApply(a, b) }
+
+      val lambda = smaller.flatMap { inner =>
+        val freeVars = inner.varsIn.map(_.name)
+        val nonFree = Gen.identifier
+        val genVar =
+          if (freeVars.isEmpty) nonFree
+          else Gen.oneOf(freeVars)
+
+        genVar.map(Type.TypeLambda(_, inner))
+      }
+
+      Gen.oneOf(arrow, tap, lambda)
+    }
+
+  implicit val arbType: Arbitrary[Type] =
+    Arbitrary(Gen.oneOf(0 to 3).flatMap(genDepth(_)))
+}
+
 class TypeTest extends FunSuite {
+  import TypeGen._
+
   test("simple varsIn examples") {
     val varA = Var("a")
     val varB = Var("b")
@@ -21,6 +65,40 @@ class TypeTest extends FunSuite {
     assert(Substitutable[Type].typeVars(TypeLambda("a", varB)) == Set("b"))
   }
 
+  test("varsIn matches typeVars") {
+    forAll { t: Type =>
+      assert(t.varsIn.map(_.name).toSet == Substitutable[Type].typeVars(t))
+    }
+  }
+
+  test("normalize is an idempotent pure function") {
+    forAll { t: Type =>
+      val normt = normalize(t)
+      assert(normt == normalize(t))
+      assert(normt == normalize(normt))
+    }
+  }
+
+  test("free type vars don't change under normalize") {
+    forAll { t: Type =>
+      assert(normalize(t).varsIn == t.varsIn)
+    }
+  }
+
+  test("simplify can only remove unused free variables") {
+    def law(t: Type) =
+      assert(simplifyApply(t).varsIn.toSet.subsetOf(t.varsIn.toSet))
+
+    forAll(law _)
+
+    val regressions =
+      List(
+        TypeApply(TypeLambda("a", Var("b")), Var("c"))
+      )
+
+    regressions.foreach(law _)
+  }
+
   test("simple normalization examples") {
     assert(normalize(Var("a")) == Var("a"))
     assert(normalize(TypeLambda("z", Var("z"))) == TypeLambda("a", Var("a")))
@@ -30,7 +108,53 @@ class TypeTest extends FunSuite {
   }
 
   test("apply lambda simplifies") {
-
     assert(simplifyApply(TypeApply(TypeLambda("a", Var("a")), Var("b"))) == Var("b"))
+  }
+
+  test("simplifyApply is an idempotent pure function") {
+    forAll { t: Type =>
+      val appt = simplifyApply(t)
+      assert(appt == simplifyApply(t))
+      assert(appt == simplifyApply(appt))
+    }
+  }
+
+  test("simplifyApply removes all cases of apply on lambda") {
+    def isGood(t: Type): Boolean =
+      t match {
+        case Declared(_,_) | Var(_) => true
+        case TypeApply(TypeLambda(_, _), _) => sys.error(t.toString)
+        case TypeApply(a, b) => isGood(a) && isGood(b)
+        case TypeLambda(_, t) => isGood(t)
+        case Arrow(a, b) => isGood(a) && isGood(b)
+      }
+    forAll { t: Type =>
+      assert(isGood(simplifyApply(t)))
+    }
+
+    val regressions = List(
+      TypeApply(
+        TypeApply(
+          TypeLambda("gngm5rnpqeii8",Var("gngm5rnpqeii8")),
+          TypeLambda("o1vmshpsf",Declared(PackageName(NonEmptyList.of("xJUgsavuLrqdfma1bfLxkp7byaw")),"zbcg8neK0x"))),
+        TypeLambda("dc5rnic6mhogrrnOoqh",
+          TypeApply(Var("dc5rnic6mhogrrnOoqh"),Declared(PackageName(NonEmptyList.of("hdiilmruzbjzRex")),"knxeCajMsm8fpdcrnDgfs1yarx")))))
+
+    regressions.foreach { t => assert(isGood(simplifyApply(t))) }
+
+  }
+
+  test("Scheme is isomorphic to Type") {
+    forAll { t: Type =>
+      val scheme = Scheme.fromType(t)
+
+      assert(scheme.toType == simplifyApply(t))
+    }
+  }
+
+  test("Scheme knows all the free vars in Type") {
+    forAll { t: Type =>
+      assert(Scheme.typeConstructor(t).toType.varsIn.isEmpty)
+    }
   }
 }

--- a/core/src/test/scala/org/bykn/bosatsu/TypeTest.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/TypeTest.scala
@@ -1,0 +1,35 @@
+package org.bykn.bosatsu
+
+import org.scalatest.FunSuite
+
+import Type._
+
+// TODO write property checks for more of these
+class TypeTest extends FunSuite {
+  test("simple varsIn examples") {
+    val varA = Var("a")
+    val varB = Var("b")
+    assert(varA.varsIn == List(varA))
+    assert(Substitutable[Type].typeVars(varA) == Set("a"))
+    assert(Arrow(varA, varB).varsIn == List(varA, varB))
+    assert(Substitutable[Type].typeVars(Arrow(varA, varB)) == Set("a", "b"))
+    // a is bound and not a free variable here
+    assert(TypeLambda("a", varA).varsIn == Nil)
+    assert(Substitutable[Type].typeVars(TypeLambda("a", varA)).isEmpty)
+    // b is a free variable
+    assert(TypeLambda("a", varB).varsIn == List(varB))
+    assert(Substitutable[Type].typeVars(TypeLambda("a", varB)) == Set("b"))
+  }
+
+  test("simple normalization examples") {
+    assert(normalize(Var("a")) == Var("a"))
+    assert(normalize(TypeLambda("z", Var("z"))) == TypeLambda("a", Var("a")))
+    assert(normalize(TypeLambda("z", Var("b"))) == TypeLambda("a", Var("b")))
+    assert(normalize(TypeLambda("z", TypeLambda("q", Var("b")))) == TypeLambda("a", TypeLambda("c", Var("b"))))
+  }
+
+  test("apply lambda simplifies") {
+
+    assert(simplifyApply(TypeApply(TypeLambda("a", Var("a")), Var("b"))) == Var("b"))
+  }
+}

--- a/core/src/test/scala/org/bykn/bosatsu/TypeTest.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/TypeTest.scala
@@ -26,6 +26,7 @@ class TypeTest extends FunSuite {
     assert(normalize(TypeLambda("z", Var("z"))) == TypeLambda("a", Var("a")))
     assert(normalize(TypeLambda("z", Var("b"))) == TypeLambda("a", Var("b")))
     assert(normalize(TypeLambda("z", TypeLambda("q", Var("b")))) == TypeLambda("a", TypeLambda("c", Var("b"))))
+    assert(normalize(Arrow(Var("a"), TypeLambda("z", Var("b")))) == Arrow(Var("a"), TypeLambda("c", Var("b"))))
   }
 
   test("apply lambda simplifies") {


### PR DESCRIPTION
This is part of #9 but not the whole story.

It adds TypeLambda back to the Type AST, which is what Scheme really is. It does not yet remove Scheme since we are using in many places, but Scheme should be a synonym for Type.

This does not yet do anything in Infer with TypeLambda, which I think has to be done if we are going to handle unifying them at all. I think the unification should be obvious: you can only unify with a Var or another TypeLambda, and if you unify with the TypeLambda you replace the unbound parameter to a common value.

@snoble can you take a look and let me know what you think if you have time? I think you are more concerned with semantics and syntax than typechecking, but I'd be interested in your code review.