### PR TITLE
Add annotated expression nodes

### DIFF
--- a/core/src/main/scala/org/bykn/bosatsu/Codegen.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/Codegen.scala
@@ -202,6 +202,12 @@ trait CodeGen {
    */
   def apply[T](e: Expr[T], topLevel: Boolean, pack: Package.Inferred): Output[Doc] =
     e match {
+      case Annotation(expr, _, _) =>
+        // TODO we might want to use the type info
+        apply(expr, topLevel, pack)
+      case AnnotatedLambda(arg, _, exp, t) =>
+        // TODO we might want to use the type info
+        apply(Lambda(arg, exp, t), topLevel, pack)
       case Var(n, _) =>
         NameKind(pack, n) match {
           case Some(NameKind.Constructor(_, _, _)) =>

--- a/core/src/main/scala/org/bykn/bosatsu/Declaration.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/Declaration.scala
@@ -8,7 +8,7 @@ import fastparse.all._
 import org.typelevel.paiges.{ Doc, Document }
 
 /**
- * Represents the syntax of declarations
+ * Represents the syntax version of Expr
  */
 sealed abstract class Declaration {
   import Declaration._

--- a/core/src/main/scala/org/bykn/bosatsu/Evaluation.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/Evaluation.scala
@@ -95,6 +95,8 @@ case class Evaluation(pm: PackageMap.Inferred, externals: Externals) {
     import Expr._
 
     expr match {
+      case Annotation(e, _, _) => evalExpr(p, e, env, recurse)
+      case al@AnnotatedLambda(_, _, _, _) => evalExpr(p, al.toLambda, env, recurse)
       case Var(v, (_, scheme)) =>
         env.get(v) match {
           case Some(a) => (Eval.now(a), scheme)

--- a/core/src/main/scala/org/bykn/bosatsu/Infer.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/Infer.scala
@@ -253,6 +253,12 @@ object Inference {
 
   def inferTypeTag[T: HasRegion](expr: Expr[T]): Infer[(Type, Expr[(T, Scheme)])] =
     expr match {
+      case Expr.Annotation(expr, _, _) =>
+        println(s"warning, ignoring annotation: $expr")
+        inferTypeTag(expr)
+      case al@Expr.AnnotatedLambda(_, _, _, _) =>
+        println(s"warning, ignoring annotation: $expr")
+        inferTypeTag(al.toLambda)
       case Expr.Var(n, tag) =>
         lookup(n, HasRegion.region(expr.tag)).map { t =>
           (t, Expr.Var(n, (tag, Scheme.fromType(t))))

--- a/core/src/test/scala/org/bykn/bosatsu/InferTest.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/InferTest.scala
@@ -142,6 +142,26 @@ main = match x:
   NonEmpty(y, z):
     y
 """, Type.intT)
+
+   // parseProgram("""#
+// enum Opt:
+  // None
+  // Some(a)
+
+// struct Monad(pure: forall a. a -> f[a], bind: forall a, b. f[a] -> (a -> f[b]) -> f[b])
+
+// def optPure(a):
+  // Some(a)
+
+// def optBind(opt, bindFn):
+  // match opt:
+   //  None:
+   //    None
+   //  Some(a):
+   //    bindFn(a)
+
+// main = Monad(optPure, optBind)
+// """, Type.intT)
 }
 
   // def evalTest(str: String, v: Any) =


### PR DESCRIPTION
We want to allow annotating types for both documentation but also improving error reporting in type checking.

This adds two expressions: annotating an expression, and annotating the argument to a lambda.

We don't currently use it at all.