### PR TITLE
Add If support to rank-n types

### DIFF
--- a/core/src/main/scala/org/bykn/bosatsu/rankn/Term.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/rankn/Term.scala
@@ -11,11 +11,27 @@ sealed abstract class Term {
 }
 
 object Term {
+  sealed abstract class Literal
+  object Literal {
+    def apply(fromLong: Long): Literal = Integer(fromLong)
+    def apply(fromBool: Boolean): Literal = Bool(fromBool)
+
+    case class Integer(toLong: Long) extends Literal
+    case class Bool(toBool: Boolean) extends Literal
+  }
+
   case class Var(name: String) extends Term
-  case class Lit(toLong: Long) extends Term
+  case class Lit(toLiteral: Literal) extends Term
   case class App(fn: Term, arg: Term) extends Term
   case class Lam(name: String, result: Term) extends Term
   case class ALam(name: String, tpe: Type, result: Term) extends Term
   case class Let(name: String, value: Term, in: Term) extends Term
   case class Ann(term: Term, tpe: Type) extends Term
+  case class If(cond: Term, ifTrue: Term, ifFalse: Term) extends Term
+
+  object Lit {
+    def apply(l: Long): Lit = Lit(Literal(l))
+    def apply(b: Boolean): Lit = Lit(Literal(b))
+  }
+
 }

--- a/core/src/main/scala/org/bykn/bosatsu/rankn/Type.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/rankn/Type.scala
@@ -15,6 +15,7 @@ object Type {
   case class TyMeta(toMeta: Meta) extends Type
 
   val intType: Type = TyConst(Const.IntType)
+  val boolType: Type = TyConst(Const.BoolType)
 
   sealed abstract class Const
   object Const {

--- a/core/src/test/scala/org/bykn/bosatsu/rankn/RankNTcTest.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/rankn/RankNTcTest.scala
@@ -29,6 +29,17 @@ class RankNTcTest extends FunSuite {
     testType(App(Lam("x", Var("x")), Lit(100L)), Type.intType)
     testType(Ann(App(Lam("x", Var("x")), Lit(100L)), Type.intType), Type.intType)
     testType(App(ALam("x", Type.intType, Var("x")), Lit(100L)), Type.intType)
+
+    // test branches
+    testType(If(Lit(true), Lit(0), Lit(1)), Type.intType)
+    testType(Let("x", Lit(0), If(Lit(true), Var("x"), Lit(1))), Type.intType)
+
+    val identFnType =
+      ForAll(NonEmptyList.of(Bound("a")),
+        Type.Fun(Type.TyVar(Bound("a")), Type.TyVar(Bound("a"))))
+    testType(Let("x", Lam("y", Var("y")),
+      If(Lit(true), Var("x"),
+        Ann(Lam("x", Var("x")), identFnType))), identFnType)
   }
 
   test("test all binders") {


### PR DESCRIPTION
This implements the suggestion from the paper on handling matches.

Here we only support if, not a full match, which requires us to think about pattern matches.

Some form of pattern matching will be next.