### PR TITLE
Add Pattern to rank-n support

### DIFF
--- a/core/src/main/scala/org/bykn/bosatsu/rankn/Pattern.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/rankn/Pattern.scala
@@ -1,0 +1,10 @@
+package org.bykn.bosatsu.rankn
+
+sealed abstract class Pattern
+
+object Pattern {
+  case object WildCard extends Pattern
+  case class Var(name: String) extends Pattern
+  case class PositionalStruct(name: String, params: List[Pattern]) extends Pattern
+  //case class BindingStruct(name: String, bindings: List[(String, Pattern)], ignoreRest: Boolean) extends Pattern
+}

--- a/core/src/main/scala/org/bykn/bosatsu/rankn/Tc.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/rankn/Tc.scala
@@ -508,6 +508,18 @@ object Tc {
         condTpe *> rest
       case Match(term, branches) =>
         // all of the branches must return the same type:
+
+        // TODO: it's fishy that both branches have to
+        // infer the type of term and then push it down
+        // as a Check, if we only ever call check there, why accept an Expect?
+        // The paper is not clear on this (they didn't implement this
+        // method as far as I can see)
+        // on the other hand, the patterns in some cases should be enough
+        // to see the type of matching term, but we are only accessing that
+        // via check currently.
+        //
+        // It feels like there should be another inference rule, which we
+        // are missing here.
         expect match {
           case Expected.Check(resT) =>
             for {

--- a/core/src/main/scala/org/bykn/bosatsu/rankn/Term.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/rankn/Term.scala
@@ -1,5 +1,7 @@
 package org.bykn.bosatsu.rankn
 
+import cats.data.NonEmptyList
+
 sealed abstract class Term {
   import Term._
 
@@ -28,6 +30,7 @@ object Term {
   case class Let(name: String, value: Term, in: Term) extends Term
   case class Ann(term: Term, tpe: Type) extends Term
   case class If(cond: Term, ifTrue: Term, ifFalse: Term) extends Term
+  case class Match(term: Term, branches: NonEmptyList[(Pattern, Term)]) extends Term
 
   object Lit {
     def apply(l: Long): Lit = Lit(Literal(l))

--- a/core/src/main/scala/org/bykn/bosatsu/rankn/Type.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/rankn/Type.scala
@@ -21,6 +21,7 @@ object Type {
   object Const {
     case object IntType extends Const
     case object BoolType extends Const
+    case class Defined(name: String) extends Const
   }
 
   sealed abstract class Var {

--- a/core/src/test/scala/org/bykn/bosatsu/rankn/RankNTcTest.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/rankn/RankNTcTest.scala
@@ -6,7 +6,7 @@ import org.scalatest.FunSuite
 class RankNTcTest extends FunSuite {
 
   def testType(term: Term, ty: Type) =
-    Tc.typeCheck(term).runFully(Map.empty) match {
+    Tc.typeCheck(term).runFully(Map.empty, Map.empty) match {
       case Left(err) => assert(false, err)
       case Right(tpe) => assert(tpe == ty, term.toString)
     }
@@ -40,6 +40,73 @@ class RankNTcTest extends FunSuite {
     testType(Let("x", Lam("y", Var("y")),
       If(Lit(true), Var("x"),
         Ann(Lam("x", Var("x")), identFnType))), identFnType)
+  }
+
+  test("Match inference") {
+    import Term._
+
+    testType(
+      Match(Lit(10),
+        NonEmptyList.of(
+          (Pattern.WildCard, Lit(0))
+          )), Type.intType)
+
+    testType(
+      Match(Lit(true),
+        NonEmptyList.of(
+          (Pattern.WildCard, Lit(0))
+          )), Type.intType)
+  }
+
+  test("Match with custom non-generic types") {
+    def b(a: String): Type.Var = Type.Var.Bound(a)
+    def v(a: String): Type = Type.TyVar(b(a))
+
+    val optType: Type.Tau = Type.TyConst(Type.Const.Defined("Option"))
+
+    val definedOption = Map(
+      ("Some", (List(Type.intType), optType)),
+      ("None", (Nil, optType)))
+
+    // TODO: I think we need TypeApply(optType, "a") below
+    // to support generic constructors
+    val constructors = Map(
+      ("Some", Type.Fun(Type.intType, optType))
+    )
+
+    def testWithOpt(term: Term, ty: Type) =
+      Tc.typeCheck(term).runFully(constructors, definedOption) match {
+        case Left(err) => assert(false, err)
+        case Right(tpe) => assert(tpe == ty, term.toString)
+      }
+
+    def failWithOpt(term: Term, ty: Type) =
+      Tc.typeCheck(term).runFully(constructors, definedOption) match {
+        case Left(err) => assert(true)
+        case Right(tpe) => assert(false, s"expected to fail, but inferred type $tpe")
+      }
+
+    import Term._
+
+    testWithOpt(
+      Match(App(Var("Some"), Lit(1)),
+        NonEmptyList.of(
+          (Pattern.WildCard, Lit(0))
+          )), Type.intType)
+
+    testWithOpt(
+      Match(App(Var("Some"), Lit(1)),
+        NonEmptyList.of(
+          (Pattern.PositionalStruct("Some", List(Pattern.Var("a"))), Var("a")),
+          (Pattern.PositionalStruct("None", Nil), Lit(42))
+          )), Type.intType)
+
+    // this should fail, the pattern for Some has too many positions
+    failWithOpt(
+      Match(App(Var("Some"), Lit(1)),
+        NonEmptyList.of(
+          (Pattern.PositionalStruct("Some", List(Pattern.WildCard, Pattern.WildCard)), Lit(0))
+          )), Type.intType)
   }
 
   test("test all binders") {

--- a/core/src/test/scala/org/bykn/bosatsu/rankn/RankNTcTest.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/rankn/RankNTcTest.scala
@@ -155,7 +155,7 @@ class RankNTcTest extends FunSuite {
     testWithOpt(
       Match(App(Var("Some"), App(Var("Some"), Lit(1))),
         NonEmptyList.of(
-          (Pattern.PositionalStruct("Some", List(Pattern.Var("a"))), Var("a")),
+          (Pattern.PositionalStruct("Some", List(Pattern.Var("a"))), Var("a"))
           )), Type.TyApply(optType, Type.intType))
 
     // this should fail, the pattern for Some has too many positions


### PR DESCRIPTION
This continues following the paper into section 7 where patterns and matching is discussed.

Unfortunately the paper does not include inference rules for a match statement, and my current understanding is only enough to follow the directions in the paper, not prove results. So, I can't yet see the right way to extend the inference rules for the case of a match.

In the case of `if` we know the type of the argument, but in the case of `match` we have to infer the type of the argument.

In addition to the above difficulty, we also have the problem that parametric type constructors `struct Option[a](a: a)` cannot be supported currently because we have no way to remember if we have an `Option[Int]` or `Option[String]`. For this, we need, I think a TypeApply term in the rankn.Type ast.
