### PR TITLE
Add higher rank test

### DIFF
--- a/core/src/main/scala/org/bykn/bosatsu/rankn/Type.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/rankn/Type.scala
@@ -8,7 +8,12 @@ object Type {
   type Rho = Type // no top level ForAll
   type Tau = Type // no forall anywhere
 
-  case class ForAll(vars: NonEmptyList[Var], in: Rho) extends Type
+  case class ForAll(vars: NonEmptyList[Var], in: Rho) extends Type {
+    in match {
+      case ForAll(_, _) => sys.error(s"invalid nested ForAll")
+      case _ => ()
+    }
+  }
   case class TyConst(tpe: Const) extends Type
   case class TyVar(toVar: Var) extends Type
   case class TyMeta(toMeta: Meta) extends Type

--- a/core/src/test/scala/org/bykn/bosatsu/rankn/RankNTcTest.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/rankn/RankNTcTest.scala
@@ -186,8 +186,8 @@ class RankNTcTest extends FunSuite {
       ("None", (List(b("a")), Nil, optName)))
 
     val constructors = Map(
-      ("Pure", Type.ForAll(NonEmptyList.of(b("f"), b("a")),
-        Type.Fun(Type.Fun(v("a"), Type.TyApply(v("f"), v("a"))),
+      ("Pure", Type.ForAll(NonEmptyList.of(b("f")),
+        Type.Fun(Type.ForAll(NonEmptyList.of(b("a")), Type.Fun(v("a"), Type.TyApply(v("f"), v("a")))),
           Type.TyApply(Type.TyConst(pureName), v("f")) ))),
       ("Some", Type.ForAll(NonEmptyList.of(b("a")), Type.Fun(v("a"), Type.TyApply(optType, v("a"))))),
       ("None", Type.ForAll(NonEmptyList.of(b("a")), Type.TyApply(optType, v("a"))))


### PR DESCRIPTION
I added a test for the main event here: higher ranked inference.

I stumbled implementing this because I created an invalid `ForAll` node. By testing the invariant on construction, we avoid creating bad nodes which allowed me to solve the issue.

I'd like to check these invariants in the types and not have to resort to a runtime check.