### PR TITLE
Use PackageName in rankN defined types

### DIFF
--- a/core/src/main/scala/org/bykn/bosatsu/PackageName.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/PackageName.scala
@@ -12,6 +12,10 @@ case class PackageName(parts: NonEmptyList[String]) {
 }
 
 object PackageName {
+
+  def parts(first: String, rest: String*): PackageName =
+    PackageName(NonEmptyList.of(first, rest :_*))
+
   implicit val document: Document[PackageName] =
     Document.instance[PackageName] { pn => Doc.text(pn.asString) }
 
@@ -28,5 +32,8 @@ object PackageName {
 
   implicit val order: Order[PackageName] =
     Order[NonEmptyList[String]].contramap[PackageName](_.parts)
+
+  val predef: PackageName =
+    PackageName(NonEmptyList.of("Bosatsu", "Predef"))
 }
 

--- a/core/src/main/scala/org/bykn/bosatsu/Type.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/Type.scala
@@ -48,7 +48,7 @@ object Type {
   case class Var(name: String) extends Type
 
   private def predef(t: String): Type =
-    Declared(PackageName(NonEmptyList.of("Bosatsu", "Predef")), t)
+    Declared(PackageName.predef, t)
 
   val intT: Type = predef("Int")
   val boolT: Type = predef("Bool")

--- a/core/src/main/scala/org/bykn/bosatsu/rankn/Type.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/rankn/Type.scala
@@ -1,6 +1,7 @@
 package org.bykn.bosatsu.rankn
 
 import cats.data.NonEmptyList
+import org.bykn.bosatsu.PackageName
 
 sealed abstract class Type
 
@@ -41,7 +42,7 @@ object Type {
     case object IntType extends Const
     case object BoolType extends Const
     case object FnType extends Const
-    case class Defined(name: String) extends Const
+    case class Defined(packageName: PackageName, name: String) extends Const
   }
 
   sealed abstract class Var {

--- a/core/src/test/scala/org/bykn/bosatsu/rankn/RankNInferTest.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/rankn/RankNInferTest.scala
@@ -2,8 +2,12 @@ package org.bykn.bosatsu.rankn
 
 import cats.data.NonEmptyList
 import org.scalatest.FunSuite
+import org.bykn.bosatsu.PackageName
 
 class RankNInferTest extends FunSuite {
+
+  def defType(n: String): Type.Const.Defined =
+    Type.Const.Defined(PackageName.parts("Test"), n)
 
   def testType(term: Term, ty: Type) =
     Infer.typeCheck(term).runFully(Map.empty, Map.empty) match {
@@ -62,7 +66,7 @@ class RankNInferTest extends FunSuite {
     def b(a: String): Type.Var = Type.Var.Bound(a)
     def v(a: String): Type = Type.TyVar(b(a))
 
-    val optName = Type.Const.Defined("Option")
+    val optName = defType("Option")
     val optType: Type.Tau = Type.TyConst(optName)
 
     val definedOption = Map(
@@ -111,7 +115,7 @@ class RankNInferTest extends FunSuite {
     def b(a: String): Type.Var = Type.Var.Bound(a)
     def v(a: String): Type = Type.TyVar(b(a))
 
-    val optName = Type.Const.Defined("Option")
+    val optName = defType("Option")
     val optType: Type.Tau = Type.TyConst(optName)
 
     val definedOption = Map(
@@ -168,9 +172,9 @@ class RankNInferTest extends FunSuite {
     def b(a: String): Type.Var = Type.Var.Bound(a)
     def v(a: String): Type = Type.TyVar(b(a))
 
-    val pureName = Type.Const.Defined("Pure")
+    val pureName = defType("Pure")
     val pureType: Type.Tau = Type.TyConst(pureName)
-    val optName = Type.Const.Defined("Option")
+    val optName = defType("Option")
     val optType: Type.Tau = Type.TyConst(optName)
 
     /**


### PR DESCRIPTION
This is a step in merging rank n inference to be the only system.

The approach is to match `Expr[A]` up to `Term` and replace the `Type` with `rankn.Type`