### PR TITLE
Add type annotation to patterns

### DIFF
--- a/core/src/main/scala/org/bykn/bosatsu/Expr.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/Expr.scala
@@ -48,7 +48,7 @@ object Expr {
   case class Let[T](arg: String, expr: Expr[T], in: Expr[T], tag: T) extends Expr[T]
   case class Literal[T](lit: Lit, tag: T) extends Expr[T]
   case class If[T](cond: Expr[T], ifTrue: Expr[T], ifFalse: Expr[T], tag: T) extends Expr[T]
-  case class Match[T](arg: Expr[T], branches: NonEmptyList[(Pattern[(PackageName, ConstructorName)], Expr[T])], tag: T) extends Expr[T]
+  case class Match[T](arg: Expr[T], branches: NonEmptyList[(Pattern[(PackageName, ConstructorName), rankn.Type], Expr[T])], tag: T) extends Expr[T]
 
   implicit def hasRegion[T: HasRegion]: HasRegion[Expr[T]] =
     HasRegion.instance[Expr[T]] { e => HasRegion.region(e.tag) }
@@ -86,8 +86,8 @@ object Expr {
 
       // Traverse on NonEmptyList[(Pattern[_], Expr[?])]
       private lazy val tne = {
-        type Tup[T] = (Pattern[(PackageName, ConstructorName)], T)
-        type TupExpr[T] = (Pattern[(PackageName, ConstructorName)], Expr[T])
+        type Tup[T] = (Pattern[(PackageName, ConstructorName), rankn.Type], T)
+        type TupExpr[T] = (Pattern[(PackageName, ConstructorName), rankn.Type], Expr[T])
         val tup: Traverse[TupExpr] = Traverse[Tup].compose(exprTraverse)
         Traverse[NonEmptyList].compose(tup)
       }

--- a/core/src/main/scala/org/bykn/bosatsu/Infer.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/Infer.scala
@@ -136,10 +136,10 @@ object Inference {
 
   private def instantiateMatch[T: HasRegion](arg: Type,
     dt: DefinedType,
-    branches: NonEmptyList[(Pattern[(PackageName, ConstructorName)], Expr[T])],
-    matchTag: T): Infer[(Type, NonEmptyList[(Pattern[(PackageName, ConstructorName)], Expr[(T, Scheme)])])] = {
+    branches: NonEmptyList[(Pattern[(PackageName, ConstructorName), rankn.Type], Expr[T])],
+    matchTag: T): Infer[(Type, NonEmptyList[(Pattern[(PackageName, ConstructorName), rankn.Type], Expr[(T, Scheme)])])] = {
 
-    def withBind(args: List[Pattern[(PackageName, ConstructorName)]], ts: List[Type], result: Expr[T]): Infer[(Type, Expr[(T, Scheme)])] =
+    def withBind(args: List[Pattern[(PackageName, ConstructorName), rankn.Type]], ts: List[Type], result: Expr[T]): Infer[(Type, Expr[(T, Scheme)])] =
       inferTypeTag(result)
         .local { te: TypeEnv =>
           args.zip(ts.map(Scheme.fromType _)).foldLeft(te) {
@@ -150,7 +150,7 @@ object Inference {
           }
         }
 
-    type Element[A] = (Pattern[(PackageName, ConstructorName)], Expr[A])
+    type Element[A] = (Pattern[(PackageName, ConstructorName), rankn.Type], Expr[A])
     def inferBranch(mp: Map[ConstructorName, List[Type]])(ce: Element[T]): Infer[(Type, Element[(T, Scheme)])] = {
       // TODO make sure we have proven that this map-get is safe:
       val (p@Pattern.PositionalStruct((_, cname), bindings), branchRes) = ce

--- a/core/src/test/scala/org/bykn/bosatsu/Gen.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/Gen.scala
@@ -166,7 +166,7 @@ object Generators {
         }
       } yield Pattern.PositionalStruct(nm, argPat)
 
-      val genCase: Gen[(Pattern[String], Padding[Indented[Declaration]])] =
+      val genCase: Gen[(Pattern[String, TypeRef], Padding[Indented[Declaration]])] =
         Gen.zip(genPattern, padBody)
 
       val padIndCase = padding(genCase.map(Indented(i, _)))

--- a/core/src/test/scala/org/bykn/bosatsu/rankn/RankNInferTest.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/rankn/RankNInferTest.scala
@@ -35,10 +35,10 @@ class RankNInferTest extends FunSuite {
   def alam(arg: String, tpe: Type, res: Expr[Unit]): Expr[Unit] = AnnotatedLambda(arg, tpe, res, ())
 
   def ife(cond: Expr[Unit], ift: Expr[Unit], iff: Expr[Unit]): Expr[Unit] = If(cond, ift, iff, ())
-  def matche(arg: Expr[Unit], branches: NonEmptyList[(Pattern[String], Expr[Unit])]): Expr[Unit] =
+  def matche(arg: Expr[Unit], branches: NonEmptyList[(Pattern[String, Type], Expr[Unit])]): Expr[Unit] =
     Match(arg,
       branches.map { case (p, e) =>
-        val p1 = p.map { n => (PackageName.parts("Test"), ConstructorName(n)) }
+        val p1 = p.mapName { n => (PackageName.parts("Test"), ConstructorName(n)) }
         (p1, e)
       },
       ())
@@ -82,6 +82,12 @@ class RankNInferTest extends FunSuite {
       matche(lit(true),
         NonEmptyList.of(
           (Pattern.WildCard, lit(0))
+          )), Type.IntType)
+
+    testType(
+      matche(lit(true),
+        NonEmptyList.of(
+          (Pattern.Annotation(Pattern.WildCard, Type.BoolType), lit(0))
           )), Type.IntType)
   }
 


### PR DESCRIPTION
Moving towards replacing the old type inference, we need a way to fully annotate the types of the inferred expressions.

The old approach was to embed the annotation on each expression node on the tag. It is not 100% clear this was ever totally good enough for us.

We need to know the types during evaluation if we want to use compact representations of structs and enums, because we need to know what index a field name corresponds to, or what name a variant index refers to.

Section 8 of then rankn paper (see #5) discusses type directed translation. In this approach, when we infer, we also emit a new AST that is fully annotated such that inference of types is trivial. This is what we want to move towards, but to do this, it seemed likely we would need to implement type annotations in patterns, so I went ahead and did that.

This does complicate the Pattern type a bit, because at different phases, we have different information. On approach, which I'm still not sure is wrong, is to have different ASTs at different phases. We use this approach in a few places (e.g. Declaration vs Expr or TypeRef vs Type). This approach is nice when there is an injective mapping when we want to rule out some kinds of recursions in either the syntax or the internal representation, but it has the cost of code duplication. On the other hand, Pattern does not (yet) have the property that the syntactic and internal representations are different except the way we refer to type names (are they fully qualified or not).