### PR TITLE
Use type annotations in defs in converting to Expr

### DIFF
--- a/core/src/main/scala/org/bykn/bosatsu/Expr.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/Expr.scala
@@ -191,6 +191,18 @@ object Expr {
             foldRight(arg, b2)(f)
         }
     }
+
+  def buildLambda[A](args: NonEmptyList[(String, Option[rankn.Type])], body: Expr[A], outer: A): Expr[A] =
+    args match {
+      case NonEmptyList((arg, None), Nil) =>
+        Expr.Lambda(arg, body, outer)
+      case NonEmptyList((arg, Some(tpe)), Nil) =>
+        Expr.AnnotatedLambda(arg, tpe, body, outer)
+      case NonEmptyList(arg, h :: tail) =>
+        val body1 = buildLambda(NonEmptyList(h, tail), body, outer)
+        buildLambda(NonEmptyList.of(arg), body1, outer)
+    }
+
 }
 
 case class Program[D, S](types: TypeEnv, lets: List[(String, Expr[D])], from: S) {

--- a/core/src/main/scala/org/bykn/bosatsu/TypeRef.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/TypeRef.scala
@@ -73,6 +73,9 @@ sealed abstract class TypeRef {
             case NonEmptyList(a0, a1 :: as) => loop(TyApply(fn, a0.toNType(p)), NonEmptyList(a1, as))
           }
         loop(a.toNType(p), bs)
+      case TypeLambda(pars0, TypeLambda(pars1, e)) =>
+        // we normalize to lifting all the foralls to the outside
+        TypeLambda(pars0 ::: pars1, e).toNType(p)
       case TypeLambda(pars, e) =>
         ForAll(pars.map { case TypeVar(v) => NType.Var.Bound(v) }, e.toNType(p))
     }


### PR DESCRIPTION
closes #6 

The hard work was already done in the #34 rankn work. Currently old infer still ignores this information, but we are plumbing it all the way through here.

