### PR TITLE
convert Expr to TypedExpr

### DIFF
--- a/core/src/main/scala/org/bykn/bosatsu/Expr.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/Expr.scala
@@ -10,15 +10,6 @@ import cats.evidence.Is
 import cats.data.NonEmptyList
 import cats.{Applicative, Eval, Traverse}
 
-sealed abstract class Lit
-object Lit {
-  case class Integer(toInt: Int) extends Lit
-  case class Str(toStr: String) extends Lit
-
-  def apply(i: Int): Lit = Integer(i)
-  def apply(str: String): Lit = Str(str)
-}
-
 sealed abstract class Expr[T] {
   import Expr._
 

--- a/core/src/main/scala/org/bykn/bosatsu/Lit.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/Lit.scala
@@ -1,0 +1,11 @@
+package org.bykn.bosatsu
+
+sealed abstract class Lit
+object Lit {
+  case class Integer(toInt: Int) extends Lit
+  case class Str(toStr: String) extends Lit
+
+  def apply(i: Int): Lit = Integer(i)
+  def apply(str: String): Lit = Str(str)
+}
+

--- a/core/src/main/scala/org/bykn/bosatsu/TypedExpr.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/TypedExpr.scala
@@ -9,20 +9,6 @@ sealed abstract class TypedExpr[T] {
   import TypedExpr._
 
   def tag: T
-  // def setTag(t: T): TypedExpr[T] =
-  //   this match {
-  //     case tl@TyLam(_, _, _) => tl.copy(tag = t)
-  //     case ta@TyApp(_, _, _) => ta.copy(tag = t)
-  //     case v@Var(_, _, _) => v.copy(tag = t)
-  //     case a@App(_, _, _) => a.copy(tag = t)
-  //     case a@Annotation(_, _, _) => a.copy(tag = t)
-  //     case a@AnnotatedLambda(_, _, _, _) => a.copy(tag = t)
-  //     case l@Let(_, _, _, _) => l.copy(tag = t)
-  //     case l@Literal(_, _, _) => l.copy(tag = t)
-  //     case i@If(_, _, _, _) => i.copy(tag = t)
-  //     case m@Match(_, _, _) => m.copy(tag = t)
-  //   }
-
   /**
    * For any well typed expression, i.e.
    * one that has already gone through type
@@ -101,11 +87,6 @@ object TypedExpr {
    * The paper says to add TyLam and TyApp nodes, but it never mentions what to do with them
    */
   case class Generic[T](typeVars: NonEmptyList[rankn.Type.Var.Bound], in: TypedExpr[T], tag: T) extends TypedExpr[T]
-  // /**
-  //  * This says that we have a generic type, and we are applying a specfic Tau (no
-  //  * forall anywhere) into the type
-  //  */
-  // case class TyApp[T](generic: TypedExpr[T], typeArg: rankn.Type.Tau, tag: T) extends TypedExpr[T]
   case class Annotation[T](term: TypedExpr[T], coerce: rankn.Type, tag: T) extends TypedExpr[T]
   case class AnnotatedLambda[T](arg: String, tpe: rankn.Type, expr: TypedExpr[T], tag: T) extends TypedExpr[T]
   case class Var[T](name: String, tpe: rankn.Type, tag: T) extends TypedExpr[T]
@@ -158,141 +139,4 @@ object TypedExpr {
 
   implicit def typedExprHasRegion[T: HasRegion]: HasRegion[TypedExpr[T]] =
     HasRegion.instance[TypedExpr[T]] { e => HasRegion.region(e.tag) }
-
-  /**
-   * Return a value so next(e).tag == e and also this is true
-   * recursively
-   */
-  // def nest[T](e: TypedExpr[T]): TypedExpr[TypedExpr[T]] =
-  //   e match {
-  //     case TyLam(v, te, _) =>
-  //       TyLam(v, nest(te), e)
-  //     case TyApp(te, tpe, _) =>
-  //       TyApp(nest(te), tpe, e)
-  //     case AnnotatedLambda(arg, tpe, expr, _) =>
-  //       AnnotatedLambda(arg, tpe, nest(expr), e)
-  //     case Var(s, tpe, _) =>
-  //       Var(s, tpe, e)
-  //     case App(fn, a, _) =>
-  //       App(nest(fn), nest(a), e)
-  //     case Let(arg, exp, in, _) =>
-  //       Let(arg, nest(exp), nest(in), e)
-  //     case Literal(lit, tpe, _) =>
-  //       Literal(lit, tep, e)
-  //     case If(cond, ift, iff, _) =>
-  //       If(nest(cond), nest(ift), nest(iff), e)
-  //     case Match(arg, branches, _) =>
-  //       Match(nest(arg), branches.map {
-  //         case (pat, exp) => (pat, nest(exp))
-  //       }, e)
-  //   }
-
-//   implicit val typedExprTraverse: Traverse[TypedExpr] =
-//     new Traverse[TypedExpr] {
-
-//       // Traverse on NonEmptyList[(Pattern[_], TypedExpr[?])]
-//       private lazy val tne = {
-//         type Tup[T] = (Pattern[(PackageName, ConstructorName), rankn.Type], T)
-//         type TupTypedExpr[T] = (Pattern[(PackageName, ConstructorName), rankn.Type], TypedExpr[T])
-//         val tup: Traverse[TupTypedExpr] = Traverse[Tup].compose(typedExprTraverse)
-//         Traverse[NonEmptyList].compose(tup)
-//       }
-
-//       def traverse[G[_]: Applicative, A, B](fa: TypedExpr[A])(f: A => G[B]): G[TypedExpr[B]] =
-//         fa match {
-//           case TyLam(v, e, a) =>
-//             (e.traverse(f), f(a)).mapN(TyLam(v, _, _))
-//           case TyApp(e, tpe, a) =>
-//             (e.traverse(f), f(a)).mapN(TyApp(_, tpe, _))
-//           case AnnotatedLambda(arg, tpe, expr, a) =>
-//             (expr.traverse(f), f(a)).mapN(AnnotatedLambda(arg, tpe, _, _))
-//           case Var(s, tpe, t) =>
-//             f(t).map(Var(s, tpe, _))
-//           case App(fn, a, t) =>
-//             (fn.traverse(f), a.traverse(f), f(t)).mapN { (fn1, a1, b) =>
-//               App(fn1, a1, b)
-//             }
-//           case Let(arg, exp, in, tag) =>
-//             (exp.traverse(f), in.traverse(f), f(tag)).mapN { (e1, i1, t1) =>
-//               Let(arg, e1, i1, t1)
-//             }
-//           case Literal(lit, tag) =>
-//             f(tag).map(Literal(lit, _))
-//           case If(cond, ift, iff, tag) =>
-//             (cond.traverse(f), ift.traverse(f), iff.traverse(f), f(tag))
-//               .mapN(If(_, _, _, _))
-//           case Match(arg, branches, tag) =>
-//             val argB = arg.traverse(f)
-//             val branchB = tne.traverse(branches)(f)
-//             (argB, branchB, f(tag)).mapN { (a, bs, t) =>
-//               Match(a, bs, t)
-//             }
-//         }
-
-//       def foldLeft[A, B](fa: TypedExpr[A], b: B)(f: (B, A) => B): B =
-//         fa match {
-//           case TyLam(_, e, tag) =>
-//             val b1 = foldLeft(e, b)(f)
-//             f(b1, tag)
-//           case TyApp(e, _, tag) =>
-//             val b1 = foldLeft(e, b)(f)
-//             f(b1, tag)
-//           case AnnotatedLambda(_, _, e, tag) =>
-//             val b1 = foldLeft(e, b)(f)
-//             f(b1, tag)
-//           case Var(_, _, tag) => f(b, tag)
-//           case App(fn, a, tag) =>
-//             val b1 = foldLeft(fn, b)(f)
-//             val b2 = foldLeft(a, b1)(f)
-//             f(b2, tag)
-//           case Let(_, exp, in, tag) =>
-//             val b1 = foldLeft(exp, b)(f)
-//             val b2 = foldLeft(in, b1)(f)
-//             f(b2, tag)
-//           case Literal(_, tag) =>
-//             f(b, tag)
-//           case If(cond, ift, iff, tag) =>
-//             val b1 = foldLeft(cond, b)(f)
-//             val b2 = foldLeft(ift, b1)(f)
-//             val b3 = foldLeft(iff, b2)(f)
-//             f(b3, tag)
-//           case Match(arg, branches, tag) =>
-//             val b1 = foldLeft(arg, b)(f)
-//             val b2 = tne.foldLeft(branches, b1)(f)
-//             f(b2, tag)
-//         }
-
-//       def foldRight[A, B](fa: TypedExpr[A], lb: Eval[B])(f: (A, Eval[B]) => Eval[B]): Eval[B] =
-//         fa match {
-//           case TyLam(_, e, tag) =>
-//             val lb1 = foldRight(e, lb)(f)
-//             f(tag, lb1)
-//           case TyApp(e, _, tag) =>
-//             val lb1 = foldRight(e, lb)(f)
-//             f(tag, lb1)
-//           case AnnotatedLambda(_, _, e, tag) =>
-//             val lb1 = foldRight(e, lb)(f)
-//             f(tag, lb1)
-//           case Var(_, _, tag) => f(tag, lb)
-//           case App(fn, a, tag) =>
-//             val b1 = f(tag, lb)
-//             val b2 = foldRight(a, b1)(f)
-//             foldRight(fn, b2)(f)
-//           case Let(_, exp, in, tag) =>
-//             val b1 = f(tag, lb)
-//             val b2 = foldRight(in, b1)(f)
-//             foldRight(exp, b2)(f)
-//           case Literal(_, tag) =>
-//             f(tag, lb)
-//           case If(cond, ift, iff, tag) =>
-//             val b1 = f(tag, lb)
-//             val b2 = foldRight(iff, b1)(f)
-//             val b3 = foldRight(ift, b2)(f)
-//             foldRight(cond, b3)(f)
-//           case Match(arg, branches, tag) =>
-//             val b1 = f(tag, lb)
-//             val b2 = tne.foldRight(branches, b1)(f)
-//             foldRight(arg, b2)(f)
-//         }
-//     }
 }

--- a/core/src/main/scala/org/bykn/bosatsu/TypedExpr.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/TypedExpr.scala
@@ -1,0 +1,248 @@
+package org.bykn.bosatsu
+
+import cats.arrow.FunctionK
+import cats.implicits._
+import cats.evidence.Is
+import cats.data.NonEmptyList
+import cats.{Applicative, Eval, Traverse}
+
+sealed abstract class TypedExpr[T] {
+  import TypedExpr._
+
+  def tag: T
+  // def setTag(t: T): TypedExpr[T] =
+  //   this match {
+  //     case tl@TyLam(_, _, _) => tl.copy(tag = t)
+  //     case ta@TyApp(_, _, _) => ta.copy(tag = t)
+  //     case v@Var(_, _, _) => v.copy(tag = t)
+  //     case a@App(_, _, _) => a.copy(tag = t)
+  //     case a@Annotation(_, _, _) => a.copy(tag = t)
+  //     case a@AnnotatedLambda(_, _, _, _) => a.copy(tag = t)
+  //     case l@Let(_, _, _, _) => l.copy(tag = t)
+  //     case l@Literal(_, _, _) => l.copy(tag = t)
+  //     case i@If(_, _, _, _) => i.copy(tag = t)
+  //     case m@Match(_, _, _) => m.copy(tag = t)
+  //   }
+
+  /**
+   * For any well typed expression, i.e.
+   * one that has already gone through type
+   * inference, we should be able to get a type
+   * for each expression
+   *
+   */
+  def getType: rankn.Type =
+    this match {
+      // case TyLam(v, e, _) =>
+      //   val bound = rankn.Type.Var.Bound(v)
+      //   e.getType match {
+      //     case rankn.Type.ForAll(vars, in) =>
+      //       rankn.Type.ForAll(bound :: vars, in)
+      //     case notForAll =>
+      //       rankn.Type.ForAll(NonEmptyList.of(bound), notForAll)
+      //   }
+      // case TyApp(e, tpe, _) =>
+      //   ???
+      case Annotation(t, _) =>
+        // ignore the original annotation and return
+        // the type from the underlying thing, but this might be wrong
+        t.getType
+      case a@AnnotatedLambda(arg, tpe, res, _) =>
+        rankn.Type.Fun(tpe, res.getType)
+      case Var(_, tpe, _) => tpe
+      case App(fn, arg, _) =>
+        /**
+         * this is a bit tricky
+         * if we have fn: forall a. a -> Foo[a]
+         * then fn(1): Foo[Int].
+         */
+        ???
+      case Let(_, _, in, _) =>
+        in.getType
+      case Literal(_, tpe, _) =>
+        tpe
+      case If(_, ift, _, _) =>
+        // all branches have the same type:
+        ift.getType
+      case Match(_, branches, _) =>
+        // all branches have the same type:
+        // TODO: this is probably not right
+        // since the patterns set an environment
+        // of types
+        //branches.head._2.getType(env)
+        ???
+    }
+
+  def typeTraverse[F[_]: Applicative](fn: rankn.Type => F[rankn.Type]): F[TypedExpr[T]] =
+    ???
+}
+
+object TypedExpr {
+
+  type Rho[A] = TypedExpr[A] // an expression with a Rho type (no top level forall)
+  // /**
+  //  * This says that the resulting term is generic on a given param
+  //  */
+  // case class TyLam[T](varType: String, in: TypedExpr[T], tag: T) extends TypedExpr[T]
+  // /**
+  //  * This says that we have a generic type, and we are applying a specfic Tau (no
+  //  * forall anywhere) into the type
+  //  */
+  // case class TyApp[T](generic: TypedExpr[T], typeArg: rankn.Type.Tau, tag: T) extends TypedExpr[T]
+  case class Annotation[T](term: TypedExpr[T], tag: T) extends TypedExpr[T]
+  case class AnnotatedLambda[T](arg: String, tpe: rankn.Type, expr: TypedExpr[T], tag: T) extends TypedExpr[T]
+  case class Var[T](name: String, tpe: rankn.Type, tag: T) extends TypedExpr[T]
+  case class App[T](fn: TypedExpr[T], arg: TypedExpr[T], tag: T) extends TypedExpr[T]
+  case class Let[T](arg: String, expr: TypedExpr[T], in: TypedExpr[T], tag: T) extends TypedExpr[T]
+  case class Literal[T](lit: Lit, tpe: rankn.Type, tag: T) extends TypedExpr[T]
+  case class If[T](cond: TypedExpr[T], ifTrue: TypedExpr[T], ifFalse: TypedExpr[T], tag: T) extends TypedExpr[T]
+  case class Match[T](arg: TypedExpr[T], branches: NonEmptyList[(Pattern[(PackageName, ConstructorName), rankn.Type], TypedExpr[T])], tag: T) extends TypedExpr[T]
+
+
+  type Coerce = FunctionK[TypedExpr, TypedExpr]
+  def coerceRho(tpe: rankn.Type.Rho): Coerce = ???
+
+  def coerceFn(arg: rankn.Type.Rho, coarg: Coerce, cores: Coerce): Coerce = ???
+
+  def forAll[A](params: NonEmptyList[rankn.Type.Var], expr: TypedExpr[A]): TypedExpr[A] = ???
+
+  implicit def typedExprHasRegion[T: HasRegion]: HasRegion[TypedExpr[T]] =
+    HasRegion.instance[TypedExpr[T]] { e => HasRegion.region(e.tag) }
+
+  /**
+   * Return a value so next(e).tag == e and also this is true
+   * recursively
+   */
+  // def nest[T](e: TypedExpr[T]): TypedExpr[TypedExpr[T]] =
+  //   e match {
+  //     case TyLam(v, te, _) =>
+  //       TyLam(v, nest(te), e)
+  //     case TyApp(te, tpe, _) =>
+  //       TyApp(nest(te), tpe, e)
+  //     case AnnotatedLambda(arg, tpe, expr, _) =>
+  //       AnnotatedLambda(arg, tpe, nest(expr), e)
+  //     case Var(s, tpe, _) =>
+  //       Var(s, tpe, e)
+  //     case App(fn, a, _) =>
+  //       App(nest(fn), nest(a), e)
+  //     case Let(arg, exp, in, _) =>
+  //       Let(arg, nest(exp), nest(in), e)
+  //     case Literal(lit, tpe, _) =>
+  //       Literal(lit, tep, e)
+  //     case If(cond, ift, iff, _) =>
+  //       If(nest(cond), nest(ift), nest(iff), e)
+  //     case Match(arg, branches, _) =>
+  //       Match(nest(arg), branches.map {
+  //         case (pat, exp) => (pat, nest(exp))
+  //       }, e)
+  //   }
+
+//   implicit val typedExprTraverse: Traverse[TypedExpr] =
+//     new Traverse[TypedExpr] {
+
+//       // Traverse on NonEmptyList[(Pattern[_], TypedExpr[?])]
+//       private lazy val tne = {
+//         type Tup[T] = (Pattern[(PackageName, ConstructorName), rankn.Type], T)
+//         type TupTypedExpr[T] = (Pattern[(PackageName, ConstructorName), rankn.Type], TypedExpr[T])
+//         val tup: Traverse[TupTypedExpr] = Traverse[Tup].compose(typedExprTraverse)
+//         Traverse[NonEmptyList].compose(tup)
+//       }
+
+//       def traverse[G[_]: Applicative, A, B](fa: TypedExpr[A])(f: A => G[B]): G[TypedExpr[B]] =
+//         fa match {
+//           case TyLam(v, e, a) =>
+//             (e.traverse(f), f(a)).mapN(TyLam(v, _, _))
+//           case TyApp(e, tpe, a) =>
+//             (e.traverse(f), f(a)).mapN(TyApp(_, tpe, _))
+//           case AnnotatedLambda(arg, tpe, expr, a) =>
+//             (expr.traverse(f), f(a)).mapN(AnnotatedLambda(arg, tpe, _, _))
+//           case Var(s, tpe, t) =>
+//             f(t).map(Var(s, tpe, _))
+//           case App(fn, a, t) =>
+//             (fn.traverse(f), a.traverse(f), f(t)).mapN { (fn1, a1, b) =>
+//               App(fn1, a1, b)
+//             }
+//           case Let(arg, exp, in, tag) =>
+//             (exp.traverse(f), in.traverse(f), f(tag)).mapN { (e1, i1, t1) =>
+//               Let(arg, e1, i1, t1)
+//             }
+//           case Literal(lit, tag) =>
+//             f(tag).map(Literal(lit, _))
+//           case If(cond, ift, iff, tag) =>
+//             (cond.traverse(f), ift.traverse(f), iff.traverse(f), f(tag))
+//               .mapN(If(_, _, _, _))
+//           case Match(arg, branches, tag) =>
+//             val argB = arg.traverse(f)
+//             val branchB = tne.traverse(branches)(f)
+//             (argB, branchB, f(tag)).mapN { (a, bs, t) =>
+//               Match(a, bs, t)
+//             }
+//         }
+
+//       def foldLeft[A, B](fa: TypedExpr[A], b: B)(f: (B, A) => B): B =
+//         fa match {
+//           case TyLam(_, e, tag) =>
+//             val b1 = foldLeft(e, b)(f)
+//             f(b1, tag)
+//           case TyApp(e, _, tag) =>
+//             val b1 = foldLeft(e, b)(f)
+//             f(b1, tag)
+//           case AnnotatedLambda(_, _, e, tag) =>
+//             val b1 = foldLeft(e, b)(f)
+//             f(b1, tag)
+//           case Var(_, _, tag) => f(b, tag)
+//           case App(fn, a, tag) =>
+//             val b1 = foldLeft(fn, b)(f)
+//             val b2 = foldLeft(a, b1)(f)
+//             f(b2, tag)
+//           case Let(_, exp, in, tag) =>
+//             val b1 = foldLeft(exp, b)(f)
+//             val b2 = foldLeft(in, b1)(f)
+//             f(b2, tag)
+//           case Literal(_, tag) =>
+//             f(b, tag)
+//           case If(cond, ift, iff, tag) =>
+//             val b1 = foldLeft(cond, b)(f)
+//             val b2 = foldLeft(ift, b1)(f)
+//             val b3 = foldLeft(iff, b2)(f)
+//             f(b3, tag)
+//           case Match(arg, branches, tag) =>
+//             val b1 = foldLeft(arg, b)(f)
+//             val b2 = tne.foldLeft(branches, b1)(f)
+//             f(b2, tag)
+//         }
+
+//       def foldRight[A, B](fa: TypedExpr[A], lb: Eval[B])(f: (A, Eval[B]) => Eval[B]): Eval[B] =
+//         fa match {
+//           case TyLam(_, e, tag) =>
+//             val lb1 = foldRight(e, lb)(f)
+//             f(tag, lb1)
+//           case TyApp(e, _, tag) =>
+//             val lb1 = foldRight(e, lb)(f)
+//             f(tag, lb1)
+//           case AnnotatedLambda(_, _, e, tag) =>
+//             val lb1 = foldRight(e, lb)(f)
+//             f(tag, lb1)
+//           case Var(_, _, tag) => f(tag, lb)
+//           case App(fn, a, tag) =>
+//             val b1 = f(tag, lb)
+//             val b2 = foldRight(a, b1)(f)
+//             foldRight(fn, b2)(f)
+//           case Let(_, exp, in, tag) =>
+//             val b1 = f(tag, lb)
+//             val b2 = foldRight(in, b1)(f)
+//             foldRight(exp, b2)(f)
+//           case Literal(_, tag) =>
+//             f(tag, lb)
+//           case If(cond, ift, iff, tag) =>
+//             val b1 = f(tag, lb)
+//             val b2 = foldRight(iff, b1)(f)
+//             val b3 = foldRight(ift, b2)(f)
+//             foldRight(cond, b3)(f)
+//           case Match(arg, branches, tag) =>
+//             val b1 = f(tag, lb)
+//             val b2 = tne.foldRight(branches, b1)(f)
+//             foldRight(arg, b2)(f)
+//         }
+//     }
+}

--- a/core/src/main/scala/org/bykn/bosatsu/rankn/Infer.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/rankn/Infer.scala
@@ -3,7 +3,7 @@ import cats.Monad
 import cats.data.NonEmptyList
 import cats.implicits._
 
-import org.bykn.bosatsu.{Pattern => GenPattern, Expr, Lit, ConstructorName, PackageName}
+import org.bykn.bosatsu.{Pattern => GenPattern, Expr, Lit, ConstructorName, PackageName, TypedExpr}
 
 sealed abstract class Infer[+A] {
   import Infer.Error
@@ -236,13 +236,13 @@ object Infer {
     /**
      * Quantify over the specified type variables (all flexible)
      */
-    def quantify(forAlls: List[Type.Meta], rho: Type.Rho): Infer[Type] =
+    def quantify[A](forAlls: List[Type.Meta], rho: TypedExpr.Rho[A]): Infer[TypedExpr[A]] =
       forAlls match {
         case Nil =>
           // this case is not really discussed in the paper
-          zonkType(rho)
+          zonkTypedExpr(rho)
         case ne@(h :: tail) =>
-          val used = tyVarBinders(List(rho), Set.empty)
+          val used = tyVarBinders(List(rho.getType), Set.empty)
           // on 2.11 without the iterator this seems to run forever
           def newBinders = Type.allBinders.iterator.filterNot(used)
           val newBindersNE =
@@ -254,7 +254,7 @@ object Infer {
             .traverse_ { case (m, n) =>
               writeMeta(m, Type.TyVar(n))
             }
-          (bound *> zonkType(rho)).map(Type.ForAll(newBindersNE, _))
+          (bound *> zonkTypedExpr(rho)).map(TypedExpr.forAll(newBindersNE, _))//map(Type.ForAll(newBindersNE, _))
       }
 
     def skolemize(t: Type): Infer[(List[Type.Var], Type.Rho)] =
@@ -299,6 +299,10 @@ object Infer {
     def getFreeTyVars(ts: List[Type]): Infer[Set[Type.Var]] =
       ts.traverse(zonkType).map(freeTyVars(_))
 
+    /**
+     * This fills in any meta vars that have been
+     * quantified and replaces them with what they point to
+     */
     def zonkType(t: Type): Infer[Type] =
       t match {
         case Type.ForAll(ns, ty) =>
@@ -317,6 +321,9 @@ object Infer {
               }
           }
       }
+
+    def zonkTypedExpr[A](e: TypedExpr[A]): Infer[TypedExpr[A]] =
+      e.typeTraverse(zonkType _)
 
     def initRef[A](err: Error): Infer[Ref[Either[Error, A]]] =
       lift(RefSpace.newRef[Either[Error, A]](Left(err)))
@@ -350,12 +357,15 @@ object Infer {
         case rho => pure(rho)
       }
 
-    def subsCheckFn(a1: Type, r1: Type.Rho, a2: Type, r2: Type.Rho): Infer[Unit] =
+    def subsCheckFn(a1: Type, r1: Type.Rho, a2: Type, r2: Type.Rho): Infer[TypedExpr.Coerce] =
       // note due to contravariance in input, we reverse the order there
-      subsCheck(a2, a1) *> subsCheckRho(r1, r2)
+      for {
+        coarg <- subsCheck(a2, a1)
+        cores <- subsCheckRho(r1, r2)
+      } yield TypedExpr.coerceFn(a1, coarg, cores)
 
     // invariant: second argument is in weak prenex form
-    def subsCheckRho(t: Type, rho: Type.Rho): Infer[Unit] =
+    def subsCheckRho(t: Type, rho: Type.Rho): Infer[TypedExpr.Coerce] =
       (t, rho) match {
         case (fa@Type.ForAll(_, _), rho) =>
           // Rule SPEC
@@ -374,15 +384,18 @@ object Infer {
           }
         case (t1, t2) =>
           // rule: MONO
-          unify(t1, t2)
+          unify(t1, t2).as(TypedExpr.coerceRho(t1)) // TODO this coerce seems right, since we have unified
       }
 
-    def instSigma(sigma: Type, expect: Expected[Type.Rho]): Infer[Unit] =
+    def instSigma(sigma: Type, expect: Expected[Type.Rho]): Infer[TypedExpr.Coerce] =
       expect match {
         case Expected.Check(t) =>
           subsCheckRho(sigma, t)
         case infer@Expected.Inf(_) =>
-          instantiate(sigma).flatMap(infer.set(_))
+          for {
+            rho <- instantiate(sigma)
+            _ <- infer.set(rho)
+          } yield TypedExpr.coerceRho(rho)
       }
 
     def unifyFn(fnType: Type): Infer[(Type, Type)] =
@@ -456,99 +469,119 @@ object Infer {
       lift(m.ref.set(Some(v)))
 
     // DEEP-SKOL rule
-    def subsCheck(inferred: Type, declared: Type): Infer[Unit] =
+    def subsCheck(inferred: Type, declared: Type): Infer[TypedExpr.Coerce] =
       for {
         skolRho <- skolemize(declared)
         (skolTvs, rho2) = skolRho
-        _ <- subsCheckRho(inferred, rho2)
+        coerce <- subsCheckRho(inferred, rho2)
         escTvs <- getFreeTyVars(List(inferred, declared))
         badTvs = skolTvs.filter(escTvs)
         _ <- require(badTvs.isEmpty, Error.SubsumptionCheckFailure(inferred, declared))
-      } yield ()
+      } yield coerce
 
     /**
      * Invariant: if the second argument is (Check rho) then rho is in weak prenex form
      */
-    def typeCheckRho(term: Expr[_], expect: Expected[Type.Rho]): Infer[Unit] = {
+    def typeCheckRho[A](term: Expr[A], expect: Expected[Type.Rho]): Infer[TypedExpr.Rho[A]] = {
       import Expr._
 
       term match {
-        case Literal(Lit.Integer(_), _) =>
-          instSigma(Type.IntType, expect)
-        case Literal(Lit.Str(_), _) =>
-          instSigma(Type.StrType, expect)
-        case Var(name, _) =>
+        case Literal(lit, t) =>
+          val tpe = lit match {
+            case Lit.Integer(_) => Type.IntType
+            case Lit.Str(_) => Type.StrType
+          }
+          instSigma(tpe, expect).map(_(TypedExpr.Literal(lit, tpe, t)))
+        case Var(name, tag) =>
           for {
             vSigma <- lookupVarType(name)
-            _ <- instSigma(vSigma, expect)
-           } yield ()
-        case App(fn, arg, _) =>
+            coerce <- instSigma(vSigma, expect)
+           } yield coerce(TypedExpr.Var(name, vSigma, tag))
+        case App(fn, arg, tag) =>
            for {
-             fnT <- inferRho(fn)
+             typedFn <- inferRho(fn)
+             fnT = typedFn.getType
              argRes <- unifyFn(fnT)
              (argT, resT) = argRes
-             _ <- checkSigma(arg, argT)
-             _ <- instSigma(resT, expect)
-           } yield ()
-        case Lambda(name, result, _) =>
+             typedArg <- checkSigma(arg, argT)
+             coerce <- instSigma(resT, expect)
+           } yield coerce(TypedExpr.App(typedFn, typedArg, tag))
+        case Lambda(name, result, tag) =>
           expect match {
             case Expected.Check(expTy) =>
-              unifyFn(expTy).flatMap {
-                case (varT, bodyT) =>
-                  extendEnv(name, varT) {
+              for {
+                vb <- unifyFn(expTy)
+                (varT, bodyT) = vb
+                typedBody <- extendEnv(name, varT) {
                     checkRho(result, bodyT)
                   }
-                }
+              } yield TypedExpr.AnnotatedLambda(name, varT, typedBody, tag)
             case infer@Expected.Inf(_) =>
               for {
                 varT <- newTyVarTy
-                bodyT <- extendEnv(name, varT)(inferRho(result))
+                typedBody <- extendEnv(name, varT)(inferRho(result))
+                bodyT = typedBody.getType
                 _ <- infer.set(Type.Fun(varT, bodyT))
-              } yield ()
+              } yield TypedExpr.AnnotatedLambda(name, varT, typedBody, tag)
           }
-        case AnnotatedLambda(name, tpe, result, _) =>
+        case AnnotatedLambda(name, tpe, result, tag) =>
           expect match {
             case Expected.Check(expTy) =>
-              unifyFn(expTy).flatMap {
-                case (varT, bodyT) =>
-                  extendEnv(name, varT) {
+              for {
+                vb <- unifyFn(expTy)
+                (varT, bodyT) = vb
+                typedBody <- extendEnv(name, varT) {
+                    // TODO we are ignoring the result of subsCheck here
+                    // should we be coercing a var?
                     subsCheck(tpe, varT) *> checkRho(result, bodyT)
                   }
-                }
+              } yield TypedExpr.AnnotatedLambda(name, varT /* or tpe? */, typedBody, tag)
             case infer@Expected.Inf(_) =>
-              for {
-                bodyT <- extendEnv(name, tpe)(inferRho(result))
+              for { // TODO do we need to narrow or instantiate tpe?
+                typedBody <- extendEnv(name, tpe)(inferRho(result))
+                bodyT = typedBody.getType
                 _ <- infer.set(Type.Fun(tpe, bodyT))
-              } yield ()
+              } yield TypedExpr.AnnotatedLambda(name, tpe, typedBody, tag)
           }
-        case Let(name, rhs, body, _) =>
+        case Let(name, rhs, body, tag) =>
           for {
-            varT <- inferSigma(rhs)
-            _ <- extendEnv(name, varT)(typeCheckRho(body, expect))
-          } yield ()
-        case Annotation(term, tpe, _) =>
-          checkSigma(term, tpe) *> instSigma(tpe, expect)
-        case If(cond, ifTrue, ifFalse, _) =>
+            typedRhs <- inferSigma(rhs)
+            varT = typedRhs.getType
+            typedBody <- extendEnv(name, varT)(typeCheckRho(body, expect))
+          } yield TypedExpr.Let(name, typedRhs, typedBody, tag)
+        case Annotation(term, tpe, tag) =>
+          for {
+            typedTerm <- checkSigma(term, tpe)
+            coerce <- instSigma(tpe, expect)
+          } yield TypedExpr.Annotation(coerce(typedTerm), tag)
+        case If(cond, ifTrue, ifFalse, tag) =>
           val condTpe =
             typeCheckRho(cond,
               Expected.Check(Type.BoolType))
           val rest = expect match {
             case check@Expected.Check(_) =>
-              typeCheckRho(ifTrue, check) *>
-                typeCheckRho(ifFalse, check)
+              typeCheckRho(ifTrue, check)
+                .product(typeCheckRho(ifFalse, check))
 
             case infer@Expected.Inf(_) =>
               for {
-                rT <- inferRho(ifTrue)
-                rF <- inferRho(ifFalse)
-                _ <- subsCheck(rT, rF)
-                _ <- subsCheck(rF, rT)
+                tExp <- inferRho(ifTrue)
+                fExp <- inferRho(ifFalse)
+                rT = tExp.getType
+                rF = tExp.getType
+                cT <- subsCheck(rT, rF)
+                cF <- subsCheck(rF, rT)
                 _ <- infer.set(rT) // see section 7.1
-              } yield ()
+              } yield (cT(tExp), cF(fExp))
 
           }
-          condTpe *> rest
-        case Match(term, branches, _) =>
+
+          for {
+           c <- condTpe
+           branches <- rest
+           (tb, fb) = branches
+          } yield TypedExpr.If(c, tb, fb, tag)
+        case Match(term, branches, tag) =>
           // all of the branches must return the same type:
 
           // TODO: it's fishy that both branches have to
@@ -567,62 +600,78 @@ object Infer {
           def toStr(p: GenPattern[(PackageName, ConstructorName), Type]): GenPattern[String, Type] =
             p.mapName { case (_, c) => c.asString }
 
+         def unStr(p: Pattern): GenPattern[(PackageName, ConstructorName), Type] =
+           p.mapName { c => (PackageName.parts("TODO"), ConstructorName(c)) }
+
           expect match {
             case Expected.Check(resT) =>
               for {
                 tsigma <- inferSigma(term)
-                _ <- branches.traverse_ { case (p, r) => checkBranch(toStr(p), Expected.Check(tsigma), r, resT) }
-              } yield ()
+                tbranches <- branches.traverse { case (p, r) =>
+                  checkBranch(toStr(p), Expected.Check(tsigma.getType), r, resT)
+                }
+              } yield TypedExpr.Match(tsigma, tbranches.map { case (p, t) => (unStr(p), t) }, tag)
             case infer@Expected.Inf(_) =>
               for {
                 tsigma <- inferSigma(term)
-                resTs <- branches.traverse { case (p, r) => inferBranch(toStr(p), Expected.Check(tsigma), r) }
-                _ <- resTs.flatMap { t0 => resTs.map((t0, _)) }.traverse_ {
+                tbranches <- branches.traverse { case (p, r) =>
+                  inferBranch(toStr(p), Expected.Check(tsigma.getType), r)
+                }
+                resT = tbranches.map { case (p, te) => te.getType }
+                _ <- resT.flatMap { t0 => resT.map((t0, _)) }.traverse_ {
                   case (t0, t1) if t0 eq t1 => Infer.pure(())
+                  // TODO
+                  // we do N^2 subsCheck, which to coerce with, composed?
                   case (t0, t1) => subsCheck(t0, t1)
                 }
-                _ <- infer.set(resTs.head)
-              } yield ()
+                _ <- infer.set(resT.head)
+              } yield TypedExpr.Match(tsigma, tbranches.map { case (p, t) => (unStr(p), t) }, tag)
           }
       }
     }
 
-    def checkBranch(p: Pattern, sigma: Expected[Type], res: Expr[_], resT: Type): Infer[Unit] =
+    def checkBranch[A](p: Pattern, sigma: Expected[Type], res: Expr[A], resT: Type): Infer[(Pattern, TypedExpr[A])] =
       for {
-        bindings <- typeCheckPattern(p, sigma)
-        _ <- extendEnvList(bindings)(checkRho(res, resT))
-      } yield ()
+        patBind <- typeCheckPattern(p, sigma)
+        (pattern, bindings) = patBind
+        tres <- extendEnvList(bindings)(checkRho(res, resT))
+      } yield (pattern, tres)
 
-    def inferBranch(p: Pattern, sigma: Expected[Type], res: Expr[_]): Infer[Type] =
+    def inferBranch[A](p: Pattern, sigma: Expected[Type], res: Expr[A]): Infer[(Pattern, TypedExpr[A])] =
       for {
-        bindings <- typeCheckPattern(p, sigma)
+        patBind <- typeCheckPattern(p, sigma)
+        (pattern, bindings) = patBind
         res <- extendEnvList(bindings)(inferRho(res))
-      } yield res
+      } yield (pattern, res)
 
     /**
      * patterns can be a sigma type, not neccesarily a rho/tau
      * return a list of bound names and their (sigma) types
      */
-    def typeCheckPattern(pat: Pattern, sigma: Expected[Type]): Infer[List[(String, Type)]] =
+    def typeCheckPattern(pat: Pattern, sigma: Expected[Type]): Infer[(Pattern, List[(String, Type)])] =
       pat match {
-        case GenPattern.WildCard => Infer.pure(Nil)
+        case GenPattern.WildCard => Infer.pure((pat, Nil))
         case GenPattern.Var(n) =>
+          // We always return an annotation here, which is the only
+          // place we need to be careful
           sigma match {
-            case Expected.Check(t) => Infer.pure(List((n, t)))
+            case Expected.Check(t) =>
+              Infer.pure((GenPattern.Annotation(pat, t), List((n, t))))
             case infer@Expected.Inf(_) =>
               for {
                 t <- newTyVarTy
                 _ <- infer.set(t)
-              } yield List((n, t))
+              } yield (GenPattern.Annotation(pat, t), List((n, t)))
           }
         case GenPattern.Annotation(p, tpe) =>
           // like in the case of an annotation, we check the type, then
           // instantiate a sigma type
           // checkSigma(term, tpe) *> instSigma(tpe, expect)
           for {
-            binds <- checkPat(p, tpe)
+            patBind <- checkPat(p, tpe)
+            (p1, binds) = patBind
             _ <- instPatSigma(tpe, sigma)
-          } yield binds
+          } yield (p1, binds)
         case GenPattern.PositionalStruct(nm, args) =>
           for {
             paramRes <- instDataCon(nm)
@@ -632,12 +681,14 @@ object Infer {
             // but we don't want to error type-checking since we want to show
             // the maximimum number of errors to the user
             envs <- args.zip(params).traverse { case (p, t) => checkPat(p, t) }
+            pats = envs.map(_._1)
+            bindings = envs.map(_._2)
             _ <- instPatSigma(res, sigma)
-          } yield envs.flatten
+          } yield (GenPattern.PositionalStruct(nm, pats), bindings.flatten)
       }
 
 
-    def checkPat(pat: Pattern, sigma: Type): Infer[List[(String, Type)]] =
+    def checkPat(pat: Pattern, sigma: Type): Infer[(Pattern, List[(String, Type)])] =
       typeCheckPattern(pat, Expected.Check(sigma))
 
     def inferPat(pat: Pattern): Infer[Type] =
@@ -651,7 +702,7 @@ object Infer {
     def instPatSigma(sigma: Type, exp: Expected[Type]): Infer[Unit] =
       exp match {
         case infer@Expected.Inf(_) => infer.set(sigma)
-        case Expected.Check(texp) => subsCheck(texp, sigma)
+        case Expected.Check(texp) => subsCheck(texp, sigma).as(()) // this unit does not seem right
       }
 
     /**
@@ -675,40 +726,41 @@ object Infer {
   }
 
 
-  def typeCheck(t: Expr[_]): Infer[Type] =
-    inferSigma(t).flatMap(zonkType _)
+  def typeCheck[A](t: Expr[A]): Infer[TypedExpr[A]] =
+    inferSigma(t).flatMap(zonkTypedExpr _)
 
-  def inferSigma(e: Expr[_]): Infer[Type] =
+  def inferSigma[A](e: Expr[A]): Infer[TypedExpr[A]] =
     for {
-      expTy <- inferRho(e)
+      rho <- inferRho(e)
+      expTy = rho.getType
       envTys <- getEnv
       envTypeVars <- getMetaTyVars(envTys.values.toList)
       resTypeVars <- getMetaTyVars(List(expTy))
       forAllTvs = resTypeVars -- envTypeVars
-      q <- quantify(forAllTvs.toList, expTy)
+      q <- quantify(forAllTvs.toList, rho)
     } yield q
 
-  def checkSigma(t: Expr[_], tpe: Type): Infer[Unit] =
+  def checkSigma[A](t: Expr[A], tpe: Type): Infer[TypedExpr[A]] =
     for {
       skolRho <- skolemize(tpe)
       (skols, rho) = skolRho
-      _ <- checkRho(t, rho)
+      te <- checkRho(t, rho)
       envTys <- getEnv
       escTvs <- getFreeTyVars(tpe :: envTys.values.toList)
       badTvs = skols.filter(escTvs)
       _ <- require(badTvs.isEmpty, Error.NotPolymorphicEnough(tpe, t))
-    } yield ()
+    } yield te // should be fine since the everything after te is just checking
 
-  def checkRho(t: Expr[_], rho: Type.Rho): Infer[Unit] =
+  def checkRho[A](t: Expr[A], rho: Type.Rho): Infer[TypedExpr[A]] =
     typeCheckRho(t, Expected.Check(rho))
 
-  def inferRho(t: Expr[_]): Infer[Type.Rho] =
+  def inferRho[A](t: Expr[A]): Infer[TypedExpr.Rho[A]] =
     for {
       ref <- initRef[Type.Rho](Error.InferIncomplete("inferRho", t))
-      _ <- typeCheckRho(t, Expected.Inf(ref))
+      expr <- typeCheckRho(t, Expected.Inf(ref))
       rho <- (Lift(ref.get): Infer[Type.Rho])
       _ <- lift(ref.reset) // we don't need this ref, and it does not escape, so reset
-    } yield rho
+    } yield expr
 
 
   def extendEnv[A](varName: String, tpe: Type)(of: Infer[A]): Infer[A] =

--- a/core/src/main/scala/org/bykn/bosatsu/rankn/Infer.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/rankn/Infer.scala
@@ -263,7 +263,7 @@ object Infer {
             .traverse_ { case (m, n) =>
               writeMeta(m, Type.TyVar(n))
             }
-          (bound *> zonkTypedExpr(rho)).map(TypedExpr.forAll(newBindersNE, _))//map(Type.ForAll(newBindersNE, _))
+          (bound *> zonkTypedExpr(rho)).map(TypedExpr.forAll(newBindersNE, _))
       }
 
     /**

--- a/core/src/main/scala/org/bykn/bosatsu/rankn/Type.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/rankn/Type.scala
@@ -9,10 +9,6 @@ object Type {
   type Rho = Type // no top level ForAll
   type Tau = Type // no forall anywhere
 
-  /**
-   * TODO: I think vars can be NonEmptyList[Var.Bound]
-   * we never put skolem vars there, that's the whole point
-   */
   case class ForAll(vars: NonEmptyList[Var.Bound], in: Rho) extends Type {
     in match {
       case ForAll(_, _) => sys.error(s"invalid nested ForAll")
@@ -24,6 +20,10 @@ object Type {
   case class TyMeta(toMeta: Meta) extends Type
   case class TyApply(on: Type, arg: Type) extends Type
 
+  /**
+   * These are upper-case to leverage scala's pattern
+   * matching on upper-cased vals
+   */
   val IntType: Type = TyConst(Const.predef("Integer"))
   val BoolType: Type = TyConst(Const.predef("Boolean"))
   val StrType: Type = TyConst(Const.predef("String"))

--- a/core/src/main/scala/org/bykn/bosatsu/rankn/Type.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/rankn/Type.scala
@@ -13,7 +13,7 @@ object Type {
    * TODO: I think vars can be NonEmptyList[Var.Bound]
    * we never put skolem vars there, that's the whole point
    */
-  case class ForAll(vars: NonEmptyList[Var], in: Rho) extends Type {
+  case class ForAll(vars: NonEmptyList[Var.Bound], in: Rho) extends Type {
     in match {
       case ForAll(_, _) => sys.error(s"invalid nested ForAll")
       case _ => ()
@@ -84,11 +84,4 @@ object Type {
       }
     go(s, Set.empty)
   }
-
-  /**
-   * This is used in generating TypedExpr. When we have
-   * a parametric type, we should instantiate that type
-   * with the param
-   */
-  def instantiate(parametric: Type, param: Tau): Type = ???
 }

--- a/core/src/main/scala/org/bykn/bosatsu/rankn/Type.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/rankn/Type.scala
@@ -9,6 +9,10 @@ object Type {
   type Rho = Type // no top level ForAll
   type Tau = Type // no forall anywhere
 
+  /**
+   * TODO: I think vars can be NonEmptyList[Var.Bound]
+   * we never put skolem vars there, that's the whole point
+   */
   case class ForAll(vars: NonEmptyList[Var], in: Rho) extends Type {
     in match {
       case ForAll(_, _) => sys.error(s"invalid nested ForAll")
@@ -80,4 +84,11 @@ object Type {
       }
     go(s, Set.empty)
   }
+
+  /**
+   * This is used in generating TypedExpr. When we have
+   * a parametric type, we should instantiate that type
+   * with the param
+   */
+  def instantiate(parametric: Type, param: Tau): Type = ???
 }

--- a/core/src/test/scala/org/bykn/bosatsu/rankn/RankNInferTest.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/rankn/RankNInferTest.scala
@@ -92,7 +92,7 @@ class RankNInferTest extends FunSuite {
   }
 
   test("matche with custom non-generic types") {
-    def b(a: String): Type.Var = Type.Var.Bound(a)
+    def b(a: String): Type.Var.Bound = Type.Var.Bound(a)
     def tv(a: String): Type = Type.TyVar(b(a))
 
     val optName = defType("Option")
@@ -139,7 +139,7 @@ class RankNInferTest extends FunSuite {
   }
 
   test("matche with custom generic types") {
-    def b(a: String): Type.Var = Type.Var.Bound(a)
+    def b(a: String): Type.Var.Bound = Type.Var.Bound(a)
     def tv(a: String): Type = Type.TyVar(b(a))
 
     val optName = defType("Option")
@@ -194,7 +194,7 @@ class RankNInferTest extends FunSuite {
   }
 
   test("Test a constructor with ForAll") {
-    def b(a: String): Type.Var = Type.Var.Bound(a)
+    def b(a: String): Type.Var.Bound = Type.Var.Bound(a)
     def tv(a: String): Type = Type.TyVar(b(a))
 
     val pureName = defType("Pure")

--- a/core/src/test/scala/org/bykn/bosatsu/rankn/RankNInferTest.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/rankn/RankNInferTest.scala
@@ -21,7 +21,7 @@ class RankNInferTest extends FunSuite {
   def testType(term: Expr[_], ty: Type) =
     Infer.typeCheck(term).runFully(withBools, Map.empty) match {
       case Left(err) => assert(false, err)
-      case Right(tpe) => assert(tpe == ty, term.toString)
+      case Right(tpe) => assert(tpe.getType == ty, term.toString)
     }
 
   def lit(i: Int): Expr[Unit] = Literal(Lit(i), ())
@@ -109,7 +109,7 @@ class RankNInferTest extends FunSuite {
     def testWithOpt(term: Expr[_], ty: Type) =
       Infer.typeCheck(term).runFully(withBools ++ constructors, definedOption) match {
         case Left(err) => assert(false, err)
-        case Right(tpe) => assert(tpe == ty, term.toString)
+        case Right(tpe) => assert(tpe.getType == ty, term.toString)
       }
 
     def failWithOpt(term: Expr[_]) =
@@ -157,7 +157,7 @@ class RankNInferTest extends FunSuite {
     def testWithOpt(term: Expr[_], ty: Type) =
       Infer.typeCheck(term).runFully(withBools ++ constructors, definedOption) match {
         case Left(err) => assert(false, err)
-        case Right(tpe) => assert(tpe == ty, term.toString)
+        case Right(tpe) => assert(tpe.getType == ty, term.toString)
       }
 
     def failWithOpt(term: Expr[_]) =
@@ -223,7 +223,7 @@ class RankNInferTest extends FunSuite {
     def testWithTypes(term: Expr[_], ty: Type) =
       Infer.typeCheck(term).runFully(withBools ++ constructors, defined) match {
         case Left(err) => assert(false, err)
-        case Right(tpe) => assert(tpe == ty, term.toString)
+        case Right(tpe) => assert(tpe.getType == ty, term.toString)
       }
 
     testWithTypes(


### PR DESCRIPTION
This, I think, what the paper calls type directed translation. It is not totally clear on the details, and I am foggy on a few bits here.

The idea is to convert Expr to a fully typed (or trivially type-inferred) AST. I have followed section 8 mostly in the paper. I have not fully grokked section 4.8.

Currently, I'm only checking the returned types of the AST, not that they are fully typed in sane ways. We need more tests here.

I also wanted to depart from the paper because it uses a single AST but promises the resulting ast is typed. I wanted to have a different AST so we can see from the type it must be fully typed. They make an off-hand suggestion about adding two new nodes. I couldn't see fully what they meant by that. I added one node and was able to get my very simple tests to pass.

I think it would be good to merge what I have and iterate rather than puzzle over this and make it longer. Since the paper says it is possible, I assume it is a tractable problem, even if I have yet to fully crack it here.

I'm more concerned with continuing to remove the old inference code and refactor to support interface and typed-AST output. We can fix issues as they are discovered.