### PR TITLE
Add ImportMap

### DIFF
--- a/core/src/main/scala/org/bykn/bosatsu/ExportedName.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/ExportedName.scala
@@ -1,0 +1,41 @@
+package org.bykn.bosatsu
+
+import cats.data.NonEmptyList
+import cats.implicits._
+import fastparse.all._
+import org.typelevel.paiges.{Doc, Document}
+
+import Parser.{lowerIdent, upperIdent}
+
+sealed abstract class ExportedName[+T] {
+  def name: String
+  def tag: T
+}
+object ExportedName {
+  case class Binding[T](name: String, tag: T) extends ExportedName[T]
+  case class TypeName[T](name: String, tag: T) extends ExportedName[T]
+  case class Constructor[T](name: String, tag: T) extends ExportedName[T]
+
+  private[this] val consDoc = Doc.text("()")
+
+  implicit val document: Document[ExportedName[Unit]] =
+    Document.instance[ExportedName[Unit]] {
+      case Binding(n, _) => Doc.text(n)
+      case TypeName(n, _) => Doc.text(n)
+      case Constructor(n, _) => Doc.text(n) + consDoc
+    }
+
+  val parser: P[ExportedName[Unit]] =
+    lowerIdent.map(Binding(_, ())) |
+      P(upperIdent ~ "()".!.?).map {
+        case (n, None) => TypeName(n, ())
+        case (n, Some(_)) => Constructor(n, ())
+      }
+
+  private[bosatsu] def buildExportMap[T](exs: List[ExportedName[T]]): Map[String, NonEmptyList[ExportedName[T]]] =
+    exs match {
+      case Nil => Map.empty
+      case h :: tail => NonEmptyList(h, tail).groupBy(_.name)
+    }
+}
+

--- a/core/src/main/scala/org/bykn/bosatsu/Import.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/Import.scala
@@ -1,0 +1,88 @@
+package org.bykn.bosatsu
+
+import cats.data.NonEmptyList
+import fastparse.all._
+import org.typelevel.paiges.{Doc, Document}
+
+import Parser.{lowerIdent, upperIdent, spaces, maybeSpace, Combinators}
+
+sealed abstract class ImportedName[T] {
+  def originalName: String
+  def localName: String
+  def tag: T
+  def setTag(t: T): ImportedName[T]
+  def isRenamed: Boolean = originalName != localName
+}
+
+object ImportedName {
+  case class OriginalName[T](originalName: String, tag: T) extends ImportedName[T] {
+    def localName = originalName
+    def setTag(t: T): ImportedName[T] = OriginalName(originalName, t)
+  }
+  case class Renamed[T](originalName: String, localName: String, tag: T) extends ImportedName[T] {
+    def setTag(t: T): ImportedName[T] = Renamed(originalName, localName, t)
+  }
+
+  implicit val document: Document[ImportedName[Unit]] =
+    Document.instance[ImportedName[Unit]] {
+      case ImportedName.OriginalName(nm, _) => Doc.text(nm)
+      case ImportedName.Renamed(from, to, _) => Doc.text(from) + Doc.text(" as ") + Doc.text(to)
+    }
+
+  val parser: P[ImportedName[Unit]] = {
+    def basedOn(of: P[String]): P[ImportedName[Unit]] =
+      P(of ~ (spaces ~ "as" ~ spaces ~ of).?).map {
+        case (from, Some(to)) => ImportedName.Renamed(from, to, ())
+        case (orig, None) => ImportedName.OriginalName(orig, ())
+      }
+
+    basedOn(lowerIdent) | basedOn(upperIdent)
+  }
+}
+
+case class Import[A, B](pack: A, items: NonEmptyList[ImportedName[B]])
+
+object Import {
+  implicit val document: Document[Import[PackageName, Unit]] =
+    Document.instance[Import[PackageName, Unit]] { case Import(pname, items) =>
+      Doc.text("import ") + Document[PackageName].document(pname) + Doc.space +
+        // TODO: use paiges to pack this in nicely using .group or something
+        Doc.char('[') + Doc.intercalate(Doc.text(", "), items.toList.map(Document[ImportedName[Unit]].document _)) + Doc.char(']')
+    }
+
+  val parser: P[Import[PackageName, Unit]] = {
+    P("import" ~ spaces ~/ PackageName.parser ~ maybeSpace ~
+      ImportedName.parser.nonEmptyListSyntax).map { case (pname, imported) =>
+        Import(pname, imported)
+      }
+  }
+}
+
+/**
+ * There are all the distinct imported names and the original ImportedName
+ */
+case class ImportMap[A, B](toMap: Map[String, (A, ImportedName[B])]) {
+  def apply(name: String): Option[(A, ImportedName[B])] =
+    toMap.get(name)
+
+  def +(that: (A, ImportedName[B])): ImportMap[A, B] =
+    ImportMap(toMap.updated(that._2.localName, that))
+}
+
+object ImportMap {
+  def empty[A, B]: ImportMap[A, B] = ImportMap(Map.empty)
+  // Return the list of collisions in local names along with a map
+  // with the last name overwriting the import
+  def fromImports[A, B](is: List[Import[A, B]]): (List[(A, ImportedName[B])], ImportMap[A, B]) =
+    is.iterator
+      .flatMap { case Import(p, is) => is.toList.iterator.map((p, _)) }
+      .foldLeft((List.empty[(A, ImportedName[B])], ImportMap.empty[A, B])) {
+        case ((dups, imap), pim@(pack, im)) =>
+          val dups1 = imap(im.localName) match {
+            case Some(nm) => nm :: dups
+            case None => dups
+          }
+
+          (dups1, imap + pim)
+        }
+}

--- a/core/src/main/scala/org/bykn/bosatsu/Statement.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/Statement.scala
@@ -158,8 +158,9 @@ object Indented {
 
 sealed abstract class Statement {
 
-  def toProgram(pn: PackageName): Program[Declaration, Statement] = {
+  def toProgram(pn: PackageName, importMap: ImportMap[PackageName, Unit]): Program[Declaration, Statement] = {
     import Statement._
+    // TODO use the importMap to see what names come from where
 
     def loop(s: Statement): Program[Declaration, Statement] =
       s match {

--- a/core/src/test/scala/org/bykn/bosatsu/Gen.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/Gen.scala
@@ -308,5 +308,5 @@ object Generators {
       imports <- Gen.listOfN(ic, importGen)
       exports <- Gen.listOfN(ec, exportedNameGen)
       body <- genStatement
-    } yield Package(p, imports, exports, body.toProgram(p))
+    } yield Package(p, imports, exports, body)
 }

--- a/core/src/test/scala/org/bykn/bosatsu/InferTest.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/InferTest.scala
@@ -55,7 +55,7 @@ class InferTest extends FunSuite {
   def parseProgram(str: String, t: Type) =
     Statement.parser.parse(str) match {
       case Parsed.Success(exp, _) =>
-        val prog = exp.toProgram(testPack)
+        val prog = exp.toProgram(testPack, ImportMap.empty)
         prog.getMainDecl match {
           case None => fail(s"found no main expression")
           case Some(main) =>


### PR DESCRIPTION
imports and name mappings were added when I worked on packages, but they were never really well plumbed back down in the conversion from the syntactic representation to the expression representation.

There are TODOs around this in then rankn infer. To clean this up, I first pulled the import code out of the top level (package, which kind of sees everything) and make them independent. Then we can make statements require an import map to convert statements into a program.

We don't do any of this yet, but it is plumbed through and ready.