### PR TITLE
Generics in defs don't work

### DIFF
--- a/core/src/main/scala/org/bykn/bosatsu/Evaluation.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/Evaluation.scala
@@ -259,7 +259,9 @@ case class Evaluation(pm: PackageMap.Inferred, externals: Externals) {
     import TypedExpr._
 
      expr match {
-       case Generic(_, _, _) => ???
+       case Generic(_, e, _) =>
+         // TODO, we need to probably do something with this
+         evalTypedExpr(p, e, env, recurse)
        case Annotation(e, _, _) => evalTypedExpr(p, e, env, recurse)
        case Var(v, tpe, _) =>
          env.get(v) match {

--- a/core/src/main/scala/org/bykn/bosatsu/rankn/Infer.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/rankn/Infer.scala
@@ -331,6 +331,14 @@ object Infer {
       subst(env, t)
     }
 
+    def substExpr[A](keys: NonEmptyList[Type.Var], vals: NonEmptyList[Type], expr: Expr[A]): Expr[A] = {
+
+      // TODO: I don't think we can introduce new forall bindings in annotations,
+      // the forall would only apply for the scope of the type
+      val fn = substTy(keys, vals, _: Type)
+      Expr.traverseType[A, cats.Id](expr, fn)
+    }
+
     // Return a Rho type (not a Forall)
     def instantiate(t: Type): Infer[Type.Rho] =
       t match {
@@ -464,6 +472,21 @@ object Infer {
     def writeMeta(m: Type.Meta, v: Type.Tau): Infer[Unit] =
       lift(m.ref.set(Some(v)))
 
+    /**
+     * Here we substitute any free variables in t with meta and
+     * do the same substitution inside expr
+     */
+    def freeLambdaMeta[A](t: Type, expr: Expr[A]): Infer[(Type, Expr[A])] =
+      Type.freeTyVars(t :: Nil) match {
+        case Nil => Infer.pure((t, expr))
+        case h :: tail =>
+          val frees = NonEmptyList(h, tail)
+          val metas = frees.traverse(_ => newMetaType)
+          metas.map { ms =>
+            (substTy(frees, ms, t), substExpr(frees, ms, expr))
+          }
+      }
+
     // DEEP-SKOL rule
     def subsCheck(inferred: Type, declared: Type): Infer[TypedExpr.Coerce] =
       for {
@@ -520,24 +543,37 @@ object Infer {
                 _ <- infer.set(Type.Fun(varT, bodyT))
               } yield TypedExpr.AnnotatedLambda(name, varT, typedBody, tag)
           }
-        case AnnotatedLambda(name, tpe, result, tag) =>
-          expect match {
-            case Expected.Check(expTy) =>
-              for {
-                vb <- unifyFn(expTy)
-                (varT, bodyT) = vb
-                typedBody <- extendEnv(name, varT) {
-                    // TODO we are ignoring the result of subsCheck here
-                    // should we be coercing a var?
-                    subsCheck(tpe, varT) *> checkRho(result, bodyT)
-                  }
-              } yield TypedExpr.AnnotatedLambda(name, varT /* or tpe? */, typedBody, tag)
-            case infer@Expected.Inf(_) =>
-              for { // TODO do we need to narrow or instantiate tpe?
-                typedBody <- extendEnv(name, tpe)(inferRho(result))
-                bodyT = typedBody.getType
-                _ <- infer.set(Type.Fun(tpe, bodyT))
-              } yield TypedExpr.AnnotatedLambda(name, tpe, typedBody, tag)
+        case AnnotatedLambda(name, tpe0, result0, tag) =>
+          /**
+           * This is a deviation from the paper.
+           * We are allowing a syntax like:
+           *
+           * def indentity(x: a) -> a:
+           *   x
+           *
+           * here, we want to treat a like we would a forAll. So
+           * if we see a free Type.Var.Bound in the annotation type
+           * we replace it with a meta variable
+           */
+          freeLambdaMeta(tpe0, result0).flatMap { case (tpe, result) =>
+            expect match {
+              case Expected.Check(expTy) =>
+                for {
+                  vb <- unifyFn(expTy)
+                  (varT, bodyT) = vb
+                  typedBody <- extendEnv(name, varT) {
+                      // TODO we are ignoring the result of subsCheck here
+                      // should we be coercing a var?
+                      subsCheck(tpe, varT) *> checkRho(result, bodyT)
+                    }
+                } yield TypedExpr.AnnotatedLambda(name, varT /* or tpe? */, typedBody, tag)
+              case infer@Expected.Inf(_) =>
+                for { // TODO do we need to narrow or instantiate tpe?
+                  typedBody <- extendEnv(name, tpe)(inferRho(result))
+                  bodyT = typedBody.getType
+                  _ <- infer.set(Type.Fun(tpe, bodyT))
+                } yield TypedExpr.AnnotatedLambda(name, tpe, typedBody, tag)
+            }
           }
         case Let(name, rhs, body, tag) =>
           for {

--- a/core/src/test/scala/org/bykn/bosatsu/EvaluationTest.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/EvaluationTest.scala
@@ -114,6 +114,18 @@ same = sum0.eq_Int(sum1)
 
   }
 
+  test("test generics in defs") {
+    evalTest(
+      List("""
+package Foo
+
+def id(x: a) -> a:
+  x
+
+main = id(1)
+"""), "Foo", VInt(1))
+  }
+
   test("exercise struct creation") {
     evalTest(
       List("""

--- a/core/src/test/scala/org/bykn/bosatsu/rankn/RankNInferTest.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/rankn/RankNInferTest.scala
@@ -366,14 +366,12 @@ main = match x:
     y
 """, "Int")
 
-  // TODO this does not unify with rankn types
    parseProgram("""#
 enum List:
   Empty
   NonEmpty(a: a, tail: List[a])
 
 x = NonEmpty(1, Empty)
-#x = Empty
 main = match x:
   Empty:
     0


### PR DESCRIPTION
Previously, we ignored type annotations in defs. Since rankn types landed we don't, but it does not work for generics:

What is?
```
def indent(x: a) -> a:
  x
```
We currently translate it into an `AnnotatedLambda` with input type annotation of `TyVar(Var.Bound("a"))`. The problem is, that's an unbound variable.

Bounds should only be inside an outer `ForAll` now or they are not valid.

Maybe a solution is in the Infer code when we encounter an unbound Bound as an input type annotation, we introduce either a skolem variable or a meta variable (I'm not really sure which is correct). Ideally, we want to see that `identity: forall a. a -> a`.

Clearly we need more tests on the code.

related to #32 