### PR TITLE
Use partial evaluation to go faster

### DIFF
--- a/core/src/main/scala/org/bykn/bosatsu/Evaluation.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/Evaluation.scala
@@ -313,7 +313,10 @@ case class Evaluation(pm: PackageMap.Inferred, externals: Externals) {
                     else {
                       None
                     }
-                  case other => sys.error(s"ill typed in match: $other")
+                  case other =>
+                    // $COVERAGE-OFF$this should be unreachable
+                    sys.error(s"ill typed in match: $other")
+                    // $COVERAGE-ON$
                 }
               }
 
@@ -398,7 +401,10 @@ case class Evaluation(pm: PackageMap.Inferred, externals: Externals) {
          condR.flatMap {
            case (env, True) => ifR.inEnv(env)
            case (env, False) => elseR.inEnv(env)
-           case other => sys.error(s"ill-typed, expected boolean: $other")
+           case other =>
+             // $COVERAGE-OFF$this should be unreachable
+             sys.error(s"ill-typed, expected boolean: $other")
+             // $COVERAGE-ON$
          }
 
        case Match(arg, branches, _) =>

--- a/core/src/main/scala/org/bykn/bosatsu/NameKind.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/NameKind.scala
@@ -55,8 +55,9 @@ object NameKind {
           ExternalDef(pn, item, tpe)
       }
 
-    getLet.orElse(
-      getConstructor.orElse(getImport.orElse(getExternal))
-    )
+    getLet
+      .orElse(getConstructor)
+      .orElse(getImport)
+      .orElse(getExternal)
   }
 }

--- a/core/src/test/scala/org/bykn/bosatsu/EvaluationTest.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/EvaluationTest.scala
@@ -87,6 +87,14 @@ package Foo
 
 x = 1
 """), "Foo", VInt(1))
+
+    evalTest(
+      List("""
+package Foo
+
+# exercise calling directly a lambda
+x = (\y -> y)("hello")
+"""), "Foo", Str("hello"))
   }
 
   test("test if/else") {

--- a/test_workspace/euler1.bosatsu
+++ b/test_workspace/euler1.bosatsu
@@ -9,10 +9,8 @@ def reverse(as):
 
 def filter(as, fn):
   as.foldLeft(EmptyList, \tail, item ->
-    if fn(item):
-      NonEmptyList(item, tail)
-    else:
-      tail)
+    if fn(item): NonEmptyList(item, tail)
+    else: tail)
 
 under1000 = range(1000)
 


### PR DESCRIPTION
This PR is based on a comment I heard in a talk on the Unity programming language. The idea is that an interpreter can partially evaluate a fair amount statically by currying the environment. By doing this, you can build and cache everything you need in one advance pass, then pass the environments along, which are the things that change and probably are not useful to cache.

This seems to cut the bazel bosatsu test time way down (maybe 3x faster, and note we are still paying JVM startup cost, so it may be more than that if we carefully account for the improvement).

cc @snoble if you have time to take a look at this approach.