### PR TITLE
Add list literal constructors

### DIFF
--- a/core/src/main/resources/bosatsu/predef.bosatsu
+++ b/core/src/main/resources/bosatsu/predef.bosatsu
@@ -41,7 +41,9 @@ def reverse(as: List[a]) -> List[a]:
   reverse_concat(as, EmptyList)
 
 def concat(front: List[a], back: List[a]) -> List[a]:
-  reverse_concat(reverse(front), back)
+  match back:
+    EmptyList: front
+    _: reverse_concat(reverse(front), back)
 
 enum Comparison:
   LT

--- a/core/src/main/resources/bosatsu/predef.bosatsu
+++ b/core/src/main/resources/bosatsu/predef.bosatsu
@@ -9,12 +9,15 @@ export [
   String,
   Test(),
   add,
-  eq_Int,
   cmp_Int,
+  concat,
+  eq_Int,
   foldLeft,
   mod_Int,
-  sub,
   range,
+  reverse,
+  reverse_concat,
+  sub,
   times,
   trace,
 ]
@@ -30,6 +33,15 @@ enum List:
 external def foldLeft(lst: List[a], item: b, fn: b -> a -> b) -> b
 
 external def range(exclusiveUpper: Int) -> List[Int]
+
+def reverse_concat(front: List[a], back: List[a]) -> List[a]:
+  foldLeft(front, back, \tail, h -> NonEmptyList(h, tail))
+
+def reverse(as: List[a]) -> List[a]:
+  reverse_concat(as, EmptyList)
+
+def concat(front: List[a], back: List[a]) -> List[a]:
+  reverse_concat(reverse(front), back)
 
 enum Comparison:
   LT

--- a/core/src/main/scala/org/bykn/bosatsu/Codegen.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/Codegen.scala
@@ -209,7 +209,7 @@ trait CodeGen {
       case Annotation(expr, _, _) =>
         // TODO we might want to use the type info
         apply(expr, topLevel, pack)
-      case Var(n, _, _) =>
+      case Var(None, n, _, _) =>
         NameKind(pack, n) match {
           case Some(NameKind.Constructor(_, _, _, _)) =>
             Monad[Output].pure(Doc.text(toConstructorName(n)))
@@ -220,6 +220,8 @@ trait CodeGen {
               v = scope.toMap.get(n).fold(toExportedName(n)) { u => toFieldName(n, u.id) }
             } yield Doc.text(v)
         }
+      case Var(Some(_), n, _, _) =>
+        sys.error("TODO: handle fully qualified names")
       case App(fn, arg, _,  _) =>
         for {
           fnDoc <- apply(fn, topLevel, pack)

--- a/core/src/main/scala/org/bykn/bosatsu/Declaration.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/Declaration.scala
@@ -171,12 +171,13 @@ sealed abstract class Declaration {
 
               // TODO we need to refer to Predef/EmptyList no matter what here
               // but we have no way to fully refer to an item
-              val empty: Expr[Declaration] = Expr.Var("EmptyList", l)
+              val pn = Option(Predef.packageName)
+              val empty: Expr[Declaration] = Expr.Var(pn, "EmptyList", l)
               def cons(head: Expr[Declaration], tail: Expr[Declaration]): Expr[Declaration] =
-                Expr.App(Expr.App(Expr.Var("NonEmptyList", l), head, l), tail, l)
+                Expr.App(Expr.App(Expr.Var(pn, "NonEmptyList", l), head, l), tail, l)
 
               def concat(headList: Expr[Declaration], tail: Expr[Declaration]): Expr[Declaration] =
-                Expr.App(Expr.App(Expr.Var("concat", l), headList, l), tail, l)
+                Expr.App(Expr.App(Expr.Var(pn, "concat", l), headList, l), tail, l)
 
               revDecs.foldLeft(empty) {
                 case (tail, ListLang.SpliceOrItem.Item(i)) =>

--- a/core/src/main/scala/org/bykn/bosatsu/Declaration.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/Declaration.scala
@@ -119,7 +119,7 @@ sealed abstract class Declaration {
         case Comment(CommentStatement(_, Padding(_, decl))) =>
           loop(decl).map(_ => this)
         case Constructor(name) =>
-          Expr.Var(name, this)
+          Expr.Var(None, name, this)
         case DefFn(defstmt@DefStatement(_, _, _, _)) =>
           val (bodyExpr, inExpr) = defstmt.result match {
             case (oaBody, Padding(_, in)) =>
@@ -151,7 +151,7 @@ sealed abstract class Declaration {
         case Parens(p) =>
           loop(p).map(_ => this)
         case Var(name) =>
-          Expr.Var(name, this)
+          Expr.Var(None, name, this)
         case Match(arg, branches) =>
           val expBranches = branches.get.map { case (pat, oidecl) =>
             val decl = oidecl.get

--- a/core/src/main/scala/org/bykn/bosatsu/Evaluation.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/Evaluation.scala
@@ -366,10 +366,14 @@ case class Evaluation(pm: PackageMap.Inferred, externals: Externals) {
          // TODO, we need to probably do something with this
          evalTypedExpr(p, e, recurse)
        case Annotation(e, _, _) => evalTypedExpr(p, e, recurse)
-       case Var(v, _, _) =>
+       case Var(None, v, _, _) =>
          val onMissing = recurse((p, Left(v)))._1
 
          Scoped.orElse(v, onMissing)
+       case Var(Some(p), v, _, _) =>
+         val pack = pm.toMap.get(p).getOrElse(sys.error(s"cannot find $p, shouldn't happen due to typechecking"))
+         val (scoped, _) = eval((Package.asInferred(pack), Left(v)))
+         scoped
        case App(AnnotatedLambda(name, _, fn, _), arg, _, _) =>
          val argE = recurse((p, Right(arg)))._1
          val fnE = recurse((p, Right(fn)))._1

--- a/core/src/main/scala/org/bykn/bosatsu/ListLang.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/ListLang.scala
@@ -1,0 +1,67 @@
+package org.bykn.bosatsu
+
+import fastparse.all._
+
+import Parser.{maybeSpacesAndLines, spacesAndLines}
+import org.typelevel.paiges.{Doc, Document}
+
+/**
+ * Represents the list construction sublanguage
+ */
+sealed abstract class ListLang[A]
+object ListLang {
+  sealed abstract class SpliceOrItem[A] {
+    def value: A
+  }
+  object SpliceOrItem {
+    case class Splice[A](value: A) extends SpliceOrItem[A]
+    case class Item[A](value: A) extends SpliceOrItem[A]
+
+    def parser[A](pa: P[A]): P[SpliceOrItem[A]] =
+      P("*" ~ pa).map(Splice(_)) | pa.map(Item(_))
+
+    implicit def document[A](implicit A: Document[A]): Document[SpliceOrItem[A]] =
+      Document.instance[SpliceOrItem[A]] {
+        case Splice(a) => Doc.char('*') + A.document(a)
+        case Item(a) => A.document(a)
+      }
+  }
+
+  case class Cons[A](items: List[SpliceOrItem[A]]) extends ListLang[A]
+  case class Comprehension[A](expr: A, binding: A, in: A, filter: Option[A]) extends ListLang[A]
+
+  def parser[A](pa: P[A]): P[ListLang[A]] = {
+    val cons = SpliceOrItem.parser(pa)
+      .rep(sep = P(maybeSpacesAndLines ~ "," ~ maybeSpacesAndLines))
+      .map { splices => Cons(splices.toList) }
+
+    val filterExpr = P("if" ~ spacesAndLines ~/ pa).?
+    val comp = P(pa ~ spacesAndLines ~
+      "for" ~ spacesAndLines ~/ pa ~ spacesAndLines ~/
+      "in" ~ spacesAndLines ~/ pa ~ maybeSpacesAndLines ~
+      filterExpr
+      ).map { case (e, b, i, f) => Comprehension(e, b, i, f) }
+
+    val inner = comp | cons
+
+    P("[" ~ maybeSpacesAndLines ~ inner ~ maybeSpacesAndLines ~ "]")
+  }
+
+  implicit def document[A](implicit A: Document[A]): Document[ListLang[A]] =
+    Document.instance[ListLang[A]] {
+      case Cons(items) =>
+        Doc.char('[') + Doc.intercalate(Doc.text(", "),
+          items.map(SpliceOrItem.document(A).document(_))) +
+          Doc.char(']')
+      case Comprehension(e, b, i, f) =>
+        val filt = f match {
+          case None => Doc.empty
+          case Some(e) => Doc.text(" if ") + A.document(e)
+        }
+        Doc.char('[') + A.document(e) + Doc.text(" for ") +
+          A.document(b) + Doc.text(" in ") +
+          A.document(i) + filt +
+          Doc.char(']')
+    }
+}
+

--- a/core/src/main/scala/org/bykn/bosatsu/Package.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/Package.scala
@@ -118,8 +118,15 @@ object Package {
     val importedValues: Map[String, rankn.Type] =
       Referant.importedValues(imps) ++ typeEnv.localValuesOf(p)
 
+    val withFQN: Map[(Option[PackageName], String), rankn.Type] =
+      (Referant.fullyQualifiedImportedValues(imps)(_.unfix.name)
+        .iterator
+        .map { case ((p, n), t) => ((Some(p), n), t) } ++
+          importedValues.iterator.map { case (n, t) => ((None, n), t) }
+        ).toMap
+
     Infer.typeCheckLets(lets)
-      .runFully(importedValues,
+      .runFully(withFQN,
         Referant.typeConstructors(imps) ++ typeEnv.typeConstructors
       )
       .map { lets => (typeEnv, lets) }

--- a/core/src/main/scala/org/bykn/bosatsu/Parser.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/Parser.scala
@@ -145,6 +145,11 @@ object Parser {
   val nonSpaces: P[String] = P(CharsWhile { c => !isSpace(c) }.!)
   val maybeSpace: P[Unit] = spaces.?
 
+  val spacesAndLines: P[Unit] = P(CharsWhile { c =>
+    isSpace(c) || (c == '\n' || c == '\r')
+  })
+  val maybeSpacesAndLines: P[Unit] = spacesAndLines.?
+
   val lowerIdent: P[String] =
     P(CharIn('a' to 'z').! ~ CharsWhile(identifierChar _).?.!)
       .map { case (a, b) => a + b }
@@ -233,6 +238,9 @@ object Parser {
 
     def parens: P[T] =
       wrappedSpace("(", ")")
+
+    def parensCut: P[T] =
+      P("(" ~/ maybeSpace ~ item ~ maybeSpace ~ ")")
   }
 
   val toEOL: P[Unit] = P(maybeSpace ~ "\n")

--- a/core/src/main/scala/org/bykn/bosatsu/Parser.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/Parser.scala
@@ -147,8 +147,10 @@ object Parser {
 
   val spacesAndLines: P[Unit] = P(CharsWhile { c =>
     isSpace(c) || (c == '\n' || c == '\r')
-  })
-  val maybeSpacesAndLines: P[Unit] = spacesAndLines.?
+  }).opaque("spacesAndLines")
+
+  val maybeSpacesAndLines: P[Unit] =
+    spacesAndLines.?.opaque("maybeSpacesAndLines")
 
   val lowerIdent: P[String] =
     P(CharIn('a' to 'z').! ~ CharsWhile(identifierChar _).?.!)

--- a/core/src/main/scala/org/bykn/bosatsu/Predef.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/Predef.scala
@@ -52,10 +52,13 @@ object Predef {
         "TestList",
         "add",
         "eq_Int",
+        "concat",
         "cmp_Int",
         "mod_Int",
         "foldLeft",
         "range",
+        "reverse",
+        "reverse_concat",
         "sub",
         "times",
         "trace"

--- a/core/src/main/scala/org/bykn/bosatsu/Referant.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/Referant.scala
@@ -37,6 +37,22 @@ object Referant {
       case Referant.Value(t) => t
       case Referant.Constructor(_, _, _, t) => t
     }
+  /**
+   * Fully qualified original names
+   */
+  def fullyQualifiedImportedValues[A](imps: List[Import[A, NonEmptyList[Referant]]])(nameOf: A => PackageName): Map[(PackageName, String), rankn.Type] =
+    imps.iterator.flatMap { item =>
+      val pn = nameOf(item.pack)
+      item.items.toList.iterator.flatMap { i =>
+        val orig = i.originalName
+        val key = (pn, orig)
+        i.tag.toList.iterator.collect {
+          case Referant.Value(t) => (key, t)
+          case Referant.Constructor(_, _, _, t) => (key, t)
+        }
+      }
+    }
+    .toMap
 
   def typeConstructors[A](imps: List[Import[A, NonEmptyList[Referant]]]): Map[(PackageName, ConstructorName), (List[rankn.Type.Var], List[rankn.Type], rankn.Type.Const.Defined)] = {
     val refs: Iterator[Referant] = imps.iterator.flatMap(_.items.toList.iterator.flatMap(_.tag.toList))

--- a/core/src/test/scala/org/bykn/bosatsu/EvaluationTest.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/EvaluationTest.scala
@@ -235,11 +235,11 @@ def zip(as: List[a], bs: List[b]) -> List[Pair[a, b]]:
   def cons(pair: Pair[List[Pair[a, b]], List[b]], item: a) -> Pair[List[Pair[a, b]], List[b]]:
     match pair:
       Pair(acc, EmptyList):
-        Pair(acc, EmptyList)
+        Pair(acc, [])
       Pair(acc, NonEmptyList(h, tail)):
         Pair(NonEmptyList(Pair(item, h), acc), tail)
 
-  rev = as.foldLeft(Pair(EmptyList, bs), cons)
+  rev = as.foldLeft(Pair([], bs), cons)
   match rev:
     Pair(res, _):
       reverse(res)

--- a/core/src/test/scala/org/bykn/bosatsu/EvaluationTest.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/EvaluationTest.scala
@@ -295,7 +295,7 @@ struct EmptyList
 
 main = [1, 2]
 """), "Foo",
-  ConsValue(VInt(1), UnitValue))
+  VList.Cons(VInt(1), VList.Cons(VInt(2), VList.VNil)))
 
     evalTest(
       List("""
@@ -305,7 +305,7 @@ struct NonEmptyList
 
 main = [1, 2]
 """), "Foo",
-  ConsValue(VInt(1), UnitValue))
+  VList.Cons(VInt(1), VList.Cons(VInt(2), VList.VNil)))
 
     evalTest(
       List("""
@@ -315,6 +315,6 @@ def concat(a): a
 
 main = [1, 2]
 """), "Foo",
-  ConsValue(VInt(1), UnitValue))
+  VList.Cons(VInt(1), VList.Cons(VInt(2), VList.VNil)))
   }
 }

--- a/core/src/test/scala/org/bykn/bosatsu/EvaluationTest.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/EvaluationTest.scala
@@ -285,4 +285,36 @@ else:
   "1"
 """), "Foo")
   }
+
+  test("test the list literals work even when we have conflicting local names") {
+    evalTest(
+      List("""
+package Foo
+
+struct EmptyList
+
+main = [1, 2]
+"""), "Foo",
+  ConsValue(VInt(1), UnitValue))
+
+    evalTest(
+      List("""
+package Foo
+
+struct NonEmptyList
+
+main = [1, 2]
+"""), "Foo",
+  ConsValue(VInt(1), UnitValue))
+
+    evalTest(
+      List("""
+package Foo
+
+def concat(a): a
+
+main = [1, 2]
+"""), "Foo",
+  ConsValue(VInt(1), UnitValue))
+  }
 }

--- a/core/src/test/scala/org/bykn/bosatsu/EvaluationTest.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/EvaluationTest.scala
@@ -142,7 +142,7 @@ z = match x:
       List("""
 package Foo
 
-three = NonEmptyList(1, NonEmptyList(2, EmptyList))
+three = [1, 2]
 
 def sum(ls):
   ls.foldLeft(0, add)
@@ -185,21 +185,17 @@ three = NonEmptyList(0, NonEmptyList(1, EmptyList))
 # exercise the built-in range function (not implementable in bosatsu)
 threer = range(3)
 
-def reverse(ls):
-  # note foldLeft is also built in, and not implementable
-  ls.foldLeft(EmptyList, \tail, h -> NonEmptyList(h, tail))
-
 struct Pair(fst, sec)
 
 def zip(as: List[a], bs: List[b]) -> List[Pair[a, b]]:
   def cons(pair, item):
     match pair:
       Pair(acc, EmptyList):
-        Pair(acc, EmptyList)
+        Pair(acc, [])
       Pair(acc, NonEmptyList(h, tail)):
-        Pair(NonEmptyList(Pair(item, h), acc), tail)
+        Pair([Pair(item, h), *acc], tail)
 
-  rev = as.foldLeft(Pair(EmptyList, bs), cons)
+  rev = as.foldLeft(Pair([], bs), cons)
   match rev:
     Pair(res, _):
       reverse(res)
@@ -225,10 +221,6 @@ evalTest(
   List("""
 package Foo
 
-def reverse(ls):
-  # note foldLeft is also built in, and not implementable
-  ls.foldLeft(EmptyList, \tail, h -> NonEmptyList(h, tail))
-
 struct Pair(fst, sec)
 
 def zip(as: List[a], bs: List[b]) -> List[Pair[a, b]]:
@@ -237,7 +229,7 @@ def zip(as: List[a], bs: List[b]) -> List[Pair[a, b]]:
       Pair(acc, EmptyList):
         Pair(acc, [])
       Pair(acc, NonEmptyList(h, tail)):
-        Pair(NonEmptyList(Pair(item, h), acc), tail)
+        Pair([Pair(item, h), *acc], tail)
 
   rev = as.foldLeft(Pair([], bs), cons)
   match rev:

--- a/core/src/test/scala/org/bykn/bosatsu/Gen.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/Gen.scala
@@ -95,6 +95,32 @@ object Generators {
       body <- dec
     } yield DefStatement(name, args, retType, body)
 
+  def listGen(dec0: Gen[Declaration]): Gen[Declaration.ListDecl] = {
+    lazy val filterFn: Declaration => Boolean = {
+      case Declaration.Comment(_) => false
+      case Declaration.DefFn(_) => false
+      case Declaration.Binding(_) => false
+      case Declaration.Parens(p) => filterFn(p)
+      case Declaration.IfElse(_, _) => false
+      case Declaration.Match(_, _) => false
+      case Declaration.Lambda(_, body) => filterFn(body)
+      case Declaration.Apply(f, args, _) =>
+        filterFn(f) && args.forall(filterFn)
+      case _ => true
+    }
+    val dec = dec0.filter(filterFn)
+
+    val genSplice = Gen.oneOf(dec.map(ListLang.SpliceOrItem.Splice(_)),
+      dec.map(ListLang.SpliceOrItem.Item(_)))
+    val cons = Gen.choose(0, 10).flatMap(Gen.listOfN(_, genSplice).map(ListLang.Cons(_)))
+
+    // TODO we can't parse if since we get confused about it being a ternary expression
+    val comp = Gen.zip(dec, dec, dec, Gen.option(dec))
+      .map { case (a, b, c, _) => ListLang.Comprehension(a, b, c, None) }
+
+    Gen.oneOf(cons, comp).map(Declaration.ListDecl(_)(emptyRegion))
+  }
+
   def applyGen(dec: Gen[Declaration]): Gen[Declaration] = {
     import Declaration._
     Gen.lzy(for {
@@ -206,6 +232,7 @@ object Generators {
       (2, applyGen(recur)),
       (2, bindGen(recur, padding(recur, 1)).map(Binding(_)(emptyRegion))),
       (1, ifElseGen(recur)),
+      (1, listGen(recur)),
       (1, matchGen(recur))
     )
   }
@@ -240,6 +267,10 @@ object Generators {
           case LiteralString(str, q) => Stream.empty
           case Parens(p) => p #:: Stream.empty
           case Var(_) => Stream.empty
+          case ListDecl(ListLang.Cons(items)) =>
+            items.map(_.value).toStream
+          case ListDecl(ListLang.Comprehension(a, b, c, d)) =>
+            (a :: b :: c :: d.toList).toStream
         }
     })
 

--- a/core/src/test/scala/org/bykn/bosatsu/Gen.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/Gen.scala
@@ -115,7 +115,7 @@ object Generators {
     val cons = Gen.choose(0, 10).flatMap(Gen.listOfN(_, genSplice).map(ListLang.Cons(_)))
 
     // TODO we can't parse if since we get confused about it being a ternary expression
-    val comp = Gen.zip(dec, dec, dec, Gen.option(dec))
+    val comp = Gen.zip(genSplice, dec, dec, Gen.option(dec))
       .map { case (a, b, c, _) => ListLang.Comprehension(a, b, c, None) }
 
     Gen.oneOf(cons, comp).map(Declaration.ListDecl(_)(emptyRegion))
@@ -270,7 +270,7 @@ object Generators {
           case ListDecl(ListLang.Cons(items)) =>
             items.map(_.value).toStream
           case ListDecl(ListLang.Comprehension(a, b, c, d)) =>
-            (a :: b :: c :: d.toList).toStream
+            (a.value :: b :: c :: d.toList).toStream
         }
     })
 

--- a/core/src/test/scala/org/bykn/bosatsu/ParserTest.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/ParserTest.scala
@@ -6,7 +6,7 @@ import fastparse.all._
 import org.scalacheck.{Arbitrary, Gen}
 import org.scalatest.FunSuite
 import org.scalatest.prop.PropertyChecks.{ forAll, PropertyCheckConfiguration }
-import org.typelevel.paiges.Document
+import org.typelevel.paiges.{Doc, Document}
 
 import Parser.Indy
 
@@ -172,6 +172,20 @@ class ParserTest extends FunSuite {
     forAll(Generators.typeRefGen) { tref =>
       parseTestAll(TypeRef.parser, tref.toDoc.render(80), tref)
     }
+  }
+
+  test("we can parse python style list expressions") {
+    val pident = Parser.lowerIdent
+    implicit val stringDoc: Document[String] = Document.instance[String](Doc.text(_))
+
+    roundTrip(ListLang.parser(pident), "[a]")
+    roundTrip(ListLang.parser(pident), "[]")
+    roundTrip(ListLang.parser(pident), "[a , b]")
+    roundTrip(ListLang.parser(pident), "[a , b]")
+    roundTrip(ListLang.parser(pident), "[a , *b]")
+    roundTrip(ListLang.parser(pident), "[a ,\n*b,\n c]")
+    roundTrip(ListLang.parser(pident), "[x for y in z]")
+    roundTrip(ListLang.parser(pident), "[x for y in z if w]")
   }
 
   test("we can parse comments") {
@@ -411,6 +425,16 @@ else:
   Bar(_, _):
       if True: 0
       else: 10""")
+  }
+
+  test("we can parse declaration lists") {
+    roundTrip(Declaration.parser(""), "[]")
+    roundTrip(Declaration.parser(""), "[1]")
+    roundTrip(Declaration.parser(""), "[1, 2, 3]")
+    roundTrip(Declaration.parser(""), "[1, *x, 3]")
+    roundTrip(Declaration.parser(""), "[Foo(a, b), *acc]")
+    roundTrip(Declaration.parser(""), "[x for y in [1, 2]]")
+    //roundTrip(Declaration.parser(""), "[x for y in [1, 2] if foo]")
   }
 
   test("we can parse any Declaration") {

--- a/core/src/test/scala/org/bykn/bosatsu/rankn/RankNInferTest.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/rankn/RankNInferTest.scala
@@ -51,14 +51,14 @@ class RankNInferTest extends FunSuite {
       "False" -> Type.BoolType)
 
   def testType(term: Expr[_], ty: Type) =
-    Infer.typeCheck(term).runFully(withBools, Map.empty) match {
+    Infer.typeCheck(term).runFully(Infer.asFullyQualified(withBools), Map.empty) match {
       case Left(err) => assert(false, err)
       case Right(tpe) => assert(tpe.getType == ty, term.toString)
     }
 
   def testLetTypes[A](terms: List[(String, Expr[A], Type)]) =
     Infer.typeCheckLets(terms.map { case (k, v, _) => (k, v) })
-      .runFully(withBools, Map.empty) match {
+      .runFully(Infer.asFullyQualified(withBools), Map.empty) match {
         case Left(err) => assert(false, err)
         case Right(tpes) =>
           assert(tpes.size == terms.size)
@@ -70,10 +70,10 @@ class RankNInferTest extends FunSuite {
 
 
   def lit(i: Int): Expr[Unit] = Literal(Lit(i.toLong), ())
-  def lit(b: Boolean): Expr[Unit] = if (b) Var("True", ()) else Var("False", ())
+  def lit(b: Boolean): Expr[Unit] = if (b) Var(None, "True", ()) else Var(None, "False", ())
   def let(n: String, expr: Expr[Unit], in: Expr[Unit]): Expr[Unit] = Let(n, expr, in, ())
   def lambda(arg: String, result: Expr[Unit]): Expr[Unit] = Lambda(arg, result, ())
-  def v(name: String): Expr[Unit] = Var(name, ())
+  def v(name: String): Expr[Unit] = Var(None, name, ())
   def ann(expr: Expr[Unit], t: Type): Expr[Unit] = Annotation(expr, t, ())
 
   def app(fn: Expr[Unit], arg: Expr[Unit]): Expr[Unit] = App(fn, arg, ())
@@ -214,13 +214,13 @@ class RankNInferTest extends FunSuite {
     )
 
     def testWithOpt(term: Expr[_], ty: Type) =
-      Infer.typeCheck(term).runFully(withBools ++ constructors, definedOption) match {
+      Infer.typeCheck(term).runFully(Infer.asFullyQualified(withBools ++ constructors), definedOption) match {
         case Left(err) => assert(false, err)
         case Right(tpe) => assert(tpe.getType == ty, term.toString)
       }
 
     def failWithOpt(term: Expr[_]) =
-      Infer.typeCheck(term).runFully(withBools ++ constructors, definedOption) match {
+      Infer.typeCheck(term).runFully(Infer.asFullyQualified(withBools ++ constructors), definedOption) match {
         case Left(err) => assert(true)
         case Right(tpe) => assert(false, s"expected to fail, but inferred type $tpe")
       }
@@ -257,13 +257,13 @@ class RankNInferTest extends FunSuite {
     )
 
     def testWithOpt(term: Expr[_], ty: Type) =
-      Infer.typeCheck(term).runFully(withBools ++ constructors, definedOptionGen) match {
+      Infer.typeCheck(term).runFully(Infer.asFullyQualified(withBools ++ constructors), definedOptionGen) match {
         case Left(err) => assert(false, err)
         case Right(tpe) => assert(tpe.getType == ty, term.toString)
       }
 
     def failWithOpt(term: Expr[_]) =
-      Infer.typeCheck(term).runFully(withBools ++ constructors, definedOptionGen) match {
+      Infer.typeCheck(term).runFully(Infer.asFullyQualified(withBools ++ constructors), definedOptionGen) match {
         case Left(err) => assert(true)
         case Right(tpe) => assert(false, s"expected to fail, but inferred type $tpe")
       }
@@ -324,7 +324,7 @@ class RankNInferTest extends FunSuite {
     )
 
     def testWithTypes(term: Expr[_], ty: Type) =
-      Infer.typeCheck(term).runFully(withBools ++ constructors, defined) match {
+      Infer.typeCheck(term).runFully(Infer.asFullyQualified(withBools ++ constructors), defined) match {
         case Left(err) => assert(false, err)
         case Right(tpe) => assert(tpe.getType == ty, term.toString)
       }

--- a/test_workspace/euler1.bosatsu
+++ b/test_workspace/euler1.bosatsu
@@ -4,12 +4,9 @@ package Euler/One
 # https://projecteuler.net/problem=1
 # Find the sum of all the multiples of 3 or 5 below 1000.
 
-def reverse(as):
-  as.foldLeft(EmptyList, \tail, head -> NonEmptyList(head, tail))
-
 def filter(as, fn):
-  as.foldLeft(EmptyList, \tail, item ->
-    if fn(item): NonEmptyList(item, tail)
+  as.foldLeft([], \tail, item ->
+    if fn(item): [item, *tail]
     else: tail)
 
 under1000 = range(1000)

--- a/test_workspace/euler2.bosatsu
+++ b/test_workspace/euler2.bosatsu
@@ -15,15 +15,15 @@ package Euler/Two
 # so n = 35 is enough
 
 def fib(n):
-  range(n).foldLeft(EmptyList, \revFib, item ->
+  range(n).foldLeft([], \revFib, item ->
     match revFib:
-      EmptyList: NonEmptyList(1, EmptyList)
-      NonEmptyList(h, EmptyList): NonEmptyList(2, NonEmptyList(h, EmptyList))
-      NonEmptyList(h1, NonEmptyList(h2, _)): NonEmptyList(h1.add(h2), revFib))
+      EmptyList: [1]
+      NonEmptyList(h, EmptyList): [2, h]
+      NonEmptyList(h1, NonEmptyList(h2, _)): [h1.add(h2), *revFib])
 
 def filter(as, fn):
-  as.foldLeft(EmptyList, \tail, item ->
-    if fn(item): NonEmptyList(item, tail)
+  as.foldLeft([], \tail, item ->
+    if fn(item): [item, *tail]
     else: tail)
 
 def keep(i):


### PR DESCRIPTION
closes #13 

This adds the construction, not pattern matching, for list literals.

There are two issues:

1. the parsing is still not correct since I can't parse function application in lists: `[ Foo(a, b), c ]` does not parse. I'm not sure why. It seems to be failing when it gets to the `,`.
2. we effectively need macros here, but I have no way to be sure I reference a particular fully qualified function. It may be that we need to expand Expr to have point to imported names instead of just Var that refers to the current environment.