### PR TITLE
Fix a bug on literal match inference

### DIFF
--- a/core/src/main/scala/org/bykn/bosatsu/rankn/Type.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/rankn/Type.scala
@@ -2,7 +2,7 @@ package org.bykn.bosatsu.rankn
 
 import cats.data.NonEmptyList
 import cats.Eq
-import org.bykn.bosatsu.PackageName
+import org.bykn.bosatsu.{PackageName, Lit}
 
 sealed abstract class Type
 
@@ -36,6 +36,12 @@ object Type {
     new Eq[Type] {
       def eqv(left: Type, right: Type): Boolean =
         left == right
+    }
+
+  def getTypeOf(lit: Lit): Type =
+    lit match {
+      case Lit.Integer(_) => Type.IntType
+      case Lit.Str(_) => Type.StrType
     }
 
   /**

--- a/core/src/test/scala/org/bykn/bosatsu/rankn/RankNInferTest.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/rankn/RankNInferTest.scala
@@ -438,4 +438,25 @@ def foo(i: Int):
 main = foo("Not an Int")
 """)
   }
+
+  test("using a literal the wrong type is ill-typed") {
+
+  parseProgramIllTyped("""#
+
+x = "foo"
+
+main = match x:
+  1: "can't really be an int"
+  y: y
+""")
+
+  parseProgramIllTyped("""#
+
+x = 1
+
+main = match x:
+  "1": "can't really be a string"
+  y: y
+""")
+  }
 }


### PR DESCRIPTION
We were just ignoring literals in type inference in matching, but we should reject ill-typed matches.