### PR TITLE
implement list patterns

### DIFF
--- a/core/src/main/scala/org/bykn/bosatsu/Parser.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/Parser.scala
@@ -146,7 +146,7 @@ object Parser {
   val maybeSpace: P[Unit] = spaces.?
 
   val spacesAndLines: P[Unit] = P(CharsWhile { c =>
-    isSpace(c) || (c == '\n' || c == '\r')
+    c.isWhitespace
   }).opaque("spacesAndLines")
 
   val maybeSpacesAndLines: P[Unit] =
@@ -226,8 +226,14 @@ object Parser {
       left ~ item ~ right
 
     def nonEmptyListSyntax: P[NonEmptyList[T]] = {
-      val ws = P(CharsWhile(_.isWhitespace)).?
+      val ws = maybeSpacesAndLines
       nonEmptyListOfWs(ws, 1).bracketed(P("[" ~/ ws), P(ws ~ "]"))
+    }
+
+    def listSyntax: P[List[T]] = {
+      val ws = maybeSpacesAndLines
+      nonEmptyListToList(nonEmptyListOfWs(ws, 1))
+        .bracketed(P("[" ~/ ws), P(ws ~ "]"))
     }
 
     def region: P[(Region, T)] =

--- a/core/src/main/scala/org/bykn/bosatsu/Pattern.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/Pattern.scala
@@ -42,8 +42,8 @@ object Pattern {
         case Pattern.Var(v) => Applicative[F].pure(Pattern.Var(v))
         case Pattern.ListPat(items) =>
           items.traverse {
-            case Left(v) => Applicative[F].pure(Left(v): Either[String, Pattern[N, T1]])
-            case Right(p) => p.traverseType(fn).map(Right(_): Either[String, Pattern[N, T1]])
+            case Left(v) => Applicative[F].pure(Left(v): Either[Option[String], Pattern[N, T1]])
+            case Right(p) => p.traverseType(fn).map(Right(_): Either[Option[String], Pattern[N, T1]])
           }.map(Pattern.ListPat(_))
         case Pattern.Annotation(p, tpe) =>
           (p.traverseType(fn), fn(tpe)).mapN(Pattern.Annotation(_, _))
@@ -57,7 +57,7 @@ object Pattern {
   case object WildCard extends Pattern[Nothing, Nothing]
   case class Literal(toLit: Lit) extends Pattern[Nothing, Nothing]
   case class Var(name: String) extends Pattern[Nothing, Nothing]
-  case class ListPat[N, T](parts: List[Either[String, Pattern[N, T]]]) extends Pattern[N, T]
+  case class ListPat[N, T](parts: List[Either[Option[String], Pattern[N, T]]]) extends Pattern[N, T]
   case class Annotation[N, T](pattern: Pattern[N, T], tpe: T) extends Pattern[N, T]
   case class PositionalStruct[N, T](name: N, params: List[Pattern[N, T]]) extends Pattern[N, T]
 
@@ -69,7 +69,8 @@ object Pattern {
       case ListPat(items) =>
         Doc.char('[') + Doc.intercalate(Doc.text(", "),
           items.map {
-            case Left(glob) => Doc.char('*') + Doc.text(glob)
+            case Left(None) => Doc.text("*_")
+            case Left(Some(glob)) => Doc.char('*') + Doc.text(glob)
             case Right(p) => document.document(p)
           }) + Doc.char(']')
       case Annotation(_, _) =>
@@ -104,7 +105,16 @@ object Pattern {
           case (n, Some(ls)) => PositionalStruct(n, ls)
         }
 
-      val nonAnnotated = pvar | plit | pwild | pparen | positional
+      val listItem: P[Either[Option[String], Pattern[String, TypeRef]]] = {
+        val maybeNamed: P[Option[String]] =
+          P("_").map(_ => None) | lowerIdent.map(Some(_))
+
+        P("*" ~ maybeNamed).map(Left(_)) | recurse.map(Right(_))
+      }
+
+      val listP = listItem.listSyntax.map(ListPat(_))
+
+      val nonAnnotated = pvar | plit | pwild | pparen | positional | listP
       val typeAnnot = P(maybeSpace ~ ":" ~/ maybeSpace ~ TypeRef.parser)
       val withType = (nonAnnotated ~ typeAnnot.?).map {
         case (p, None) => p

--- a/core/src/main/scala/org/bykn/bosatsu/Pattern.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/Pattern.scala
@@ -13,6 +13,8 @@ sealed abstract class Pattern[+N, +T] {
       case Pattern.WildCard => Pattern.WildCard
       case Pattern.Literal(lit) => Pattern.Literal(lit)
       case Pattern.Var(v) => Pattern.Var(v)
+      case Pattern.ListPat(items) =>
+        Pattern.ListPat(items.map(_.right.map(_.mapName(fn))))
       case Pattern.Annotation(p, tpe) => Pattern.Annotation(p.mapName(fn), tpe)
       case Pattern.PositionalStruct(name, params) =>
         Pattern.PositionalStruct(fn(name), params.map(_.mapName(fn)))
@@ -22,6 +24,8 @@ sealed abstract class Pattern[+N, +T] {
       case Pattern.WildCard => Pattern.WildCard
       case Pattern.Literal(lit) => Pattern.Literal(lit)
       case Pattern.Var(v) => Pattern.Var(v)
+      case Pattern.ListPat(items) =>
+        Pattern.ListPat(items.map(_.right.map(_.mapType(fn))))
       case Pattern.Annotation(p, tpe) => Pattern.Annotation(p.mapType(fn), fn(tpe))
       case Pattern.PositionalStruct(name, params) =>
         Pattern.PositionalStruct(name, params.map(_.mapType(fn)))
@@ -36,6 +40,11 @@ object Pattern {
         case Pattern.WildCard => Applicative[F].pure(Pattern.WildCard)
         case Pattern.Literal(lit) => Applicative[F].pure(Pattern.Literal(lit))
         case Pattern.Var(v) => Applicative[F].pure(Pattern.Var(v))
+        case Pattern.ListPat(items) =>
+          items.traverse {
+            case Left(v) => Applicative[F].pure(Left(v): Either[String, Pattern[N, T1]])
+            case Right(p) => p.traverseType(fn).map(Right(_): Either[String, Pattern[N, T1]])
+          }.map(Pattern.ListPat(_))
         case Pattern.Annotation(p, tpe) =>
           (p.traverseType(fn), fn(tpe)).mapN(Pattern.Annotation(_, _))
         case Pattern.PositionalStruct(name, params) =>
@@ -48,6 +57,7 @@ object Pattern {
   case object WildCard extends Pattern[Nothing, Nothing]
   case class Literal(toLit: Lit) extends Pattern[Nothing, Nothing]
   case class Var(name: String) extends Pattern[Nothing, Nothing]
+  case class ListPat[N, T](parts: List[Either[String, Pattern[N, T]]]) extends Pattern[N, T]
   case class Annotation[N, T](pattern: Pattern[N, T], tpe: T) extends Pattern[N, T]
   case class PositionalStruct[N, T](name: N, params: List[Pattern[N, T]]) extends Pattern[N, T]
 
@@ -56,6 +66,12 @@ object Pattern {
       case WildCard => Doc.char('_')
       case Literal(lit) => Document[Lit].document(lit)
       case Var(n) => Doc.text(n)
+      case ListPat(items) =>
+        Doc.char('[') + Doc.intercalate(Doc.text(", "),
+          items.map {
+            case Left(glob) => Doc.char('*') + Doc.text(glob)
+            case Right(p) => document.document(p)
+          }) + Doc.char(']')
       case Annotation(_, _) =>
         /*
          * We need to know what package we are in and what imports we depend on here.

--- a/core/src/main/scala/org/bykn/bosatsu/rankn/Infer.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/rankn/Infer.scala
@@ -705,6 +705,13 @@ object Infer {
                 _ <- infer.set(t)
               } yield (GenPattern.Annotation(pat, t), List((n, t)))
           }
+        case GenPattern.ListPat(items) =>
+          /*
+           * Here we unify the sigma with List[A] for some type A
+           * any *a patterns have type List[A], all the rest
+           * of them have type A.
+           */
+          ???
         case GenPattern.Annotation(p, tpe) =>
           // like in the case of an annotation, we check the type, then
           // instantiate a sigma type

--- a/core/src/main/scala/org/bykn/bosatsu/rankn/Type.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/rankn/Type.scala
@@ -102,6 +102,7 @@ object Type {
   val BoolType: Type = TyConst(Const.predef("Bool"))
   val StrType: Type = TyConst(Const.predef("String"))
   val FnType: Type = TyConst(Const.predef("Fn"))
+  val ListType: Type = TyConst(Const.predef("List"))
 
   object Fun {
     def unapply(t: Type): Option[(Type, Type)] =

--- a/core/src/test/scala/org/bykn/bosatsu/EvaluationTest.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/EvaluationTest.scala
@@ -225,9 +225,9 @@ struct Pair(fst, sec)
 def zip(as: List[a], bs: List[b]) -> List[Pair[a, b]]:
   def cons(pair, item):
     match pair:
-      Pair(acc, EmptyList):
+      Pair(acc, []):
         Pair(acc, [])
-      Pair(acc, NonEmptyList(h, tail)):
+      Pair(acc, [h, *tail]):
         Pair([Pair(item, h), *acc], tail)
 
   rev = as.foldLeft(Pair([], bs), cons)
@@ -261,9 +261,9 @@ struct Pair(fst, sec)
 def zip(as: List[a], bs: List[b]) -> List[Pair[a, b]]:
   def cons(pair: Pair[List[Pair[a, b]], List[b]], item: a) -> Pair[List[Pair[a, b]], List[b]]:
     match pair:
-      Pair(acc, EmptyList):
+      Pair(acc, []):
         Pair(acc, [])
-      Pair(acc, NonEmptyList(h, tail)):
+      Pair(acc, [h, *tail]):
         Pair([Pair(item, h), *acc], tail)
 
   rev = as.foldLeft(Pair([], bs), cons)
@@ -274,6 +274,20 @@ def zip(as: List[a], bs: List[b]) -> List[Pair[a, b]]:
 main = 1
 """), "Foo", VInt(1))
 
+  }
+
+  test("test some list matches") {
+    evalTest(
+      List("""
+package Foo
+
+def headOption(as):
+  match as:
+    []: None
+    [a, *_]: Some(a)
+
+main = headOption([1])
+"""), "Foo", SumValue(1, ConsValue(VInt(1), UnitValue)))
   }
 
   test("test generics in defs") {

--- a/core/src/test/scala/org/bykn/bosatsu/ParserTest.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/ParserTest.scala
@@ -429,6 +429,12 @@ else:
   Bar(_, _):
       if True: 0
       else: 10""")
+
+    roundTrip(Declaration.parser(""),
+"""match x:
+  []: 0
+  [x]: 1
+  _: 2""")
   }
 
   test("we can parse declaration lists") {

--- a/test_workspace/euler2.bosatsu
+++ b/test_workspace/euler2.bosatsu
@@ -17,9 +17,9 @@ package Euler/Two
 def fib(n):
   range(n).foldLeft([], \revFib, item ->
     match revFib:
-      EmptyList: [1]
-      NonEmptyList(h, EmptyList): [2, h]
-      NonEmptyList(h1, NonEmptyList(h2, _)): [h1.add(h2), *revFib])
+      []: [1]
+      [h]: [2, h]
+      [h1, h2, *_]: [h1.add(h2), *revFib])
 
 def filter(as, fn):
   as.foldLeft([], \tail, item ->


### PR DESCRIPTION
This allows a syntax similar to python:
```
match foo:
  []: "empty"
  [head]: "1 item"
  [head, *middle, last]: "2 or more"
```

Unlike python, I currently allow multiple `*a` patterns, and I allow `*_` when you don't care to bind a set of items.

The matching algorithm goes like this:
1. if the first item in the pattern is not prefixed with `*`, match the head item according to normal pattern matching
2. if the first item in the pattern is a splice `*`, then take the tail of the pattern which has size N, then match it against at most N items from the list, this match is done in reverse order. If that matches, then we take the prefix that is unmatched and bind it to the splice.

closes #94