### PR TITLE
Ban Recursive Structs

### DIFF
--- a/core/src/main/resources/bosatsu/predef.bosatsu
+++ b/core/src/main/resources/bosatsu/predef.bosatsu
@@ -1,16 +1,20 @@
 package Bosatsu/Predef
 
 export [
+  Assertion(),
   Bool(),
   Comparison(),
   Int,
   Option(),
-  List(),
+  List,
   String,
   Test(),
+  TestSuite(),
   add,
   cmp_Int,
   concat,
+  consList,
+  emptyList,
   eq_Int,
   foldLeft,
   mod_Int,
@@ -26,23 +30,24 @@ enum Bool:
   False
   True
 
-enum List:
-  EmptyList
-  NonEmptyList(head: a, tail: List[a])
+external struct List[a]
+
+external def emptyList -> List[a]
+external def consList(head: a, tail: List[a]) -> List[a]
 
 external def foldLeft(lst: List[a], item: b, fn: b -> a -> b) -> b
 
 external def range(exclusiveUpper: Int) -> List[Int]
 
 def reverse_concat(front: List[a], back: List[a]) -> List[a]:
-  foldLeft(front, back, \tail, h -> NonEmptyList(h, tail))
+  foldLeft(front, back, \tail, h -> consList(h, tail))
 
 def reverse(as: List[a]) -> List[a]:
-  reverse_concat(as, EmptyList)
+  reverse_concat(as, emptyList)
 
 def concat(front: List[a], back: List[a]) -> List[a]:
   match back:
-    EmptyList: front
+    []: front
     _: reverse_concat(reverse(front), back)
 
 enum Comparison:
@@ -65,9 +70,8 @@ external def mod_Int(a: Int, mod: Int) -> Int
 
 external struct String
 
-enum Test:
-  TestAssert(value: Bool)
-  TestLabel(label: String, test: Test)
-  TestList(tests: List[Test])
+struct Assertion(value: Bool, message: String)
+struct Test(name: String, assertions: List[Assertion])
+struct TestSuite(name: String, tests: List[Test])
 
 external def trace(prefix: String, item: a) -> a

--- a/core/src/main/scala/org/bykn/bosatsu/Declaration.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/Declaration.scala
@@ -168,9 +168,9 @@ sealed abstract class Declaration {
               // TODO we need to refer to Predef/EmptyList no matter what here
               // but we have no way to fully refer to an item
               val pn = Option(Predef.packageName)
-              val empty: Expr[Declaration] = Expr.Var(pn, "EmptyList", l)
+              val empty: Expr[Declaration] = Expr.Var(pn, "emptyList", l)
               def cons(head: Expr[Declaration], tail: Expr[Declaration]): Expr[Declaration] =
-                Expr.App(Expr.App(Expr.Var(pn, "NonEmptyList", l), head, l), tail, l)
+                Expr.App(Expr.App(Expr.Var(pn, "consList", l), head, l), tail, l)
 
               def concat(headList: Expr[Declaration], tail: Expr[Declaration]): Expr[Declaration] =
                 Expr.App(Expr.App(Expr.Var(pn, "concat", l), headList, l), tail, l)

--- a/core/src/main/scala/org/bykn/bosatsu/Externals.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/Externals.scala
@@ -37,8 +37,8 @@ sealed abstract class FfiCall {
         tpe match {
           case rankn.Type.ForAll(_, t) => invoke(t, args)
           case rankn.Type.Fun(a, tail) =>
-            Value.FnValue { x =>
-              Eval.always(invoke(tail, x :: args))
+            Value.FnValue { ex =>
+              ex.map { x => invoke(tail, x :: args) }
             }
           case _ =>
             m.invoke(inst, args.reverse.toArray: _*).asInstanceOf[Value]

--- a/core/src/main/scala/org/bykn/bosatsu/Predef.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/Predef.scala
@@ -17,7 +17,7 @@ object Predef {
         scala.io.Source.fromFile("target/scala-2.12/classes/bosatsu/predef.bosatsu").mkString
       }
 
-  val predefPackage: Package.Parsed =
+  lazy val predefPackage: Package.Parsed =
     Package.parser.parse(predefString) match {
       case Parsed.Success(pack, _) => pack
       case Parsed.Failure(exp, idx, extra) =>
@@ -31,26 +31,25 @@ object Predef {
   val predefImports: Import[PackageName, Unit] =
     Import(packageName,
       NonEmptyList.of(
+        "Assertion",
         "Bool",
         "Comparison",
         "LT",
         "EQ",
         "GT",
-        "EmptyList",
         "False",
         "Int",
         "List",
-        "NonEmptyList",
         "None",
         "Option",
         "Some",
         "String",
         "True",
         "Test",
-        "TestAssert",
-        "TestLabel",
-        "TestList",
+        "TestSuite",
         "add",
+        "consList",
+        "emptyList",
         "eq_Int",
         "concat",
         "cmp_Int",
@@ -68,15 +67,17 @@ object Predef {
   val jvmExternals: Externals =
     Externals
       .empty
-      .add(predefPackage.name, "add", FfiCall.ScalaCall("org.bykn.bosatsu.PredefImpl.add"))
-      .add(predefPackage.name, "sub", FfiCall.ScalaCall("org.bykn.bosatsu.PredefImpl.sub"))
-      .add(predefPackage.name, "times", FfiCall.ScalaCall("org.bykn.bosatsu.PredefImpl.times"))
-      .add(predefPackage.name, "eq_Int", FfiCall.ScalaCall("org.bykn.bosatsu.PredefImpl.eq_Int"))
-      .add(predefPackage.name, "cmp_Int", FfiCall.ScalaCall("org.bykn.bosatsu.PredefImpl.cmp_Int"))
-      .add(predefPackage.name, "foldLeft", FfiCall.ScalaCall("org.bykn.bosatsu.PredefImpl.foldLeft"))
-      .add(predefPackage.name, "mod_Int", FfiCall.ScalaCall("org.bykn.bosatsu.PredefImpl.mod_Int"))
-      .add(predefPackage.name, "range", FfiCall.ScalaCall("org.bykn.bosatsu.PredefImpl.range"))
-      .add(predefPackage.name, "trace", FfiCall.ScalaCall("org.bykn.bosatsu.PredefImpl.trace"))
+      .add(packageName, "add", FfiCall.ScalaCall("org.bykn.bosatsu.PredefImpl.add"))
+      .add(packageName, "sub", FfiCall.ScalaCall("org.bykn.bosatsu.PredefImpl.sub"))
+      .add(packageName, "times", FfiCall.ScalaCall("org.bykn.bosatsu.PredefImpl.times"))
+      .add(packageName, "eq_Int", FfiCall.ScalaCall("org.bykn.bosatsu.PredefImpl.eq_Int"))
+      .add(packageName, "emptyList", FfiCall.ScalaCall("org.bykn.bosatsu.PredefImpl.emptyList"))
+      .add(packageName, "consList", FfiCall.ScalaCall("org.bykn.bosatsu.PredefImpl.consList"))
+      .add(packageName, "cmp_Int", FfiCall.ScalaCall("org.bykn.bosatsu.PredefImpl.cmp_Int"))
+      .add(packageName, "foldLeft", FfiCall.ScalaCall("org.bykn.bosatsu.PredefImpl.foldLeft"))
+      .add(packageName, "mod_Int", FfiCall.ScalaCall("org.bykn.bosatsu.PredefImpl.mod_Int"))
+      .add(packageName, "range", FfiCall.ScalaCall("org.bykn.bosatsu.PredefImpl.range"))
+      .add(packageName, "trace", FfiCall.ScalaCall("org.bykn.bosatsu.PredefImpl.trace"))
 
   def withPredef(ps: List[Package.Parsed]): List[Package.Parsed] =
     predefPackage :: ps.map(_.withImport(predefImports))
@@ -126,6 +127,10 @@ object PredefImpl {
 
     loop(list, bv)
   }
+
+  def emptyList: Value = VList.VNil
+  def consList(head: Value, tail: Value): Value =
+    VList.Cons(head, tail)
 
   def range(v: Value): Value = {
     val max = i(v)

--- a/core/src/main/scala/org/bykn/bosatsu/rankn/Infer.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/rankn/Infer.scala
@@ -125,7 +125,7 @@ object Infer {
 
     // This could be a user error if we don't check scoping before typing
     case class VarNotInScope(varName: Name, vars: Map[Name, Type]) extends NameError {
-      def message = s"$varName not in scope: $vars"
+      def message = s"$varName not in scope: ${vars.keys.toList.sorted}"
     }
 
     // This could be a user error if we don't check scoping before typing

--- a/core/src/main/scala/org/bykn/bosatsu/rankn/Type.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/rankn/Type.scala
@@ -21,6 +21,15 @@ object Type {
   case class TyMeta(toMeta: Meta) extends Type
   case class TyApply(on: Type, arg: Type) extends Type
 
+
+  def constantsOf(t: Type): List[Const] =
+    t match {
+      case ForAll(_, t) => constantsOf(t)
+      case TyApply(on, arg) => constantsOf(on) ::: constantsOf(arg)
+      case TyConst(c) => c :: Nil
+      case TyVar(_) | TyMeta(_) => Nil
+    }
+
   @annotation.tailrec
   final def forAll(vars: List[Var.Bound], in: Type): Type =
     vars match {

--- a/core/src/test/scala/org/bykn/bosatsu/PackageTest.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/PackageTest.scala
@@ -85,7 +85,7 @@ enum Option:
 
 enum List:
   Empty
-  NonEmpty(head: a, tail: List[a])
+  NonEmpty(head, tail)
 
 def head(list):
   match list:
@@ -129,6 +129,8 @@ main = head(data1)
   }
 
   test("test Predef working") {
+
+    assert(Predef.predefPackage != null)
 
     val p = parse(
 """

--- a/core/src/test/scala/org/bykn/bosatsu/rankn/RankNInferTest.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/rankn/RankNInferTest.scala
@@ -95,7 +95,7 @@ class RankNInferTest extends FunSuite {
     Statement.parser.parse(statement) match {
       case Parsed.Success(stmt, _) =>
         Package.inferBody(PackageName.parts("Test"), Nil, stmt) match {
-          case Left(err) => fail(err.message)
+          case Left(err) => fail(err.message(Map.empty))
           case Right((tpeEnv, lets)) =>
             val parsedType = typeFrom(tpe)
             assert(lets.last._2.getType == parsedType)
@@ -384,7 +384,7 @@ main = match x:
    parseProgram("""#
 enum List:
   Empty
-  NonEmpty(a: a, tail: List[a])
+  NonEmpty(a: a, tail: b)
 
 x = NonEmpty(1, Empty)
 main = match x:

--- a/test_workspace/bo_test.bosatsu
+++ b/test_workspace/bo_test.bosatsu
@@ -1,3 +1,3 @@
 package Bo/Test
 
-test = TestAssert(True)
+test = Assertion(True, "trivial")

--- a/test_workspace/euler1.bosatsu
+++ b/test_workspace/euler1.bosatsu
@@ -24,4 +24,4 @@ def sum(as):
 # 233168
 computed = trace("computed", under1000.filter(keep).sum)
 
-test = TestAssert(computed.eq_Int(233168))
+test = Assertion(computed.eq_Int(233168), "expected 233168")

--- a/test_workspace/euler2.bosatsu
+++ b/test_workspace/euler2.bosatsu
@@ -39,4 +39,4 @@ def sum(as):
 # 4613732
 computed = fib(35).filter(keep).sum
 
-test = TestAssert(computed.eq_Int(4613732))
+test = Assertion(computed.eq_Int(4613732), "expected 4613732")

--- a/test_workspace/test.bosatsu
+++ b/test_workspace/test.bosatsu
@@ -22,10 +22,8 @@ enum Either:
 
 def is_empty(list):
   match list:
-    EmptyList:
-      True
-    NonEmptyList(_, _):
-      False
+    []: True
+    [_, *_]: False
 
 struct Monoid(empty: a, combine: a -> a -> a)
 
@@ -45,23 +43,18 @@ external def runAction(a: Action[a]) -> a
 
 def reduce(list, fn):
   match list:
-    EmptyList:
-        None
-    NonEmptyList(head, tail):
-        Some(tail.fold(head, fn))
+    []: None
+    [head, *tail]: Some(tail.fold(head, fn))
 
 def flip(fn):
   \a, b -> fn(b, a)
 
-def reverse(list):
-  fold(list, EmptyList, flip(NonEmptyList))
-
 def map(list, fn):
-  fold(list, EmptyList, \tail, item -> NonEmptyList(fn(item), tail)).reverse
+  fold(list, [], \tail, item -> [fn(item), *tail]).reverse
 
 def filter(list, fn):
-  rev_filter = fold(list, EmptyList, \tail, item -> if fn(item):
-    NonEmptyList(item, tail)
+  rev_filter = fold(list, [], \tail, item -> if fn(item):
+    [item, *tail]
   else:
     tail)
 
@@ -74,10 +67,8 @@ struct Unit
 
 e = Some(1)
 sz = match e:
-   Some(x):
-     z(x)
-   None:
-     0
+   Some(x): z(x)
+   None: 0
 
 def plus(a, b):
   add(a, b)
@@ -86,17 +77,16 @@ three = 1.plus(2)
 
 external def hc(i: Int) -> Int
 
-foo = NonEmptyList(1, NonEmptyList(2, EmptyList))
+foo = [1, 2]
 
 act = print("42").flatMap(\u -> toAction(43))
 resA = runAction(act)
 
 main = match foo:
-  EmptyList:
-    0
-  NonEmptyList(x, tail):
-    hc(resA).add(foo.map(\x -> 10.times(x)).sum)
+  []: 0
+  [x, *tail]:
+    hc(resA).add(foo.map(10.times).sum)
 
-struct File(file: String, executable: Bool, size: Int, children: List[File])
+struct File(file: String, executable: Bool, size: Int)
 
-last = File("foo", False, 100, EmptyList)
+last = File("foo", False, 100)


### PR DESCRIPTION
@avibryant asked, and then I subsequently noticed that since we were allowing recursive (though not infinite) data types, that is enough to be able to put a type on a fixed point combinator, which allows it to be expressed and breaks totality.

Original comment here:
https://github.com/johnynek/bosatsu/pull/100#discussion_r228962619

The fix here is to add a check that types form a DAG. This makes it impossible to define the list type in bosatsu, but that isn't too much of a loss (since we add it with an external type). This also requires changing the built in testing framework from a tree to an optionally 3 level construct.

This is much more limited than before, but I think we have regained totality.