### PR TITLE
Support destructuring assignment in Declaration

### DIFF
--- a/core/src/main/scala/org/bykn/bosatsu/Program.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/Program.scala
@@ -32,7 +32,7 @@ case class Program[D, S](types: rankn.TypeEnv, lets: List[(String, D)], from: S)
 
     val fn = { (nm: String, v: Declaration, in: Declaration) =>
       val r = v.region + in.region
-      Declaration.Binding(BindingStatement(nm, v, Padding(0, in)))(r)
+      Declaration.Binding(BindingStatement(Pattern.Var(nm), v, Padding(0, in)))(r)
     }
 
     getMain[Declaration](fn)

--- a/core/src/main/scala/org/bykn/bosatsu/Statement.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/Statement.scala
@@ -64,15 +64,15 @@ object DefStatement {
       P(lowerIdent ~ (":" ~/ maybeSpace ~ TypeRef.parser).?)
 }
 
-case class BindingStatement[T](name: String, value: Declaration, in: T)
+case class BindingStatement[B, T](name: B, value: Declaration, in: T)
 
 object BindingStatement {
   private[this] val eqDoc = Doc.text(" = ")
 
-  implicit def document[T: Document]: Document[BindingStatement[T]] =
-    Document.instance[BindingStatement[T]] { let =>
+  implicit def document[A: Document, T: Document]: Document[BindingStatement[A, T]] =
+    Document.instance[BindingStatement[A, T]] { let =>
       import let._
-      Doc.text(name) + eqDoc + value.toDoc + Document[T].document(in)
+      Document[A].document(name) + eqDoc + value.toDoc + Document[T].document(in)
     }
 }
 
@@ -270,7 +270,7 @@ object Statement {
       case tds: TypeDefinitionStatement => tds
     }
 
-  case class Bind(bind: BindingStatement[Padding[Statement]]) extends Statement
+  case class Bind(bind: BindingStatement[String, Padding[Statement]]) extends Statement
   case class Comment(comment: CommentStatement[Padding[Statement]]) extends Statement
   case class Def(defstatement: DefStatement[(OptIndent[Declaration], Padding[Statement])]) extends Statement
   case class Struct(name: String, args: List[(String, Option[TypeRef])], rest: Padding[Statement]) extends TypeDefinitionStatement
@@ -353,7 +353,7 @@ object Statement {
   implicit lazy val document: Document[Statement] =
     Document.instance[Statement] {
       case Bind(bs) =>
-        Document[BindingStatement[Padding[Statement]]].document(bs)
+        Document[BindingStatement[String, Padding[Statement]]].document(bs)
       case Comment(cm) =>
         Document[CommentStatement[Padding[Statement]]].document(cm)
       case Def(d) =>

--- a/core/src/test/scala/org/bykn/bosatsu/ParserTest.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/ParserTest.scala
@@ -261,7 +261,7 @@ foo""")
       """foo = 5
 
 5""",
-    Declaration.Binding(BindingStatement("foo", Declaration.Literal(Lit.fromInt(5)),
+    Declaration.Binding(BindingStatement(Pattern.Var("foo"), Declaration.Literal(Lit.fromInt(5)),
       Padding(1, Declaration.Literal(Lit.fromInt(5))))))
   }
 
@@ -309,19 +309,19 @@ foo""")
     parseTestAll(parser(""),
       """x = 4
 x""",
-    Binding(BindingStatement("x", Literal(Lit.fromInt(4)), Padding(0, Var("x")))))
+    Binding(BindingStatement(Pattern.Var("x"), Literal(Lit.fromInt(4)), Padding(0, Var("x")))))
 
     parseTestAll(parser(""),
       """x = foo(4)
 
 x""",
-    Binding(BindingStatement("x", Apply(Var("foo"), NonEmptyList.of(Literal(Lit.fromInt(4))), false), Padding(1, Var("x")))))
+    Binding(BindingStatement(Pattern.Var("x"), Apply(Var("foo"), NonEmptyList.of(Literal(Lit.fromInt(4))), false), Padding(1, Var("x")))))
 
     parseTestAll(parser(""),
       """x = foo(4)
 # x is really great
 x""",
-    Binding(BindingStatement("x",Apply(Var("foo"),NonEmptyList.of(Literal(Lit.fromInt(4))), false),Padding(0,Comment(CommentStatement(NonEmptyList.of(" x is really great"),Padding(0,Var("x"))))))))
+    Binding(BindingStatement(Pattern.Var("x"),Apply(Var("foo"),NonEmptyList.of(Literal(Lit.fromInt(4))), false),Padding(0,Comment(CommentStatement(NonEmptyList.of(" x is really great"),Padding(0,Var("x"))))))))
 
   }
 


### PR DESCRIPTION
Still left to do:

1. generate patterns for parsing testing
2. support reading a pattern in the parser

part of #19 

Since we already have #107 this should just work once we support it in the parser.

