### PR TITLE
Fix flakey string tests

### DIFF
--- a/core/src/main/scala/org/bykn/bosatsu/Lit.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/Lit.scala
@@ -40,7 +40,7 @@ object Lit {
         Doc.text(i.toString)
       case Str(str) =>
         val q = if (str.contains('\'') && !str.contains('"')) '"' else '\''
-        Doc.char(q) + Doc.text(Parser.escape(Set(q), str)) + Doc.char(q)
+        Doc.char(q) + Doc.text(Parser.escape(q, str)) + Doc.char(q)
     }
 }
 

--- a/core/src/main/scala/org/bykn/bosatsu/Parser.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/Parser.scala
@@ -243,12 +243,15 @@ object Parser {
     val sb = new java.lang.StringBuilder
     def decodeNum(idx: Int, size: Int, base: Int): Int = {
       val end = idx + size
-      sb.append(Integer.parseInt(str.substring(idx, end), base).toChar)
-      end
+      if (end <= str.length) {
+        sb.append(Integer.parseInt(str.substring(idx, end), base).toChar)
+        end
+      } else ~(str.length)
     }
     @annotation.tailrec
     def loop(idx: Int): Option[Int] =
       if (idx >= str.length) None
+      else if (idx < 0) Some(~idx) // error from decodeNum
       else {
         val c0 = str.charAt(idx)
         if (c0 != '\\') {

--- a/core/src/main/scala/org/bykn/bosatsu/Parser.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/Parser.scala
@@ -177,21 +177,105 @@ object Parser {
       }
   }
 
-  def escapedString(q: Char): P[String] = {
-    val qstr = q.toString
-    val char = P((!qstr ~ AnyChar) | ("\\" ~ AnyChar)).!
-    P(qstr ~ char.rep() ~ qstr).map(_.mkString)
+
+  private val decodeTable: Map[Char, Char] =
+    Map(
+      ('\\', '\\'),
+      ('\'', '\''),
+      ('\"', '\"'),
+      ('a', 7.toChar), // bell
+      ('b', 8.toChar), // backspace
+      ('f', 12.toChar), // form-feed
+      ('n', '\n'),
+      ('r', '\r'),
+      ('t', '\t'),
+      ('v', 11.toChar)) // vertical tab
+
+  private val encodeTable = decodeTable.iterator.map { case (v, k) => (k, s"\\$v") }.toMap
+
+  private val nonPrintEscape: Array[String] =
+    (0 until 32).map { c =>
+      val strHex = c.toHexString
+      val strPad = List.fill(4 - strHex.length)('0').mkString
+      s"\\u$strPad$strHex"
+    }.toArray
+
+  private val escapeString: P[Unit] = {
+    val escapes = CharIn(decodeTable.keys.toSeq)
+    val oct = CharIn('0' until '8')
+    val hex = CharIn(('0' to '9') ++ ('a' to 'f') ++ ('A' to 'F'))
+    val octP = P("o" ~ oct ~ oct)
+    val hexP = P("x" ~ hex ~ hex)
+    val u4 = P("u" ~ hex.rep(4))
+    val u8 = P("U" ~ hex.rep(8))
+    val after = escapes | octP | hexP | u4 | u8
+    P("\\" ~ after)
   }
 
-  def escape(chars: Set[Char], str: String): String = {
-    val escaped = chars + '\\'
-    if (str.exists(escaped)) {
-      str.flatMap {
-        case c if chars(c) => s"\\$c"
-        case c => c.toString
+  def escapedString(q: Char): P[String] = {
+    val qstr = q.toString
+    val char = P(escapeString | (!qstr ~ AnyChar)).!
+    P(qstr ~ char.rep() ~ qstr).map(_.mkString)
+      .flatMap { str =>
+        unescape(str) match {
+          case Right(str1) => PassWith(str1)
+          case Left(_) => Fail
+        }
+      }
+  }
+
+  def escape(quoteChar: Char, str: String): String = {
+    // We can ignore escaping the opposite character used for the string
+    // x isn't escaped anyway and is kind of a hack here
+    val ignoreEscape = if (quoteChar == '\'') '"' else if (quoteChar == '"') '\'' else 'x'
+    str.flatMap { c =>
+      if (c == ignoreEscape) c.toString
+      else if (c < ' ') nonPrintEscape(c.toInt)
+      else encodeTable.get(c) match {
+        case None => c.toString
+        case Some(esc) => esc
       }
     }
-    else str
+  }
+
+  def unescape(str: String): Either[Int, String] = {
+    val sb = new java.lang.StringBuilder
+    def decodeNum(idx: Int, size: Int, base: Int): Int = {
+      val end = idx + size
+      sb.append(Integer.parseInt(str.substring(idx, end), base).toChar)
+      end
+    }
+    @annotation.tailrec
+    def loop(idx: Int): Option[Int] =
+      if (idx >= str.length) None
+      else {
+        val c0 = str.charAt(idx)
+        if (c0 != '\\') {
+          sb.append(c0)
+          loop(idx + 1)
+        }
+        else {
+          val c = str.charAt(idx + 1)
+          decodeTable.get(c) match {
+            case Some(d) =>
+              sb.append(d)
+              loop(idx + 2)
+            case None =>
+              c match {
+                case 'o' => loop(decodeNum(idx + 2, 2, 8))
+                case 'x' => loop(decodeNum(idx + 2, 2, 16))
+                case 'u' => loop(decodeNum(idx + 2, 4, 16))
+                case 'U' => loop(decodeNum(idx + 2, 8, 16))
+                case _ => Some(idx)
+              }
+          }
+        }
+      }
+
+    loop(0) match {
+      case None => Right(sb.toString)
+      case Some(err) => Left(err)
+    }
   }
 
   def nonEmptyListToList[T](p: P[NonEmptyList[T]]): P[List[T]] =

--- a/core/src/main/scala/org/bykn/bosatsu/Parser.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/Parser.scala
@@ -244,7 +244,11 @@ object Parser {
     def decodeNum(idx: Int, size: Int, base: Int): Int = {
       val end = idx + size
       if (end <= str.length) {
-        sb.append(Integer.parseInt(str.substring(idx, end), base).toChar)
+        val intStr = str.substring(idx, end)
+        val asInt =
+          try Integer.parseInt(intStr, base)
+          catch { case _: NumberFormatException => ~idx }
+        sb.append(asInt.toChar)
         end
       } else ~(str.length)
     }

--- a/core/src/main/scala/org/bykn/bosatsu/Parser.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/Parser.scala
@@ -230,9 +230,10 @@ object Parser {
     val ignoreEscape = if (quoteChar == '\'') '"' else if (quoteChar == '"') '\'' else 'x'
     str.flatMap { c =>
       if (c == ignoreEscape) c.toString
-      else if (c < ' ') nonPrintEscape(c.toInt)
       else encodeTable.get(c) match {
-        case None => c.toString
+        case None =>
+          if (c < ' ') nonPrintEscape(c.toInt)
+          else c.toString
         case Some(esc) => esc
       }
     }

--- a/core/src/test/scala/org/bykn/bosatsu/ParserTest.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/ParserTest.scala
@@ -114,6 +114,14 @@ class ParserTest extends FunSuite {
     assert(Parser.unescape("\\u000").isLeft)
     assert(Parser.unescape("\\U0000").isLeft)
     forAll { s: String => Parser.unescape(s); succeed }
+    // more brutal tests
+    forAll { s: String =>
+      val prefixes = List('x', 'o', 'u', 'U').map { c => s"\\$c" }
+      prefixes.foreach { p =>
+        Parser.unescape(s"$p$s")
+        succeed
+      }
+    }
 
     assert(Parser.unescape("\\u0020") == Right(" "))
   }

--- a/core/src/test/scala/org/bykn/bosatsu/ParserTest.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/ParserTest.scala
@@ -105,6 +105,17 @@ class ParserTest extends FunSuite {
 
     assert(Parser.escape('"', "\t") == "\\t")
     assert(Parser.escape('"', "\n") == "\\n")
+
+    // unescape never throws:
+    assert(Parser.unescape("\\x0").isLeft)
+    assert(Parser.unescape("\\o0").isLeft)
+    assert(Parser.unescape("\\u0").isLeft)
+    assert(Parser.unescape("\\u00").isLeft)
+    assert(Parser.unescape("\\u000").isLeft)
+    assert(Parser.unescape("\\U0000").isLeft)
+    forAll { s: String => Parser.unescape(s); succeed }
+
+    assert(Parser.unescape("\\u0020") == Right(" "))
   }
 
   test("we can parse quoted strings") {

--- a/core/src/test/scala/org/bykn/bosatsu/ParserTest.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/ParserTest.scala
@@ -102,6 +102,9 @@ class ParserTest extends FunSuite {
         case t: Throwable => fail(s"failed to decode: $str1 from $str, exception: $t")
       }
     }
+
+    assert(Parser.escape('"', "\t") == "\\t")
+    assert(Parser.escape('"', "\n") == "\\n")
   }
 
   test("we can parse quoted strings") {


### PR DESCRIPTION
close #35 for real.

Two issues:
1.  bug was a scalacheck misuse around bad shrinking.
2. actual bugs in some escaped strings.

I fixed both issues and ran 500k tests and it passed. The escaping/unescaping can probably be optimized. This copies most of pythons escaping syntax:
copied from here:
https://docs.python.org/3/reference/lexical_analysis.html

The `\N{unicode name}` is not supported (yet) since it seems we need a database for that.