### PR TITLE
Parse pattern match assignment

### DIFF
--- a/core/src/main/scala/org/bykn/bosatsu/ListLang.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/ListLang.scala
@@ -38,7 +38,7 @@ object ListLang {
       .map { tail => { a: SpliceOrItem[A] => Cons(a :: tail.toList) } }
       .opaque("ConsListTail")
 
-    val filterExpr = P("if" ~ spacesAndLines ~/ pa).?
+    val filterExpr = P("if" ~ spacesAndLines ~ pa).?
     val comp = P(
       "for" ~ spacesAndLines ~ pa ~ spacesAndLines ~
       "in" ~ spacesAndLines ~ pa ~ maybeSpacesAndLines ~

--- a/core/src/main/scala/org/bykn/bosatsu/Parser.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/Parser.scala
@@ -55,7 +55,7 @@ object Parser {
       blockLike(first, next, ":")
 
     def blockLike[A, B](first: Indy[A], next: Indy[B], sep: String): Indy[(A, OptIndent[B])] =
-      (first <* lift(P(sep ~/ maybeSpace)))
+      (first <* lift(P(sep ~ maybeSpace)))
         .product(OptIndent.indy(next))
 
     implicit class IndyMethods[A](val toKleisli: Indy[A]) extends AnyVal {
@@ -319,13 +319,13 @@ object Parser {
 
     def nonEmptyListSyntax: P[NonEmptyList[T]] = {
       val ws = maybeSpacesAndLines
-      nonEmptyListOfWs(ws, 1).bracketed(P("[" ~/ ws), P(ws ~ "]"))
+      nonEmptyListOfWs(ws, 1).bracketed(P("[" ~ ws), P(ws ~ "]"))
     }
 
     def listSyntax: P[List[T]] = {
       val ws = maybeSpacesAndLines
       nonEmptyListToList(nonEmptyListOfWs(ws, 1))
-        .bracketed(P("[" ~/ ws), P(ws ~ "]"))
+        .bracketed(P("[" ~ ws), P(ws ~ "]"))
     }
 
     def region: P[(Region, T)] =
@@ -338,9 +338,6 @@ object Parser {
 
     def parens: P[T] =
       wrappedSpace("(", ")")
-
-    def parensCut: P[T] =
-      P("(" ~/ maybeSpace ~ item ~ maybeSpace ~ ")")
   }
 
   val toEOL: P[Unit] = P(maybeSpace ~ "\n")

--- a/core/src/main/scala/org/bykn/bosatsu/Pattern.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/Pattern.scala
@@ -118,7 +118,7 @@ object Pattern {
       val plit = Lit.parser.map(Literal(_))
       val pparen = recurse.parens
 
-      val positional = P(upperIdent ~/ (recurse.listN(1).parens).?)
+      val positional = P(upperIdent ~ (recurse.listN(1).parens).?)
         .map {
           case (n, None) => PositionalStruct(n, Nil)
           case (n, Some(ls)) => PositionalStruct(n, ls)
@@ -134,7 +134,7 @@ object Pattern {
       val listP = listItem.listSyntax.map(ListPat(_))
 
       val nonAnnotated = pvar | plit | pwild | pparen | positional | listP
-      val typeAnnot = P(maybeSpace ~ ":" ~/ maybeSpace ~ TypeRef.parser)
+      val typeAnnot = P(maybeSpace ~ ":" ~ maybeSpace ~ TypeRef.parser)
       val withType = (nonAnnotated ~ typeAnnot.?).map {
         case (p, None) => p
         case (p, Some(t)) => Annotation(p, t)

--- a/core/src/test/scala/org/bykn/bosatsu/EvaluationTest.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/EvaluationTest.scala
@@ -28,7 +28,7 @@ class EvaluationTest extends FunSuite {
         errs.toList.foreach { p =>
           p.showContext.foreach(System.err.println)
         }
-        sys.error(errs.toString)
+        sys.error("failed to parse") //errs.toString)
     }
 
     PackageMap.resolveThenInfer(Predef.withPredefA(("predef", LocationMap("")), parsedPaths)) match {
@@ -244,19 +244,16 @@ def zip(as: List[a], bs: List[b]) -> List[Pair[a, b]]:
       Pair(acc, [h, *tail]):
         Pair([Pair(item, h), *acc], tail)
 
-  rev = as.foldLeft(Pair([], bs), cons)
-  match rev:
-    Pair(res, _):
-      reverse(res)
+  Pair(res, _) = as.foldLeft(Pair([], bs), cons)
+  reverse(res)
 
 def and(a, b):
   b if a else False
 
 def same_items(items, eq):
   def test(p):
-    match trace("in same items", p):
-      Pair(a, b):
-        eq(a, b)
+    Pair(a, b) = p
+    eq(a, b)
 
   items.foldLeft(True, \res, t -> and(res, test(t)))
 

--- a/core/src/test/scala/org/bykn/bosatsu/ParserTest.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/ParserTest.scala
@@ -43,6 +43,24 @@ class ParserTest extends FunSuite {
     PropertyCheckConfiguration(minSuccessful = 300)
     //PropertyCheckConfiguration(minSuccessful = 5)
 
+  def parseUnsafe[A](p: Parser[A], str: String): A =
+    p.parse(str) match {
+      case Parsed.Success(a, idx) =>
+        assert(idx == str.length)
+        a
+      case Parsed.Failure(exp, idx, extra) =>
+        fail(s"failed to parse: $str: $exp at $idx in region ${region(str, idx)} with trace: ${extra.traced.trace}")
+        sys.error("nope")
+    }
+  def parseOpt[A](p: Parser[A], str: String): Option[A] =
+    p.parse(str) match {
+      case Parsed.Success(a, idx) if idx == str.length =>
+        Some(a)
+      case _ =>
+        None
+    }
+
+
   def parseTest[T](p: Parser[T], str: String, expected: T, exidx: Int) =
     p.parse(str) match {
       case Parsed.Success(t, idx) =>
@@ -359,6 +377,46 @@ x""")
   test("we can parse patterns") {
     roundTrip(Pattern.parser, "Foo([])")
     roundTrip(Pattern.parser, "Foo([], bar)")
+  }
+
+  test("Declaration.toPattern works for all Pattern-like declarations") {
+    forAll(Generators.patternDecl(5)) { dec =>
+      Declaration.toPattern(dec) match {
+        case None => fail("expected to convert to pattern")
+        case Some(pat) =>
+          // if we convert to string this parses the same as a pattern:
+          val decStr = dec.toDoc.render(80)
+          val parsePat = parseUnsafe(Pattern.parser, decStr)
+          assert(pat == parsePat)
+      }
+    }
+
+    // for all Declarations, either it parses like a pattern or toPattern is None
+    forAll(Generators.genDeclaration(5)) { dec =>
+      val decStr = dec.toDoc.render(80)
+      val parsePat = parseOpt(Pattern.parser, decStr)
+      (Declaration.toPattern(dec), parsePat) match {
+        case (None, None) => succeed
+        case (Some(p0), Some(p1)) => assert(p0 == p1)
+        case (None, Some(_)) => fail(s"toPattern failed, but parsed $decStr to: $parsePat")
+        case (Some(p), None) => fail(s"toPattern succeeded: $p but pattern parse failed")
+      }
+    }
+
+
+    def testEqual(decl: String) = {
+      val dec = parseUnsafe(Declaration.parser(""), decl)
+      val patt = parseUnsafe(Pattern.parser, decl)
+      Declaration.toPattern(dec) match {
+        case Some(p2) => assert(p2 == patt)
+        case None => fail(s"could not convert $decl to pattern")
+      }
+    }
+
+    testEqual("a")
+    testEqual("Foo(a)")
+    testEqual("[1, Foo, a]")
+    testEqual("[*a, Foo([]), bar]")
   }
 
   test("we can parse bind") {


### PR DESCRIPTION
This is the parsing side to #112 which closes out #19 

Since we already have totality checking, this is perfectly safe since it is just a match statement internally, and we already needed to check match statements.

Testing the parser changes here made me see I was misusing cuts, which should probably very rarely appear in combinators since you don't know how they might be used. The cuts were making it impossible to do a simple parsing of patterns as binding targets (on the left of an equals) since the basic approach uses backtracking.

The performance is not stellar, but we do through insanely brutal randomly generated code at the parser.