### PR TITLE
Add Euler 3 using intLoop and rangeFold in Predef

### DIFF
--- a/core/src/main/resources/bosatsu/predef.bosatsu
+++ b/core/src/main/resources/bosatsu/predef.bosatsu
@@ -20,10 +20,10 @@ export [
   emptyList,
   eq_Int,
   foldLeft,
-  intLoop,
+  int_loop,
   mod_Int,
   range,
-  rangeFold,
+  range_fold,
   reverse,
   reverse_concat,
   sub,
@@ -78,11 +78,11 @@ external def mod_Int(a: Int, mod: Int) -> Int
 external def range(exclusiveUpper: Int) -> List[Int]
 
 # this loops until the returned Int is <= 0 or the returned Int is >= intValue
-external def intLoop(intValue: Int, state: a, fn: Int -> a -> Tuple2[Int, Tuple2[a, Unit]]) -> a
+external def int_loop(intValue: Int, state: a, fn: Int -> a -> Tuple2[Int, Tuple2[a, Unit]]) -> a
 
-def rangeFold(inclusiveLower: Int, exclusiveUpper: Int, init: a, fn: a -> Int -> a) -> a:
+def range_fold(inclusiveLower: Int, exclusiveUpper: Int, init: a, fn: a -> Int -> a) -> a:
   diff = exclusiveUpper.sub(inclusiveLower)
-  intLoop(diff, init, \diff0, a ->
+  int_loop(diff, init, \diff0, a ->
     idx = exclusiveUpper.sub(diff0)
     a1 = fn(a, idx)
     Tuple2(diff0.sub(1), Tuple2(a1, Unit)))

--- a/core/src/main/resources/bosatsu/predef.bosatsu
+++ b/core/src/main/resources/bosatsu/predef.bosatsu
@@ -16,6 +16,7 @@ export [
   cmp_Int,
   concat,
   consList,
+  div,
   emptyList,
   eq_Int,
   foldLeft,
@@ -69,6 +70,7 @@ external struct Int
 external def add(a: Int, b: Int) -> Int
 external def sub(a: Int, b: Int) -> Int
 external def times(a: Int, b: Int) -> Int
+external def div(a: Int, b: Int) -> Option[Int]
 external def eq_Int(a: Int, b: Int) -> Bool
 external def cmp_Int(a: Int, b: Int) -> Comparison
 external def mod_Int(a: Int, mod: Int) -> Int

--- a/core/src/main/resources/bosatsu/predef.bosatsu
+++ b/core/src/main/resources/bosatsu/predef.bosatsu
@@ -19,8 +19,10 @@ export [
   emptyList,
   eq_Int,
   foldLeft,
+  intLoop,
   mod_Int,
   range,
+  rangeFold,
   reverse,
   reverse_concat,
   sub,
@@ -41,8 +43,6 @@ external def emptyList -> List[a]
 external def consList(head: a, tail: List[a]) -> List[a]
 
 external def foldLeft(lst: List[a], item: b, fn: b -> a -> b) -> b
-
-external def range(exclusiveUpper: Int) -> List[Int]
 
 def reverse_concat(front: List[a], back: List[a]) -> List[a]:
   foldLeft(front, back, \tail, h -> consList(h, tail))
@@ -72,6 +72,18 @@ external def times(a: Int, b: Int) -> Int
 external def eq_Int(a: Int, b: Int) -> Bool
 external def cmp_Int(a: Int, b: Int) -> Comparison
 external def mod_Int(a: Int, mod: Int) -> Int
+
+external def range(exclusiveUpper: Int) -> List[Int]
+
+# this loops until the returned Int is <= 0 or the returned Int is >= intValue
+external def intLoop(intValue: Int, state: a, fn: Int -> a -> Tuple2[Int, Tuple2[a, Unit]]) -> a
+
+def rangeFold(inclusiveLower: Int, exclusiveUpper: Int, init: a, fn: a -> Int -> a) -> a:
+  diff = exclusiveUpper.sub(inclusiveLower)
+  intLoop(diff, init, \diff0, a ->
+    idx = exclusiveUpper.sub(diff0)
+    a1 = fn(a, idx)
+    Tuple2(diff0.sub(1), Tuple2(a1, Unit)))
 
 external struct String
 

--- a/core/src/main/scala/org/bykn/bosatsu/Evaluation.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/Evaluation.scala
@@ -96,6 +96,9 @@ object Evaluation {
     }
 
     object VOption {
+      val none: Value = SumValue(0, UnitValue)
+      def some(v: Value): Value = SumValue(1, ConsValue(v, UnitValue))
+
       def unapply(v: Value): Option[Option[Value]] =
         v match {
           case UnitValue =>
@@ -307,8 +310,9 @@ case class Evaluation(pm: PackageMap.Inferred, externals: Externals) {
           case Nil => None
           case (Pattern.WildCard, next):: tail =>
             Some((acc, next))
-          case (Pattern.Literal(lit), next) :: tail if arg == Value.fromLit(lit) =>
-            Some((acc, next))
+          case (Pattern.Literal(lit), next) :: tail =>
+            if (arg == Value.fromLit(lit)) Some((acc, next))
+            else bindEnv(arg, tail, acc)
           case (Pattern.Var(n), next) :: tail => Some((acc + (n -> Eval.now(arg)), next))
           case (Pattern.ListPat(items), next) :: tail =>
             // we need this to be lazy, thus the def

--- a/core/src/main/scala/org/bykn/bosatsu/Predef.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/Predef.scala
@@ -57,10 +57,10 @@ object Predef {
         "concat",
         "cmp_Int",
         "foldLeft",
-        "intLoop",
+        "int_loop",
         "mod_Int",
         "range",
-        "rangeFold",
+        "range_fold",
         "reverse",
         "reverse_concat",
         "sub",
@@ -83,7 +83,7 @@ object Predef {
       .add(packageName, "foldLeft", FfiCall.ScalaCall("org.bykn.bosatsu.PredefImpl.foldLeft"))
       .add(packageName, "mod_Int", FfiCall.ScalaCall("org.bykn.bosatsu.PredefImpl.mod_Int"))
       .add(packageName, "range", FfiCall.ScalaCall("org.bykn.bosatsu.PredefImpl.range"))
-      .add(packageName, "intLoop", FfiCall.ScalaCall("org.bykn.bosatsu.PredefImpl.intLoop"))
+      .add(packageName, "int_loop", FfiCall.ScalaCall("org.bykn.bosatsu.PredefImpl.intLoop"))
       .add(packageName, "trace", FfiCall.ScalaCall("org.bykn.bosatsu.PredefImpl.trace"))
 
   def withPredef(ps: List[Package.Parsed]): List[Package.Parsed] =

--- a/core/src/main/scala/org/bykn/bosatsu/Predef.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/Predef.scala
@@ -51,6 +51,7 @@ object Predef {
         "Unit",
         "add",
         "consList",
+        "div",
         "emptyList",
         "eq_Int",
         "concat",
@@ -72,6 +73,7 @@ object Predef {
     Externals
       .empty
       .add(packageName, "add", FfiCall.ScalaCall("org.bykn.bosatsu.PredefImpl.add"))
+      .add(packageName, "div", FfiCall.ScalaCall("org.bykn.bosatsu.PredefImpl.div"))
       .add(packageName, "sub", FfiCall.ScalaCall("org.bykn.bosatsu.PredefImpl.sub"))
       .add(packageName, "times", FfiCall.ScalaCall("org.bykn.bosatsu.PredefImpl.times"))
       .add(packageName, "eq_Int", FfiCall.ScalaCall("org.bykn.bosatsu.PredefImpl.eq_Int"))
@@ -104,6 +106,12 @@ object PredefImpl {
 
   def add(a: Value, b: Value): Value =
     VInt(i(a).add(i(b)))
+
+  def div(a: Value, b: Value): Value = {
+    val bi = i(b)
+    if (bi.equals(BigInteger.ZERO)) VOption.none
+    else VOption.some(VInt(i(a).divide(bi)))
+  }
 
   def sub(a: Value, b: Value): Value =
     VInt(i(a).subtract(i(b)))

--- a/core/src/test/scala/org/bykn/bosatsu/EvaluationTest.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/EvaluationTest.scala
@@ -251,6 +251,17 @@ package Foo
 
 main = 6.mod_Int(4)
 """), "Foo", VInt(2))
+
+    evalTest(
+      List("""
+package Foo
+
+main = match 6.div(4):
+  Some(0): 42
+  Some(1): 100
+  Some(x): x
+  None: -1
+"""), "Foo", VInt(100))
   }
 
   test("use range") {

--- a/core/src/test/scala/org/bykn/bosatsu/EvaluationTest.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/EvaluationTest.scala
@@ -318,26 +318,26 @@ main = 1
 
   }
 
-  test("test rangeFold") {
+  test("test range_fold") {
 evalTest(
   List("""
 package Foo
 
-main = rangeFold(0, 10, 0, add)
+main = range_fold(0, 10, 0, add)
 """), "Foo", VInt(45))
 
 evalTest(
   List("""
 package Foo
 
-main = rangeFold(0, 10, 0, \x, y -> y)
+main = range_fold(0, 10, 0, \x, y -> y)
 """), "Foo", VInt(9))
 
 evalTest(
   List("""
 package Foo
 
-main = rangeFold(0, 10, 100, \x, y -> x)
+main = range_fold(0, 10, 100, \x, y -> x)
 """), "Foo", VInt(100))
   }
 

--- a/core/src/test/scala/org/bykn/bosatsu/EvaluationTest.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/EvaluationTest.scala
@@ -307,6 +307,29 @@ main = 1
 
   }
 
+  test("test rangeFold") {
+evalTest(
+  List("""
+package Foo
+
+main = rangeFold(0, 10, 0, add)
+"""), "Foo", VInt(45))
+
+evalTest(
+  List("""
+package Foo
+
+main = rangeFold(0, 10, 0, \x, y -> y)
+"""), "Foo", VInt(9))
+
+evalTest(
+  List("""
+package Foo
+
+main = rangeFold(0, 10, 100, \x, y -> x)
+"""), "Foo", VInt(100))
+  }
+
   test("test some list matches") {
     evalTest(
       List("""

--- a/test_workspace/BUILD
+++ b/test_workspace/BUILD
@@ -33,3 +33,8 @@ bosatsu_test(
     name = "euler2",
     srcs = ["euler2.bosatsu"],
     size = "small")
+
+bosatsu_test(
+    name = "euler3",
+    srcs = ["euler3.bosatsu"],
+    size = "small")

--- a/test_workspace/euler3.bosatsu
+++ b/test_workspace/euler3.bosatsu
@@ -11,13 +11,13 @@ def smallest_factor(n):
   match n:
     1: 1
     _:
-      intLoop(n, -1, \i, res ->
+      int_loop(n, -1, \i, res ->
         trial = n.sub(i).add(2)
         if n.mod_Int(trial).eq_Int(0): (0, trial)
         else: (i.sub(1), -1))
 
 def all_factors(n):
-  intLoop(n, [], \i, facs ->
+  int_loop(n, [], \i, facs ->
     next_factor = smallest_factor(i)
     next_facs = [next_factor, *facs]
     match i.div(next_factor):

--- a/test_workspace/euler3.bosatsu
+++ b/test_workspace/euler3.bosatsu
@@ -1,0 +1,34 @@
+package Euler/Three
+
+# see:
+# https://projecteuler.net/problem=3
+# What is the largest prime factor of the number 600851475143 ?
+
+#number = 13195
+number = 600851475143
+
+def smallest_factor(n):
+  match n:
+    1: 1
+    _:
+      intLoop(n, -1, \i, res ->
+        trial = n.sub(i).add(2)
+        if n.mod_Int(trial).eq_Int(0): (0, trial)
+        else: (i.sub(1), -1))
+
+def all_factors(n):
+  intLoop(n, [], \i, facs ->
+    next_factor = smallest_factor(i)
+    next_facs = [next_factor, *facs]
+    match i.div(next_factor):
+      None: (0, next_facs)
+      Some(1): (0, next_facs)
+      Some(smaller): (smaller, next_facs))
+
+def largest_factor(n):
+  match all_factors(n):
+    []: n
+    [h, *_]: h
+
+#test = Assertion(trace("factor:", largest_factor(number)).eq_Int(29), "trial")
+test = Assertion(trace("factor:", largest_factor(number)).eq_Int(6857), "trial")


### PR DESCRIPTION
This adds a general intLoop (total) function to aid in common looping cases, and uses it to implement rangeFold (which is basically the same as range followed by fold, but definitely never materializes the list in memory).

intLoop is a bit specialized, but surely terminates. Hopefully that will be universal for Int based recursions that we need to run.