### PR TITLE
Implement Union Patterns

### DIFF
--- a/core/src/main/scala/org/bykn/bosatsu/Evaluation.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/Evaluation.scala
@@ -360,6 +360,9 @@ case class Evaluation(pm: PackageMap.Inferred, externals: Externals) {
           case (Pattern.Annotation(p, _), next) :: tail =>
             // TODO we may need to use the type here
             bindEnv(arg, (p, next) :: tail, acc)
+          case (Pattern.Union(h, t), next) :: tail =>
+            // we can just loop expanding these out:
+            bindEnv(arg, (h, next) :: t.toList.map((_, next)) ::: tail, acc)
           case (Pattern.PositionalStruct(pc@(pack, ctor), items), next) :: tail =>
             /*
              * The type in question is not the outer dt, but the type associated

--- a/core/src/main/scala/org/bykn/bosatsu/ListOrdering.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/ListOrdering.scala
@@ -1,0 +1,21 @@
+package org.bykn.bosatsu
+
+object ListOrdering {
+
+  def onType[A](o: Ordering[A]): Ordering[List[A]] =
+    apply(o)
+
+  def apply[A: Ordering]: Ordering[List[A]] =
+    new Ordering[List[A]] {
+      val ordA = implicitly[Ordering[A]]
+      def compare(a: List[A], b: List[A]): Int =
+        (a, b) match {
+          case (Nil, Nil) => 0
+          case (h0 :: t0, h1 :: t1) =>
+            val c = ordA.compare(h0, h1)
+            if (c != 0) c else compare(t0, t1)
+          case (_ :: _, Nil) => 1
+          case (Nil, _ :: _) => -1
+        }
+    }
+}

--- a/core/src/main/scala/org/bykn/bosatsu/Lit.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/Lit.scala
@@ -32,6 +32,17 @@ object Lit {
     str(q1) | str(q2)
   }
 
+  implicit val litOrdering: Ordering[Lit] =
+    new Ordering[Lit] {
+      def compare(a: Lit, b: Lit): Int =
+        (a, b) match {
+          case (Integer(a), Integer(b)) => a.compareTo(b)
+          case (Integer(_), Str(_)) => -1
+          case (Str(_), Integer(_)) => 1
+          case (Str(a), Str(b)) => a.compareTo(b)
+        }
+    }
+
   val parser: P[Lit] = integerParser | stringParser
 
   implicit val document: Document[Lit] =

--- a/core/src/main/scala/org/bykn/bosatsu/PackageName.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/PackageName.scala
@@ -33,6 +33,9 @@ object PackageName {
   implicit val order: Order[PackageName] =
     Order[NonEmptyList[String]].contramap[PackageName](_.parts)
 
+  implicit val packageNameOrdering: Ordering[PackageName] =
+    order.toOrdering
+
   val predef: PackageName =
     PackageName(NonEmptyList.of("Bosatsu", "Predef"))
 }

--- a/core/src/test/scala/org/bykn/bosatsu/EvaluationTest.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/EvaluationTest.scala
@@ -149,6 +149,36 @@ z = match x:
 """), "Foo", VInt(11))
   }
 
+  test("test matching unions") {
+    evalTest(
+      List("""
+package Foo
+
+struct Pair(a, b)
+
+x = Pair(Pair(1, "1"), "2")
+
+main = match x:
+  Pair(_, "2" | "3"): "good"
+  _: "bad"
+"""), "Foo", Str("good"))
+
+    evalTest(
+      List("""
+package Foo
+
+enum Res: Err(a), Good(a)
+
+x = Err("good")
+
+def run(z):
+  Err(y) | Good(y) = z
+  y
+
+main = run(x)
+"""), "Foo", Str("good"))
+  }
+
   test("test matching literals") {
     evalTest(
       List("""

--- a/core/src/test/scala/org/bykn/bosatsu/Gen.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/Gen.scala
@@ -256,7 +256,15 @@ object Generators {
         }
         .map(Pattern.ListPat(_))
 
-      Gen.oneOf(genVar, genWild, genLitPat, genStruct, genList /*, genTyped */)
+      val genUnion = Gen.choose(2, 4)
+        .flatMap(Gen.listOfN(_, recurse))
+        .map {
+          case h0 :: h1 :: tail =>
+            Pattern.Union(h0, NonEmptyList(h1, tail))
+          case other => sys.error(s"unreachable due to size: $other")
+        }
+
+      Gen.oneOf(genVar, genWild, genLitPat, genStruct, genList, genUnion /*, genTyped */)
     }
   }
 

--- a/core/src/test/scala/org/bykn/bosatsu/OrderingLaws.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/OrderingLaws.scala
@@ -1,0 +1,35 @@
+package org.bykn.bosatsu
+
+import org.scalatest.Assertions._
+
+object OrderingLaws {
+  def law[A: Ordering](a: A, b: A, c: A): Unit = {
+    val ord = implicitly[Ordering[A]]
+
+    if (ord.lteq(a, b) && ord.lteq(b, c)) assert(ord.lteq(a, c), s"$a $b $c")
+    if (ord.gteq(a, b) && ord.gteq(b, c)) assert(ord.gteq(a, c), s"$a $b $c")
+    if (ord.lt(a, b) && ord.lt(b, c)) assert(ord.lt(a, c), s"$a $b $c")
+    if (ord.gt(a, b) && ord.gt(b, c)) assert(ord.gt(a, c), s"$a $b $c")
+    if (ord.equiv(a, b) && ord.equiv(b, c)) assert(ord.equiv(a, c), s"$a $b $c")
+
+    if (a == b) assert(ord.equiv(a, b))
+
+    assert(ord.lt(a, b) == !ord.gteq(a, b))
+    assert(ord.gt(a, b) == !ord.lteq(a, b))
+    assert(ord.equiv(a, b) == !(ord.lt(a, b) || ord.gt(a, b)))
+
+    assert(ord.lteq(a, b) == ord.gteq(b, a))
+    assert(ord.lteq(a, c) == ord.gteq(c, a))
+    assert(ord.lteq(b, c) == ord.gteq(c, b))
+
+    assert(ord.equiv(a, a))
+    assert(ord.equiv(b, b))
+    assert(ord.equiv(c, c))
+
+    assert(!ord.lt(a, a))
+    assert(!ord.lt(b, b))
+    assert(!ord.lt(c, c))
+
+    ()
+  }
+}

--- a/core/src/test/scala/org/bykn/bosatsu/ParserTest.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/ParserTest.scala
@@ -601,6 +601,21 @@ else:
     roundTrip(Declaration.parser(""),
 """Foo(x) = bar
 x""")
+
+    roundTrip(Declaration.parser(""),
+"""match x:
+  Some(_) | None: 1""")
+
+    roundTrip(Declaration.parser(""),
+"""match x:
+  Some(_) | None: 1
+  y: y
+  [x | y, _]: z""")
+
+
+    roundTrip(Declaration.parser(""),
+"""Foo(x) | Bar(x) = bar
+x""")
   }
 
   test("we can parse declaration lists") {

--- a/core/src/test/scala/org/bykn/bosatsu/TypeRefTest.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/TypeRefTest.scala
@@ -1,0 +1,18 @@
+package org.bykn.bosatsu
+
+import org.scalatest.FunSuite
+import org.scalatest.prop.PropertyChecks.{ forAll, PropertyCheckConfiguration }
+
+class TypeRefTest extends FunSuite {
+  implicit val generatorDrivenConfig =
+    //PropertyCheckConfiguration(minSuccessful = 500000)
+    PropertyCheckConfiguration(minSuccessful = 5000)
+
+  import Generators.typeRefGen
+
+  test("Ordering is lawful") {
+    forAll(typeRefGen, typeRefGen, typeRefGen) { (a, b, c) =>
+      OrderingLaws.law(a, b, c)
+    }
+  }
+}

--- a/core/src/test/scala/org/bykn/bosatsu/rankn/TypeTest.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/rankn/TypeTest.scala
@@ -54,6 +54,12 @@ class TypeTest extends FunSuite {
     }
   }
 
+  test("types are well ordered") {
+    forAll(NTypeGen.genDepth03, NTypeGen.genDepth03, NTypeGen.genDepth03) {
+      org.bykn.bosatsu.OrderingLaws.law(_, _, _)
+    }
+  }
+
   test("test all binders") {
     assert(Type.allBinders.filter(_.name.startsWith("a")).take(100).map(_.name) ==
       ("a" #:: Stream.iterate(0)(_ + 1).map { i => s"a$i" }).take(100))


### PR DESCRIPTION
closes #110 

Seems to be correct, but some of the more hard-core intersection tests I couldn't get to pass with unions. I think this is due to the fact that with unions we no longer have a normal form without expanding unions out, which could cause exponential blowup.

The more important tests seem to pass: the totality checks, and adding missing branches causes us to reach totality.

We should add more tests of evaluation, but we have some basic ones here.