### PR TITLE
Add a failing test showing incorrect unification of generic

### DIFF
--- a/core/src/main/scala/org/bykn/bosatsu/rankn/Infer.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/rankn/Infer.scala
@@ -493,11 +493,11 @@ object Infer {
       lift(m.ref.set(Some(v)))
 
     /**
-     * Here we substitute any free variables in t with meta and
+     * Here we substitute any free bound variables in t with meta and
      * do the same substitution inside expr
      */
     def freeLambdaMeta[A](t: Type, expr: Expr[A]): Infer[(Type, Expr[A])] =
-      Type.freeTyVars(t :: Nil) match {
+      Type.freeBoundTyVars(t :: Nil) match {
         case Nil => Infer.pure((t, expr))
         case h :: tail =>
           val frees = NonEmptyList(h, tail)

--- a/core/src/main/scala/org/bykn/bosatsu/rankn/Infer.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/rankn/Infer.scala
@@ -264,7 +264,7 @@ object Infer {
           (bound *> zonkTypedExpr(rho)).map(TypedExpr.forAll(aligned.map(_._2), _))
       }
 
-    def makeGeneric[B, A](forAlls: List[Type.Var.Skolem], rho: TypedExpr.Rho[A]): Infer[TypedExpr[A]] =
+    def makeGeneric[A](forAlls: List[Type.Var.Skolem], rho: TypedExpr.Rho[A]): Infer[TypedExpr[A]] =
       NonEmptyList.fromList(forAlls) match {
         case None =>
           zonkTypedExpr(rho)

--- a/core/src/main/scala/org/bykn/bosatsu/rankn/Type.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/rankn/Type.scala
@@ -222,7 +222,8 @@ object Type {
 
   def alignBinders[A](items: NonEmptyList[A], avoid: Set[Var.Bound]): NonEmptyList[(A, Var.Bound)] = {
     val sz = items.size
-    val bs = NonEmptyList.fromListUnsafe(allBinders.filterNot(avoid).take(sz).toList)
+    // for some reason on 2.11 we need to do .iterator or this will be an infinite loop
+    val bs = NonEmptyList.fromListUnsafe(allBinders.iterator.filterNot(avoid).take(sz).toList)
     NonEmptyList((items.head, bs.head), items.tail.zip(bs.tail))
   }
 

--- a/core/src/main/scala/org/bykn/bosatsu/rankn/Type.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/rankn/Type.scala
@@ -150,6 +150,13 @@ object Type {
   }
 
   /**
+   * Return the Bound variables that
+   * are free in the given list of types
+   */
+  def freeBoundTyVars(ts: List[Type]): List[Type.Var.Bound] =
+    freeTyVars(ts).collect { case b@Type.Var.Bound(_) => b }
+
+  /**
    * These are upper-case to leverage scala's pattern
    * matching on upper-cased vals
    */

--- a/core/src/main/scala/org/bykn/bosatsu/rankn/Type.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/rankn/Type.scala
@@ -220,6 +220,12 @@ object Type {
     letters.map { c => Var.Bound(c.toString) } #::: lettersWithNumber
   }
 
+  def alignBinders[A](items: NonEmptyList[A], avoid: Set[Var.Bound]): NonEmptyList[(A, Var.Bound)] = {
+    val sz = items.size
+    val bs = NonEmptyList.fromListUnsafe(allBinders.filterNot(avoid).take(sz).toList)
+    NonEmptyList((items.head, bs.head), items.tail.zip(bs.tail))
+  }
+
   case class Meta(id: Long, ref: Ref[Option[Type]])
 
   def metaTvs(s: List[Type]): Set[Meta] = {

--- a/core/src/test/scala/org/bykn/bosatsu/EvaluationTest.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/EvaluationTest.scala
@@ -626,4 +626,16 @@ main = getValue(int)
 
   }
 
+  test("overly generic methods fail compilation") {
+    evalFail(
+      List("""
+package A
+
+# this shouldn't compile, a is too generic
+def plus(x: a, y):
+  x.add(y)
+
+main = plus(1, 2)
+"""), "A"){ case PackageError.TypeErrorIn(_, _) => () }
+  }
 }

--- a/core/src/test/scala/org/bykn/bosatsu/EvaluationTest.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/EvaluationTest.scala
@@ -586,10 +586,9 @@ struct Leib(subst: forall f. f[a] -> f[b])
 struct Id(a)
 
 def coerce(a, leib):
-  match leib:
-    Leib(subst):
-      match subst(Id(a)):
-        Id(b): b
+  Leib(subst) = leib
+  Id(b) = subst(Id(a))
+  b
 
 # there is really only one (polymorphic) value of Leib
 refl = Leib(\x -> x)
@@ -602,7 +601,7 @@ str = IsStr("foo", refl)
 int = IsInt(42, refl)
 
 # this takes StringOrInt[a] and returns a
-def getValue(v):
+def getValue(v: StringOrInt[a]) -> a:
   match v:
     IsStr(s, leib): coerce(s, leib)
     IsInt(i, leib): coerce(i, leib)


### PR DESCRIPTION
The issue is, if we have something we declare to be generic, we currently can unify it with a concrete type, which is not what we want that syntax to mean.

It seems like we should be using skolem variables here, but if we do that, predef fails to compile.