### PR TITLE
Track regions when doing type inference

### DIFF
--- a/core/src/main/scala/org/bykn/bosatsu/LocationMap.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/LocationMap.scala
@@ -113,7 +113,7 @@ case class LocationMap(fromString: String) { self =>
           val newPrev = l1 - l0
           showContext(region.start, previousLines).get +
             "\nto:\n" +
-            showContext(region.end - 1, newPrev)
+            showContext(region.end - 1, newPrev).get
         }
       }
 

--- a/core/src/test/scala/org/bykn/bosatsu/EvaluationTest.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/EvaluationTest.scala
@@ -192,8 +192,7 @@ def go(x):
 main = go(IntCase(42))
 """), "Err") { case PackageError.TypeErrorIn(_, _) => () }
 
-    evalFail(
-      List("""
+    val errPack = """
 package Err
 
 enum IntOrString: IntCase(i: Int), StringCase(s: String)
@@ -204,7 +203,13 @@ def go(x):
   y
 
 main = go(IntCase(42))
-"""), "Err") { case PackageError.TypeErrorIn(_, _) => () }
+"""
+    val packs = Map((PackageName.parts("Err"), (LocationMap(errPack), "Err.bosatsu")))
+    evalFail(List(errPack), "Err") { case te@PackageError.TypeErrorIn(_, _) =>
+      val msg = te.message(packs)
+      assert(msg.contains("Bosatsu/Predef#Int does not unify with type Bosatsu/Predef#String"))
+      ()
+    }
 
     evalTest(
       List("""


### PR DESCRIPTION
When we moved to the rankn type inference, we lost the tracking of regions where types are inferred.

Here is an example now with an error added to euler4.bosatsu
```
in file: test_workspace/euler4.bosatsu, package Euler/Four, type Bosatsu/Predef#String does not unify with type Bosatsu/Predef#Int
54|  res
55|
56|fail = 1.add("2")
                ^^^
```

This is far from perfect. We need to solve #132 to improve some error messages.

Also, and open issue is how to test this best. I think the scala compiler just uses golden data tests where they commit what they expect the output to be.