### PR TITLE
Support zero argument defs

### DIFF
--- a/core/src/main/scala/org/bykn/bosatsu/DefStatement.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/DefStatement.scala
@@ -1,0 +1,76 @@
+package org.bykn.bosatsu
+
+import Parser.{ Combinators, lowerIdent, maybeSpace, spaces }
+import cats.Functor
+import cats.data.NonEmptyList
+import cats.implicits._
+import fastparse.all._
+import org.bykn.fastparse_cats.StringInstances._
+import org.typelevel.paiges.{ Doc, Document }
+
+case class DefStatement[T](
+    name: String,
+    args: List[(String, Option[TypeRef])],
+    retType: Option[TypeRef], result: T) {
+
+
+  /**
+   * This ignores the name completely and just returns the lambda expression here
+   *
+   * This could be a traversal: TypeRef => F[rankn.Type] for an Applicative F[_]
+   */
+  def toLambdaExpr[A](resultExpr: Expr[A], tag: A)(trFn: TypeRef => rankn.Type): Expr[A] = {
+    val unTypedBody = resultExpr
+    val bodyExp =
+      retType.fold(unTypedBody) { t =>
+        Expr.Annotation(unTypedBody, trFn(t), tag)
+      }
+    NonEmptyList.fromList(args) match {
+      case None => bodyExp
+      case Some(neargs) =>
+        val deepFunctor = Functor[NonEmptyList].compose[(String, ?)].compose[Option]
+        Expr.buildLambda(deepFunctor.map(neargs)(trFn), bodyExp, tag)
+    }
+  }
+}
+
+object DefStatement {
+  private[this] val defDoc = Doc.text("def ")
+
+  implicit def document[T: Document]: Document[DefStatement[T]] =
+    Document.instance[DefStatement[T]] { defs =>
+      import defs._
+      val res = retType.fold(Doc.empty) { t => Doc.text(" -> ") + t.toDoc }
+      val argDoc =
+        if (args.isEmpty) Doc.empty
+        else {
+          Doc.char('(') +
+            Doc.intercalate(Doc.text(", "), args.map(TypeRef.argDoc _)) +
+            Doc.char(')')
+        }
+      val line0 = defDoc + Doc.text(name) + argDoc + res + Doc.text(":")
+
+      line0 + Document[T].document(result)
+    }
+
+    /**
+     * The resultTParser should parse some indentation any newlines
+     */
+    def parser[T](resultTParser: P[T]): P[DefStatement[T]] = {
+      val args = argParser.nonEmptyList
+      val result = P(maybeSpace ~ "->" ~/ maybeSpace ~ TypeRef.parser).?
+      P("def" ~ spaces ~/ lowerIdent ~ ("(" ~ maybeSpace ~ args ~ maybeSpace ~ ")").? ~
+        result ~ maybeSpace ~ ":" ~/ resultTParser)
+        .map {
+          case (name, optArgs, resType, res) =>
+            val args = optArgs match {
+              case None => Nil
+              case Some(ne) => ne.toList
+            }
+            DefStatement(name, args, resType, res)
+        }
+    }
+
+    val argParser: P[(String, Option[TypeRef])] =
+      P(lowerIdent ~ (":" ~/ maybeSpace ~ TypeRef.parser).?)
+}

--- a/core/src/main/scala/org/bykn/bosatsu/Statement.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/Statement.scala
@@ -1,6 +1,6 @@
 package org.bykn.bosatsu
 
-import Parser.{ Combinators, lowerIdent, upperIdent, maybeSpace, spaces }
+import Parser.{ Combinators, Indy, lowerIdent, upperIdent, maybeSpace, spaces }
 import cats.Functor
 import cats.data.{ NonEmptyList, State }
 import cats.implicits._
@@ -8,61 +8,8 @@ import fastparse.all._
 import org.typelevel.paiges.{ Doc, Document }
 
 import org.bykn.fastparse_cats.StringInstances._
-import Parser.Indy
 
 import Indy.IndyMethods
-
-case class DefStatement[T](
-    name: String,
-    args: NonEmptyList[(String, Option[TypeRef])],
-    retType: Option[TypeRef], result: T) {
-
-
-  /**
-   * This ignores the name completely and just returns the lambda expression here
-   *
-   * This could be a traversal: TypeRef => F[rankn.Type] for an Applicative F[_]
-   */
-  def toLambdaExpr[A](resultExpr: Expr[A], tag: A)(trFn: TypeRef => rankn.Type): Expr[A] = {
-    val unTypedBody = resultExpr
-    val bodyExp =
-      retType.fold(unTypedBody) { t =>
-        Expr.Annotation(unTypedBody, trFn(t), tag)
-      }
-    val deepFunctor = Functor[NonEmptyList].compose[(String, ?)].compose[Option]
-    Expr.buildLambda(deepFunctor.map(args)(trFn), bodyExp, tag)
-  }
-}
-
-object DefStatement {
-  private[this] val defDoc = Doc.text("def ")
-
-  implicit def document[T: Document]: Document[DefStatement[T]] =
-    Document.instance[DefStatement[T]] { defs =>
-      import defs._
-      val res = retType.fold(Doc.empty) { t => Doc.text(" -> ") + t.toDoc }
-      val line0 = defDoc + Doc.text(name) + Doc.char('(') +
-        Doc.intercalate(Doc.text(", "), args.toList.map(TypeRef.argDoc _)) +
-        Doc.char(')') + res + Doc.text(":")
-      line0 + Document[T].document(result)
-    }
-
-    /**
-     * The resultTParser should parse some indentation any newlines
-     */
-    def parser[T](resultTParser: P[T]): P[DefStatement[T]] = {
-      val args = argParser.nonEmptyList
-      val result = P(maybeSpace ~ "->" ~/ maybeSpace ~ TypeRef.parser).?
-      P("def" ~ spaces ~/ lowerIdent ~ "(" ~ maybeSpace ~ args ~ maybeSpace ~ ")" ~
-        result ~ maybeSpace ~ ":" ~/ resultTParser)
-        .map {
-          case (name, args, resType, res) => DefStatement(name, args, resType, res)
-        }
-    }
-
-    val argParser: P[(String, Option[TypeRef])] =
-      P(lowerIdent ~ (":" ~/ maybeSpace ~ TypeRef.parser).?)
-}
 
 case class BindingStatement[B, T](name: B, value: Declaration, in: T)
 

--- a/core/src/test/scala/org/bykn/bosatsu/EvaluationTest.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/EvaluationTest.scala
@@ -322,6 +322,17 @@ same = sum0.eq_Int(sum1)
 
   }
 
+  test("test zero arg defs") {
+    evalTest(
+      List("""
+package Foo
+
+def foo: 42
+
+main = foo
+"""), "Foo", VInt(42))
+  }
+
   test("test Int functions") {
     evalTest(
       List("""

--- a/core/src/test/scala/org/bykn/bosatsu/Gen.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/Gen.scala
@@ -97,7 +97,7 @@ object Generators {
   def defGen[T](dec: Gen[T]): Gen[DefStatement[T]] =
     for {
       name <- lowerIdent
-      args <- nonEmpty(argGen)
+      args <- Gen.listOf(argGen)
       retType <- Gen.option(typeRefGen)
       body <- dec
     } yield DefStatement(name, args, retType, body)

--- a/core/src/test/scala/org/bykn/bosatsu/ParserTest.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/ParserTest.scala
@@ -331,7 +331,7 @@ foo"""
     parseTestAll(
       Declaration.parser(""),
       defWithComment,
-      Declaration.DefFn(DefStatement("foo", NonEmptyList.of(("a", None)), None,
+      Declaration.DefFn(DefStatement("foo", List(("a", None)), None,
         (OptIndent.paddedIndented(1, 2, Declaration.Comment(CommentStatement(NonEmptyList.of(" comment here"),
           Padding(0, Declaration.Var("a"))))),
          Padding(0, Declaration.Var("foo"))))))


### PR DESCRIPTION
close #124 

Allow a syntax like this:
```
def foo:
  x = 42
  y = 36
  x.times(y)
```