### PR TITLE
Second attempt at dealing with generic types in defs

### DIFF
--- a/core/src/main/scala/org/bykn/bosatsu/DefStatement.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/DefStatement.scala
@@ -13,7 +13,6 @@ case class DefStatement[T](
     args: List[(String, Option[TypeRef])],
     retType: Option[TypeRef], result: T) {
 
-
   /**
    * This ignores the name completely and just returns the lambda expression here
    *

--- a/core/src/main/scala/org/bykn/bosatsu/PackageMap.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/PackageMap.scala
@@ -322,7 +322,10 @@ object PackageError {
 
   case class TypeErrorIn(tpeErr: Infer.Error, pack: PackageName) extends PackageError {
     def message(sourceMap: Map[PackageName, (LocationMap, String)]) = {
-      val (lm, sourceName) = sourceMap(pack)
+      val (lm, sourceName) = sourceMap.get(pack) match {
+        case None => (LocationMap(""), "<unknown source>")
+        case Some(found) => found
+      }
 
       import rankn.Type
 

--- a/core/src/main/scala/org/bykn/bosatsu/TypedExpr.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/TypedExpr.scala
@@ -133,11 +133,11 @@ object TypedExpr {
     new FunctionK[TypedExpr, TypedExpr] { self =>
       def apply[A](expr: TypedExpr[A]) =
         expr match {
+          case Annotation(t, _, _) => self(t)
           case Generic(params, expr, tag) =>
             // This definitely feels wrong,
             // but without this, I don't see what else we can do
             Generic(params, self(expr), tag)
-          case Annotation(t, _, tag) => Annotation(self(t), tpe, tag)
           case Var(p, name, _, t) => Var(p, name, tpe, t)
           case AnnotatedLambda(arg, argT, res, tag) =>
             // only some coercions would make sense here

--- a/core/src/main/scala/org/bykn/bosatsu/rankn/Infer.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/rankn/Infer.scala
@@ -878,10 +878,9 @@ object Infer {
      *
      * def foo(x: a): x
      *
-     * We handle this by converting a to a meta variable,
-     * running inference, then quantifying over that meta
-     * variable. We require that the meta variable is still
-     * unknown before we quantify.
+     * We handle this by converting a to a skolem variable,
+     * running inference, then quantifying over that skolem
+     * variable.
      */
     val res = skolemizeFreeVars(t) match {
       case None => run(t)

--- a/core/src/main/scala/org/bykn/bosatsu/rankn/Infer.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/rankn/Infer.scala
@@ -897,8 +897,7 @@ object Infer {
         (skols, rho) = skolRho
         te <- checkRho(t, rho)
         envTys <- getEnv
-        zonked <- (tpe :: envTys.values.toList).traverse(zonkType)
-        escTvs = Type.freeTyVars(zonked).toSet
+        escTvs <- getFreeTyVars(tpe :: envTys.values.toList)
         badTvs = skols.filter(escTvs)
         _ <- require(badTvs.isEmpty, Error.NotPolymorphicEnough(tpe, t, NonEmptyList.fromListUnsafe(badTvs), region(t)))
       } yield te // should be fine since the everything after te is just checking

--- a/core/src/main/scala/org/bykn/bosatsu/rankn/Infer.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/rankn/Infer.scala
@@ -113,10 +113,6 @@ object Infer {
       def message = s"${tStr(left)} ($leftRegion) cannot be unified with ${tStr(right)} ($rightRegion)"
     }
 
-    case class UnexpectedSolvedMeta(tpe: Type, in: Expr[_], reg: Region) extends TypeError {
-      def message = s"solved: $tpe expected to be generic in expr: $in at $reg"
-    }
-
     case class NotPolymorphicEnough(tpe: Type, in: Expr[_], badTvs: NonEmptyList[Type.Var.Skolem], reg: Region) extends TypeError {
       def message = s"type ${tStr(tpe)} not polymorphic enough in $in, bad type variables: $badTvs, at $reg"
     }

--- a/core/src/main/scala/org/bykn/bosatsu/rankn/Infer.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/rankn/Infer.scala
@@ -325,16 +325,12 @@ object Infer {
           }
       }
 
-    def assertMetaIsUnknown[A: HasRegion](expr: Expr[A], t: Type): Infer[Unit] =
-      t match {
-        case Type.TyMeta(m) =>
-          readMeta(m).flatMap {
-            case None => Infer.unit
-            case Some(m@Type.TyMeta(_)) => assertMetaIsUnknown(expr, m)
-            case Some(notMeta) =>
-              fail(Error.UnexpectedSolvedMeta(notMeta, expr, region(expr)))
-          }
-        case _ => Infer.unit
+    def assertMetaIsUnknown[A: HasRegion](expr: Expr[A], t: Type.TyMeta): Infer[Unit] =
+      readMeta(t.toMeta).flatMap {
+        case None => Infer.unit
+        case Some(m@Type.TyMeta(_)) => assertMetaIsUnknown(expr, m)
+        case Some(notMeta) =>
+          fail(Error.UnexpectedSolvedMeta(notMeta, expr, region(expr)))
       }
 
     def zonkTypedExpr[A](e: TypedExpr[A]): Infer[TypedExpr[A]] =

--- a/core/src/test/scala/org/bykn/bosatsu/rankn/RankNInferTest.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/rankn/RankNInferTest.scala
@@ -371,6 +371,24 @@ main = ident(1)
 
     parseProgram("""#
 
+enum MyBool: T, F
+struct Pair(fst, snd)
+
+def swap_maybe(x: a, y, swap) -> Pair[a, a]:
+  match swap:
+    T: Pair(y, x)
+    F: Pair(x, y)
+
+def res:
+  Pair(r, _) = swap_maybe(1, 2, F)
+  r
+
+main = res
+""", "Int")
+
+
+    parseProgram("""#
+
 struct Pair(fst: a, snd: a)
 
 def mkPair(y, x: a):

--- a/core/src/test/scala/org/bykn/bosatsu/rankn/RankNInferTest.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/rankn/RankNInferTest.scala
@@ -356,6 +356,14 @@ main = y
   test("test inference with partial def annotation") {
     parseProgram("""#
 
+def ident -> forall a. a -> a:
+  \x -> x
+
+main = ident(1)
+""", "Int")
+
+    parseProgram("""#
+
 def ident(x: a): x
 
 main = ident(1)
@@ -496,6 +504,27 @@ def use_bind(a, b, c, m: Monad[f]):
 
 main = use_bind(None, None, None, option_monad)
 """, "forall a. Opt[a]")
+  }
+
+  test("test zero arg defs") {
+   parseProgram("""#
+
+struct Foo
+
+def fst -> Foo: Foo
+
+main = fst
+""", "Foo")
+
+   parseProgram("""#
+
+enum Foo:
+  Bar, Baz(a)
+
+def fst -> Foo[a]: Bar
+
+main = fst
+""", "forall a. Foo[a]")
   }
 
   test("def with type annotation and use the types inside") {

--- a/core/src/test/scala/org/bykn/bosatsu/rankn/RankNInferTest.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/rankn/RankNInferTest.scala
@@ -371,6 +371,13 @@ main = ident(1)
 
     parseProgram("""#
 
+def ident(x) -> a: x
+
+main = ident(1)
+""", "Int")
+
+    parseProgram("""#
+
 enum MyBool: T, F
 struct Pair(fst, snd)
 

--- a/core/src/test/scala/org/bykn/bosatsu/rankn/RankNInferTest.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/rankn/RankNInferTest.scala
@@ -1,10 +1,9 @@
 package org.bykn.bosatsu.rankn
 
 import cats.data.{NonEmptyList, Validated}
-import org.scalatest.FunSuite
-import org.bykn.bosatsu.{Expr, HasRegion, Lit, PackageName, Package, Pattern, TypeRef, ConstructorName, Region, Statement}
-
 import fastparse.all.Parsed
+import org.scalatest.{Assertion, FunSuite}
+import org.bykn.bosatsu.{Declaration, Expr, HasRegion, Lit, PackageName, Package, Pattern, TypeRef, TypedExpr, ConstructorName, Region, Statement}
 
 import Expr._
 import Type.Var.Bound
@@ -92,21 +91,26 @@ class RankNInferTest extends FunSuite {
       },
       ())
 
-  /**
-   * Check that a no import program has a given type
-   */
-  def parseProgram(statement: String, tpe: String) =
+  def checkLast(statement: String)(fn: TypedExpr[Declaration] => Assertion): Assertion =
     Statement.parser.parse(statement) match {
       case Parsed.Success(stmt, _) =>
         Package.inferBody(PackageName.parts("Test"), Nil, stmt) match {
           case Validated.Invalid(errs) => fail(errs.toList.map(_.message(Map.empty)).mkString("\n"))
-          case Validated.Valid((tpeEnv, lets)) =>
-            val parsedType = typeFrom(tpe)
-            assert(lets.last._2.getType == parsedType)
+          case Validated.Valid((_, lets)) =>
+            fn(lets.last._2)
         }
       case Parsed.Failure(exp, idx, extra) =>
         fail(s"failed to parse: $statement: $exp at $idx with trace: ${extra.traced.trace}")
     }
+  /**
+   * Check that a no import program has a given type
+   */
+  def parseProgram(statement: String, tpe: String) =
+    checkLast(statement) { te => assert(te.getType == typeFrom(tpe)) }
+
+  // this could be used to test the string representation of expressions
+  def checkTERepr(statement: String, repr: String) =
+    checkLast(statement) { te => assert(te.repr == repr) }
 
   /**
    * Test that a program is ill-typed
@@ -372,6 +376,16 @@ enum Option:
 main = Some
 """, "forall a. a -> Option[a]")
 
+    parseProgram("""#
+id = \x -> x
+main = id
+""", "forall a. a -> a")
+
+    parseProgram("""#
+id = \x -> x
+main = id(1)
+""", "Int")
+
    parseProgram("""#
 enum Option:
   None
@@ -379,10 +393,8 @@ enum Option:
 
 x = Some(1)
 main = match x:
-  None:
-    0
-  Some(y):
-    y
+  None: 0
+  Some(y): y
 """, "Int")
 
    parseProgram("""#
@@ -392,31 +404,47 @@ enum List:
 
 x = NonEmpty(1, Empty)
 main = match x:
-  Empty:
-    0
-  NonEmpty(y, z):
-    y
+  Empty: 0
+  NonEmpty(y, z): y
 """, "Int")
 
    parseProgram("""#
 enum Opt:
-  None
-  Some(a)
+  None, Some(a)
 
 struct Monad(pure: forall a. a -> f[a], bind: forall a, b. f[a] -> (a -> f[b]) -> f[b])
 
-def optPure(a):
-  Some(a)
-
 def optBind(opt, bindFn):
   match opt:
-    None:
-      None
-    Some(a):
-      bindFn(a)
+    None: None
+    Some(a): bindFn(a)
 
-main = Monad(optPure, optBind)
+main = Monad(Some, optBind)
 """, "Monad[Opt]")
+
+   parseProgram("""#
+enum Opt:
+  None, Some(a)
+
+struct Monad(pure: forall a. a -> f[a], bind: forall a, b. f[a] -> (a -> f[b]) -> f[b])
+
+def opt_bind(opt, bind_fn):
+  match opt:
+    None: None
+    Some(a): bind_fn(a)
+
+option_monad = Monad(Some, opt_bind)
+
+def use_bind(a, b, c, m: Monad[f]):
+  Monad(pure, bind) = m
+  a1 = bind(a, pure)
+  b1 = bind(b, pure)
+  c1 = bind(c, pure)
+  bind(a1)(\x -> bind(b1)(\x -> c1))
+
+main = use_bind(None, None, None, option_monad)
+""", "Int")
+//""", "forall a -> Opt[a]")
   }
 
   test("def with type annotation and use the types inside") {
@@ -425,9 +453,8 @@ main = Monad(optPure, optBind)
 struct Pair(fst, snd)
 
 def fst(p: Pair[a, b]) -> a:
-  match p:
-    Pair(f, _):
-      f
+  Pair(f, _) = p
+  f
 
 main = fst(Pair(1, "1"))
 """, "Int")
@@ -436,8 +463,7 @@ main = fst(Pair(1, "1"))
   test("test that we see some ill typed programs") {
   parseProgramIllTyped("""#
 
-def foo(i: Int):
-  i
+def foo(i: Int): i
 
 main = foo("Not an Int")
 """)

--- a/core/src/test/scala/org/bykn/bosatsu/rankn/TypeTest.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/rankn/TypeTest.scala
@@ -49,8 +49,8 @@ object NTypeGen {
 class TypeTest extends FunSuite {
 
   test("free vars are not duplicated") {
-    forAll(NTypeGen.genDepth03) { t =>
-      val frees = Type.freeTyVars(t :: Nil)
+    forAll(Gen.listOf(NTypeGen.genDepth03)) { ts =>
+      val frees = Type.freeTyVars(ts)
       assert(frees.distinct == frees)
     }
   }

--- a/core/src/test/scala/org/bykn/bosatsu/rankn/TypeTest.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/rankn/TypeTest.scala
@@ -1,5 +1,6 @@
 package org.bykn.bosatsu.rankn
 
+import cats.data.NonEmptyList
 import org.scalacheck.Gen
 import org.scalatest.prop.PropertyChecks.forAll
 import org.scalatest.FunSuite
@@ -90,5 +91,14 @@ class TypeTest extends FunSuite {
       if (hnv) assert(allT.forall(Type.hasNoVars), "hasNoVars == true")
       else assert(allT.exists { t => !Type.hasNoVars(t) }, "hasNoVars == false")
     }
+  }
+
+  test("Type.freeTyVars is empty for ForAll fully bound") {
+    val ba = Type.Var.Bound("a")
+    val fa = Type.ForAll(NonEmptyList.of(ba), Type.TyVar(ba))
+    assert(Type.freeTyVars(fa :: Nil).isEmpty)
+
+    val fb = Type.ForAll(NonEmptyList.of(ba), Type.Fun(Type.TyVar(ba), Type.IntType))
+    assert(Type.freeTyVars(fb :: Nil).isEmpty)
   }
 }


### PR DESCRIPTION
After #131 was thought to be fixed:

I get:
```
[info] - test inference with some defined types *** FAILED *** (170 milliseconds)
[info]   in file: <unknown source>, package Test, type Opt does not unify with type $f
[info]   Region(414,418) (RankNInferTest.scala:98)  
```

In this example, it is trying to unify `Opt` with a skolem variable `f`.

It's not really clear what is going on, but I think the code should typecheck. 

The fix in #131 was not correct. Here we revert that and add a few more tests to exercise use of universal quantification (generics) in syntax.

I'm much more confident in the current approach.