### PR TITLE
support evaluation of top level pattern matches

### DIFF
--- a/core/src/main/scala/org/bykn/bosatsu/Evaluation.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/Evaluation.scala
@@ -199,7 +199,7 @@ object Evaluation {
     def unreachable: Scoped =
       const(Eval.later(sys.error("unreachable reached")))
 
-    def orElse(name: String, next: => Scoped): Scoped = {
+    def orElse(name: String)(next: => Scoped): Scoped = {
       lazy val nextComputed = next
       fromFn { env =>
         env.get(name) match {
@@ -447,10 +447,10 @@ case class Evaluation(pm: PackageMap.Inferred, externals: Externals) {
          evalTypedExpr(p, e, recurse)
        case Annotation(e, _, _) => evalTypedExpr(p, e, recurse)
        case Var(None, v, _, _) =>
+         Scoped.orElse(v) {
          // this needs to be lazy
-         def onMissing = recurse((p, Left(v)))._1
-
-         Scoped.orElse(v, onMissing)
+           recurse((p, Left(v)))._1
+         }
        case Var(Some(p), v, _, _) =>
          val pack = pm.toMap.get(p).getOrElse(sys.error(s"cannot find $p, shouldn't happen due to typechecking"))
          val (scoped, _) = eval((Package.asInferred(pack), Left(v)))

--- a/core/src/main/scala/org/bykn/bosatsu/Evaluation.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/Evaluation.scala
@@ -199,13 +199,15 @@ object Evaluation {
     def unreachable: Scoped =
       const(Eval.later(sys.error("unreachable reached")))
 
-    def orElse(name: String, next: Scoped): Scoped =
+    def orElse(name: String, next: => Scoped): Scoped = {
+      lazy val nextComputed = next
       fromFn { env =>
         env.get(name) match {
-          case None => next.inEnv(env)
+          case None => nextComputed.inEnv(env)
           case Some(v) => v
         }
       }
+    }
 
     private case class Let(name: String, arg: Scoped, in: Scoped) extends Scoped {
       def inEnv(env: Env) = {
@@ -445,7 +447,8 @@ case class Evaluation(pm: PackageMap.Inferred, externals: Externals) {
          evalTypedExpr(p, e, recurse)
        case Annotation(e, _, _) => evalTypedExpr(p, e, recurse)
        case Var(None, v, _, _) =>
-         val onMissing = recurse((p, Left(v)))._1
+         // this needs to be lazy
+         def onMissing = recurse((p, Left(v)))._1
 
          Scoped.orElse(v, onMissing)
        case Var(Some(p), v, _, _) =>

--- a/core/src/test/scala/org/bykn/bosatsu/EvaluationTest.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/EvaluationTest.scala
@@ -92,6 +92,14 @@ x = 1
       List("""
 package Foo
 
+# test shadowing
+x = match 1: x: x
+"""), "Foo", VInt(1))
+
+    evalTest(
+      List("""
+package Foo
+
 # exercise calling directly a lambda
 x = (\y -> y)("hello")
 """), "Foo", Str("hello"))
@@ -474,6 +482,37 @@ main = Bar(1)
 """), "Foo",
   ConsValue(VInt(1), UnitValue))
 
+    evalTest(
+      List("""
+package Foo
+
+struct Bar(a: Int)
+
+# destructuring top-level let
+Bar(main) = Bar(1)
+"""), "Foo", VInt(1))
+
+    evalTest(
+      List("""
+package Foo
+
+struct Bar(a: Int)
+
+# destructuring top-level let
+Bar(main: Int) = Bar(1)
+"""), "Foo", VInt(1))
+
+    evalTest(
+      List("""
+package Foo
+
+struct Bar(a: Int)
+
+y = Bar(1)
+# destructuring top-level let
+Bar(main: Int) = y
+"""), "Foo", VInt(1))
+
     evalTestJson(
       List("""
 package Foo
@@ -567,7 +606,17 @@ def unbox(gb: GoodOrBad[a]):
     Good(g): g
     Bad(b): b
 
-main = unbox(Good(42))
+(main: Int) = unbox(Good(42))
+"""), "A", VInt(42))
+
+  evalTest(
+    List("""
+package A
+
+enum GoodOrBad:
+  Bad(a: a), Good(a: a)
+
+Bad(main) | Good(main) = Good(42)
 """), "A", VInt(42))
   }
 

--- a/core/src/test/scala/org/bykn/bosatsu/PatternTest.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/PatternTest.scala
@@ -1,0 +1,27 @@
+package org.bykn.bosatsu
+
+import org.scalacheck.Gen
+import org.scalatest.FunSuite
+import org.scalatest.prop.PropertyChecks.forAll
+
+class PatternTest extends FunSuite {
+  val patGen = Gen.choose(0, 5).flatMap(Generators.genPattern(_))
+
+  test("Pattern.unbind is the same as filterVars(Set.empty)") {
+    forAll(patGen) { p =>
+      assert(p.unbind == p.filterVars(Set.empty))
+    }
+  }
+
+  test("filtering for names not in a pattern is unbind") {
+    forAll(patGen, Gen.listOf(Gen.identifier)) { (p, ids) =>
+      assert(p.unbind == p.filterVars(ids.toSet.filterNot(p.names.toSet)))
+    }
+  }
+
+  test("filtering and keeping all names is identity") {
+    forAll(patGen, Gen.listOf(Gen.identifier)) { (p, ids) =>
+      assert(p.filterVars(p.names.toSet) == p)
+    }
+  }
+}

--- a/core/src/test/scala/org/bykn/bosatsu/rankn/RankNInferTest.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/rankn/RankNInferTest.scala
@@ -594,4 +594,24 @@ main = match x:
   y: y
 """)
   }
+
+  test("badly shaped top-level match fails to compile") {
+    parseProgramIllTyped("""#
+
+struct Foo(x)
+x = 1
+
+Foo(_) = x
+main = 1
+""")
+
+    parseProgramIllTyped("""#
+
+enum LR: L(a), R(b)
+
+# this isn't legit: it is a non-total match
+L(_) = L(1)
+main = 1
+""")
+  }
 }


### PR DESCRIPTION
evaluation part of #140 follow on to #141 

I found a bug in evaluation that this triggered that requires a code branch to be lazy which was being strict. That was probably really hurting performance.