### PR TITLE
Add variance tests, show some issues

### DIFF
--- a/core/src/test/scala/org/bykn/bosatsu/rankn/RankNInferTest.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/rankn/RankNInferTest.scala
@@ -552,6 +552,182 @@ main = fst
 """, "forall a. Foo[a]")
   }
 
+
+  test("substition works correctly") {
+
+    parseProgram("""#
+(id: forall a. a -> a) = \x -> x
+
+struct Foo
+
+def apply(fn, arg: Foo): fn(arg)
+
+main = apply(id, Foo)
+""", "Foo")
+
+    parseProgram("""#
+(id: forall a. a -> a) = \x -> x
+
+struct Foo
+
+(idFoo: Foo -> Foo) = id
+
+def apply(fn, arg: Foo): fn(arg)
+
+main = apply(id, Foo)
+""", "Foo")
+
+    parseProgram("""#
+
+struct FnWrapper(fn: a -> a)
+
+(id: forall a. FnWrapper[a]) = FnWrapper(\x -> x)
+
+struct Foo
+
+(idFoo: FnWrapper[Foo]) = id
+
+def apply(fn, arg: Foo):
+  FnWrapper(f) = fn
+  f(arg)
+
+main = apply(id, Foo)
+""", "Foo")
+
+    parseProgram("""#
+struct Foo
+(id: forall a. a -> Foo) = \x -> Foo
+
+(idFoo: Foo -> Foo) = id
+
+main = Foo
+""", "Foo")
+
+    parseProgramIllTyped("""#
+
+struct Foo
+(idFooRet: forall a. a -> Foo) = \x -> Foo
+
+(id: forall a. a -> a) = idFooRet
+
+main = Foo
+""")
+
+    parseProgram("""#
+enum Foo: Bar, Baz
+
+struct Cont(cont: (b -> a) -> a)
+
+(bar1: forall a. Cont[Foo, a]) = Cont(\fn -> fn(Bar))
+(baz1: forall a. Cont[Foo, a]) = Cont(\fn -> fn(Baz))
+(bar2: forall a. Cont[a, Foo]) = Cont(\fn -> Bar)
+(baz2: forall a. Cont[a, Foo]) = Cont(\fn -> Baz)
+
+(bar31: Cont[Foo, Foo]) = bar1
+(bar32: Cont[Foo, Foo]) = bar2
+(baz31: Cont[Foo, Foo]) = baz1
+(baz32: Cont[Foo, Foo]) = baz2
+
+(producer: Foo -> (forall a. Cont[Foo, a])) = \x -> bar1
+# in the covariant position, we can substitute
+(producer1: Foo -> Cont[Foo, Foo]) = producer
+
+main = Bar
+""", "Foo")
+
+    parseProgramIllTyped("""#
+enum Foo: Bar, Baz
+
+struct Cont(cont: (b -> a) -> a)
+
+(consumer: (forall a. Cont[Foo, a]) -> Foo) = \x -> Bar
+# in the contravariant position, we cannot substitute
+(consumer1: Cont[Foo, Foo] -> Foo) = consumer
+
+main = Bar
+""")
+
+     parseProgram("""#
+struct Foo
+enum Opt: Nope, Yep(a)
+
+(producer: Foo -> forall a. Opt[a]) = \x -> Nope
+# in the covariant position, we can substitute
+(producer1: Foo -> Opt[Foo]) = producer
+(consumer: Opt[Foo]-> Foo) = \x -> Foo
+# in the contravariant position, we can generalize
+(consumer1: (forall a. Opt[a])  -> Foo) = consumer
+
+main = Foo
+""", "Foo")
+
+     parseProgramIllTyped("""#
+struct Foo
+enum Opt: Nope, Yep(a)
+
+(consumer: (forall a. Opt[a]) -> Foo) = \x -> Foo
+# in the contravariant position, we cannot substitute
+(consumer1: Opt[Foo] -> Foo) = consumer
+
+main = Foo
+""")
+     parseProgramIllTyped("""#
+struct Foo
+enum Opt: Nope, Yep(a)
+
+(producer: Foo -> Opt[Foo]) = \x -> Nope
+# the variance forbid generalizing in this direction
+(producer1: Foo -> forall a. Opt[a]) = producer
+
+main = Foo
+""")
+
+    parseProgram("""#
+struct Foo
+enum Opt: Nope, Yep(a)
+
+struct FnWrapper(fn: a -> b)
+
+# TODO: this should pass because FnWrapper is covariant, but skolemization ignores custom types
+#(producer: FnWrapper[Foo, forall a. Opt[a]]) = FnWrapper(\x -> Nope)
+# in the covariant position, we can substitute
+#(producer1: FnWrapper[Foo, Opt[Foo]]) = producer
+(consumer: FnWrapper[Opt[Foo], Foo]) = FnWrapper(\x -> Foo)
+# in the contravariant position, we can generalize
+# TODO: this should pass because FnWrapper is contravariant in the first type
+# but subsCheck only knows about contravariance in the Fn type
+#(consumer1: FnWrapper[forall a. Opt[a], Foo]) = consumer
+
+main = Foo
+""", "Foo")
+
+    parseProgramIllTyped("""#
+struct Foo
+enum Opt: Nope, Yep(a)
+
+struct FnWrapper(fn: a -> b)
+
+(consumer: FnWrapper[forall a. Opt[a], Foo]) = FnWrapper(\x -> Foo)
+# in the contravariant position, we cannot substitute
+(consumer1: FnWrapper[Opt[Foo], Foo]) = consumer
+
+main = Foo
+""")
+    parseProgramIllTyped("""#
+struct Foo
+enum Opt: Nope, Yep(a)
+
+struct FnWrapper(fn: a -> b)
+
+(producer: FnWrapper[Foo, Opt[Foo]]) = FnWrapper(\x -> Nope)
+# in the covariant position, we can't generalize
+(producer1: FnWrapper[Foo, forall a. Opt[a]]) = producer
+
+main = Foo
+""")
+
+  }
+
   test("def with type annotation and use the types inside") {
    parseProgram("""#
 


### PR DESCRIPTION
The paper we derive the type system from does not directly address user defined types. So, there is a question of what special casing of the function types need to be done for user defined types.

This PR adds some tests that show two good statements (I think) that are ruled out, despite them being safe, which I think could be allowed if we tracked variance of structs (see #143 #106).

Basically, any test that passes with a function type should pass if we replace the function with a wrapper of function: `struct FnWrapper(fn: a -> b)`, but this test shows two examples of that not being true.