### PR TITLE
Refactor circularity check

### DIFF
--- a/core/src/main/scala/org/bykn/bosatsu/Tree.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/Tree.scala
@@ -1,0 +1,49 @@
+package org.bykn.bosatsu
+
+import cats.data.{NonEmptyList, Validated, ValidatedNel}
+
+import cats.implicits._
+
+case class Tree[A](item: A, children: List[Tree[A]])
+
+object Tree {
+
+  def neighborsFn[A](t: Tree[A]): A => List[A] = {
+    def toMap(t: Tree[A]): Map[A, Tree[A]] =
+      Map(t.item -> t) ++ (t.children.flatMap(toMap(_)))
+
+    val mapToTree: Map[A, Tree[A]] = toMap(t)
+
+
+    { a: A => mapToTree.get(a).fold(List.empty[A])(_.children.map(_.item)) }
+  }
+
+  /**
+   * either return a tree representation of this dag or all cycles
+   *
+   * Note, this could run in a monadic context if we needed that:
+   * nfn: A => F[List[A]] for some monad F[_]
+   */
+  def dagToTree[A](node: A)(nfn: A => List[A]): ValidatedNel[NonEmptyList[A], Tree[A]] = {
+    def treeOf(path: NonEmptyList[A], visited: Set[A]): ValidatedNel[NonEmptyList[A], Tree[A]] = {
+      val children = nfn(path.head)
+      def assumeValid(children: List[A]): ValidatedNel[NonEmptyList[A], Tree[A]] =
+        children.traverse { a =>
+          // we grow the path out here
+          treeOf(a :: path, visited + a)
+        }
+        .map(Tree(path.head, _))
+
+      NonEmptyList.fromList(children.filter(visited)) match {
+        case Some(loops) =>
+          val paths = loops.map(_ :: path)
+          val invalid = Validated.invalid(paths)
+          // also search all the valid cases
+          invalid *> assumeValid(children.filterNot(visited))
+        case None => assumeValid(children)
+      }
+    }
+    treeOf(NonEmptyList(node, Nil), Set(node))
+  }
+}
+

--- a/core/src/main/scala/org/bykn/bosatsu/TypeRecursionCheck.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/TypeRecursionCheck.scala
@@ -1,0 +1,35 @@
+package org.bykn.bosatsu
+
+import cats.data.{NonEmptyList, ValidatedNel}
+import org.bykn.bosatsu.rankn.{ DefinedType, Type, TypeEnv }
+
+import cats.implicits._
+
+/**
+ * This checks to make sure any recursion of types is legal
+ * Note, since packages from a DAG, we know that anything
+ * in imports cannot refer to packageDefinedTypes
+ */
+object TypeRecursionCheck {
+
+  def check(imports: TypeEnv[Unit],
+    packageDefinedTypes: List[DefinedType[Unit]]): ValidatedNel[NonEmptyList[DefinedType[Unit]], Unit] = {
+
+    val typeMap = DefinedType.listToMap(packageDefinedTypes)
+    /*
+     * Check that the types defined here are not circular.
+     * Since the packages already form a DAG we know
+     * that we don't need to check across package boundaries
+     */
+    def typeDepends(dt: DefinedType[Unit]): List[DefinedType[Unit]] =
+      (for {
+        cons <- dt.constructors
+        Type.Const.Defined(p, n) <- cons._2.flatMap { case (_, t) => Type.constantsOf(t) }
+        dt1 <- typeMap.get((p, TypeName(n))).toList
+      } yield dt1).distinct
+
+    packageDefinedTypes.traverse_ { dt =>
+      Tree.dagToTree(dt)(typeDepends _)
+    }
+  }
+}

--- a/core/src/test/scala/org/bykn/bosatsu/TreeTest.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/TreeTest.scala
@@ -1,0 +1,64 @@
+package org.bykn.bosatsu
+
+import cats.data.Validated
+import org.scalacheck.Gen
+import org.scalatest.FunSuite
+import org.scalatest.prop.PropertyChecks.forAll
+
+class TreeTest extends FunSuite {
+
+  test("explicit dags never fail") {
+    val dagFn:  Gen[Int => List[Int]] =
+      Gen.choose(1L, Long.MaxValue).map { seed =>
+
+        val rng = new java.util.Random(seed)
+
+        val cache = scala.collection.mutable.Map[Int, List[Int]]()
+
+        { node: Int =>
+          // the expected number of neighbors is 1.5, that means the graph is expected to be finite
+          cache.getOrElseUpdate(node, {
+            val count = rng.nextInt(3)
+            (node + 1 until (node + count + 1)).toList.filter(_ > node)
+          })
+        }
+
+      }
+
+    forAll(Gen.choose(0, Int.MaxValue), dagFn) { (start, nfn) =>
+      Tree.dagToTree(start)(nfn) match {
+        case v@Validated.Valid(tree) =>
+          // the neightbor function should give the same tree:
+          val treeFn = Tree.neighborsFn(tree)
+          val tree2 = Tree.dagToTree(tree.item)(treeFn)
+          assert(tree2 == v)
+        case Validated.Invalid(circs) =>
+          fail(s"circular paths found: $circs")
+      }
+    }
+  }
+
+  test("circular graphs are invalid") {
+    val prime = Gen.oneOf(2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53, 59, 61, 67, 71, 73, 79, 83, 89)
+
+    val dagFn:  Gen[(Int, Int => List[Int])] =
+      for {
+        p <- prime
+        p1 = p - 1
+        nodeGen = Gen.choose(0, p1)
+        init <- nodeGen
+        a <- Gen.choose(1, p1)
+        b <- nodeGen
+      } yield {
+
+        (init, { node: Int =>
+          // only 1 neighbor, but this is in a cyclic group so it can't be a dag
+          List((node * a + b) % p)
+        })
+      }
+
+    forAll(dagFn) { case (start, nfn) =>
+      assert(Tree.dagToTree(start)(nfn).isInvalid)
+    }
+  }
+}


### PR DESCRIPTION
This is a step in addressing #148 

Here we factor the code so that the circularity checking is in a single file. The next step is to run variance inference, and then using the variance annotations, ignore cycles that are covariant or phantom, and only bad contravariant and invariant loops.