### PR TITLE
Add ParsedTypeEnv

### DIFF
--- a/core/src/main/scala/org/bykn/bosatsu/PackageMap.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/PackageMap.scala
@@ -6,7 +6,7 @@ import cats.data.{NonEmptyList, Validated, ValidatedNel, ReaderT, State}
 import cats.Order
 import cats.implicits._
 
-import rankn.Infer
+import rankn.{Infer, TypeEnv}
 
 case class PackageMap[A, B, C, D](toMap: Map[PackageName, Package[A, B, C, D]]) {
   def +(pack: Package[A, B, C, D]): PackageMap[A, B, C, D] =
@@ -52,7 +52,7 @@ object PackageMap {
   type MapF2[A, B] = MapF3[A, A, B]
   type ParsedImp = PackageMap[PackageName, Unit, Unit, (Statement, ImportMap[PackageName, Unit])]
   type Resolved = MapF2[Unit, (Statement, ImportMap[PackageName, Unit])]
-  type Inferred = MapF3[NonEmptyList[Referant[Unit]], Referant[Unit], Program[TypedExpr[Declaration], Statement]]
+  type Inferred = MapF3[NonEmptyList[Referant[Unit]], Referant[Unit], Program[TypeEnv[Unit], TypedExpr[Declaration], Statement]]
 
   /**
    * This builds a DAG of actual packages where names have been replaced by the fully resolved
@@ -153,7 +153,7 @@ object PackageMap {
   def inferAll(ps: Resolved): ValidatedNel[PackageError, Inferred] = {
 
     type PackIn = PackageF2[Unit, (Statement, ImportMap[PackageName, Unit])]
-    type PackOut = PackageF[NonEmptyList[Referant[Unit]], Referant[Unit], Program[TypedExpr[Declaration], Statement]]
+    type PackOut = PackageF[NonEmptyList[Referant[Unit]], Referant[Unit], Program[TypeEnv[Unit], TypedExpr[Declaration], Statement]]
 
     /*
      * We memoize this function to avoid recomputing diamond dependencies
@@ -197,7 +197,7 @@ object PackageMap {
                           Package[a,
                             NonEmptyList[Referant[Unit]],
                             Referant[Unit],
-                            Program[TypedExpr[Declaration], Statement]]]](
+                            Program[TypeEnv[Unit], TypedExpr[Declaration], Statement]]]](
                       packF),
                     imps)
                 }
@@ -281,7 +281,7 @@ object PackageError {
   // We could check if we forgot to export the name in the package and give that error
   case class UnknownImportName[A, B](
     in: Package.PackageF2[Unit, (Statement, ImportMap[PackageName, Unit])],
-    importing: Package.PackageF[NonEmptyList[Referant[Unit]], Referant[Unit], Program[TypedExpr[Declaration], Statement]],
+    importing: Package.PackageF[NonEmptyList[Referant[Unit]], Referant[Unit], Program[TypeEnv[Unit], TypedExpr[Declaration], Statement]],
     iname: ImportedName[A],
     exports: List[ExportedName[B]]) extends PackageError {
       def message(sourceMap: Map[PackageName, (LocationMap, String)]) = {

--- a/core/src/main/scala/org/bykn/bosatsu/Tree.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/Tree.scala
@@ -4,7 +4,7 @@ import cats.data.{NonEmptyList, Validated, ValidatedNel}
 
 import cats.implicits._
 
-case class Tree[A](item: A, children: List[Tree[A]])
+case class Tree[+A](item: A, children: List[Tree[A]])
 
 object Tree {
 

--- a/core/src/main/scala/org/bykn/bosatsu/rankn/ParsedTypeEnv.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/rankn/ParsedTypeEnv.scala
@@ -1,0 +1,17 @@
+package org.bykn.bosatsu.rankn
+
+import org.bykn.bosatsu.PackageName
+
+case class ParsedTypeEnv[+A](allDefinedTypes: List[DefinedType[A]], externalDefs: List[(PackageName, String, Type)]) {
+  def addDefinedType[A1 >: A](dt: DefinedType[A1]): ParsedTypeEnv[A1] =
+    copy(allDefinedTypes = dt :: allDefinedTypes)
+
+  def addExternalValue(pn: PackageName, name: String, tpe: Type): ParsedTypeEnv[A] =
+    copy(externalDefs = (pn, name, tpe) :: externalDefs)
+}
+
+object ParsedTypeEnv {
+  val Empty: ParsedTypeEnv[Nothing] = ParsedTypeEnv(Nil, Nil)
+
+  def empty[A]: ParsedTypeEnv[A] = Empty
+}

--- a/core/src/main/scala/org/bykn/bosatsu/rankn/TypeEnv.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/rankn/TypeEnv.scala
@@ -99,4 +99,9 @@ object TypeEnv {
 
   def fromDefinitions[A](defs: List[DefinedType[A]]): TypeEnv[A] =
     defs.foldLeft(empty: TypeEnv[A])(_.addDefinedType(_))
+
+  def fromParsed[A](p: ParsedTypeEnv[A]): TypeEnv[A] = {
+    val t1 = p.allDefinedTypes.foldLeft(empty: TypeEnv[A])(_.addDefinedType(_))
+    p.externalDefs.foldLeft(t1) { case (t1, (p, n, t)) => t1.addExternalValue(p, n, t) }
+  }
 }

--- a/core/src/test/scala/org/bykn/bosatsu/TestUtils.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/TestUtils.scala
@@ -23,7 +23,7 @@ object TestUtils {
           tpeFn,
           consFn,
           stmt)
-        prog.types
+        TypeEnv.fromParsed(prog.types)
       case Parsed.Failure(exp, idx, extra) =>
         sys.error(s"failed to parse: $str: $exp at $idx in region ${region(str, idx)} with trace: ${extra.traced.trace}")
     }


### PR DESCRIPTION
Once again, the pattern of using a type parameter that changes at different phases becomes useful. After we have parsed the syntax, we have one notion of what types are present, but after we have fully inferred and resolved imports we have another notion.

This change allows us to express that change pretty cleanly. It also makes it explicit that we only have two kinds of changes to the type environment from parsing after imports: defined types, and external definitions.