### PR TITLE
Infer variance, but ignore it for now

### DIFF
--- a/core/src/main/scala/org/bykn/bosatsu/NameKind.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/NameKind.scala
@@ -6,7 +6,7 @@ object NameKind {
   case class Constructor(
     cn: ConstructorName,
     params: List[(ParamName, rankn.Type)],
-    defined: rankn.DefinedType[Unit],
+    defined: rankn.DefinedType[Variance],
     valueType: rankn.Type) extends NameKind
   case class Import(fromPack: Package.Inferred, originalName: String) extends NameKind
   case class ExternalDef(pack: PackageName, defName: String, defType: rankn.Type) extends NameKind

--- a/core/src/main/scala/org/bykn/bosatsu/TypeRecursionCheck.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/TypeRecursionCheck.scala
@@ -12,8 +12,8 @@ import cats.implicits._
  */
 object TypeRecursionCheck {
 
-  def check(imports: TypeEnv[Unit],
-    packageDefinedTypes: List[DefinedType[Unit]]): ValidatedNel[NonEmptyList[DefinedType[Unit]], Unit] = {
+  def check[A](imports: TypeEnv[A],
+    packageDefinedTypes: List[DefinedType[A]]): ValidatedNel[NonEmptyList[DefinedType[A]], Unit] = {
 
     val typeMap = DefinedType.listToMap(packageDefinedTypes)
     /*
@@ -21,7 +21,7 @@ object TypeRecursionCheck {
      * Since the packages already form a DAG we know
      * that we don't need to check across package boundaries
      */
-    def typeDepends(dt: DefinedType[Unit]): List[DefinedType[Unit]] =
+    def typeDepends(dt: DefinedType[A]): List[DefinedType[A]] =
       (for {
         cons <- dt.constructors
         Type.Const.Defined(p, n) <- cons._2.flatMap { case (_, t) => Type.constantsOf(t) }


### PR DESCRIPTION
This wires in the code, and lines up the types, to infer variance properly.

This could make some programs not compile if there are bugs in variance inference. A following PR will correctly use the variance to look for allowable a cases of recursion in types.