### PR TITLE
Allow basic restricted recursion in types.

### DIFF
--- a/core/src/main/scala/org/bykn/bosatsu/Package.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/Package.scala
@@ -144,7 +144,8 @@ object Package {
        * Check that the types defined here are not circular.
        */
       val circularCheck: ValidatedNel[PackageError, Unit] =
-        TypeRecursionCheck.check(importedTypeEnv, parsedTypeEnv.allDefinedTypes)
+        //TypeRecursionCheck.check(importedTypeEnv, parsedTypeEnv.allDefinedTypes)
+        TypeRecursionCheck.checkLegitRecursion(importedTypeEnv, parsedTypeEnv.allDefinedTypes)
           .leftMap { badPaths =>
             badPaths.map(PackageError.CircularType(p, _))
           }

--- a/core/src/main/scala/org/bykn/bosatsu/Package.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/Package.scala
@@ -144,7 +144,6 @@ object Package {
        * Check that the types defined here are not circular.
        */
       val circularCheck: ValidatedNel[PackageError, Unit] =
-        //TypeRecursionCheck.check(importedTypeEnv, parsedTypeEnv.allDefinedTypes)
         TypeRecursionCheck.checkLegitRecursion(importedTypeEnv, parsedTypeEnv.allDefinedTypes)
           .leftMap { badPaths =>
             badPaths.map(PackageError.CircularType(p, _))

--- a/core/src/main/scala/org/bykn/bosatsu/TypeRecursionCheck.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/TypeRecursionCheck.scala
@@ -1,7 +1,7 @@
 package org.bykn.bosatsu
 
 import cats.data.{NonEmptyList, Validated, ValidatedNel}
-import org.bykn.bosatsu.rankn.{ DefinedType, Type, TypeEnv }
+import org.bykn.bosatsu.rankn.{DefinedType, Type, TypeEnv}
 import org.bykn.bosatsu.graph.{Tree, Paths}
 
 import cats.implicits._
@@ -35,8 +35,10 @@ object TypeRecursionCheck {
   }
 
   /**
-   * If we only have recursion along covariant or phantom paths, this is okay, and cannot
-   * be used to break totality
+   * We require that defined types form a DAG excluding any links to themselves.
+   *
+   * For self references, we only have recursion along covariant or phantom paths,
+   * this is okay, and cannot be used to break totality
    */
   def checkLegitRecursion(
     imports: TypeEnv[Variance],
@@ -44,8 +46,36 @@ object TypeRecursionCheck {
 
     val typeMap = DefinedType.listToMap(packageDefinedTypes)
 
+    // Check DAG-ness of non-self-loops in current package,
+    // imports are already a DAG
+    def typeLocalDepends(dt: DefinedType[Variance]): List[DefinedType[Variance]] = {
+      val depends = for {
+        cons <- dt.constructors
+        Type.Const.Defined(p, n) <- cons._2.flatMap { case (_, t) => Type.constantsOf(t) }
+        dt1 <- typeMap.get((p, TypeName(n))).toList // we only need edges into this package,
+      } yield dt1
 
-    def buildEdges(dt: DefinedType[Variance]): List[(DefinedType[Variance], Variance, DefinedType[Variance])] = ???
+      // we handle self loops separtely
+      depends.distinct.filterNot(_ == dt)
+    }
+
+    val assertDag: ValidatedNel[NonEmptyList[DefinedType[Variance]], Unit] =
+      packageDefinedTypes.traverse_ { dt =>
+        // TODO, this can be optimized to check the entire graph at once
+        NonEmptyList.fromList(Paths.allCycle0(dt)(typeLocalDepends _)) match {
+          case None => Validated.valid(())
+          case Some(paths) =>
+            Validated.invalid(paths.map(dt :: _))
+        }
+      }
+
+    def getDT(dt: Type.Const.Defined): Option[DefinedType[Variance]] = {
+      val tn = TypeName(dt.name)
+      typeMap.get((dt.packageName, tn))
+        .orElse(imports.getType(dt.packageName, tn))
+    }
+
+    def buildEdges(dt: DefinedType[Variance]): List[(DefinedType[Variance], Variance, DefinedType[Variance])] = {
       /*
        * enum L: E, N(head: a, tail: L[a])
        *
@@ -53,44 +83,89 @@ object TypeRecursionCheck {
        *
        * Tree[a] -> + L[Tree[a]] => Tree -> + L, L -> + Tree
        */
-      // val next = for {
-      //   cons <- dt.constructors
-      //   (_, consArgs, _) = cons
-      //   Type.Const.Defined(p, n) <- consArgs.flatMap { case (_, t) => Type.constantsOf(t) }
-      //   dt1 <- typeMap.get((p, TypeName(n))).toList
-      // } yield dt1
+      def tpeToEdge(
+        src: DefinedType[Variance],
+        v: Variance,
+        t: Type): List[(DefinedType[Variance], Variance, DefinedType[Variance])] = {
+          import Type._
+          t match {
+            case Fun(a, b) =>
+              tpeToEdge(src, v * Variance.contra, a) :::
+                tpeToEdge(src, v * Variance.co, b)
+            case TyConst(dest@Const.Defined(_, _)) =>
+              getDT(dest) match {
+                case None => Nil
+                case Some(destDT) => (src, v, destDT) :: Nil
+              }
+            case TyVar(_) | TyMeta(_) => Nil
+            case rest@(ForAll(_, _) | TyApply(_, _)) =>
+              def build(t: Type, targs: List[Type]): (Option[DefinedType[Variance]], List[(Variance, Type)]) = {
+                val (left, newArgs) = Type.applicationArgs(t)
+                val args = newArgs ::: targs
+                lazy val worstCaseArgs = args.map((Variance.in, _))
+                left match {
+                  case FnType => (None, List(Variance.contra, Variance.co).zip(args))
+                  case TyConst(dt@Const.Defined(_, _)) =>
+                    getDT(dt) match {
+                      case None =>
+                        (None, worstCaseArgs)
+                      case s@Some(dt) =>
+                        val vars = dt.annotatedTypeParams.map(_._2)
+                        (s, vars.zip(args))
+                    }
+                  case ForAll(_, fa) =>
+                    build(fa, args)
+                  case _ => (None, worstCaseArgs)
+                }
+              }
 
-      // next.distinct
+              val (dest, vargs) = build(rest, Nil)
+              val next = vargs.flatMap { case (v1, a) => tpeToEdge(src, v * v1, a) }
+              dest.fold(next) { dtDest =>
+                (dt, v, dtDest) :: next
+              }
+          }
+        }
 
-    val fullEdgeList = packageDefinedTypes.flatMap(buildEdges)
-    val graph = fullEdgeList
-      .groupBy(_._1)
-      .iterator
-      .map { case (src, edges) =>
-        (src, edges.map { case (_, v, r) => (v, r) })
-      }
-      .toMap
+      for {
+        cons <- dt.constructors
+        (_, consArgs, _) = cons
+        argType <- consArgs
+        (_, tpe) = argType
+        edge <-tpeToEdge(dt, Variance.co, tpe)
+      } yield edge
 
-    def typeDepends(dt: DefinedType[Variance]): List[(Variance, DefinedType[Variance])] =
-      graph.get(dt) match {
-        case None => Nil
-        case Some(es) => es
-      }
-
-    def checkCycle(
-      start: DefinedType[Variance],
-      loop: NonEmptyList[(Variance, DefinedType[Variance])]): ValidatedNel[NonEmptyList[DefinedType[Variance]], Unit] = {
-
-      val loopVariance = loop.tail.foldLeft(loop.head._1) { case (v0, (v1, _)) => v0 * v1 }
-      if ((loopVariance == Variance.in) || (loopVariance == Variance.contra)) {
-        Validated.invalidNel(start :: loop.map(_._2))
-      }
-      else Validated.valid(())
     }
 
-    packageDefinedTypes.traverse_ { dt =>
-      val cycles = Paths.allCycles(dt)(typeDepends _)
-      cycles.traverse_(checkCycle(dt, _))
+    // Here we are just checking if we can find a loop from dt to dt that is covariant
+    def checkSelfRecursions(dt: DefinedType[Variance]): ValidatedNel[NonEmptyList[DefinedType[Variance]], Unit] = {
+      val graph = buildEdges(dt)
+        .groupBy(_._1)
+        .iterator
+        .map { case (src, edges) =>
+          (src, edges.map { case (_, v, r) => (v, r) })
+        }
+        .toMap
+
+      val loops = Paths.allCycles(dt)(graph.getOrElse(_, Nil))
+      // filter bad loops:
+      val bad = loops.filter { loop =>
+        val variances: NonEmptyList[Variance] = loop.map(_._1)
+        val variance = variances.reduce[Variance](_ * _)
+        (variance == Variance.in) || (variance == Variance.contra)
+      }
+
+      NonEmptyList.fromList(bad) match {
+        case None => Validated.valid(())
+        case Some(badPaths) =>
+          Validated.invalid(badPaths.map { path => dt :: path.map(_._2) })
+      }
     }
+
+    val assertRecursions =
+      packageDefinedTypes.traverse_(checkSelfRecursions _)
+
+    assertDag *> assertRecursions
+
   }
 }

--- a/core/src/main/scala/org/bykn/bosatsu/TypeRecursionCheck.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/TypeRecursionCheck.scala
@@ -2,7 +2,7 @@ package org.bykn.bosatsu
 
 import cats.data.{NonEmptyList, Validated, ValidatedNel}
 import org.bykn.bosatsu.rankn.{DefinedType, Type, TypeEnv}
-import org.bykn.bosatsu.graph.{Tree, Paths}
+import org.bykn.bosatsu.graph.Paths
 
 import cats.implicits._
 
@@ -12,27 +12,6 @@ import cats.implicits._
  * in imports cannot refer to packageDefinedTypes
  */
 object TypeRecursionCheck {
-
-  def check[A](imports: TypeEnv[A],
-    packageDefinedTypes: List[DefinedType[A]]): ValidatedNel[NonEmptyList[DefinedType[A]], Unit] = {
-
-    val typeMap = DefinedType.listToMap(packageDefinedTypes)
-    /*
-     * Check that the types defined here are not circular.
-     * Since the packages already form a DAG we know
-     * that we don't need to check across package boundaries
-     */
-    def typeDepends(dt: DefinedType[A]): List[DefinedType[A]] =
-      (for {
-        cons <- dt.constructors
-        Type.Const.Defined(p, n) <- cons._2.flatMap { case (_, t) => Type.constantsOf(t) }
-        dt1 <- typeMap.get((p, TypeName(n))).toList
-      } yield dt1).distinct
-
-    packageDefinedTypes.traverse_ { dt =>
-      Tree.dagToTree(dt)(typeDepends _)
-    }
-  }
 
   /**
    * We require that defined types form a DAG excluding any links to themselves.

--- a/core/src/main/scala/org/bykn/bosatsu/TypeRecursionCheck.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/TypeRecursionCheck.scala
@@ -1,6 +1,6 @@
 package org.bykn.bosatsu
 
-import cats.data.{NonEmptyList, ValidatedNel}
+import cats.data.{NonEmptyList, Validated, ValidatedNel}
 import org.bykn.bosatsu.rankn.{ DefinedType, Type, TypeEnv }
 
 import cats.implicits._
@@ -29,7 +29,58 @@ object TypeRecursionCheck {
       } yield dt1).distinct
 
     packageDefinedTypes.traverse_ { dt =>
-      Tree.dagToTree(dt)(typeDepends _)
+      graph.Tree.dagToTree(dt)(typeDepends _)
+    }
+  }
+
+  /**
+   * If we only have recursion along covariant or phantom paths, this is okay, and cannot
+   * be used to break totality
+   */
+  def checkLegitRecursion(
+    imports: TypeEnv[Variance],
+    packageDefinedTypes: List[DefinedType[Variance]]): ValidatedNel[NonEmptyList[DefinedType[Variance]], Unit] = {
+
+    val typeMap = DefinedType.listToMap(packageDefinedTypes)
+    /*
+     * Check that the types defined here are not circular.
+     * Since the packages already form a DAG we know
+     * that we don't need to check across package boundaries
+     */
+    def typeDepends(dt: DefinedType[Variance]): List[(Variance, DefinedType[Variance])] = {
+      /**
+       * enum L: E, N(head: a, tail: L[a])
+       *
+       * struct Tree(root: a, children: L[Tree[a]])
+       *
+       * Tree[a] -> + L[Tree[a]]
+       * L[Tree[a]] -> + Tree[a], +L[Tree[a]]
+       */
+      // val next = for {
+      //   cons <- dt.constructors
+      //   (_, consArgs, _) = cons
+      //   Type.Const.Defined(p, n) <- consArgs.flatMap { case (_, t) => Type.constantsOf(t) }
+      //   dt1 <- typeMap.get((p, TypeName(n))).toList
+      // } yield dt1
+
+      // next.distinct
+      ???
+    }
+
+    def checkCycle(
+      start: DefinedType[Variance],
+      loop: NonEmptyList[(Variance, DefinedType[Variance])]): ValidatedNel[NonEmptyList[DefinedType[Variance]], Unit] = {
+
+      val loopVariance = loop.tail.foldLeft(loop.head._1) { case (v0, (v1, _)) => v0 * v1 }
+      if ((loopVariance == Variance.in) || (loopVariance == Variance.contra)) {
+        Validated.invalidNel(start :: loop.map(_._2))
+      }
+      else Validated.valid(())
+    }
+
+    packageDefinedTypes.traverse_ { dt =>
+      val cycles = graph.Paths.allCycles(dt)(typeDepends _)
+      cycles.traverse_(checkCycle(dt, _))
     }
   }
 }

--- a/core/src/main/scala/org/bykn/bosatsu/TypeRecursionCheck.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/TypeRecursionCheck.scala
@@ -150,8 +150,11 @@ object TypeRecursionCheck {
       val loops = Paths.allCycles(dt)(graph.getOrElse(_, Nil))
       // filter bad loops:
       val bad = loops.filter { loop =>
-        val variances: NonEmptyList[Variance] = loop.map(_._1)
-        val variance = variances.reduce[Variance](_ * _)
+        val variance =
+          loop.toList
+            .iterator
+            .map(_._1)
+            .reduce(_ * _) // reduce is safe since we have a non-empty list
         (variance == Variance.in) || (variance == Variance.contra)
       }
 

--- a/core/src/main/scala/org/bykn/bosatsu/VarianceFormula.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/VarianceFormula.scala
@@ -333,10 +333,6 @@ object VarianceFormula {
       val unknowns = te.toList.filter(isUn)
       NonEmptyList.fromList(unknowns) match {
         case None =>
-          /*
-           * TODO: external defs have no constructors, we should assume their types
-           * are invariant, but this may be setting them to phantom, which is unsound
-           */
           Right(travListDT.map(te)(ss.solutions.getOrElse(_, Phantom)).toList)
         case Some(err) =>
           Left(err.sortBy { dt => (dt.packageName, dt.name) }.map(_.as(())))

--- a/core/src/main/scala/org/bykn/bosatsu/graph/Paths.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/graph/Paths.scala
@@ -1,0 +1,47 @@
+package org.bykn.bosatsu.graph
+
+import cats.data.NonEmptyList
+
+object Paths {
+  /**
+   * A list of cycles all terminating at node
+   * E is intended to carry state about the edge in the graph
+   */
+  def allCycles[A, E](node: A)(nfn: A => List[(E, A)]): List[NonEmptyList[(E, A)]] =
+    allPaths(node, node)(nfn)
+
+  /**
+   * A list of paths all terminating at to, but omitting from.
+   * E is intended to carry state about the edge in the graph
+   */
+  def allPaths[A, E](from: A, to: A)(nfn: A => List[(E, A)]): List[NonEmptyList[(E, A)]] = {
+    def loop(from: A, to: A, avoid: Set[A]): List[NonEmptyList[(E, A)]] = {
+      val newPaths = nfn(from).filterNot { case (_, a) => avoid(a) }
+      val (ends, notEnds) = newPaths.partition { case (_, a) => a == to }
+
+      val rest = notEnds.flatMap { case edge@(_, a) =>
+        // don't loop back on a, loops to a are handled by ends
+        loop(a, to, avoid + a).map(edge :: _)
+      }
+
+      NonEmptyList.fromList(ends) match {
+        case None => rest
+        case Some(endsNE) => endsNE :: rest
+      }
+    }
+
+    loop(from, to, Set.empty)
+  }
+
+  /**
+   * Same as allPaths but without the edge annotation type
+   */
+  def allPaths0[A](start: A, end: A)(nfn: A => List[A]): List[NonEmptyList[A]] =
+    allPaths(start, end)(nfn.andThen(_.map(((), _)))).map(_.map(_._2))
+
+  /**
+   * Same as allCycles but without the edge annotation type
+   */
+  def allCycle0[A](start: A)(nfn: A => List[A]): List[NonEmptyList[A]] =
+    allPaths0(start, start)(nfn)
+}

--- a/core/src/main/scala/org/bykn/bosatsu/graph/Tree.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/graph/Tree.scala
@@ -1,4 +1,4 @@
-package org.bykn.bosatsu
+package org.bykn.bosatsu.graph
 
 import cats.data.{NonEmptyList, Validated, ValidatedNel}
 
@@ -45,5 +45,6 @@ object Tree {
     }
     treeOf(NonEmptyList(node, Nil), Set(node))
   }
+
 }
 

--- a/core/src/main/scala/org/bykn/bosatsu/rankn/Type.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/rankn/Type.scala
@@ -108,6 +108,16 @@ object Type {
       case TyApply(left, _) => rootConst(left)
     }
 
+  def applicationArgs(t: Type): (Type, List[Type]) = {
+    @annotation.tailrec
+    def loop(t: Type, tail: List[Type]): (Type, List[Type]) =
+      t match {
+        case TyApply(left, right) => loop(left, right :: tail)
+        case notApply => (notApply, tail)
+      }
+    loop(t, Nil)
+  }
+
   /**
    * Return the Bound and Skolem variables that
    * are free in the given list of types

--- a/core/src/test/scala/org/bykn/bosatsu/TypeRecursionCheckTest.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/TypeRecursionCheckTest.scala
@@ -1,0 +1,73 @@
+package org.bykn.bosatsu
+
+import cats.data.Validated
+import org.bykn.bosatsu.rankn.TypeEnv
+import org.scalatest.FunSuite
+
+class TypeRecursionCheckTest extends FunSuite {
+
+  def allowed(teStr: String) = {
+    val te = TestUtils.typeEnvOf(Predef.packageName, teStr)
+    VarianceFormula.solve(TypeEnv.empty, te.allDefinedTypes) match {
+      case Left(errs) => fail(s"couldn't solve: $errs")
+      case Right(teVar) =>
+        assert(
+          TypeRecursionCheck.checkLegitRecursion(TypeEnv.empty, teVar) ==
+            Validated.valid(()))
+    }
+  }
+
+  def disallowed(teStr: String) = {
+    val te = TestUtils.typeEnvOf(Predef.packageName, teStr)
+    VarianceFormula.solve(TypeEnv.empty, te.allDefinedTypes) match {
+      case Left(errs) => fail(s"couldn't solve: $errs")
+      case Right(teVar) =>
+        assert(
+          TypeRecursionCheck.checkLegitRecursion(TypeEnv.empty, teVar).isInvalid)
+    }
+  }
+
+  test("linked list is allowed") {
+    allowed("""#
+enum Lst: E, N(head: a, tail: Lst[a])
+""")
+  }
+
+  test("tree is allowed") {
+    allowed("""#
+enum Lst: E, N(head: a, tail: Lst[a])
+
+struct Tree(root: a, children: Lst[Tree[a]])
+""")
+  }
+
+  test("directory example is allowed") {
+    allowed("""#
+enum Lst: E, N(head: a, tail: Lst[a])
+
+enum Path:
+  Dir(name: String, children: Lst[Path])
+  File(name: String, content: String)
+""")
+  }
+
+  test("cont is allowed with Tree") {
+    allowed("""#
+struct Cont(fn: (a -> b) -> b)
+
+struct Tree(root: a, children: Cont[Tree[a], b])
+""")
+
+    disallowed("""#
+struct ICont(fn: (a -> a) -> a)
+
+struct Tree(root: a, children: ICont[Tree[a]])
+""")
+  }
+
+  test("y-combinator type is disallowed") {
+    disallowed("""#
+struct W(fn: W[a, b] -> a -> b)
+""")
+  }
+}

--- a/core/src/test/scala/org/bykn/bosatsu/TypeRecursionCheckTest.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/TypeRecursionCheckTest.scala
@@ -70,4 +70,17 @@ struct Tree(root: a, children: ICont[Tree[a]])
 struct W(fn: W[a, b] -> a -> b)
 """)
   }
+
+  test("mutual recursion is (currently) completely unallowed") {
+    disallowed("""#
+struct Foo(bar: Bar)
+struct Bar(foo: Foo)
+""")
+  }
+
+  test("recursion with type construtors is disallowed") {
+    disallowed("""#
+struct Tree(root: a, children: f[Tree[a]])
+""")
+  }
 }


### PR DESCRIPTION
This PR attempts to address #148 undoing #102.

The check currently is rather restrictive. The graph of types must:
1. form a DAG *excluding self references*.
2. for each type, all self referential loops must be via covariant or phantom variance paths.

This allows us to write all the kinds of types that I think we want, and are also safe: List, Tree, etc... while banning types that can be used to allow recursion, e.g. types associated with the y-combinator.

A follow up to this PR will be making List a normal type again, and not an external def, but I will keep the special python inspired syntax we have for lists.