### PR TITLE
Make List a native, non-external type again

### DIFF
--- a/core/src/main/resources/bosatsu/predef.bosatsu
+++ b/core/src/main/resources/bosatsu/predef.bosatsu
@@ -6,7 +6,7 @@ export [
   Comparison(),
   Int,
   Option(),
-  List,
+  List(),
   String,
   Test(),
   TestSuite(),
@@ -15,9 +15,7 @@ export [
   add,
   cmp_Int,
   concat,
-  consList,
   div,
-  emptyList,
   eq_Int,
   foldLeft,
   gcd_Int,
@@ -39,18 +37,16 @@ enum Bool:
   False
   True
 
-external struct List[a]
-
-external def emptyList -> List[a]
-external def consList(head: a, tail: List[a]) -> List[a]
+enum List:
+  EmptyList, NonEmptyList(head: a, tail: List[a])
 
 external def foldLeft(lst: List[a], item: b, fn: b -> a -> b) -> b
 
 def reverse_concat(front: List[a], back: List[a]) -> List[a]:
-  foldLeft(front, back, \tail, h -> consList(h, tail))
+  foldLeft(front, back, \tail, h -> NonEmptyList(h, tail))
 
 def reverse(as: List[a]) -> List[a]:
-  reverse_concat(as, emptyList)
+  reverse_concat(as, EmptyList)
 
 def concat(front: List[a], back: List[a]) -> List[a]:
   match back:

--- a/core/src/main/scala/org/bykn/bosatsu/Declaration.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/Declaration.scala
@@ -196,9 +196,9 @@ sealed abstract class Declaration {
               // TODO we need to refer to Predef/EmptyList no matter what here
               // but we have no way to fully refer to an item
               val pn = Option(Predef.packageName)
-              val empty: Expr[Declaration] = Expr.Var(pn, "emptyList", l)
+              val empty: Expr[Declaration] = Expr.Var(pn, "EmptyList", l)
               def cons(head: Expr[Declaration], tail: Expr[Declaration]): Expr[Declaration] =
-                Expr.App(Expr.App(Expr.Var(pn, "consList", l), head, l), tail, l)
+                Expr.App(Expr.App(Expr.Var(pn, "NonEmptyList", l), head, l), tail, l)
 
               def concat(headList: Expr[Declaration], tail: Expr[Declaration]): Expr[Declaration] =
                 Expr.App(Expr.App(Expr.Var(pn, "concat", l), headList, l), tail, l)

--- a/core/src/main/scala/org/bykn/bosatsu/Predef.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/Predef.scala
@@ -34,25 +34,25 @@ object Predef {
         "Assertion",
         "Bool",
         "Comparison",
-        "LT",
         "EQ",
-        "GT",
+        "EmptyList",
         "False",
+        "GT",
         "Int",
+        "LT",
         "List",
+        "NonEmptyList",
         "None",
         "Option",
         "Some",
         "String",
-        "True",
         "Test",
         "TestSuite",
+        "True",
         "Tuple2",
         "Unit",
         "add",
-        "consList",
         "div",
-        "emptyList",
         "eq_Int",
         "concat",
         "cmp_Int",
@@ -78,8 +78,6 @@ object Predef {
       .add(packageName, "sub", FfiCall.ScalaCall("org.bykn.bosatsu.PredefImpl.sub"))
       .add(packageName, "times", FfiCall.ScalaCall("org.bykn.bosatsu.PredefImpl.times"))
       .add(packageName, "eq_Int", FfiCall.ScalaCall("org.bykn.bosatsu.PredefImpl.eq_Int"))
-      .add(packageName, "emptyList", FfiCall.ScalaCall("org.bykn.bosatsu.PredefImpl.emptyList"))
-      .add(packageName, "consList", FfiCall.ScalaCall("org.bykn.bosatsu.PredefImpl.consList"))
       .add(packageName, "cmp_Int", FfiCall.ScalaCall("org.bykn.bosatsu.PredefImpl.cmp_Int"))
       .add(packageName, "foldLeft", FfiCall.ScalaCall("org.bykn.bosatsu.PredefImpl.foldLeft"))
       .add(packageName, "gcd_Int", FfiCall.ScalaCall("org.bykn.bosatsu.PredefImpl.gcd_Int"))
@@ -148,10 +146,6 @@ object PredefImpl {
 
   def gcd_Int(a: Value, b: Value): Value =
     VInt(i(a).gcd(i(b)))
-
-  def emptyList: Value = VList.VNil
-  def consList(head: Value, tail: Value): Value =
-    VList.Cons(head, tail)
 
   def range(v: Value): Value = {
     val max = i(v)

--- a/core/src/test/scala/org/bykn/bosatsu/EvaluationTest.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/EvaluationTest.scala
@@ -251,6 +251,18 @@ main = match x:
       List("""
 package Foo
 
+x = [1]
+
+# test using List literals
+main = match x:
+  EmptyList: "empty"
+  NonEmptyList(_, _): "notempty"
+"""), "Foo", Str("notempty"))
+
+    evalTest(
+      List("""
+package Foo
+
 x = "1"
 
 main = match x:

--- a/docs/language_guide.md
+++ b/docs/language_guide.md
@@ -181,7 +181,15 @@ neg = Pair(1, -1)
 ```
 Types are assigned left to right when they are omitted.
 
-Structs may not be recursive. The following is not allowed:
+Types must form a directed acyclic graph (DAG) with the exception that they
+may refer to themselves in covariant positions (i.e. not in the inputs to functions).
+
+E.g. in Predef we will find a standard linked list:
+```
+enum List: EmptyList, NonEmptyList(head: a, tail: List[a])
+```
+
+On the other hand, the following is disallowed:
 ```
 struct W(fn: W[a, b] -> a -> b)
 ```
@@ -328,11 +336,8 @@ There is syntax for declaring external values and functions. This is obviously d
 gives the user a chance to violate totality. Use with caution.
 
 
-As we discussed above, we cannot implement `List` in Bosatu. In the predef, we can find the following:
+As we discussed above, we cannot implement `foldLeft` in Bosatu. In the predef, we can find the following:
 ```
-external struct List[a]
-external def emptyList -> List[a]
-external def consList(head: a, tail: List[a]) -> List[a]
 external def foldLeft(lst: List[a], init: b, fn: b -> a -> b) -> b
 external def range(exclusive_upper: Int): List[Int]
 ```


### PR DESCRIPTION
This reverts the list change in #102 

now that we can support recursive types in covariant position, no need to have List as an external type.