### PR TITLE
Plumb variance information through the inference

### DIFF
--- a/core/src/main/scala/org/bykn/bosatsu/Referant.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/Referant.scala
@@ -58,10 +58,10 @@ object Referant {
 
   def typeConstructors[A, B](
     imps: List[Import[A, NonEmptyList[Referant[B]]]]):
-      Map[(PackageName, ConstructorName), (List[rankn.Type.Var], List[rankn.Type], rankn.Type.Const.Defined)] = {
+      Map[(PackageName, ConstructorName), (List[(rankn.Type.Var, B)], List[rankn.Type], rankn.Type.Const.Defined)] = {
     val refs: Iterator[Referant[B]] = imps.iterator.flatMap(_.items.toList.iterator.flatMap(_.tag.toList))
     refs.collect { case Constructor(cn, dt, params, _) =>
-      ((dt.packageName, cn), (dt.typeParams, params.map(_._2), dt.toTypeConst))
+      ((dt.packageName, cn), (dt.annotatedTypeParams, params.map(_._2), dt.toTypeConst))
     }
     .toMap
   }

--- a/core/src/main/scala/org/bykn/bosatsu/rankn/TypeEnv.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/rankn/TypeEnv.scala
@@ -70,10 +70,10 @@ class TypeEnv[+A] private (
 
   // TODO to support parameter named patterns we'd need to know the
   // parameter names
-  lazy val typeConstructors: SortedMap[(PackageName, ConstructorName), (List[Type.Var], List[Type], Type.Const.Defined)] =
+  lazy val typeConstructors: SortedMap[(PackageName, ConstructorName), (List[(Type.Var, A)], List[Type], Type.Const.Defined)] =
     constructors.map { case (pc, (params, dt, _)) =>
       (pc,
-        (dt.typeParams,
+        (dt.annotatedTypeParams,
           params.map(_._2),
           dt.toTypeConst))
     }

--- a/core/src/test/scala/org/bykn/bosatsu/rankn/RankNInferTest.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/rankn/RankNInferTest.scala
@@ -3,7 +3,7 @@ package org.bykn.bosatsu.rankn
 import cats.data.{NonEmptyList, Validated}
 import fastparse.all.Parsed
 import org.scalatest.{Assertion, FunSuite}
-import org.bykn.bosatsu.{Declaration, Expr, HasRegion, Lit, PackageName, Package, Pattern, TypeRef, TypedExpr, ConstructorName, Region, Statement}
+import org.bykn.bosatsu.{Declaration, Expr, HasRegion, Lit, PackageName, Package, Pattern, TypeRef, TypedExpr, ConstructorName, Region, Statement, Variance}
 
 import Expr._
 import Type.Var.Bound
@@ -207,8 +207,8 @@ class RankNInferTest extends FunSuite {
       ((pn, ConstructorName("None")), (Nil, Nil, optName)))
 
     val definedOptionGen = Map(
-      ((pn, ConstructorName("Some")), (List(Bound("a")), List(Type.TyVar(Bound("a"))), optName)),
-      ((pn, ConstructorName("None")), (List(Bound("a")), Nil, optName)))
+      ((pn, ConstructorName("Some")), (List((Bound("a"), Variance.co)), List(Type.TyVar(Bound("a"))), optName)),
+      ((pn, ConstructorName("None")), (List((Bound("a"), Variance.co)), Nil, optName)))
   }
 
   test("match with custom non-generic types") {
@@ -317,11 +317,11 @@ class RankNInferTest extends FunSuite {
      * struct Pure(pure: forall a. a -> f[a])
      */
     val defined = Map(
-      ((pn, ConstructorName("Pure")), (List(b("f")),
+      ((pn, ConstructorName("Pure")), (List((b("f"), Variance.in)),
         List(Type.ForAll(NonEmptyList.of(b("a")), Type.Fun(tv("a"), Type.TyApply(tv("f"), tv("a"))))),
         pureName)),
-      ((pn, ConstructorName("Some")), (List(b("a")), List(tv("a")), optName)),
-      ((pn, ConstructorName("None")), (List(b("a")), Nil, optName)))
+      ((pn, ConstructorName("Some")), (List((b("a"), Variance.co)), List(tv("a")), optName)),
+      ((pn, ConstructorName("None")), (List((b("a"), Variance.co)), Nil, optName)))
 
     val constructors = Map(
       ("Pure", Type.ForAll(NonEmptyList.of(b("f")),


### PR DESCRIPTION
see #106 and #144 

This makes variance information available to inference, but we do not yet use it.

In a follow up PR we can stop specializing on Type.Fun in inference and instead use the variance of each type parameter of a given user defined type.