### PR TITLE
Define Package.Interface to avoid using all of the package

### DIFF
--- a/core/src/main/scala/org/bykn/bosatsu/Package.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/Package.scala
@@ -29,6 +29,9 @@ case class Package[A, B, C, D](
 
   def mapProgram[D1](fn: D => D1): Package[A, B, C, D1] =
     Package(name, imports, exports, fn(program))
+
+  def replaceImports[A1, B1](newImports: List[Import[A1, B1]]): Package[A1, B1, C, D] =
+    Package(name, newImports, exports, program)
 }
 
 object Package {
@@ -37,7 +40,7 @@ object Package {
   type PackageF2[A, B] = PackageF[A, A, B]
   type Parsed = Package[PackageName, Unit, Unit, Statement]
   type Resolved = FixPackage[Unit, Unit, (Statement, ImportMap[PackageName, Unit])]
-  type Interface = FixPackage[NonEmptyList[Referant[Variance]], Referant[Variance], Unit]
+  type Interface = FixPackage[Nothing, Referant[Variance], Unit]
   type Inferred = Package[Interface, NonEmptyList[Referant[Variance]], Referant[Variance], Program[TypeEnv[Variance], TypedExpr[Declaration], Statement]]
 
   /**
@@ -50,9 +53,9 @@ object Package {
   def interfaceOf(inferred: Inferred): Interface =
     Fix[Lambda[A =>
       Package[A,
-        NonEmptyList[Referant[Variance]],
+        Nothing,
         Referant[Variance],
-        Unit]]](inferred.mapProgram(_ => ()))
+        Unit]]](inferred.mapProgram(_ => ()).replaceImports(Nil))
 
   implicit val document: Document[Package[PackageName, Unit, Unit, Statement]] =
     Document.instance[Package.Parsed] { case Package(name, imports, exports, program) =>

--- a/core/src/test/scala/org/bykn/bosatsu/CodegenTest.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/CodegenTest.scala
@@ -47,8 +47,8 @@ z = x
     def packToDoc(p: Package.Inferred): Doc =
       CodeGen.run(cg.genPackage(p, Externals.empty))._1
 
-    val doc1 = packToDoc(Package.asInferred(pm.toMap.toList(0)._2))
-    val doc2 = packToDoc(Package.asInferred(pm.toMap.toList(1)._2))
+    val doc1 = packToDoc(pm.toMap.toList(0)._2)
+    val doc2 = packToDoc(pm.toMap.toList(1)._2)
     assert(doc1.render(80).nonEmpty) // TODO
     assert(doc2.render(80).nonEmpty)
   }


### PR DESCRIPTION
relates to #161 

This weakens the view, in the types, of what inference sees to be clear you don't see the full bodies of the expressions you import.

This cleans up things a bit, and hopefully makes it easier to add separate compilation since now we could add not only parsed inputs but previously inferred interface files as well.