### PR TITLE
filter free vars in lambda

### DIFF
--- a/core/src/main/resources/bosatsu/predef.bosatsu
+++ b/core/src/main/resources/bosatsu/predef.bosatsu
@@ -40,10 +40,13 @@ enum Bool:
 enum List:
   EmptyList, NonEmptyList(head: a, tail: List[a])
 
-recursive def foldLeft(lst: List[a], item: b, fn: b -> a -> b) -> b:
-  recur lst:
-    EmptyList: item
-    NonEmptyList(head, tail): foldLeft(tail, fn(item, head), fn)
+def foldLeft(lst: List[a], item: b, fn: b -> a -> b) -> b:
+  # make the loop function as small as possible
+  recursive def loop(lst, item):
+    recur lst:
+      EmptyList: item
+      NonEmptyList(head, tail): loop(tail, fn(item, head))
+  loop(lst, item)
 
 def reverse_concat(front: List[a], back: List[a]) -> List[a]:
   foldLeft(front, back, \tail, h -> NonEmptyList(h, tail))

--- a/core/src/main/scala/org/bykn/bosatsu/TypedExpr.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/TypedExpr.scala
@@ -191,7 +191,14 @@ object TypedExpr {
         case If(c, ift, iff, _) :: tail =>
           go(c :: ift :: iff :: tail, bound, acc)
         case Match(arg, branches, _) :: tail =>
-          go(arg :: branches.toList.map(_._2) ::: tail, bound, acc)
+          // Maintain the order we encounter things:
+          val acc1 = cheat(arg, bound, acc)
+          val acc2 = branches.foldLeft(acc1) { case (acc1, (p, b)) =>
+            // these are not free variables in this branch
+            val newBinds = p.names
+            cheat(b, bound ++ newBinds, acc1)
+          }
+          go(tail, bound, acc2)
       }
 
     go(ts, Set.empty, Nil)

--- a/core/src/main/scala/org/bykn/bosatsu/TypedExpr.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/TypedExpr.scala
@@ -165,8 +165,8 @@ object TypedExpr {
   def freeVars[A](ts: List[TypedExpr[A]]): List[String] = {
 
     // usually we can recurse in a loop, but sometimes not
-    def cheat(ts: List[TypedExpr[A]], bound: Set[String], acc: List[String]): List[String] =
-      go(ts, bound, acc)
+    def cheat(te: TypedExpr[A], bound: Set[String], acc: List[String]): List[String] =
+      go(te :: Nil, bound, acc)
 
     @annotation.tailrec
     def go(ts: List[TypedExpr[A]], bound: Set[String], acc: List[String]): List[String] =
@@ -179,12 +179,12 @@ object TypedExpr {
         case Var(opt, name, _, _) :: tail if bound(name) || opt.isDefined => go(tail, bound, acc)
         case Var(None, name, _, _) :: tail => go(tail, bound, name :: acc)
         case AnnotatedLambda(arg, _, res, _) :: tail =>
-          val acc1 = cheat(res :: Nil, bound + arg, acc)
+          val acc1 = cheat(res, bound + arg, acc)
           go(tail, bound, acc1)
         case App(fn, arg, _, _) :: tail =>
           go(fn :: arg :: tail, bound, acc)
         case Let(arg, argE, in, _, _) :: tail =>
-          val acc1 = cheat(in :: Nil, bound + arg, acc)
+          val acc1 = cheat(in, bound + arg, acc)
           go(argE :: tail, bound, acc1)
         case Literal(_, _, _) :: tail =>
           go(tail, bound, acc)
@@ -194,15 +194,9 @@ object TypedExpr {
           go(arg :: branches.toList.map(_._2) ::: tail, bound, acc)
       }
 
-    ts.foldLeft(List.empty[String]) { (acc, t) =>
-      go(t :: Nil, Set.empty, acc)
-    }
-    // reverse and distinct in one go
-    .foldLeft((Set.empty[String], List.empty[String])) {
-      case (res@(vset, vs), v) if vset(v) => res
-      case ((vset, vs), v) => (vset + v, v :: vs)
-    }
-    ._2
+    go(ts, Set.empty, Nil)
+      .reverse
+      .distinct
   }
 
   /**

--- a/core/src/test/scala/org/bykn/bosatsu/TestUtils.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/TestUtils.scala
@@ -1,8 +1,12 @@
 package org.bykn.bosatsu
 
 import org.bykn.bosatsu.rankn._
+import cats.data.Validated
+import org.scalatest.{Assertion, Assertions}
 
 import fastparse.all.Parsed
+
+import Assertions.fail
 
 object TestUtils {
   import TestParseUtils.region
@@ -40,4 +44,16 @@ object TestUtils {
         sys.error(s"failed to parse: $str: $exp at $idx in region ${region(str, idx)} with trace: ${extra.traced.trace}")
     }
   }
+
+  def checkLast(statement: String)(fn: TypedExpr[Declaration] => Assertion): Assertion =
+    Statement.parser.parse(statement) match {
+      case Parsed.Success(stmt, _) =>
+        Package.inferBody(PackageName.parts("Test"), Nil, stmt) match {
+          case Validated.Invalid(errs) => fail(errs.toList.map(_.message(Map.empty)).mkString("\n"))
+          case Validated.Valid((_, lets)) =>
+            fn(lets.last._3)
+        }
+      case Parsed.Failure(exp, idx, extra) =>
+        fail(s"failed to parse: $statement: $exp at $idx with trace: ${extra.traced.trace}")
+    }
 }

--- a/core/src/test/scala/org/bykn/bosatsu/TypedExprTest.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/TypedExprTest.scala
@@ -1,0 +1,25 @@
+package org.bykn.bosatsu
+
+import org.scalatest.FunSuite
+
+import TestUtils.checkLast
+
+class TypedExprTest extends FunSuite {
+  test("freeVars on simple cases works") {
+    checkLast("""#
+x = 1
+def id(x): x
+y = id(x)
+""") { te => assert(TypedExpr.freeVars(te :: Nil) == List("id", "x")) }
+
+    checkLast("""#
+x = 1
+""") { te => assert(TypedExpr.freeVars(te :: Nil) == Nil) }
+
+    checkLast("""#
+struct Tup2(a, b)
+
+x = Tup2(1, 2)
+""") { te => assert(TypedExpr.freeVars(te :: Nil) == List("Tup2")) }
+  }
+}

--- a/core/src/test/scala/org/bykn/bosatsu/TypedExprTest.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/TypedExprTest.scala
@@ -21,5 +21,13 @@ struct Tup2(a, b)
 
 x = Tup2(1, 2)
 """) { te => assert(TypedExpr.freeVars(te :: Nil) == List("Tup2")) }
+
+    checkLast("""#
+struct Tup2(a, b)
+
+x = Tup2(1, 2)
+y = match x:
+  Tup2(a, _): a
+""") { te => assert(TypedExpr.freeVars(te :: Nil) == List("x")) }
   }
 }

--- a/core/src/test/scala/org/bykn/bosatsu/rankn/RankNInferTest.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/rankn/RankNInferTest.scala
@@ -2,12 +2,14 @@ package org.bykn.bosatsu.rankn
 
 import cats.data.{NonEmptyList, Validated}
 import fastparse.all.Parsed
-import org.scalatest.{Assertion, FunSuite}
-import org.bykn.bosatsu.{Declaration, Expr, HasRegion, Lit, PackageName, Package, Pattern, TypeRef, TypedExpr, ConstructorName, Region, Statement, Variance, RecursionKind}
+import org.scalatest.FunSuite
+import org.bykn.bosatsu._
 
 import Expr._
 import Type.Var.Bound
 import Type.ForAll
+
+import TestUtils.checkLast
 
 class RankNInferTest extends FunSuite {
 
@@ -91,17 +93,6 @@ class RankNInferTest extends FunSuite {
       },
       ())
 
-  def checkLast(statement: String)(fn: TypedExpr[Declaration] => Assertion): Assertion =
-    Statement.parser.parse(statement) match {
-      case Parsed.Success(stmt, _) =>
-        Package.inferBody(PackageName.parts("Test"), Nil, stmt) match {
-          case Validated.Invalid(errs) => fail(errs.toList.map(_.message(Map.empty)).mkString("\n"))
-          case Validated.Valid((_, lets)) =>
-            fn(lets.last._3)
-        }
-      case Parsed.Failure(exp, idx, extra) =>
-        fail(s"failed to parse: $statement: $exp at $idx with trace: ${extra.traced.trace}")
-    }
   /**
    * Check that a no import program has a given type
    */


### PR DESCRIPTION
Filter the environment we capture before building a Lambda function. This seems to help somewhat, and is just good for GC also. A real code generator would need to do this.

Also, I noticed on a test I added, performance of foldLeft is about 4-5x better if I only recur on the two variables that are changing, and let fn be captured by a closure. That is likely a general strategy: minimize the function size for recursive functions while we don't have any optimization of multiple argument functions (so they are implemented via currying).