### PR TITLE
Unify def and recursive def

### DIFF
--- a/core/src/main/resources/bosatsu/predef.bosatsu
+++ b/core/src/main/resources/bosatsu/predef.bosatsu
@@ -42,7 +42,7 @@ enum List:
 
 def foldLeft(lst: List[a], item: b, fn: b -> a -> b) -> b:
   # make the loop function as small as possible
-  recursive def loop(lst, item):
+  def loop(lst, item):
     recur lst:
       EmptyList: item
       NonEmptyList(head, tail): loop(tail, fn(item, head))

--- a/core/src/main/scala/org/bykn/bosatsu/DefRecursionCheck.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/DefRecursionCheck.scala
@@ -206,14 +206,13 @@ object DefRecursionCheck {
               val idx = inrec.index
               // here we are calling our recursive function
               // make sure we do so on a substructural match
-              val defname = inrec.defname
-              if (nm == defname) {
+              if (nm == irb.defname) {
                 args.get(idx.toLong) match {
                   case None =>
                     // not enough args to check recursion
                     failSt(InvalidRecursion(nm, decl.region))
                   case Some(arg) =>
-                    toSt(strictSubstructure(defname, branch, arg)) *>
+                    toSt(strictSubstructure(irb.defname, branch, arg)) *>
                       setSt(irb.incRecCount) // we have recurred again
                 }
               }
@@ -271,7 +270,7 @@ object DefRecursionCheck {
           getSt.flatMap {
             case TopLevel | InRecurBranch(_, _) | InDefRecurred(_, _, _, _) =>
               failSt(UnexpectedRecur(recur))
-            case ir@InDef(_, defname, args) =>
+            case InDef(_, defname, args) =>
               toSt(getRecurIndex(defname, args, recur)).flatMap { idx =>
                 // on all these branchs, use the the same
                 // parent state
@@ -284,7 +283,7 @@ object DefRecursionCheck {
                       setSt(InRecurBranch(irr, pat))
                     case illegal =>
                       // $COVERAGE-OFF$ this should be unreachable
-                      sys.error(s"unreachable: $ir -> $pat -> $illegal")
+                      sys.error(s"unreachable: $pat -> $illegal")
                       // $COVERAGE-ON$
                     }
 

--- a/core/src/main/scala/org/bykn/bosatsu/DefStatement.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/DefStatement.scala
@@ -9,10 +9,9 @@ import org.bykn.fastparse_cats.StringInstances._
 import org.typelevel.paiges.{ Doc, Document }
 
 case class DefStatement[T](
-    kind: RecursionKind,
-    name: String,
-    args: List[(String, Option[TypeRef])],
-    retType: Option[TypeRef], result: T) {
+  name: String,
+  args: List[(String, Option[TypeRef])],
+  retType: Option[TypeRef], result: T) {
 
 
   def map[A](fn: T => A): DefStatement[A] =
@@ -39,7 +38,6 @@ case class DefStatement[T](
 
 object DefStatement {
   private[this] val defDoc = Doc.text("def ")
-  private[this] val recDefDoc = Doc.text("recursive def ")
 
   implicit def document[T: Document]: Document[DefStatement[T]] =
     Document.instance[DefStatement[T]] { defs =>
@@ -52,11 +50,7 @@ object DefStatement {
             Doc.intercalate(Doc.text(", "), args.map(TypeRef.argDoc _)) +
             Doc.char(')')
         }
-      val dd = kind match {
-        case RecursionKind.NonRecursive => defDoc
-        case RecursionKind.Recursive => recDefDoc
-      }
-      val line0 = dd + Doc.text(name) + argDoc + res + Doc.text(":")
+      val line0 = defDoc + Doc.text(name) + argDoc + res + Doc.text(":")
 
       line0 + Document[T].document(result)
     }
@@ -67,17 +61,15 @@ object DefStatement {
     def parser[T](resultTParser: P[T]): P[DefStatement[T]] = {
       val args = argParser.nonEmptyList
       val result = P(maybeSpace ~ "->" ~/ maybeSpace ~ TypeRef.parser).?
-      val recKind = P("recursive" ~ spaces ~ "def").map(_ => RecursionKind.Recursive)
-      val notRec = P("def").map(_ => RecursionKind.NonRecursive)
-      P((recKind | notRec) ~ spaces ~/ lowerIdent ~ ("(" ~ maybeSpace ~ args ~ maybeSpace ~ ")").? ~
+      P("def" ~ spaces ~/ lowerIdent ~ ("(" ~ maybeSpace ~ args ~ maybeSpace ~ ")").? ~
         result ~ maybeSpace ~ ":" ~/ resultTParser)
         .map {
-          case (kind, name, optArgs, resType, res) =>
+          case (name, optArgs, resType, res) =>
             val args = optArgs match {
               case None => Nil
               case Some(ne) => ne.toList
             }
-            DefStatement(kind, name, args, resType, res)
+            DefStatement(name, args, resType, res)
         }
     }
 

--- a/core/src/main/scala/org/bykn/bosatsu/Program.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/Program.scala
@@ -122,14 +122,14 @@ object Program {
           Program(te, nonRec ::: binds, stmt)
         case Comment(CommentStatement(_, Padding(_, on))) =>
           loop(on).copy(from = s)
-        case Def(defstmt@DefStatement(kind, _, _, _, _)) =>
+        case Def(defstmt@DefStatement(_, _, _, _)) =>
           val (lam, Program(te, binds, _)) = defstmt.result match {
             case (body, Padding(_, in)) =>
               // using body for the outer here is a bummer, but not really a good outer otherwise
               val l = defstmt.toLambdaExpr(declToE(body.get), body.get)(_.toType(nameToType))
               (l, loop(in))
           }
-          Program(te, (defstmt.name, kind, lam) :: binds, stmt)
+          Program(te, (defstmt.name, RecursionKind.Recursive, lam) :: binds, stmt)
         case s@Struct(_, _, Padding(_, rest)) =>
           val p = loop(rest)
           p.copy(types = defToT(p.types, s), from = s)

--- a/core/src/main/scala/org/bykn/bosatsu/Statement.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/Statement.scala
@@ -61,7 +61,7 @@ sealed abstract class Statement {
           s #:: loop(rest)
         case Comment(CommentStatement(_, Padding(_, rest))) =>
           s #:: loop(rest)
-        case Def(DefStatement(_, _, _, _, (_, Padding(_, rest)))) =>
+        case Def(DefStatement(_, _, _, (_, Padding(_, rest)))) =>
           s #:: loop(rest)
         case Struct(_, _, Padding(_, rest)) =>
           s #:: loop(rest)

--- a/core/src/test/scala/org/bykn/bosatsu/DefRecursionCheckTest.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/DefRecursionCheckTest.scala
@@ -400,4 +400,15 @@ def len(lst):
     [_, *t]: len(t)
 """)
   }
+
+  test("we can call a non-outer function in a recur branch") {
+allowed("""#
+def id(x): x
+
+def len(lst):
+  recur lst:
+    []: 0
+    [_, *t]: id(len(t))
+""")
+  }
 }

--- a/core/src/test/scala/org/bykn/bosatsu/EvaluationTest.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/EvaluationTest.scala
@@ -389,7 +389,7 @@ three = [0, 1]
 # exercise the built-in range function (not implementable in bosatsu)
 threer = range(3)
 
-recursive def zip(as, bs):
+def zip(as, bs):
   recur as:
     []: []
     [ah, *atail]:
@@ -417,7 +417,7 @@ evalTest(
   List("""
 package Foo
 
-recursive def zip(as: List[a], bs: List[b]) -> List[(a, b)]:
+def zip(as: List[a], bs: List[b]) -> List[(a, b)]:
   recur as:
     []: []
     [ah, *atail]:
@@ -723,7 +723,7 @@ main = plus(1, 2)
     List("""
 package A
 
-recursive def len(lst, acc):
+def len(lst, acc):
   recur lst:
     []: acc
     [_, *tail]: len(tail, acc.add(1))
@@ -737,7 +737,7 @@ package A
 
 enum PNat: One, Even(of: PNat), Odd(of: PNat)
 
-recursive def toInt(pnat):
+def toInt(pnat):
   recur pnat:
     One: 1
     Even(of): toInt(of).times(2)
@@ -752,7 +752,7 @@ package A
 
 enum Foo: Bar, Baz
 
-recursive def bad(foo):
+def bad(foo):
   recur foo:
     Bar: 0
     baz: bad(baz)
@@ -776,12 +776,12 @@ package A
 
 enum Nat: Zero, Succ(of: Nat)
 
-recursive def toInt(pnat):
+def toInt(pnat):
   recur pnat:
     Zero: 0
     Succ(n): toInt(n).add(1)
 
-recursive def sum(nat):
+def sum(nat):
   recur nat:
     Zero: 0
     Succ(n): sum(n).add(toInt(nat))

--- a/core/src/test/scala/org/bykn/bosatsu/Gen.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/Gen.scala
@@ -99,12 +99,11 @@ object Generators {
 
   def defGen[T](dec: Gen[T]): Gen[DefStatement[T]] =
     for {
-      recKind <- Gen.frequency((10, Gen.const(RecursionKind.NonRecursive)), (1, Gen.const(RecursionKind.Recursive)))
       name <- lowerIdent
       args <- Gen.listOf(argGen)
       retType <- Gen.option(typeRefGen)
       body <- dec
-    } yield DefStatement(recKind, name, args, retType, body)
+    } yield DefStatement(name, args, retType, body)
 
   def genSpliceOrItem[A](spliceGen: Gen[A], itemGen: Gen[A]): Gen[ListLang.SpliceOrItem[A]] =
     Gen.oneOf(spliceGen.map(ListLang.SpliceOrItem.Splice(_)),

--- a/core/src/test/scala/org/bykn/bosatsu/PackageTest.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/PackageTest.scala
@@ -96,10 +96,8 @@ def head(list):
 
 def tail(list):
   match list:
-    Empty:
-      None
-    NonEmpty(h, tail):
-      Some(tail)
+    Empty: None
+    NonEmpty(h, t): Some(t)
 """)
 
     val p6 = parse(

--- a/core/src/test/scala/org/bykn/bosatsu/ParserTest.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/ParserTest.scala
@@ -399,7 +399,7 @@ foo"""
     parseTestAll(
       Declaration.parser(""),
       defWithComment,
-      Declaration.DefFn(DefStatement(RecursionKind.NonRecursive, "foo", List(("a", None)), None,
+      Declaration.DefFn(DefStatement("foo", List(("a", None)), None,
         (OptIndent.paddedIndented(1, 2, Declaration.Comment(CommentStatement(NonEmptyList.of(" comment here"),
           Padding(0, Declaration.Var("a"))))),
          Padding(0, Declaration.Var("foo"))))))

--- a/core/src/test/scala/org/bykn/bosatsu/rankn/RankNInferTest.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/rankn/RankNInferTest.scala
@@ -393,8 +393,8 @@ def mkPair(y, x: a):
   Pair(x, y)
 
 def fst:
-  Pair(fst, _) = mkPair(1, 2)
-  fst
+  Pair(f, _) = mkPair(1, 2)
+  f
 
 main = fst
 """, "Int")
@@ -819,7 +819,7 @@ main = 1
 
 enum Nat: Zero, Succ(prev: Nat)
 
-recursive def len(l):
+def len(l):
   recur l:
     Zero: 0
     Succ(p): len(p)
@@ -832,7 +832,7 @@ main = len(Succ(Succ(Zero)))
 enum Nat: Zero, Succ(prev: Nat)
 
 def len(l):
-  recursive def len0(l):
+  def len0(l):
     recur l:
       Zero: 0
       Succ(p): len0(p)

--- a/docs/language_guide.md
+++ b/docs/language_guide.md
@@ -111,7 +111,7 @@ So, we can write:
 def add_with_three(x, y):
   add_Int(add_Int(x, y), 3)
 ```
-using the `add_Int` function from the `Bosatsu/Predef`. Bosatsu also has anonymous function syntax similar to Haskell. The above is exactly the same as:
+using the `add_Int` function from the `Bosatsu/Predef`. Bosatsu also has anonymous function syntax similar to Haskell. The above is almost exactly the same as:
 ```
 add_with_three = \x, y -> add_Int(add_Int(x, y), 3)
 ```
@@ -123,6 +123,13 @@ add_with_three = \x -> \y -> add_Int(add_Int(x, y), 3)
 Think of `\` ans an ASCII version of `λ`.
 
 All of these functions have type `Int -> Int -> Int`, which is to say, given two integers (the two on the left) we can produce a new integer (always! remember Bosatsu is total, no exceptions!).
+
+### Scope difference for defs
+Unlike normal bindings, defs ARE in scope in their body. However, in order to prevent unbounded
+loops there are strict rules on accessing defs inside themselves. If you don't intend to write
+a recursive def, then you can never reuse or access the defs name anywhere inside the body.
+Specifically, shadowing the def name is not allowed. To write a recursive def see the section
+on recursive functions below.
 
 ### Method syntax
 Bosatu does not have methods, only functions, it does however have method syntax.
@@ -145,18 +152,19 @@ terminate. Here is an example:
 ```
 enum List: Empty, NonEmpty(head: a, tail: List[a])
 
-recursive def len(lst):
+def len(lst):
   recur lst:
     Empty: 0
     NonEmpty(_, tail): len(tail).add(1)
 ```
+In the above, we see the `recur` syntax. This is a normal match with two restrictions: 1. it can only be
+on a literal parameter of the nearest enclosing def, 2. a function may have at most one recur in a
+body, which is not enclosed by a inner def. Inside the branches of such a recur, recursion
+on the enclosing def is permitted if it meets certain constraints which prevent unbounded loops:
 
-1. recursive defs must be labeled `recursive def`
-2. recursive defs cannot be nested inside other recursive defs
-3. there must be exactly one recur inside each recursive def, which is like a match that must take one of the def arguments.
-4. in at least one branch of the recur match there must be a recursive call that must take a
-   substructure of the argument the recur is matching on. In the above example, tail is a
-   substructure of lst, and is used in the same parameter as list appeared in.
+In at least one branch of the recur match there must be a recursive call that must take a
+substructure of the argument the recur is matching on. In the above example, tail is a
+substructure of lst, and is used in the same parameter as list appeared in.
 
 These are strict rules, but they guarantee that each recursive function terminates in a finite
 number of steps, and can never loop forever. The recommendation is to avoid recursive defs as much


### PR DESCRIPTION
as @avibryant suggested on this thread:
https://github.com/johnynek/bosatsu/pull/164#issuecomment-472038378

it is a bit awkward to have `def` and `recursive def`. There is the verbosity problem, but also the problem that scoping rules were different in each case. This PR changes that: all defs have the most restrictive rules. This rules out a few older programs that worked that shadowed def names inside themselves, which is no longer allowed.

We still require a `recur` to signify a recursive match, which helps readability for humans, but also simplifies the matching algorithm somewhat.

I think the change which harmonizes the rules is valuable.

cc @snoble as usual, I would welcome your comments.