### PR TITLE
Recursive inference improvements

### DIFF
--- a/core/src/main/scala/org/bykn/bosatsu/RecursionKind.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/RecursionKind.scala
@@ -3,6 +3,9 @@ package org.bykn.bosatsu
 sealed abstract class RecursionKind(val isRecursive: Boolean)
 
 object RecursionKind {
+  def recursive(isRec: Boolean): RecursionKind =
+    if (isRec) Recursive else NonRecursive
+
   case object NonRecursive extends RecursionKind(false)
   case object Recursive extends RecursionKind(true)
 }

--- a/core/src/main/scala/org/bykn/bosatsu/rankn/Infer.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/rankn/Infer.scala
@@ -614,7 +614,8 @@ object Infer {
                     typedRhs <- inferSigma(rhs)
                     varT = typedRhs.getType
                     // the type variable needs to be unified with varT
-                    _ <- unify(rhsTpe, varT, region(term), region(term))
+                    // note, varT could be a sigma type, it is not a Tau or Rho
+                    _ <- subsCheck(rhsTpe, varT, region(term), region(term))
                     typedBody <- typeCheckRho(body, expect)
                     // TODO: a more efficient algorithm would do this top down
                     // for each top level TypedExpr and build it bottom up.

--- a/core/src/main/scala/org/bykn/bosatsu/rankn/Infer.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/rankn/Infer.scala
@@ -598,16 +598,29 @@ object Infer {
           }
         case Let(name, rhs, body, isRecursive, tag) =>
           if (isRecursive.isRecursive) {
+            // all defs are marked at potentially recursive.
             // We have elsewhere checked that this is legitimate recursion,
             // here we are only typechecking. To typecheck a recursive let,
-            // first allocate a metavariable to extend the environment first
+            // first allocate a metavariable to extend the environment before
+            // typechecking the rhs.
+            //
+            // After we typecheck we see if this is truly recursive so
+            // compilers/evaluation can possibly optimize non-recursive
+            // cases differently
             newMetaType
               .flatMap { rhsTpe =>
                 extendEnv(name, rhsTpe) {
                   for {
                     typedRhs <- inferSigma(rhs)
                     varT = typedRhs.getType
+                    // the type variable needs to be unified with varT
+                    _ <- unify(rhsTpe, varT, region(term), region(term))
                     typedBody <- typeCheckRho(body, expect)
+                    // TODO: a more efficient algorithm would do this top down
+                    // for each top level TypedExpr and build it bottom up.
+                    // we could do this after all typechecking is done
+                    frees = TypedExpr.freeVars(typedRhs :: Nil)
+                    isRecursive = RecursionKind.recursive(frees.contains(name))
                   } yield TypedExpr.Let(name, typedRhs, typedBody, isRecursive, tag)
                 }
               }


### PR DESCRIPTION
1. we were not unifying the inferred type with the variable we created. This should be a bug in some cases.
2. after #172 all defs were marked recursive, but they are slightly more expensive to evaluate. This detects is a let is truly recursive and labels it as such, so it is accurate in TypedExpr.