### PR TITLE
Get list comprehensions working

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,25 +18,18 @@ package Euler/One
 # https://projecteuler.net/problem=1
 # Find the sum of all the multiples of 3 or 5 below 1000.
 
-def filter(as, fn):
-  as.foldLeft([], \tail, item ->
-    if fn(item): [item, *tail]
-    else: tail)
-
-under1000 = range(1000)
-
-def or(a, b):
-  True if a else b
+def or(a, b): True if a else b
 
 def keep(i):
   or(i.mod_Int(3).eq_Int(0), i.mod_Int(5).eq_Int(0))
 
-def sum(as):
-  as.foldLeft(0, add)
+def sum(as): as.foldLeft(0, add)
 
+# python:
 # >>> sum(i for i in xrange(1000) if keep_fn(i))
 # 233168
-computed = trace("computed", under1000.filter(keep).sum)
+
+computed = sum([i for i in range(1000) if keep(i)])
 
 test = Assertion(computed.eq_Int(233168), "expected 233168")
 ```

--- a/core/src/main/resources/bosatsu/predef.bosatsu
+++ b/core/src/main/resources/bosatsu/predef.bosatsu
@@ -17,9 +17,11 @@ export [
   concat,
   div,
   eq_Int,
+  flat_map_List,
   foldLeft,
   gcd_Int,
   int_loop,
+  map_List,
   mod_Int,
   range,
   range_fold,
@@ -53,6 +55,12 @@ def reverse_concat(front: List[a], back: List[a]) -> List[a]:
 
 def reverse(as: List[a]) -> List[a]:
   reverse_concat(as, EmptyList)
+
+def map_List(lst: List[a], fn: a -> b) -> List[b]:
+  lst.foldLeft(EmptyList, \t, a -> NonEmptyList(fn(a), t)).reverse
+
+def flat_map_List(lst: List[a], fn: a -> List[b]) -> List[b]:
+  lst.foldLeft(EmptyList, \t, a -> fn(a).reverse_concat(t)).reverse
 
 def concat(front: List[a], back: List[a]) -> List[a]:
   match back:

--- a/core/src/main/scala/org/bykn/bosatsu/Declaration.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/Declaration.scala
@@ -103,7 +103,7 @@ sealed abstract class Declaration {
       case Var(name) => Doc.text(name)
 
       case ListDecl(list) =>
-        ListLang.document.document(list)
+        ListLang.document[Declaration, Pattern[Option[String], TypeRef]].document(list)
     }
   }
 
@@ -203,8 +203,6 @@ sealed abstract class Declaration {
                   ListLang.SpliceOrItem.Item(loop(item))
               }
 
-              // TODO we need to refer to Predef/EmptyList no matter what here
-              // but we have no way to fully refer to an item
               val pn = Option(Predef.packageName)
               val empty: Expr[Declaration] = Expr.Var(pn, "EmptyList", l)
               def cons(head: Expr[Declaration], tail: Expr[Declaration]): Expr[Declaration] =
@@ -219,7 +217,70 @@ sealed abstract class Declaration {
                 case (tail, ListLang.SpliceOrItem.Splice(s)) =>
                   concat(s, tail)
               }
-            case ListLang.Comprehension(_, _, _, _) => ???
+            case ListLang.Comprehension(res, binding, in, filter) =>
+              /*
+               * [x for y in z] ==
+               * z.map_List(\v ->
+               *   y = v
+               *   x)
+               *
+               * [x for y in z if w] =
+               * z.flat_map_List(\v ->
+               *   y = v
+               *   if w: [x]
+               *   else: []
+               * )
+               *
+               * [*x for y in z] =
+               * z.flat_map_List(\v ->
+               *   y = v
+               *   x
+               * )
+               *
+               * [*x for y in z if w] =
+               * z.flat_map_List(\v ->
+               *   y = v
+               *   if w: x
+               *   else: []
+               * )
+               */
+              val pn = Option(Predef.packageName)
+              val opName = (res, filter) match {
+                case (ListLang.SpliceOrItem.Item(_), None) =>
+                  "map_List"
+                case (ListLang.SpliceOrItem.Item(_) | ListLang.SpliceOrItem.Splice(_), _) =>
+                  "flat_map_List"
+              }
+              val opExpr: Expr[Declaration] = Expr.Var(pn, opName, l)
+              val resExpr: Expr[Declaration] = (res, filter) match {
+                case (itOrSp, None) =>
+                  loop(itOrSp.value)
+                case (itOrSp, Some(cond)) =>
+                  val empty: Expr[Declaration] = Expr.Var(pn, "EmptyList", cond)
+                  // we need theReturn
+                  val r = itOrSp.value
+                  val ritem = loop(r)
+                  val sing = itOrSp match {
+                    case ListLang.SpliceOrItem.Item(_) =>
+                      Expr.App(
+                        Expr.App(Expr.Var(pn, "NonEmptyList", r), ritem, r),
+                        empty,
+                        r)
+                    case ListLang.SpliceOrItem.Splice(_) => ritem
+                  }
+
+                  Expr.If(loop(cond),
+                    sing,
+                    empty,
+                    cond)
+              }
+              val unusedSymbol0: String = "$a" // TODO we should have better ways to gensym
+              val newPattern = unTuplePattern(binding, nameToType, nameToCons)
+              val body: Expr[Declaration] =
+                Expr.Match(Expr.Var(None, unusedSymbol0, l),
+                  NonEmptyList.of((newPattern, resExpr)), l)
+              val fnExpr: Expr[Declaration] = Expr.Lambda(unusedSymbol0, body, l)
+              Expr.App(Expr.App(opExpr, loop(in), l), fnExpr, l)
           }
       }
 
@@ -292,7 +353,7 @@ object Declaration {
   /**
    * This represents the list construction language
    */
-  case class ListDecl(list: ListLang[Declaration])(implicit val region: Region) extends Declaration
+  case class ListDecl(list: ListLang[Declaration, Pattern[Option[String], TypeRef]])(implicit val region: Region) extends Declaration
 
   val matchKindParser: P[RecursionKind] =
     (P("match").map(_ => RecursionKind.NonRecursive) | P("recur").map(_ => RecursionKind.Recursive))
@@ -364,7 +425,7 @@ object Declaration {
   def ifElseP(expr: Indy[Declaration]): Indy[IfElse] = {
 
     def ifelif(str: String): Indy[(Declaration, OptIndent[Declaration])] =
-      Indy.block(Indy.lift(P(str ~ spaces ~/ maybeSpace)) *> expr, expr)
+      Indy.block(Indy.lift(P(str ~ spaces ~ maybeSpace)) *> expr, expr)
 
     /*
      * We don't need to parse the else term to the end,
@@ -393,7 +454,7 @@ object Declaration {
   val lambdaP: Indy[Lambda] = {
     val params = Indy.lift(P("\\" ~/ maybeSpace ~ lowerIdent.nonEmptyList))
 
-    Indy.blockLike(params, parser, "->")
+    Indy.blockLike(params, parser, P(maybeSpace ~ "->"))
       .region
       .map { case (r, (args, body)) => Lambda(args, body.get)(r) }
   }
@@ -431,7 +492,7 @@ object Declaration {
       }
 
   private def listP(p: P[Declaration]): P[ListDecl] =
-    ListLang.parser(p)
+    ListLang.parser(p, Pattern.parser)
       .region
       .map { case (r, l) => ListDecl(l)(r) }
 
@@ -444,7 +505,7 @@ object Declaration {
         val params = recurse.nonEmptyList.parens
         // here we are using . syntax foo.bar(1, 2)
         val dotApply =
-          P("." ~/ varP ~ params.?).region.map { case (r2, (fn, argsOpt)) =>
+          P("." ~ varP ~ params.?).region.map { case (r2, (fn, argsOpt)) =>
             val args = argsOpt.fold(List.empty[Declaration])(_.toList)
 
             { head: Declaration => Apply(fn, NonEmptyList(head, args), true)(head.region + r2) }
@@ -458,7 +519,7 @@ object Declaration {
 
         // here is if/ternary operator
         val ternary =
-          P(spaces ~ "if" ~ spaces ~ recurse ~ spaces ~ "else" ~ spaces ~/ recurse)
+          P(spaces ~ "if" ~ spaces ~ recurse ~ spaces ~ "else" ~ spaces ~ recurse)
             .region
             .map { case (region, (cond, falseCase)) =>
               { trueCase: Declaration =>

--- a/core/src/main/scala/org/bykn/bosatsu/DefRecursionCheck.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/DefRecursionCheck.scala
@@ -324,9 +324,8 @@ object DefRecursionCheck {
           ll match {
             case ListLang.Cons(items) =>
               items.traverse_ { s => checkDecl(s.value) }
-            case ListLang.Comprehension(e, b, i, f) =>
+            case ListLang.Comprehension(e, _, i, f) =>
               checkDecl(e.value) *>
-                checkDecl(b) *>
                 checkDecl(i) *>
                 (f.traverse_(checkDecl))
           }

--- a/core/src/main/scala/org/bykn/bosatsu/Predef.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/Predef.scala
@@ -28,6 +28,9 @@ object Predef {
   def packageName: PackageName =
     PackageName.predef
 
+  /*
+   * TODO: we should be able to compute this from predefPackage
+   */
   val predefImports: Import[PackageName, Unit] =
     Import(packageName,
       NonEmptyList.of(
@@ -56,9 +59,11 @@ object Predef {
         "eq_Int",
         "concat",
         "cmp_Int",
+        "flat_map_List",
         "foldLeft",
         "gcd_Int",
         "int_loop",
+        "map_List",
         "mod_Int",
         "range",
         "range_fold",

--- a/core/src/test/scala/org/bykn/bosatsu/EvaluationTest.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/EvaluationTest.scala
@@ -790,4 +790,66 @@ main = sum(Succ(Succ(Succ(Zero))))
 """), "A", VInt(sumFn(3)))
 
   }
+
+  test("list comphension test") {
+  evalTest(
+    List("""
+package A
+
+main = [x for x in range(4)].foldLeft(0, add)
+"""), "A", VInt(6))
+  evalTest(
+    List("""
+package A
+
+main = [*[x] for x in range(4)].foldLeft(0, add)
+"""), "A", VInt(6))
+
+  evalTest(
+    List("""
+package A
+
+doub = [(x, x) for x in range(4)]
+
+main = [x.times(y) for (x, y) in doub].foldLeft(0, add)
+"""), "A", VInt(1 + 4 + 9))
+  evalTest(
+    List("""
+package A
+
+main = [x for x in range(4) if x.eq_Int(2)].foldLeft(0, add)
+"""), "A", VInt(2))
+
+  evalTest(
+    List("""
+package A
+
+main = [*[x, x] for x in range(4) if x.eq_Int(2)].foldLeft(0, add)
+"""), "A", VInt(4))
+
+  evalTest(
+    List("""
+package A
+
+def eq_List(lst1, lst2):
+  recur lst1:
+    []:
+      match lst2:
+        []: True
+        _: False
+    [h1, *t1]:
+      match lst2:
+        []: False
+        [h2, *t2]:
+          eq_List(t1, t2) if eq_Int(h1, h2) else False
+
+lst1 = [0, 0, 1, 1, 2, 2, 3, 3]
+lst2 = [*[x, x] for x in range(4)]
+lst3 = [*[y, y] for (y, y) in [(x, x) for x in range(4)]]
+
+main = match (eq_List(lst1, lst2), eq_List(lst1, lst3)):
+  (True, True): 1
+  notTrue: 0
+"""), "A", VInt(1))
+  }
 }

--- a/core/src/test/scala/org/bykn/bosatsu/Gen.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/Gen.scala
@@ -133,7 +133,8 @@ object Generators {
     val cons = genListLangCons(dec, dec)
 
     // TODO we can't parse if since we get confused about it being a ternary expression
-    val comp = Gen.zip(genSpliceOrItem(dec, dec), dec, dec, Gen.option(dec))
+    val pat = genPattern(1, useUnion = true)
+    val comp = Gen.zip(genSpliceOrItem(dec, dec), pat, dec, Gen.option(dec))
       .map { case (a, b, c, _) => ListLang.Comprehension(a, b, c, None) }
 
     Gen.oneOf(cons, comp).map(Declaration.ListDecl(_)(emptyRegion))
@@ -383,8 +384,8 @@ object Generators {
           case Var(_) => Stream.empty
           case ListDecl(ListLang.Cons(items)) =>
             items.map(_.value).toStream
-          case ListDecl(ListLang.Comprehension(a, b, c, d)) =>
-            (a.value :: b :: c :: d.toList).toStream
+          case ListDecl(ListLang.Comprehension(a, _, c, d)) =>
+            (a.value :: c :: d.toList).toStream
         }
     })
 

--- a/core/src/test/scala/org/bykn/bosatsu/ParserTest.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/ParserTest.scala
@@ -343,15 +343,16 @@ class ParserTest extends FunSuite {
     val pident = Parser.lowerIdent
     implicit val stringDoc: Document[String] = Document.instance[String](Doc.text(_))
 
-    roundTrip(ListLang.parser(pident), "[a]")
-    roundTrip(ListLang.parser(pident), "[]")
-    roundTrip(ListLang.parser(pident), "[a , b]")
-    roundTrip(ListLang.parser(pident), "[a , b]")
-    roundTrip(ListLang.parser(pident), "[a , *b]")
-    roundTrip(ListLang.parser(pident), "[a ,\n*b,\n c]")
-    roundTrip(ListLang.parser(pident), "[x for y in z]")
-    roundTrip(ListLang.parser(pident), "[x for y in z if w]")
-
+    val llp = ListLang.parser(pident, pident)
+    roundTrip(llp, "[a]")
+    roundTrip(llp, "[]")
+    roundTrip(llp, "[  ]")
+    roundTrip(llp, "[a , b]")
+    roundTrip(llp, "[a , b]")
+    roundTrip(llp, "[a , *b]")
+    roundTrip(llp, "[a ,\n*b,\n c]")
+    roundTrip(llp, "[x for y in z]")
+    roundTrip(llp, "[x for y in z if w]")
     roundTrip(ListLang.SpliceOrItem.parser(pident), "a")
     roundTrip(ListLang.SpliceOrItem.parser(pident), "*a")
   }
@@ -472,6 +473,10 @@ x""")
   test("we can parse patterns") {
     roundTrip(Pattern.parser, "Foo([])")
     roundTrip(Pattern.parser, "Foo([], bar)")
+    roundTrip(Pattern.parser, "x")
+    roundTrip(Pattern.parser, "_")
+    roundTrip(Pattern.parser, "(a, b)")
+    roundTrip(Pattern.parser, "(a, b) | _")
   }
 
   test("Declaration.toPattern works for all Pattern-like declarations") {
@@ -692,7 +697,15 @@ x""")
     roundTrip(Declaration.parser(""), "[1, 2, 3]")
     roundTrip(Declaration.parser(""), "[1, *x, 3]")
     roundTrip(Declaration.parser(""), "[Foo(a, b), *acc]")
-    roundTrip(ListLang.parser(Declaration.parser("")), "[foo(a, b)]")
+    roundTrip(ListLang.parser(Declaration.parser(""), Pattern.parser), "[foo(a, b)]")
+    roundTrip(ListLang.parser(Declaration.parser(""), Pattern.parser), "[x for y in z]")
+    roundTrip(ListLang.parser(Declaration.parser(""), Pattern.parser), "[x for (y, z) in w]")
+    roundTrip(ListLang.parser(Declaration.parser(""), Pattern.parser), "[x for (y, z) in w if w1]")
+    roundTrip(ListLang.parser(Declaration.parser(""), Pattern.parser), "[*x for y in z]")
+    roundTrip(ListLang.parser(Declaration.parser(""), Pattern.parser), "[*x for (y, z) in w]")
+    roundTrip(ListLang.parser(Declaration.parser(""), Pattern.parser), "[*x for (y, z) in w if w1]")
+    roundTrip(ListLang.parser(Declaration.parser(""), Pattern.parser),
+      "[x for x in range(4) if x.eq_Int(2)]")
     roundTrip(ListLang.SpliceOrItem.parser(Declaration.parser("")), "a")
     roundTrip(ListLang.SpliceOrItem.parser(Declaration.parser("")), "foo(a, b)")
     roundTrip(ListLang.SpliceOrItem.parser(Declaration.parser("")), "*foo(a, b)")

--- a/test_workspace/euler1.bosatsu
+++ b/test_workspace/euler1.bosatsu
@@ -4,24 +4,15 @@ package Euler/One
 # https://projecteuler.net/problem=1
 # Find the sum of all the multiples of 3 or 5 below 1000.
 
-def filter(as, fn):
-  as.foldLeft([], \tail, item ->
-    if fn(item): [item, *tail]
-    else: tail)
-
-under1000 = range(1000)
-
-def or(a, b):
-  True if a else b
+def or(a, b): True if a else b
 
 def keep(i):
   or(i.mod_Int(3).eq_Int(0), i.mod_Int(5).eq_Int(0))
 
-def sum(as):
-  as.foldLeft(0, add)
+def sum(as): as.foldLeft(0, add)
 
 # >>> sum(i for i in xrange(1000) if keep_fn(i))
 # 233168
-computed = trace("computed", under1000.filter(keep).sum)
+computed = [i for i in range(1000) if keep(i)].sum
 
 test = Assertion(computed.eq_Int(233168), "expected 233168")

--- a/test_workspace/euler2.bosatsu
+++ b/test_workspace/euler2.bosatsu
@@ -21,11 +21,6 @@ def fib(n):
       [h]: [2, h]
       [h1, h2, *_]: [h1.add(h2), *revFib])
 
-def filter(as, fn):
-  as.foldLeft([], \tail, item ->
-    if fn(item): [item, *tail]
-    else: tail)
-
 def keep(i):
   match i.cmp_Int(4000000):
     GT: False
@@ -37,6 +32,6 @@ def sum(as):
 # lazy val fibStream: Stream[BigInt] = BigInt(1) #:: BigInt(1) #:: (fibStream.drop(1).zip(fibStream).map { case (a, b) => a + b })
 # fibStream.filter(_ < BigInt(4000000)).filter(_ % 2 == 0).sum
 # 4613732
-computed = fib(35).filter(keep).sum
+computed = sum([f for f in fib(35) if keep(f)])
 
 test = Assertion(computed.eq_Int(4613732), "expected 4613732")

--- a/test_workspace/euler4.bosatsu
+++ b/test_workspace/euler4.bosatsu
@@ -53,11 +53,6 @@ def is_palindrome(lst, eq_fn):
       (True, [h, *t]): (eq_fn(item, h), t))
   res
 
-def eq_Int(a, b):
-  match a.cmp_Int(b):
-    EQ: True
-    _: False
-
 def num_is_palindrome(n):
   digits = digit_list(n)
   is_palindrome(digits, eq_Int)

--- a/test_workspace/euler5.bosatsu
+++ b/test_workspace/euler5.bosatsu
@@ -15,10 +15,11 @@ max_candidate = factorial(10)
 # is divisible by all
 
 def for_all(items, fn):
-  items.foldLeft(True, \res, item ->
-    match res:
-      True: fn(item)
-      False: False)
+  def loop(items):
+    recur items:
+      []: True
+      [h, *t]: loop(t) if fn(h) else False
+  loop(items)
 
 def int_loop_up(top, res, fn):
   int_loop(top, res, \i, res ->


### PR DESCRIPTION
close #99 

To solve this I had to fix a few lurking parser bugs, but the diff is small enough that I'm leaving it combined. There is no chance I don't want to have list/for comprehensions to match python.

They make several existing problems a bit more elegant and certainly looking more like python.

These are implemented basically as macros in the expansion from syntax (Declaration) into the lambda calculus based Expr. A more ambitious language might expose a means to make user defined macros which could do expansion into the Expr graph.