### PR TITLE
Remove Expr.If and TypedExpr.If

### DIFF
--- a/core/src/main/scala/org/bykn/bosatsu/Codegen.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/Codegen.scala
@@ -256,8 +256,6 @@ trait CodeGen {
         Monad[Output].pure(Doc.text("java.lang.Integer.valueOf(") + quote(i.toString) + Doc.char(')'))
       case Literal(Lit.Str(s), _,  _) =>
         Monad[Output].pure(quote(s))
-      case If(cond, ift, iff, _) =>
-        Monad[Output].pure(Doc.text("null"))
       case Match(_, _, _) =>
         Monad[Output].pure(Doc.text("null"))
     }

--- a/core/src/main/scala/org/bykn/bosatsu/Declaration.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/Declaration.scala
@@ -146,13 +146,13 @@ sealed abstract class Declaration {
           // is called. We rely on DefRecursionCheck to rule out bad recursions
           Expr.Let(defstmt.name, lambda, inExpr, recursive = RecursionKind.Recursive, decl)
         case IfElse(ifCases, elseCase) =>
-          def ifExpr(cond: Expr[Declaration], ifTrue: Expr[Declaration], ifFalse: Expr[Declaration]): Expr[Declaration] =
-            Expr.If(cond, ifTrue, ifFalse, decl)
+          // def ifExpr(cond: Expr[Declaration], ifTrue: Expr[Declaration], ifFalse: Expr[Declaration]): Expr[Declaration] =
+          //   Expr.If(cond, ifTrue, ifFalse, decl)
 
           def loop0(ifs: NonEmptyList[(Expr[Declaration], Expr[Declaration])], elseC: Expr[Declaration]): Expr[Declaration] =
             ifs match {
               case NonEmptyList((cond, ifTrue), Nil) =>
-                ifExpr(cond, ifTrue, elseC)
+                Expr.ifExpr(cond, ifTrue, elseC, decl)
               case NonEmptyList(ifTrue, h :: tail) =>
                 val elseC1 = loop0(NonEmptyList(h, tail), elseC)
                 loop0(NonEmptyList.of(ifTrue), elseC1)

--- a/core/src/main/scala/org/bykn/bosatsu/Declaration.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/Declaration.scala
@@ -146,9 +146,6 @@ sealed abstract class Declaration {
           // is called. We rely on DefRecursionCheck to rule out bad recursions
           Expr.Let(defstmt.name, lambda, inExpr, recursive = RecursionKind.Recursive, decl)
         case IfElse(ifCases, elseCase) =>
-          // def ifExpr(cond: Expr[Declaration], ifTrue: Expr[Declaration], ifFalse: Expr[Declaration]): Expr[Declaration] =
-          //   Expr.If(cond, ifTrue, ifFalse, decl)
-
           def loop0(ifs: NonEmptyList[(Expr[Declaration], Expr[Declaration])], elseC: Expr[Declaration]): Expr[Declaration] =
             ifs match {
               case NonEmptyList((cond, ifTrue), Nil) =>

--- a/core/src/main/scala/org/bykn/bosatsu/Evaluation.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/Evaluation.scala
@@ -495,22 +495,7 @@ case class Evaluation(pm: PackageMap.Inferred, externals: Externals) {
          eres.letNameIn(arg, inres)
        case Literal(lit, _, _) =>
          val res = Eval.now(Value.fromLit(lit))
-
          Scoped.const(res)
-       case If(cond, ifT, ifF, _) =>
-         val condR = recurse((p, Right(cond)))._1
-         val ifR = recurse((p, Right(ifT)))._1
-         val elseR = recurse((p, Right(ifF)))._1
-
-         condR.flatMap {
-           case (env, True) => ifR.inEnv(env)
-           case (env, False) => elseR.inEnv(env)
-           case other =>
-             // $COVERAGE-OFF$this should be unreachable
-             sys.error(s"ill-typed, expected boolean: $other")
-             // $COVERAGE-ON$
-         }
-
        case Match(arg, branches, _) =>
          val argR = recurse((p, Right(arg)))._1
          val branchR = evalBranch(arg.getType, branches, p, recurse)

--- a/core/src/main/scala/org/bykn/bosatsu/Expr.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/Expr.scala
@@ -22,7 +22,6 @@ sealed abstract class Expr[T] {
       case a@AnnotatedLambda(_, _, _, _) => a.copy(tag = t)
       case l@Let(_, _, _, _, _) => l.copy(tag = t)
       case l@Literal(_, _) => l.copy(tag = t)
-      case i@If(_, _, _, _) => i.copy(tag = t)
       case m@Match(_, _, _) => m.copy(tag = t)
     }
 }
@@ -37,12 +36,19 @@ object Expr {
   case class Lambda[T](arg: String, expr: Expr[T], tag: T) extends Expr[T]
   case class Let[T](arg: String, expr: Expr[T], in: Expr[T], recursive: RecursionKind, tag: T) extends Expr[T]
   case class Literal[T](lit: Lit, tag: T) extends Expr[T]
-  case class If[T](cond: Expr[T], ifTrue: Expr[T], ifFalse: Expr[T], tag: T) extends Expr[T]
   case class Match[T](arg: Expr[T], branches: NonEmptyList[(Pattern[(PackageName, ConstructorName), rankn.Type], Expr[T])], tag: T) extends Expr[T]
 
   implicit def hasRegion[T: HasRegion]: HasRegion[Expr[T]] =
     HasRegion.instance[Expr[T]] { e => HasRegion.region(e.tag) }
 
+  /**
+   * build a Match expression that is equivalent to if/else using Predef::True and Predef::False
+   */
+  def ifExpr[T](cond: Expr[T], ifTrue: Expr[T], ifFalse: Expr[T], tag: T): Expr[T] = {
+    val TruePat = Pattern.PositionalStruct((Predef.packageName, ConstructorName("True")), Nil)
+    val FalsePat = Pattern.PositionalStruct((Predef.packageName, ConstructorName("False")), Nil)
+    Match(cond, NonEmptyList.of((TruePat, ifTrue), (FalsePat, ifFalse)), tag)
+  }
 
   def traverseType[T, F[_]](expr: Expr[T], fn: rankn.Type => F[rankn.Type])(implicit F: Applicative[F]): F[Expr[T]] =
     expr match {
@@ -58,10 +64,6 @@ object Expr {
       case Let(arg, exp, in, rec, tag) =>
         (traverseType(exp, fn), traverseType(in, fn)).mapN(Let(arg, _, _, rec, tag))
       case l@Literal(_, _) => F.pure(l)
-      case If(cond, ift, iff, tag) =>
-        (traverseType(cond, fn), traverseType(ift, fn), traverseType(iff, fn)).mapN {
-          If(_, _, _, tag)
-        }
       case Match(arg, branches, tag) =>
         val argB = traverseType(arg, fn)
         type B = (Pattern[(PackageName, ConstructorName), rankn.Type], Expr[T])
@@ -95,8 +97,6 @@ object Expr {
         Let(arg, nest(exp), nest(in), rec, e)
       case Literal(lit, _) =>
         Literal(lit, e)
-      case If(cond, ift, iff, _) =>
-        If(nest(cond), nest(ift), nest(iff), e)
       case Match(arg, branches, _) =>
         Match(nest(arg), branches.map {
           case (pat, exp) => (pat, nest(exp))
@@ -136,9 +136,6 @@ object Expr {
             }
           case Literal(lit, tag) =>
             f(tag).map(Literal(lit, _))
-          case If(cond, ift, iff, tag) =>
-            (cond.traverse(f), ift.traverse(f), iff.traverse(f), f(tag))
-              .mapN(If(_, _, _, _))
           case Match(arg, branches, tag) =>
             val argB = arg.traverse(f)
             val branchB = tne.traverse(branches)(f)
@@ -169,11 +166,6 @@ object Expr {
             f(b2, tag)
           case Literal(_, tag) =>
             f(b, tag)
-          case If(cond, ift, iff, tag) =>
-            val b1 = foldLeft(cond, b)(f)
-            val b2 = foldLeft(ift, b1)(f)
-            val b3 = foldLeft(iff, b2)(f)
-            f(b3, tag)
           case Match(arg, branches, tag) =>
             val b1 = foldLeft(arg, b)(f)
             val b2 = tne.foldLeft(branches, b1)(f)
@@ -202,11 +194,6 @@ object Expr {
             foldRight(exp, b2)(f)
           case Literal(_, tag) =>
             f(tag, lb)
-          case If(cond, ift, iff, tag) =>
-            val b1 = f(tag, lb)
-            val b2 = foldRight(iff, b1)(f)
-            val b3 = foldRight(ift, b2)(f)
-            foldRight(cond, b3)(f)
           case Match(arg, branches, tag) =>
             val b1 = f(tag, lb)
             val b2 = tne.foldRight(branches, b1)(f)

--- a/core/src/main/scala/org/bykn/bosatsu/Expr.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/Expr.scala
@@ -41,14 +41,18 @@ object Expr {
   implicit def hasRegion[T: HasRegion]: HasRegion[Expr[T]] =
     HasRegion.instance[Expr[T]] { e => HasRegion.region(e.tag) }
 
+  /*
+   * Allocate these once
+   */
+  private[this] val TruePat: Pattern[(PackageName, ConstructorName), rankn.Type] =
+    Pattern.PositionalStruct((Predef.packageName, ConstructorName("True")), Nil)
+  private[this] val FalsePat: Pattern[(PackageName, ConstructorName), rankn.Type] =
+    Pattern.PositionalStruct((Predef.packageName, ConstructorName("False")), Nil)
   /**
    * build a Match expression that is equivalent to if/else using Predef::True and Predef::False
    */
-  def ifExpr[T](cond: Expr[T], ifTrue: Expr[T], ifFalse: Expr[T], tag: T): Expr[T] = {
-    val TruePat = Pattern.PositionalStruct((Predef.packageName, ConstructorName("True")), Nil)
-    val FalsePat = Pattern.PositionalStruct((Predef.packageName, ConstructorName("False")), Nil)
+  def ifExpr[T](cond: Expr[T], ifTrue: Expr[T], ifFalse: Expr[T], tag: T): Expr[T] =
     Match(cond, NonEmptyList.of((TruePat, ifTrue), (FalsePat, ifFalse)), tag)
-  }
 
   def traverseType[T, F[_]](expr: Expr[T], fn: rankn.Type => F[rankn.Type])(implicit F: Applicative[F]): F[Expr[T]] =
     expr match {

--- a/core/src/main/scala/org/bykn/bosatsu/TotalityCheck.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/TotalityCheck.scala
@@ -74,7 +74,6 @@ case class TotalityCheck(inEnv: TypeEnv[Any]) {
       case Var(_, _, _) | Literal(_, _) => Validated.valid(())
       case App(fn, arg, _) => checkExpr(fn) *> checkExpr(arg)
       case Let(_, e1, e2, _, _) => checkExpr(e1) *> checkExpr(e2)
-      case If(c, e1, e2, _) => checkExpr(c) *> checkExpr(e1) *> checkExpr(e2)
       case m@Match(arg, branches, _) =>
         val argAndBranchExprs = arg :: branches.toList.map(_._2)
         val recursion = argAndBranchExprs.traverse_(checkExpr)

--- a/core/src/main/scala/org/bykn/bosatsu/rankn/Infer.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/rankn/Infer.scala
@@ -628,33 +628,6 @@ object Infer {
             coerce <- instSigma(tpe, expect, region(term))
             res = coerce(TypedExpr.Annotation(typedTerm, tpe, tag))
           } yield res
-        case If(cond, ifTrue, ifFalse, tag) =>
-          val condTpe =
-            typeCheckRho(cond,
-              Expected.Check((Type.BoolType, region(cond))))
-          val rest = expect match {
-            case check@Expected.Check(_) =>
-              typeCheckRho(ifTrue, check)
-                .product(typeCheckRho(ifFalse, check))
-
-            case infer@Expected.Inf(_) =>
-              for {
-                tExp <- inferRho(ifTrue)
-                fExp <- inferRho(ifFalse)
-                rT = tExp.getType
-                rF = fExp.getType
-                cT <- subsCheck(rT, rF, region(ifTrue), region(ifFalse))
-                cF <- subsCheck(rF, rT, region(ifFalse), region(ifTrue))
-                _ <- infer.set((rT, region(ifTrue))) // see section 7.1
-              } yield (cT(tExp), cF(fExp))
-
-          }
-
-          for {
-           c <- condTpe
-           branches <- rest
-           (tb, fb) = branches
-          } yield TypedExpr.If(c, tb, fb, tag)
         case Match(term, branches, tag) =>
           // all of the branches must return the same type:
 


### PR DESCRIPTION
close #175 

Remove If, it is a special case of Match which we should optimize anyway.