### PR TITLE
Fix Json escaping (#139)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ target/
 lib_managed/
 src_managed/
 project/boot/
+project/target/
 project/plugins/project/
 
 # Scala-IDE specific

--- a/build.sbt
+++ b/build.sbt
@@ -87,6 +87,8 @@ lazy val core = (project in file("core")).
         fastparseCats,
         paiges,
         scalaCheck % Test,
-        scalaTest % Test
+        scalaTest % Test,
+        jawnParser % Test,
+        jawnAst % Test
       )
   ).dependsOn(base)

--- a/core/src/main/scala/org/bykn/bosatsu/Evaluation.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/Evaluation.scala
@@ -722,7 +722,7 @@ case class Evaluation(pm: PackageMap.Inferred, externals: Externals) {
           prod.toList.zip(params).traverse { case (a1, (ParamName(pn), t)) =>
             rec(a1, t).map((pn, _))
           }
-          .map { ps => Json.JObject(ps.toMap) }
+          .map { ps => Json.JObject(ps) }
         }
       }
     }

--- a/core/src/main/scala/org/bykn/bosatsu/Parser.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/Parser.scala
@@ -187,118 +187,14 @@ object Parser {
       }
   }
 
+  def escapedString(q: Char): P[String] =
+    StringUtil.escapedString(q)
 
-  private val decodeTable: Map[Char, Char] =
-    Map(
-      ('\\', '\\'),
-      ('\'', '\''),
-      ('\"', '\"'),
-      ('a', 7.toChar), // bell
-      ('b', 8.toChar), // backspace
-      ('f', 12.toChar), // form-feed
-      ('n', '\n'),
-      ('r', '\r'),
-      ('t', '\t'),
-      ('v', 11.toChar)) // vertical tab
+  def escape(quoteChar: Char, str: String): String =
+    StringUtil.escape(quoteChar, str)
 
-  private val encodeTable = decodeTable.iterator.map { case (v, k) => (k, s"\\$v") }.toMap
-
-  private val nonPrintEscape: Array[String] =
-    (0 until 32).map { c =>
-      val strHex = c.toHexString
-      val strPad = List.fill(4 - strHex.length)('0').mkString
-      s"\\u$strPad$strHex"
-    }.toArray
-
-  private val escapeString: P[Unit] = {
-    val escapes = CharIn(decodeTable.keys.toSeq)
-    val oct = CharIn('0' until '8')
-    val hex = CharIn(('0' to '9') ++ ('a' to 'f') ++ ('A' to 'F'))
-    val octP = P("o" ~ oct ~ oct)
-    val hexP = P("x" ~ hex ~ hex)
-    val u4 = P("u" ~ hex.rep(4))
-    val u8 = P("U" ~ hex.rep(8))
-    val after = escapes | octP | hexP | u4 | u8
-    P("\\" ~ after)
-  }
-
-  def escapedString(q: Char): P[String] = {
-    val qstr = q.toString
-    val char = P(escapeString | (!qstr ~ AnyChar)).!
-    P(qstr ~ char.rep() ~ qstr).map(_.mkString)
-      .flatMap { str =>
-        unescape(str) match {
-          case Right(str1) => PassWith(str1)
-          case Left(_) => Fail
-        }
-      }
-  }
-
-  def escape(quoteChar: Char, str: String): String = {
-    // We can ignore escaping the opposite character used for the string
-    // x isn't escaped anyway and is kind of a hack here
-    val ignoreEscape = if (quoteChar == '\'') '"' else if (quoteChar == '"') '\'' else 'x'
-    str.flatMap { c =>
-      if (c == ignoreEscape) c.toString
-      else encodeTable.get(c) match {
-        case None =>
-          if (c < ' ') nonPrintEscape(c.toInt)
-          else c.toString
-        case Some(esc) => esc
-      }
-    }
-  }
-
-  def unescape(str: String): Either[Int, String] = {
-    val sb = new java.lang.StringBuilder
-    def decodeNum(idx: Int, size: Int, base: Int): Int = {
-      val end = idx + size
-      if (end <= str.length) {
-        val intStr = str.substring(idx, end)
-        val asInt =
-          try Integer.parseInt(intStr, base)
-          catch { case _: NumberFormatException => ~idx }
-        sb.append(asInt.toChar)
-        end
-      } else ~(str.length)
-    }
-    @annotation.tailrec
-    def loop(idx: Int): Option[Int] =
-      if (idx >= str.length) None
-      else if (idx < 0) Some(~idx) // error from decodeNum
-      else {
-        val c0 = str.charAt(idx)
-        if (c0 != '\\') {
-          sb.append(c0)
-          loop(idx + 1)
-        }
-        else {
-          val nextIdx = idx + 1
-          if (nextIdx >= str.length) Some(idx)
-          else {
-            val c = str.charAt(nextIdx)
-            decodeTable.get(c) match {
-              case Some(d) =>
-                sb.append(d)
-                loop(idx + 2)
-              case None =>
-                c match {
-                  case 'o' => loop(decodeNum(idx + 2, 2, 8))
-                  case 'x' => loop(decodeNum(idx + 2, 2, 16))
-                  case 'u' => loop(decodeNum(idx + 2, 4, 16))
-                  case 'U' => loop(decodeNum(idx + 2, 8, 16))
-                  case _ => Some(idx)
-                }
-            }
-          }
-        }
-      }
-
-    loop(0) match {
-      case None => Right(sb.toString)
-      case Some(err) => Left(err)
-    }
-  }
+  def unescape(str: String): Either[Int, String] =
+    StringUtil.unescape(str)
 
   def nonEmptyListToList[T](p: P[NonEmptyList[T]]): P[List[T]] =
     p.?.map {

--- a/core/src/main/scala/org/bykn/bosatsu/StringUtil.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/StringUtil.scala
@@ -28,8 +28,8 @@ abstract class GenericStringUtil {
 
   def escapedString(q: Char): P[String] = {
     val qstr = q.toString
-    val char = P(escapeString | (!qstr ~ AnyChar)).!
-    P(qstr ~ char.rep() ~ qstr).map(_.mkString)
+    val char = P(escapeString | (!qstr ~ AnyChar))
+    P(qstr ~ char.rep().! ~ qstr)
       .flatMap { str =>
         unescape(str) match {
           case Right(str1) => PassWith(str1)

--- a/core/src/main/scala/org/bykn/bosatsu/StringUtil.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/StringUtil.scala
@@ -1,0 +1,136 @@
+package org.bykn.bosatsu
+
+import fastparse.all._
+
+abstract class GenericStringUtil {
+  protected def decodeTable: Map[Char, Char]
+
+  private val encodeTable = decodeTable.iterator.map { case (v, k) => (k, s"\\$v") }.toMap
+
+  private val nonPrintEscape: Array[String] =
+    (0 until 32).map { c =>
+      val strHex = c.toHexString
+      val strPad = List.fill(4 - strHex.length)('0').mkString
+      s"\\u$strPad$strHex"
+    }.toArray
+
+  private val escapeString: P[Unit] = {
+    val escapes = CharIn(decodeTable.keys.toSeq)
+    val oct = CharIn('0' until '8')
+    val hex = CharIn(('0' to '9') ++ ('a' to 'f') ++ ('A' to 'F'))
+    val octP = P("o" ~ oct ~ oct)
+    val hexP = P("x" ~ hex ~ hex)
+    val u4 = P("u" ~ hex.rep(4))
+    val u8 = P("U" ~ hex.rep(8))
+    val after = escapes | octP | hexP | u4 | u8
+    P("\\" ~ after)
+  }
+
+  def escapedString(q: Char): P[String] = {
+    val qstr = q.toString
+    val char = P(escapeString | (!qstr ~ AnyChar)).!
+    P(qstr ~ char.rep() ~ qstr).map(_.mkString)
+      .flatMap { str =>
+        unescape(str) match {
+          case Right(str1) => PassWith(str1)
+          case Left(_) => Fail
+        }
+      }
+  }
+
+  def escape(quoteChar: Char, str: String): String = {
+    // We can ignore escaping the opposite character used for the string
+    // x isn't escaped anyway and is kind of a hack here
+    val ignoreEscape = if (quoteChar == '\'') '"' else if (quoteChar == '"') '\'' else 'x'
+    str.flatMap { c =>
+      if (c == ignoreEscape) c.toString
+      else encodeTable.get(c) match {
+        case None =>
+          if (c < ' ') nonPrintEscape(c.toInt)
+          else c.toString
+        case Some(esc) => esc
+      }
+    }
+  }
+
+  def unescape(str: String): Either[Int, String] = {
+    val sb = new java.lang.StringBuilder
+    def decodeNum(idx: Int, size: Int, base: Int): Int = {
+      val end = idx + size
+      if (end <= str.length) {
+        val intStr = str.substring(idx, end)
+        val asInt =
+          try Integer.parseInt(intStr, base)
+          catch { case _: NumberFormatException => ~idx }
+        sb.append(asInt.toChar)
+        end
+      } else ~(str.length)
+    }
+    @annotation.tailrec
+    def loop(idx: Int): Option[Int] =
+      if (idx >= str.length) None
+      else if (idx < 0) Some(~idx) // error from decodeNum
+      else {
+        val c0 = str.charAt(idx)
+        if (c0 != '\\') {
+          sb.append(c0)
+          loop(idx + 1)
+        }
+        else {
+          val nextIdx = idx + 1
+          if (nextIdx >= str.length) Some(idx)
+          else {
+            val c = str.charAt(nextIdx)
+            decodeTable.get(c) match {
+              case Some(d) =>
+                sb.append(d)
+                loop(idx + 2)
+              case None =>
+                c match {
+                  case 'o' => loop(decodeNum(idx + 2, 2, 8))
+                  case 'x' => loop(decodeNum(idx + 2, 2, 16))
+                  case 'u' => loop(decodeNum(idx + 2, 4, 16))
+                  case 'U' => loop(decodeNum(idx + 2, 8, 16))
+                  case _ => Some(idx)
+                }
+            }
+          }
+        }
+      }
+
+    loop(0) match {
+      case None => Right(sb.toString)
+      case Some(err) => Left(err)
+    }
+  }
+}
+
+object StringUtil extends GenericStringUtil {
+  // Here are the rules for escaping in python/bosatsu
+  lazy val decodeTable: Map[Char, Char] =
+    Map(
+      ('\\', '\\'),
+      ('\'', '\''),
+      ('\"', '\"'),
+      ('a', 7.toChar), // bell
+      ('b', 8.toChar), // backspace
+      ('f', 12.toChar), // form-feed
+      ('n', '\n'),
+      ('r', '\r'),
+      ('t', '\t'),
+      ('v', 11.toChar)) // vertical tab
+}
+
+object JsonStringUtil extends GenericStringUtil {
+  // Here are the rules for escaping in json
+  lazy val decodeTable: Map[Char, Char] =
+    Map(
+      ('\\', '\\'),
+      ('\'', '\''),
+      ('\"', '\"'),
+      ('b', 8.toChar), // backspace
+      ('f', 12.toChar), // form-feed
+      ('n', '\n'),
+      ('r', '\r'),
+      ('t', '\t'))
+}

--- a/core/src/test/scala/org/bykn/bosatsu/EvaluationTest.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/EvaluationTest.scala
@@ -528,7 +528,7 @@ package Foo
 struct Bar(a: Int, s: String)
 
 main = Bar(1, "foo")
-"""), "Foo", Json.JObject(Map("a" -> Json.JNumberStr("1"), "s" -> Json.JString("foo"))))
+"""), "Foo", Json.JObject(List("a" -> Json.JNumberStr("1"), "s" -> Json.JString("foo"))))
   }
 
   test("test some type errors") {

--- a/core/src/test/scala/org/bykn/bosatsu/JsonTest.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/JsonTest.scala
@@ -1,0 +1,86 @@
+package org.bykn.bosatsu
+
+import org.scalacheck.{Arbitrary, Gen, Shrink}
+import org.scalatest.prop.PropertyChecks.{forAll, PropertyCheckConfiguration }
+import org.scalatest.FunSuite
+import org.typelevel.jawn.ast.{JValue, JParser}
+
+class JsonTest extends FunSuite {
+
+  implicit val generatorDrivenConfig =
+    PropertyCheckConfiguration(minSuccessful = 500)
+
+  def genJson(depth: Int): Gen[Json] = {
+    val genString = Gen.listOf(Gen.choose(1.toChar, 127.toChar)).map(_.mkString)
+    val str = genString.map(Json.JString(_))
+    val nd0 = Arbitrary.arbitrary[Double].map(Json.JNumber(_))
+    val nd1 = Arbitrary.arbitrary[Int].map { i => Json.JNumber(i.toDouble) }
+    val nd2 = Arbitrary.arbitrary[Double].map { d => Json.JNumberStr(d.toString) }
+    val nd3 = Arbitrary.arbitrary[Int].map { i => Json.JNumberStr(i.toString) }
+    val b = Gen.oneOf(Json.JBool(true), Json.JBool(false))
+
+    val d0 = Gen.oneOf(str, nd0, nd1, nd2, nd3, b, Gen.const(Json.JNull))
+    if (depth <= 0) d0
+    else {
+      val recurse = Gen.lzy(genJson(depth - 1))
+      val collectionSize = Gen.choose(0, depth * depth)
+      val ary = collectionSize.flatMap(Gen.listOfN(_, recurse).map { l => Json.JArray(l.toVector) })
+      val map = collectionSize.flatMap(Gen.listOfN(_, Gen.zip(genString, recurse)).map { m => Json.JObject(m) })
+      Gen.frequency((10, d0), (1, ary), (1, map))
+    }
+  }
+
+  implicit val arbJson: Arbitrary[Json] =
+    Arbitrary(Gen.choose(0, 4).flatMap(genJson(_)))
+
+  implicit def shrinkJson(
+    implicit ss: Shrink[String],
+    sd: Shrink[Double]): Shrink[Json] =
+    Shrink[Json](new Function1[Json, Stream[Json]] {
+      def apply(j: Json): Stream[Json] = {
+        import Json._
+        j match {
+          case JString(str) => ss.shrink(str).map(JString(_))
+          case JNumber(n) => sd.shrink(n).map(JNumber(_))
+          case JNumberStr(nstr) => Stream.empty
+          case JNull => Stream.empty
+          case JBool(_) => Stream.empty
+          case JArray(js) =>
+            (0 until js.size).toStream.map { sz =>
+              JArray(js.take(sz))
+            }
+          case JObject(mapList) =>
+            (0 until mapList.size).toStream.map { sz =>
+              JObject(mapList.take(sz))
+            }
+        }
+      }
+    })
+
+  def matches(j1: Json, j2: JValue): Unit = {
+    import Json._
+    j1 match {
+      case JString(str) => assert(j2.asString == str); ()
+      case JNumber(n) => assert(j2.asDouble == n); ()
+      case JNumberStr(nstr) => assert(BigDecimal(nstr) == j2.asBigDecimal); ()
+      case JNull => assert(j2.isNull); ()
+      case JBool(t) => assert(j2.asBoolean == t); ()
+      case JArray(js) =>
+        js.zipWithIndex.foreach { case (j, idx) =>
+          matches(j, j2.get(idx))
+        }
+      case JObject(map) =>
+        map.toMap.foreach { case (k, v) =>
+          matches(v, j2.get(k))
+        }
+    }
+  }
+
+  test("we match Jawn") {
+    forAll { (j: Json) =>
+      val str = j.render
+      val jvalue = JParser.parseUnsafe(str)
+      matches(j, jvalue)
+    }
+  }
+}

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -7,6 +7,8 @@ object Dependencies {
   lazy val decline = "com.monovore" %% "decline" % "0.4.2"
   lazy val fastparse = "com.lihaoyi" %% "fastparse" % "1.0.0"
   lazy val fastparseCats = "org.bykn" %% "fastparse-cats-core" % "0.1.0"
+  lazy val jawnParser = "org.typelevel" %% "jawn-parser" % "0.14.1"
+  lazy val jawnAst = "org.typelevel" %% "jawn-ast" % "0.14.1"
   lazy val paiges = "org.typelevel" %% "paiges-core" % "0.2.0"
   lazy val scalaTest = "org.scalatest" %% "scalatest" % "3.0.3"
   lazy val scalaCheck = "org.scalacheck" %% "scalacheck" % "1.13.5"


### PR DESCRIPTION
close #139 

Here we use our current escaping rules, but json has different rules than python, so we have to build a different escaping table.

I verified the fix with Jawn.

Long term, maybe we should just use Jawn directly, but Jawn is very focused on parsing fast, where as here I think we really care what the Json looks like and not so much about being as fast as possible, so for now I didn't make that change.

cc @snoble 