### PR TITLE
fix an issue with nested def type inference

### DIFF
--- a/core/src/main/scala/org/bykn/bosatsu/TypeRef.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/TypeRef.scala
@@ -126,6 +126,10 @@ object TypeRef {
         onConst(defined)
       case TyVar(Type.Var.Bound(v)) =>
         Applicative[F].pure(TypeVar(v))
+      case Type.Fun(from, to) =>
+        (loop(from), loop(to)).mapN { (ftr, ttr) =>
+          TypeArrow(ftr, ttr)
+        }
       case TyApply(on, arg) =>
         (loop(on), loop(arg)).mapN {
           case (TypeApply(of, args1), arg) =>

--- a/core/src/test/scala/org/bykn/bosatsu/rankn/RankNInferTest.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/rankn/RankNInferTest.scala
@@ -845,4 +845,19 @@ def len(l):
 main = len(Succ(Succ(Zero)))
 """, "Int")
   }
+
+  test("nested def example") {
+
+    parseProgram("""#
+struct Pair(first, second)
+
+def bar(x):
+  def baz(y):
+    Pair(x, y)
+
+  baz(10)
+
+main = bar(5)
+""", "Pair[Int, Int]")
+  }
 }


### PR DESCRIPTION
close #182 

The issue here is this code here:

https://github.com/johnynek/bosatsu/pull/173

We used subsumption checking, where we should be using unify. The difference is that subsumption assumes you are dealing with full types, not metavariables (type unknowns) that have yet to be solved. Instead, before we fully solve for the type, we should unify the solved type with itself in recursive cases.

This fixes the issue reported above.

Along the way I considerably improved the printing of types in the compiler errors, which was hampering my ability to see what the problem was here.