### PR TITLE
Add Dict syntax handling

### DIFF
--- a/core/src/main/scala/org/bykn/bosatsu/DefRecursionCheck.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/DefRecursionCheck.scala
@@ -329,6 +329,16 @@ object DefRecursionCheck {
                 checkDecl(i) *>
                 (f.traverse_(checkDecl))
           }
+        case DictDecl(ll) =>
+          ll match {
+            case ListLang.Cons(items) =>
+              items.traverse_ { s => checkDecl(s.key) *> checkDecl(s.value) }
+            case ListLang.Comprehension(e, _, i, f) =>
+              checkDecl(e.key) *>
+                checkDecl(e.value) *>
+                checkDecl(i) *>
+                (f.traverse_(checkDecl))
+          }
       }
     }
 

--- a/core/src/main/scala/org/bykn/bosatsu/ListLang.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/ListLang.scala
@@ -2,14 +2,14 @@ package org.bykn.bosatsu
 
 import fastparse.all._
 
-import Parser.{maybeSpacesAndLines, spacesAndLines, Combinators}
+import Parser.{maybeSpacesAndLines, maybeSpace, spacesAndLines, Combinators}
 import org.typelevel.paiges.{Doc, Document}
 
 /**
  * Represents the list construction sublanguage
  * A is the expression type, B is the pattern type for bindings
  */
-sealed abstract class ListLang[A, +B]
+sealed abstract class ListLang[F[_], A, +B]
 object ListLang {
   sealed abstract class SpliceOrItem[A] {
     def value: A
@@ -28,11 +28,32 @@ object ListLang {
       }
   }
 
-  case class Cons[A](items: List[SpliceOrItem[A]]) extends ListLang[A, Nothing]
-  case class Comprehension[A, B](expr: SpliceOrItem[A], binding: B, in: A, filter: Option[A]) extends ListLang[A, B]
+  case class KVPair[A](key: A, value: A)
 
-  def parser[A, B](pa: P[A], pbind: P[B]): P[ListLang[A, B]] = {
-    val sia = SpliceOrItem.parser(pa)
+  object KVPair {
+    private[this] val sep: Doc = Doc.text(": ")
+
+    def parser[A](p: P[A]): P[KVPair[A]] =
+      P(p ~ maybeSpace ~ ":" ~ maybeSpace ~ p)
+        .map { case (k, v) => KVPair(k, v) }
+
+    implicit def document[A](implicit A: Document[A]): Document[KVPair[A]] =
+      Document.instance[KVPair[A]] {
+        case KVPair(k, v) => A.document(k) + sep + A.document(v)
+      }
+  }
+
+  case class Cons[F[_], A](items: List[F[A]]) extends ListLang[F, A, Nothing]
+  case class Comprehension[F[_], A, B](expr: F[A], binding: B, in: A, filter: Option[A]) extends ListLang[F, A, B]
+
+  def parser[A, B](pa: P[A], pbind: P[B]): P[ListLang[SpliceOrItem, A, B]] =
+    genParser(P("["), SpliceOrItem.parser(pa), pa, pbind, P("]"))
+
+  def dictParser[A, B](pa: P[A], pbind: P[B]): P[ListLang[KVPair, A, B]] =
+    genParser(P("{"), KVPair.parser(pa), pa, pbind, P("}"))
+
+  def genParser[F[_], A, B](left: P[Unit], fa: P[F[A]], pa: P[A], pbind: P[B], right: P[Unit]): P[ListLang[F, A, B]] = {
+    val sia = fa
     // construct the tail of a list, so we will finally have at least one item
     val consTail = sia.nonEmptyListOfWs(maybeSpacesAndLines, 1).?
       .map { tail =>
@@ -41,7 +62,7 @@ object ListLang {
           case Some(ne) => ne.toList
         }
 
-        { a: SpliceOrItem[A] => Cons(a :: listTail) }
+        { a: F[A] => Cons(a :: listTail) }
       }
       .opaque("ConsListTail")
 
@@ -52,14 +73,14 @@ object ListLang {
       "for" ~ spacesAndLines ~/ pbind ~ maybeSpacesAndLines ~
       "in" ~ spacesAndLines ~ pa ~ (maybeSpacesAndLines ~ filterExpr).?)
         .map { case (b, i, f) =>
-          { e: SpliceOrItem[A] => Comprehension(e, b, i, f) }
+          { e: F[A] => Comprehension(e, b, i, f) }
         }
         .opaque("ListComprehension")
 
     val commaCons = ("," ~ maybeSpacesAndLines ~ consTail)
     val inner = commaCons | (spacesAndLines ~ (commaCons | comp))
 
-    P("[" ~ maybeSpacesAndLines ~ (sia ~ inner.?).? ~ maybeSpacesAndLines ~ "]")
+    P(left ~ maybeSpacesAndLines ~ (sia ~ inner.?).? ~ maybeSpacesAndLines ~ right)
       .map {
         case None => Cons(Nil)
         case Some((a, None)) => Cons(a :: Nil)
@@ -67,21 +88,27 @@ object ListLang {
       }
   }
 
-  implicit def document[A, B](implicit A: Document[A], B: Document[B]): Document[ListLang[A, B]] =
-    Document.instance[ListLang[A, B]] {
+  def genDocument[F[_], A, B](left: Doc, right: Doc)(implicit F: Document[F[A]], A: Document[A], B: Document[B]): Document[ListLang[F, A, B]] =
+    Document.instance[ListLang[F, A, B]] {
       case Cons(items) =>
-        Doc.char('[') + Doc.intercalate(Doc.text(", "),
-          items.map(SpliceOrItem.document(A).document(_))) +
-          Doc.char(']')
+        left + Doc.intercalate(Doc.text(", "),
+          items.map(F.document(_))) +
+          right
       case Comprehension(e, b, i, f) =>
         val filt = f match {
           case None => Doc.empty
           case Some(e) => Doc.text(" if ") + A.document(e)
         }
-        Doc.char('[') + SpliceOrItem.document(A).document(e) + Doc.text(" for ") +
+        left + F.document(e) + Doc.text(" for ") +
           B.document(b) + Doc.text(" in ") +
           A.document(i) + filt +
-          Doc.char(']')
+          right
     }
+
+  implicit def document[A, B](implicit A: Document[A], B: Document[B]): Document[ListLang[SpliceOrItem, A, B]] =
+    genDocument[SpliceOrItem, A, B](Doc.char('['), Doc.char(']'))
+
+  implicit def documentDict[A, B](implicit A: Document[A], B: Document[B]): Document[ListLang[KVPair, A, B]] =
+    genDocument[KVPair, A, B](Doc.char('{'), Doc.char('}'))
 }
 

--- a/core/src/test/scala/org/bykn/bosatsu/EvaluationTest.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/EvaluationTest.scala
@@ -972,5 +972,59 @@ main = match lst:
   _: "bad"
 """), "A", Str("good"))
 
+    evalTest(List("""
+package A
+
+e1 = {}
+e2 = e1.add_key("hello", "world").add_key("hello1", "world1")
+lst = e2.items
+
+main = match lst:
+  [("hello", "world"), ("hello1", "world1")]: "good"
+  _: "bad"
+"""), "A", Str("good"))
+
+    evalTest(List("""
+package A
+
+e = { "hello": "world",
+      "hello1": "world1" }
+lst = e.items
+
+main = match lst:
+  [("hello", "world"), ("hello1", "world1")]: "good"
+  _: "bad"
+"""), "A", Str("good"))
+
+    evalTest(List("""
+package A
+
+pairs = [("hello", "world"), ("hello1", "world1")]
+
+e = { k: v for (k, v) in pairs }
+lst = e.items
+
+main = match lst:
+  [("hello", "world"), ("hello1", "world1")]: "good"
+  _: "bad"
+"""), "A", Str("good"))
+
+    evalTest(List("""
+package A
+
+pairs = [("hello", 42), ("hello1", 24)]
+
+def is_hello(s):
+  match s.string_Order_fn("hello"):
+    EQ: True
+    _: False
+
+e = { k: v for (k, v) in pairs if is_hello(k) }
+lst = e.items
+
+main = match lst:
+  [("hello", res)]: res
+  _: -1
+"""), "A", VInt(42))
   }
 }


### PR DESCRIPTION
this closes #14 cc @wrobstory 

This reuses the code for handling the list comprehension syntax so we get a fair amount of reuse. There is no notion of flattening here like there is for lists, and I think that's the right call. There is also no notion (currently) of pattern matching on dicts. If you want to do that, convert them to lists via .items.

On a personal note, it feels exciting that things are in place that early issues which were fairly forward looking are being closed out. It feels like an actual release could be coming up if I can clean up the API for using bosatsu from scala/java.