### PR TITLE
Introduce Identifier remove a lot of Strings

### DIFF
--- a/core/src/main/scala/org/bykn/bosatsu/Codegen.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/Codegen.scala
@@ -209,7 +209,8 @@ trait CodeGen {
       case Annotation(expr, _, _) =>
         // TODO we might want to use the type info
         apply(expr, topLevel, pack)
-      case Var(None, n, _, _) =>
+      case Var(None, ident, _, _) =>
+        val n = ident.asString
         NameKind(pack, n) match {
           case Some(NameKind.Constructor(_, _, _, _)) =>
             Monad[Output].pure(Doc.text(toConstructorName(n)))

--- a/core/src/main/scala/org/bykn/bosatsu/Codegen.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/Codegen.scala
@@ -12,6 +12,8 @@ import alleycats.std.map._ // TODO use SortedMap everywhere
 
 import org.bykn.bosatsu.rankn.Type
 
+import Identifier.{Bindable, Constructor}
+
 trait CodeGen {
   import TypedExpr._
   import CodeGen._
@@ -22,7 +24,7 @@ trait CodeGen {
   def toExportedName(s: String): String =
     s
 
-  def toConstructorName(s: String): String =
+  def toConstructor(s: String): String =
     "cons$" + s
 
   def toPackage(p: PackageName): String =
@@ -43,7 +45,7 @@ trait CodeGen {
       Doc.char('{') + (Doc.line + d).nested(2) + Doc.line + Doc.char('}')
 
     val isExported: Set[String] =
-      unfix.exports.map(_.name).toSet
+      unfix.exports.map(_.name.asString).toSet
 
     /*
      * add the imports and return a list of lines to set up inside
@@ -52,8 +54,8 @@ trait CodeGen {
     val imps: Output[List[NonEmptyList[Option[(Package.Interface, String, String)]]]] =
       Traverse[List].traverse(unfix.imports) { case Import(pack, items) =>
         Traverse[NonEmptyList].traverse(items) { imp =>
-          def go(fn: String => Option[String]): Output[Option[(Package.Interface, String, String)]] =
-            if (imp.isRenamed || isExported(imp.localName)) {
+          def go(fn: Identifier => Option[String]): Output[Option[(Package.Interface, String, String)]] =
+            if (imp.isRenamed || isExported(imp.localName.asString)) {
               // we make a new field for this.
               val opt = for {
                 o <- fn(imp.originalName)
@@ -73,9 +75,9 @@ trait CodeGen {
             }
 
             Traverse[NonEmptyList].traverse(imp.tag) {
-              case Referant.Value(_) => go { s => Some(toExportedName(s)) }
+              case Referant.Value(_) => go { s => Some(toExportedName(s.asString)) }
               case Referant.DefinedT(_) => go { _ => None }
-              case Referant.Constructor(_, _, _, _) => go { s => Some(toConstructorName(s)) }
+              case Referant.Constructor(_, _, _, _) => go { s => Some(toConstructor(s.asString)) }
             }
         }
         .map(_.flatten)
@@ -102,9 +104,9 @@ trait CodeGen {
     /*
      * build the constructors
      */
-    val definedTypes = unfix.program.types.allDefinedTypes.toList.sortBy(_.name.asString)
+    val definedTypes = unfix.program.types.allDefinedTypes.toList.sortBy(_.name)
 
-    def mkConstructor(i: Int, cn: ConstructorName, args: List[(ParamName, Type)]): Output[Doc] = {
+    def mkConstructor(i: Int, cn: Constructor, args: List[(Bindable, Type)]): Output[Doc] = {
       val argC = args.size
 
       def go(offset: Long, arg: Int): Doc =
@@ -122,7 +124,7 @@ trait CodeGen {
 
       getIds(argC).map { init =>
         val fn = go(init.id, 0)
-        val cname = toConstructorName(cn.asString)
+        val cname = toConstructor(cn.asString)
         // TODO check exports to see if this should be private
         Doc.text(s"public final static Object $cname = ") + fn + Doc.text(";") + Doc.line
       }
@@ -138,12 +140,13 @@ trait CodeGen {
     val externals = NameKind.externals(p)
     val extDoc: Output[Unit] =
       externals.traverse_ { case NameKind.ExternalDef(p, n, scheme) =>
-        outputExternal(n, ext.toMap((p, n)), ???/*scheme*/)
+        outputExternal(n.asString, ext.toMap((p, n.asString)), ???/*scheme*/)
       }
 
     val body = Traverse[List].traverse(unfix.program.lets) { case (f, rec, e) =>
-      val priv = if (isExported(f)) "public " else "private "
-      val left = Doc.text(s"${priv}final static Object ") + Doc.text(toExportedName(f)) + Doc.text(" = ")
+      // TODO use Identifier
+      val priv = if (isExported(f.asString)) "public " else "private "
+      val left = Doc.text(s"${priv}final static Object ") + Doc.text(toExportedName(f.asString)) + Doc.text(" = ")
       for {
         eDoc <- apply(e, true, p)
         _ <- tell(left + eDoc + Doc.char(';') + Doc.line)
@@ -210,10 +213,11 @@ trait CodeGen {
         // TODO we might want to use the type info
         apply(expr, topLevel, pack)
       case Var(None, ident, _, _) =>
+        // TODO never use asString
         val n = ident.asString
-        NameKind(pack, n) match {
+        NameKind(pack, ident) match {
           case Some(NameKind.Constructor(_, _, _, _)) =>
-            Monad[Output].pure(Doc.text(toConstructorName(n)))
+            Monad[Output].pure(Doc.text(toConstructor(n)))
           case _ =>
             for {
               scope <- RWST.ask[Id, Scope, Doc, Unique]
@@ -230,13 +234,13 @@ trait CodeGen {
         } yield Doc.text("((Fn<Object, Object>)") + fnDoc + Doc.char(')') + Doc.text(".apply(") + aDoc + Doc.char(')')
 
       case AnnotatedLambda(arg, _, exp, _) =>
-        nameIn(arg) { ua =>
+        nameIn(arg.asString) { ua =>
           nameIn("anon") { uanon =>
             val attr = if (topLevel) "private final static" else "final"
             for {
               _ <- tell(Doc.text(s"$attr Object anon${uanon.id} = "))
               _ <- tell((Doc.text("new Fn() {") + Doc.line +
-                Doc.text(s"@Override public Object apply(final Object ${toFieldName(arg, ua.id)}) {") + Doc.line).nested(2))
+                Doc.text(s"@Override public Object apply(final Object ${toFieldName(arg.asString, ua.id)}) {") + Doc.line).nested(2))
               eDoc <- apply(exp, false, pack)
               _ <- tell(Doc.text("return ") + eDoc + Doc.char(';') + Doc.line + Doc.text("}") + Doc.line + Doc.text("};") + Doc.line)
             } yield Doc.text(s"anon${uanon.id}")
@@ -244,11 +248,11 @@ trait CodeGen {
         }
 
       case Let(nm, nmv, in, _, _) =>
-        nameIn(nm) { ua =>
+        nameIn(nm.asString) { ua =>
           nameIn("anon") { uanon =>
             for {
               nmDoc <- apply(nmv, topLevel, pack)
-              _ <- tell(Doc.text(s"final Object ${toFieldName(nm, ua.id)} = ") + nmDoc + Doc.char(';') + Doc.line)
+              _ <- tell(Doc.text(s"final Object ${toFieldName(nm.asString, ua.id)} = ") + nmDoc + Doc.char(';') + Doc.line)
               inDoc <- apply(in, topLevel, pack)
             } yield inDoc
           }

--- a/core/src/main/scala/org/bykn/bosatsu/DefRecursionCheck.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/DefRecursionCheck.scala
@@ -153,7 +153,7 @@ object DefRecursionCheck {
      */
     def checkForIllegalBinds[A](
       state: State,
-      bs: Iterable[Identifier.Bindable],
+      bs: Iterable[Bindable],
       decl: Declaration)(next: ValidatedNel[RecursionError, A]): ValidatedNel[RecursionError, A] =
       state.outerDefNames match {
         case Nil=> next
@@ -187,7 +187,7 @@ object DefRecursionCheck {
     val unitSt: St[Unit] = pureSt(())
 
     def checkForIllegalBindsSt[A](
-      bs: Iterable[Identifier.Bindable],
+      bs: Iterable[Bindable],
       decl: Declaration): St[Unit] =
         getSt.flatMap { state =>
           toSt(checkForIllegalBinds(state, bs, decl)(unitValid))
@@ -311,7 +311,7 @@ object DefRecursionCheck {
           tups.traverse_(checkDecl)
         case Var(Identifier.Constructor(_)) =>
           unitSt
-        case Var(v: Identifier.Bindable) =>
+        case Var(v: Bindable) =>
           getSt.flatMap {
             case TopLevel =>
               // without any recursion, normal typechecking will detect bad states:

--- a/core/src/main/scala/org/bykn/bosatsu/DefRecursionCheck.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/DefRecursionCheck.scala
@@ -4,6 +4,8 @@ import cats.data.{NonEmptyList, Validated, ValidatedNel, StateT}
 
 import cats.implicits._
 
+import Identifier.Bindable
+
 /**
  * Recursion in bosatsu is only allowed on a substructural match
  * of one of the parameters to the def. This strict rule, along
@@ -23,12 +25,12 @@ object DefRecursionCheck {
   type Res = ValidatedNel[RecursionError, Unit]
 
   sealed abstract class RecursionError
-  case class InvalidRecursion(name: String, illegalPosition: Region) extends RecursionError
-  case class IllegalShadow(fnname: String, decl: Declaration) extends RecursionError
+  case class InvalidRecursion(name: Bindable, illegalPosition: Region) extends RecursionError
+  case class IllegalShadow(fnname: Bindable, decl: Declaration) extends RecursionError
   case class UnexpectedRecur(decl: Declaration.Match) extends RecursionError
-  case class RecurNotOnArg(decl: Declaration.Match, fnname: String, args: List[String]) extends RecursionError
-  case class RecursionArgNotVar(fnname: String, invalidArg: Declaration) extends RecursionError
-  case class RecursionNotSubstructural(fnname: String, recurPat: Pattern[Option[String], TypeRef], arg: Declaration.Var) extends RecursionError
+  case class RecurNotOnArg(decl: Declaration.Match, fnname: Bindable, args: List[Bindable]) extends RecursionError
+  case class RecursionArgNotVar(fnname: Bindable, invalidArg: Declaration) extends RecursionError
+  case class RecursionNotSubstructural(fnname: Bindable, recurPat: Pattern.Parsed, arg: Declaration.Var) extends RecursionError
   case class RecursiveDefNoRecur(defstmt: DefStatement[Declaration], recur: Declaration.Match) extends RecursionError
 
   /**
@@ -70,7 +72,7 @@ object DefRecursionCheck {
      * 3. we are checking the branches of the recur match
      */
     sealed abstract class State {
-      final def outerDefNames: List[String] =
+      final def outerDefNames: List[Bindable] =
         this match {
           case TopLevel => Nil
           case InDef(outer, n, _) => n :: outer.outerDefNames
@@ -78,7 +80,7 @@ object DefRecursionCheck {
           case InRecurBranch(ir, _) => ir.outerDefNames
         }
 
-      final def defNamesContain(n: String): Boolean =
+      final def defNamesContain(n: Bindable): Boolean =
         this match {
           case TopLevel => false
           case InDef(outer, dn, _) => (dn == n) || outer.defNamesContain(n)
@@ -86,11 +88,11 @@ object DefRecursionCheck {
           case InRecurBranch(ir, _) => ir.defNamesContain(n)
         }
 
-      def inDef(fnname: String, args: List[String]): InDef =
+      def inDef(fnname: Bindable, args: List[Bindable]): InDef =
         InDef(this, fnname, args)
     }
     sealed abstract class InDefState extends State {
-      final def defname: String =
+      final def defname: Bindable =
         this match {
           case InDef(_, defname, _) => defname
           case InDefRecurred(ir, _, _, _) => ir.defname
@@ -98,7 +100,7 @@ object DefRecursionCheck {
         }
     }
     case object TopLevel extends State
-    case class InDef(outer: State, fnname: String, args: List[String]) extends InDefState {
+    case class InDef(outer: State, fnname: Bindable, args: List[Bindable]) extends InDefState {
 
       def setRecur(index: Int, m: Declaration.Match): InDefRecurred =
         InDefRecurred(this, index, m, 0)
@@ -106,7 +108,7 @@ object DefRecursionCheck {
     case class InDefRecurred(inRec: InDef, index: Int, recur: Declaration.Match, recCount: Int) extends InDefState {
       def incRecCount: InDefRecurred = copy(recCount = recCount + 1)
     }
-    case class InRecurBranch(inRec: InDefRecurred, branch: Pattern[Option[String], TypeRef]) extends InDefState {
+    case class InRecurBranch(inRec: InDefRecurred, branch: Pattern.Parsed) extends InDefState {
       def incRecCount: InRecurBranch = copy(inRec = inRec.incRecCount)
     }
 
@@ -114,13 +116,13 @@ object DefRecursionCheck {
      * What is the index into the list of def arguments where we are doing our recursion
      */
     def getRecurIndex(
-      fnname: String,
-      args: List[String],
+      fnname: Bindable,
+      args: List[Bindable],
       m: Declaration.Match): ValidatedNel[RecursionError, Int] = {
       import Declaration._
       m.arg match {
         case Var(v) =>
-          val idx = args.indexOf(v.asString)
+          val idx = args.indexOf(v)
           if (idx < 0) Validated.invalidNel(RecurNotOnArg(m, fnname, args))
           else Validated.valid(idx)
         case notVar =>
@@ -132,10 +134,10 @@ object DefRecursionCheck {
      * Check that decl is a strict substructure of pat. We do this by making sure decl is a Var
      * and that var is one of the strict substrutures of the pattern.
      */
-    def strictSubstructure(fnname: String, pat: Pattern[Option[String], TypeRef], decl: Declaration): Res =
+    def strictSubstructure(fnname: Bindable, pat: Pattern.Parsed, decl: Declaration): Res =
       decl match {
         case v@Declaration.Var(nm) =>
-          if (pat.substructures.contains(nm.asString)) unitValid
+          if (pat.substructures.contains(nm)) unitValid
           else Validated.invalidNel(RecursionNotSubstructural(fnname, pat, v))
         case notVar =>
           // we can only recur with vars
@@ -151,7 +153,7 @@ object DefRecursionCheck {
      */
     def checkForIllegalBinds[A](
       state: State,
-      bs: Iterable[String],
+      bs: Iterable[Identifier.Bindable],
       decl: Declaration)(next: ValidatedNel[RecursionError, A]): ValidatedNel[RecursionError, A] =
       state.outerDefNames match {
         case Nil=> next
@@ -185,7 +187,7 @@ object DefRecursionCheck {
     val unitSt: St[Unit] = pureSt(())
 
     def checkForIllegalBindsSt[A](
-      bs: Iterable[String],
+      bs: Iterable[Identifier.Bindable],
       decl: Declaration): St[Unit] =
         getSt.flatMap { state =>
           toSt(checkForIllegalBinds(state, bs, decl)(unitValid))
@@ -197,8 +199,7 @@ object DefRecursionCheck {
     def checkDecl(decl: Declaration): St[Unit] = {
       import Declaration._
       decl match {
-        case Apply(Var(ident), args, _) =>
-          val nm = ident.asString
+        case Apply(Var(nm: Bindable), args, _) =>
           getSt.flatMap {
             case TopLevel =>
               // without any recursion, normal typechecking will detect bad states:
@@ -272,7 +273,7 @@ object DefRecursionCheck {
               toSt(getRecurIndex(defname, args, recur)).flatMap { idx =>
                 // on all these branchs, use the the same
                 // parent state
-                def beginBranch(pat: Pattern[Option[String], TypeRef]): St[Unit] =
+                def beginBranch(pat: Pattern.Parsed): St[Unit] =
                   getSt.flatMap {
                     case ir@InDef(_, _, _) =>
                       val rec = ir.setRecur(idx, recur)
@@ -310,8 +311,7 @@ object DefRecursionCheck {
           tups.traverse_(checkDecl)
         case Var(Identifier.Constructor(_)) =>
           unitSt
-        case Var(ident: Identifier.Bindable) =>
-          val v = ident.asString
+        case Var(v: Identifier.Bindable) =>
           getSt.flatMap {
             case TopLevel =>
               // without any recursion, normal typechecking will detect bad states:

--- a/core/src/main/scala/org/bykn/bosatsu/DefStatement.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/DefStatement.scala
@@ -1,6 +1,6 @@
 package org.bykn.bosatsu
 
-import Parser.{ Combinators, lowerIdent, maybeSpace, spaces }
+import Parser.{ Combinators, maybeSpace, spaces }
 import cats.Functor
 import cats.data.NonEmptyList
 import cats.implicits._
@@ -8,9 +8,11 @@ import fastparse.all._
 import org.bykn.fastparse_cats.StringInstances._
 import org.typelevel.paiges.{ Doc, Document }
 
+import Identifier.Bindable
+
 case class DefStatement[T](
-  name: String,
-  args: List[(String, Option[TypeRef])],
+  name: Bindable,
+  args: List[(Bindable, Option[TypeRef])],
   retType: Option[TypeRef], result: T) {
 
 
@@ -30,7 +32,7 @@ case class DefStatement[T](
     NonEmptyList.fromList(args) match {
       case None => bodyExp
       case Some(neargs) =>
-        val deepFunctor = Functor[NonEmptyList].compose[(String, ?)].compose[Option]
+        val deepFunctor = Functor[NonEmptyList].compose[(Bindable, ?)].compose[Option]
         Expr.buildLambda(deepFunctor.map(neargs)(trFn), bodyExp, tag)
     }
   }
@@ -47,10 +49,10 @@ object DefStatement {
         if (args.isEmpty) Doc.empty
         else {
           Doc.char('(') +
-            Doc.intercalate(Doc.text(", "), args.map(TypeRef.argDoc _)) +
+            Doc.intercalate(Doc.text(", "), args.map(TypeRef.argDoc[Bindable] _)) +
             Doc.char(')')
         }
-      val line0 = defDoc + Doc.text(name) + argDoc + res + Doc.text(":")
+      val line0 = defDoc + Document[Bindable].document(name) + argDoc + res + Doc.text(":")
 
       line0 + Document[T].document(result)
     }
@@ -61,7 +63,7 @@ object DefStatement {
     def parser[T](resultTParser: P[T]): P[DefStatement[T]] = {
       val args = argParser.nonEmptyList
       val result = P(maybeSpace ~ "->" ~/ maybeSpace ~ TypeRef.parser).?
-      P("def" ~ spaces ~/ lowerIdent ~ ("(" ~ maybeSpace ~ args ~ maybeSpace ~ ")").? ~
+      P("def" ~ spaces ~/ Identifier.bindableParser ~ ("(" ~ maybeSpace ~ args ~ maybeSpace ~ ")").? ~
         result ~ maybeSpace ~ ":" ~/ resultTParser)
         .map {
           case (name, optArgs, resType, res) =>
@@ -73,6 +75,6 @@ object DefStatement {
         }
     }
 
-    val argParser: P[(String, Option[TypeRef])] =
-      P(lowerIdent ~ (":" ~/ maybeSpace ~ TypeRef.parser).?)
+    val argParser: P[(Bindable, Option[TypeRef])] =
+      P(Identifier.bindableParser ~ (":" ~/ maybeSpace ~ TypeRef.parser).?)
 }

--- a/core/src/main/scala/org/bykn/bosatsu/Evaluation.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/Evaluation.scala
@@ -564,12 +564,14 @@ case class Evaluation(pm: PackageMap.Inferred, externals: Externals) {
          // TODO, we need to probably do something with this
          evalTypedExpr(p, e, recurse)
        case Annotation(e, _, _) => evalTypedExpr(p, e, recurse)
-       case Var(None, v, _, _) =>
+       case Var(None, ident, _, _) =>
+         val v = ident.asString
          Scoped.orElse(v) {
          // this needs to be lazy
            recurse((p, Left(v)))._1
          }
-       case Var(Some(p), v, _, _) =>
+       case Var(Some(p), ident, _, _) =>
+         val v = ident.asString
          val pack = pm.toMap.get(p).getOrElse(sys.error(s"cannot find $p, shouldn't happen due to typechecking"))
          val (scoped, _) = eval((pack, Left(v)))
          scoped

--- a/core/src/main/scala/org/bykn/bosatsu/Evaluation.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/Evaluation.scala
@@ -7,6 +7,8 @@ import cats.implicits._
 import java.math.BigInteger
 import org.bykn.bosatsu.rankn.{DefinedType, Type}
 
+import Identifier.{Bindable, Constructor}
+
 object Evaluation {
   import Value._
 
@@ -149,14 +151,14 @@ object Evaluation {
     }
   }
 
-  type Env = Map[String, Eval[Value]]
+  type Env = Map[Identifier, Eval[Value]]
 
   sealed abstract class Scoped {
     import Scoped.fromFn
 
     def inEnv(env: Env): Eval[Value]
 
-    def letNameIn(name: String, in: Scoped): Scoped =
+    def letNameIn(name: Bindable, in: Scoped): Scoped =
       Scoped.Let(name, this, in)
 
     def flatMap(fn: (Env, Value) => Eval[Value]): Scoped =
@@ -166,7 +168,7 @@ object Evaluation {
         }
       }
 
-    def asLambda(name: String, set: Set[String]): Scoped =
+    def asLambda(name: Bindable, set: Set[Identifier]): Scoped =
       fromFn { env0 =>
         import cats.Now
         // we can remove anything not captured by the closure
@@ -204,15 +206,15 @@ object Evaluation {
     val unreachable: Scoped =
       const(Eval.always(sys.error("unreachable reached")))
 
-    def recursive(name: String, item: Scoped): Scoped = {
+    def recursive(name: Bindable, item: Scoped): Scoped = {
       fromFn { env =>
-        lazy val env1: Map[String, Eval[Value]] =
+        lazy val env1: Map[Identifier, Eval[Value]] =
           env + (name -> Eval.defer(item.inEnv(env1)).memoize)
         item.inEnv(env1)
       }
     }
 
-    def orElse(name: String)(next: => Scoped): Scoped = {
+    def orElse(name: Identifier)(next: => Scoped): Scoped = {
       lazy val nextComputed = next
       fromFn { env =>
         env.get(name) match {
@@ -222,7 +224,7 @@ object Evaluation {
       }
     }
 
-    private case class Let(name: String, arg: Scoped, in: Scoped) extends Scoped {
+    private case class Let(name: Bindable, arg: Scoped, in: Scoped) extends Scoped {
       def inEnv(env: Env) = {
         val let = arg.inEnv(env)
         in.inEnv(env.updated(name, let))
@@ -243,7 +245,7 @@ case class Evaluation(pm: PackageMap.Inferred, externals: Externals) {
   import Evaluation.{Value, Scoped, Env}
   import Value._
 
-  def evaluate(p: PackageName, varName: String): Option[(Eval[Value], Type)] =
+  def evaluate(p: PackageName, varName: Identifier): Option[(Eval[Value], Type)] =
     pm.toMap.get(p).map { pack =>
       val (s, t) = eval((pack, Left(varName)))
       (s.inEnv(Map.empty), t)
@@ -286,7 +288,7 @@ case class Evaluation(pm: PackageMap.Inferred, externals: Externals) {
 
       toType[Test](ea.value, tpe) { (any, dt, rec) =>
         if (dt.packageName == Predef.packageName) {
-          dt.name.asString match {
+          dt.name.ident.asString match {
             case "Assertion" =>
               Some(toAssert(any))
             case "Test" =>
@@ -302,11 +304,11 @@ case class Evaluation(pm: PackageMap.Inferred, externals: Externals) {
       }
     }
 
-  private type Ref = Either[String, TypedExpr[Declaration]]
+  private type Ref = Either[Identifier, TypedExpr[Declaration]]
 
   private def evalBranch(
     tpe: Type,
-    branches: NonEmptyList[(Pattern[(PackageName, ConstructorName), Type], TypedExpr[Declaration])],
+    branches: NonEmptyList[(Pattern[(PackageName, Constructor), Type], TypedExpr[Declaration])],
     p: Package.Inferred,
     recurse: ((Package.Inferred, Ref)) => (Scoped, Type)): (Value, Env) => Eval[Value] = {
       val dtConst@Type.TyConst(Type.Const.Defined(pn0, tn)) =
@@ -314,7 +316,7 @@ case class Evaluation(pm: PackageMap.Inferred, externals: Externals) {
 
       val packageForType = pm.toMap(pn0)
 
-      def definedForCons(pc: (PackageName, ConstructorName)): DefinedType[Any] =
+      def definedForCons(pc: (PackageName, Constructor)): DefinedType[Any] =
         pm.toMap(pc._1).program.types.getConstructor(pc._1, pc._2).get._2
 
       val noop: (Value, Env) => Option[Env] = { (_, env) => Some(env) }
@@ -323,7 +325,7 @@ case class Evaluation(pm: PackageMap.Inferred, externals: Externals) {
        * This is used in a loop internally, so I am avoiding map and flatMap
        * in favor of pattern matching for performance
        */
-      def maybeBind[E](pat: Pattern[(PackageName, ConstructorName), Type]): (Value, Env) => Option[Env] =
+      def maybeBind[E](pat: Pattern[(PackageName, Constructor), Type]): (Value, Env) => Option[Env] =
         pat match {
           case Pattern.WildCard => noop
           case Pattern.Literal(lit) =>
@@ -331,10 +333,10 @@ case class Evaluation(pm: PackageMap.Inferred, externals: Externals) {
 
             { (v, env) => if (v == vlit) Some(env) else None }
           case Pattern.Var(n) =>
+
             { (v, env) => Some(env.updated(n, Eval.now(v))) }
           case Pattern.Named(n, p) =>
             val inner = maybeBind(p)
-            // now transform this function:
 
             { (v, env) =>
               inner(v, env) match {
@@ -371,8 +373,9 @@ case class Evaluation(pm: PackageMap.Inferred, externals: Externals) {
                 // we don't need to match on it being a list, because we have
                 // already type checked
                 splice match {
-                  case Some(nm) =>
-                    { (v, env) => Some(env.updated(nm, Eval.now(v))) }
+                  case Some(ident) =>
+
+                    { (v, env) => Some(env.updated(ident, Eval.now(v))) }
                   case None =>
                     noop
                 }
@@ -427,7 +430,7 @@ case class Evaluation(pm: PackageMap.Inferred, externals: Externals) {
             maybeBind(p)
           case Pattern.Union(h, t) =>
             // we can just loop expanding these out:
-            def loop(ps: List[Pattern[(PackageName, ConstructorName), Type]]): (Value, Env) => Option[Env] =
+            def loop(ps: List[Pattern[(PackageName, Constructor), Type]]): (Value, Env) => Option[Env] =
               ps match {
                 case Nil => neverMatch
                 case head :: tail =>
@@ -505,7 +508,7 @@ case class Evaluation(pm: PackageMap.Inferred, externals: Externals) {
               }
             }
         }
-      def bindEnv[E](branches: List[(Pattern[(PackageName, ConstructorName), Type], E)]): (Value, Env) => (Env, E) =
+      def bindEnv[E](branches: List[(Pattern[(PackageName, Constructor), Type], E)]): (Value, Env) => (Env, E) =
         branches match {
           case Nil =>
             // This is ruled out by typechecking, we know all our matches are total
@@ -565,15 +568,13 @@ case class Evaluation(pm: PackageMap.Inferred, externals: Externals) {
          evalTypedExpr(p, e, recurse)
        case Annotation(e, _, _) => evalTypedExpr(p, e, recurse)
        case Var(None, ident, _, _) =>
-         val v = ident.asString
-         Scoped.orElse(v) {
+         Scoped.orElse(ident) {
          // this needs to be lazy
-           recurse((p, Left(v)))._1
+           recurse((p, Left(ident)))._1
          }
        case Var(Some(p), ident, _, _) =>
-         val v = ident.asString
          val pack = pm.toMap.get(p).getOrElse(sys.error(s"cannot find $p, shouldn't happen due to typechecking"))
-         val (scoped, _) = eval((pack, Left(v)))
+         val (scoped, _) = eval((pack, Left(ident)))
          scoped
        case App(AnnotatedLambda(name, _, fn, _), arg, _, _) =>
          val argE = recurse((p, Right(arg)))._1
@@ -641,7 +642,7 @@ case class Evaluation(pm: PackageMap.Inferred, externals: Externals) {
             // we reset the environment in the other package
             (other._1.emptyScope, other._2)
           case Some(NameKind.ExternalDef(pn, n, tpe)) =>
-            externals.toMap.get((pn, n)) match {
+            externals.toMap.get((pn, n.asString)) match {
               case None =>
                 throw EvaluationException(s"Missing External defintion of '${pn.parts.toList.mkString("/")} $n'. Check that your 'external' parameter is correct.")
               case Some(ext) =>
@@ -650,7 +651,7 @@ case class Evaluation(pm: PackageMap.Inferred, externals: Externals) {
         }
     }
 
-  private def constructor(c: ConstructorName, dt: rankn.DefinedType[Any]): Eval[Value] = {
+  private def constructor(c: Constructor, dt: rankn.DefinedType[Any]): Eval[Value] = {
     val (enum, arity) = dt.constructors
       .toList
       .iterator
@@ -676,11 +677,11 @@ case class Evaluation(pm: PackageMap.Inferred, externals: Externals) {
   }
 
   private def definedToJson(a: Value, dt: rankn.DefinedType[Any], rec: (Value, Type) => Option[Json]): Option[Json] = if (dt.packageName == Predef.packageName) {
-      (dt.name.asString, a) match {
+      (dt.name.ident.asString, a) match {
         case ("Option", VOption(None)) => Some(Json.JNull)
         case ("Option", VOption(Some(v))) =>
           dt.constructors match {
-            case _ :: ((ConstructorName("Some"), (_, t) :: Nil, _)) :: Nil =>
+            case _ :: ((Constructor("Some"), (_, t) :: Nil, _)) :: Nil =>
               rec(v, t)
             case other =>
               sys.error(s"expect to find Some constructor for $v: $other")
@@ -696,7 +697,7 @@ case class Evaluation(pm: PackageMap.Inferred, externals: Externals) {
         case ("List", VList(vs)) =>
           // convert the list into a JArray
           val tpe = dt.constructors match {
-            case _ :: ((ConstructorName("NonEmptyList"), (_, t) :: (_, _) :: Nil, _)) :: Nil => t
+            case _ :: ((Constructor("NonEmptyList"), (_, t) :: (_, _) :: Nil, _)) :: Nil => t
             case other => sys.error(s"unexpected constructors for list: $other")
           }
 
@@ -718,8 +719,8 @@ case class Evaluation(pm: PackageMap.Inferred, externals: Externals) {
       vp.flatMap { case (variant, prod) =>
         val cons = dt.constructors
         cons.lift(variant).flatMap { case (_, params, _) =>
-          prod.toList.zip(params).traverse { case (a1, (ParamName(pn), t)) =>
-            rec(a1, t).map((pn, _))
+          prod.toList.zip(params).traverse { case (a1, (bn, t)) =>
+            rec(a1, t).map((bn.asString, _))
           }
           .map { ps => Json.JObject(ps) }
         }
@@ -744,7 +745,7 @@ case class Evaluation(pm: PackageMap.Inferred, externals: Externals) {
      */
     Type.rootConst(t).flatMap {
       case Type.TyConst(Type.Const.Defined(pn, n)) =>
-        defined(pn, TypeName(n))
+        defined(pn, n)
     }
     .flatMap(fn(a, _, toType[T](_, _)(fn)))
   }

--- a/core/src/main/scala/org/bykn/bosatsu/Expr.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/Expr.scala
@@ -16,7 +16,7 @@ sealed abstract class Expr[T] {
 object Expr {
   case class Annotation[T](expr: Expr[T], tpe: rankn.Type, tag: T) extends Expr[T]
   case class AnnotatedLambda[T](arg: String, tpe: rankn.Type, expr: Expr[T], tag: T) extends Expr[T]
-  case class Var[T](pack: Option[PackageName], name: String, tag: T) extends Expr[T]
+  case class Var[T](pack: Option[PackageName], name: Identifier, tag: T) extends Expr[T]
   case class App[T](fn: Expr[T], arg: Expr[T], tag: T) extends Expr[T]
   case class Lambda[T](arg: String, expr: Expr[T], tag: T) extends Expr[T]
   case class Let[T](arg: String, expr: Expr[T], in: Expr[T], recursive: RecursionKind, tag: T) extends Expr[T]

--- a/core/src/main/scala/org/bykn/bosatsu/Expr.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/Expr.scala
@@ -9,19 +9,21 @@ import cats.implicits._
 import cats.data.NonEmptyList
 import cats.{Applicative, Eval, Traverse}
 
+import Identifier.{Bindable, Constructor}
+
 sealed abstract class Expr[T] {
   def tag: T
 }
 
 object Expr {
   case class Annotation[T](expr: Expr[T], tpe: rankn.Type, tag: T) extends Expr[T]
-  case class AnnotatedLambda[T](arg: String, tpe: rankn.Type, expr: Expr[T], tag: T) extends Expr[T]
+  case class AnnotatedLambda[T](arg: Bindable, tpe: rankn.Type, expr: Expr[T], tag: T) extends Expr[T]
   case class Var[T](pack: Option[PackageName], name: Identifier, tag: T) extends Expr[T]
   case class App[T](fn: Expr[T], arg: Expr[T], tag: T) extends Expr[T]
-  case class Lambda[T](arg: String, expr: Expr[T], tag: T) extends Expr[T]
-  case class Let[T](arg: String, expr: Expr[T], in: Expr[T], recursive: RecursionKind, tag: T) extends Expr[T]
+  case class Lambda[T](arg: Bindable, expr: Expr[T], tag: T) extends Expr[T]
+  case class Let[T](arg: Bindable, expr: Expr[T], in: Expr[T], recursive: RecursionKind, tag: T) extends Expr[T]
   case class Literal[T](lit: Lit, tag: T) extends Expr[T]
-  case class Match[T](arg: Expr[T], branches: NonEmptyList[(Pattern[(PackageName, ConstructorName), rankn.Type], Expr[T])], tag: T) extends Expr[T]
+  case class Match[T](arg: Expr[T], branches: NonEmptyList[(Pattern[(PackageName, Constructor), rankn.Type], Expr[T])], tag: T) extends Expr[T]
 
   implicit def hasRegion[T: HasRegion]: HasRegion[Expr[T]] =
     HasRegion.instance[Expr[T]] { e => HasRegion.region(e.tag) }
@@ -29,10 +31,10 @@ object Expr {
   /*
    * Allocate these once
    */
-  private[this] val TruePat: Pattern[(PackageName, ConstructorName), rankn.Type] =
-    Pattern.PositionalStruct((Predef.packageName, ConstructorName("True")), Nil)
-  private[this] val FalsePat: Pattern[(PackageName, ConstructorName), rankn.Type] =
-    Pattern.PositionalStruct((Predef.packageName, ConstructorName("False")), Nil)
+  private[this] val TruePat: Pattern[(PackageName, Constructor), rankn.Type] =
+    Pattern.PositionalStruct((Predef.packageName, Constructor("True")), Nil)
+  private[this] val FalsePat: Pattern[(PackageName, Constructor), rankn.Type] =
+    Pattern.PositionalStruct((Predef.packageName, Constructor("False")), Nil)
   /**
    * build a Match expression that is equivalent to if/else using Predef::True and Predef::False
    */
@@ -55,7 +57,7 @@ object Expr {
       case l@Literal(_, _) => F.pure(l)
       case Match(arg, branches, tag) =>
         val argB = traverseType(arg, fn)
-        type B = (Pattern[(PackageName, ConstructorName), rankn.Type], Expr[T])
+        type B = (Pattern[(PackageName, Constructor), rankn.Type], Expr[T])
         def branchFn(b: B): F[B] =
           b match {
             case (pat, expr) =>
@@ -71,8 +73,8 @@ object Expr {
 
       // Traverse on NonEmptyList[(Pattern[_], Expr[?])]
       private lazy val tne = {
-        type Tup[T] = (Pattern[(PackageName, ConstructorName), rankn.Type], T)
-        type TupExpr[T] = (Pattern[(PackageName, ConstructorName), rankn.Type], Expr[T])
+        type Tup[T] = (Pattern[(PackageName, Constructor), rankn.Type], T)
+        type TupExpr[T] = (Pattern[(PackageName, Constructor), rankn.Type], Expr[T])
         val tup: Traverse[TupExpr] = Traverse[Tup].compose(exprTraverse)
         Traverse[NonEmptyList].compose(tup)
       }
@@ -164,7 +166,7 @@ object Expr {
         }
     }
 
-  def buildLambda[A](args: NonEmptyList[(String, Option[rankn.Type])], body: Expr[A], outer: A): Expr[A] =
+  def buildLambda[A](args: NonEmptyList[(Bindable, Option[rankn.Type])], body: Expr[A], outer: A): Expr[A] =
     args match {
       case NonEmptyList((arg, None), Nil) =>
         Expr.Lambda(arg, body, outer)

--- a/core/src/main/scala/org/bykn/bosatsu/Identifier.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/Identifier.scala
@@ -1,0 +1,46 @@
+package org.bykn.bosatsu
+
+import org.typelevel.paiges.{ Doc, Document }
+import fastparse.all._
+
+import Parser.{lowerIdent, upperIdent}
+
+sealed abstract class Identifier {
+  def asString: String
+}
+
+object Identifier {
+  /**
+   * These are names that can appear in bindings. Importantly,
+   * we can't bind constructor names except to define types
+   */
+  sealed abstract class Bindable extends Identifier
+
+  final case class Constructor(asString: String) extends Identifier
+  final case class Name(asString: String) extends Bindable
+
+  implicit val document: Document[Identifier] =
+    Document.instance[Identifier] { ident => Doc.text(ident.asString) }
+
+  val bindableParser: P[Bindable] =
+    lowerIdent.map(Name(_))
+
+  val consParser: P[Constructor] =
+    upperIdent.map(Constructor(_))
+
+  val parser: P[Identifier] =
+    bindableParser | consParser
+
+  /**
+   * Build an Identifier by parsing a string
+   */
+  def unsafe(str: String): Identifier =
+    parser.parse(str) match {
+      case Parsed.Success(ident, idx) if idx == str.length =>
+        ident
+      case Parsed.Success(_, idx) =>
+        sys.error(s"partial parse of $str ignores: ${str.substring(idx)}")
+      case Parsed.Failure(exp, idx, extra) =>
+        sys.error(s"failed to parse: $str: $exp at $idx: (${str.substring(idx)}) with trace: ${extra.traced.trace}")
+    }
+}

--- a/core/src/main/scala/org/bykn/bosatsu/Package.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/Package.scala
@@ -9,6 +9,8 @@ import scala.collection.mutable.{Map => MMap}
 import Parser.{spaces, maybeSpace, Combinators}
 import rankn._
 
+import Identifier.{Bindable, Constructor}
+
 /**
  * Represents a package over its life-cycle: from parsed to resolved to inferred
  */
@@ -22,7 +24,7 @@ case class Package[A, B, C, D](
   private lazy val importMap: ImportMap[A, B] =
     ImportMap.fromImports(imports)._2
 
-  def localImport(n: String): Option[(A, ImportedName[B])] = importMap(n)
+  def localImport(n: Identifier): Option[(A, ImportedName[B])] = importMap(n)
 
   def withImport(i: Import[A, B]): Package[A, B, C, D] =
     copy(imports = i :: imports)
@@ -95,12 +97,12 @@ object Package {
     p: PackageName,
     imps: List[Import[Package.Interface, NonEmptyList[Referant[Variance]]]],
     stmt: Statement):
-      ValidatedNel[PackageError, (TypeEnv[Variance], List[(String, RecursionKind, TypedExpr[Declaration])])] = {
+      ValidatedNel[PackageError, (TypeEnv[Variance], List[(Bindable, RecursionKind, TypedExpr[Declaration])])] = {
 
-    val importedTypes: Map[String, (PackageName, String)] =
+    val importedTypes: Map[Identifier, (PackageName, TypeName)] =
       Referant.importedTypes(imps)
 
-    val resolveImportedCons: Map[String, (PackageName, ConstructorName)] =
+    val resolveImportedCons: Map[Identifier, (PackageName, Constructor)] =
       Referant.importedConsNames(imps)
 
     // here we make a pass to get all the local names
@@ -114,24 +116,25 @@ object Package {
     val localTypeNames = localDefs.map(_.name).toSet
     val localConstructors = localDefs.flatMap(_.constructors).toSet
 
-    val typeCache: MMap[String, Type.Const] = MMap.empty
-    val consCache: MMap[String, (PackageName, ConstructorName)] = MMap.empty
+    val typeCache: MMap[Constructor, Type.Const] = MMap.empty
+    val consCache: MMap[Constructor, (PackageName, Constructor)] = MMap.empty
 
     val Program(parsedTypeEnv, lets, _) =
       Program.fromStatement(
         p,
         { s =>
           typeCache.getOrElseUpdate(s, {
+            val ts = TypeName(s)
             val (p1, s1) =
-              if (localTypeNames(s)) (p, s)
-              else importedTypes.getOrElse(s, (p, s))
+              if (localTypeNames(s)) (p, ts)
+              else importedTypes.getOrElse(s, (p, ts))
             Type.Const.Defined(p1, s1)
           })
         }, // name to type
         { s =>
           consCache.getOrElseUpdate(s, {
-            if (localConstructors(s)) (p, ConstructorName(s))
-            else resolveImportedCons.getOrElse(s, (p, ConstructorName(s)))
+            if (localConstructors(s)) (p, s)
+            else resolveImportedCons.getOrElse(s, (p, s))
           })
         }, // name to cons
         stmt)
@@ -167,10 +170,10 @@ object Package {
       * that have been imported, this includes local external
       * defs
       */
-      val importedValues: Map[String, Type] =
+      val importedValues: Map[Identifier, Type] =
         Referant.importedValues(imps) ++ typeEnv.localValuesOf(p)
 
-      val withFQN: Map[(Option[PackageName], String), Type] =
+      val withFQN: Map[(Option[PackageName], Identifier), Type] =
         (Referant.fullyQualifiedImportedValues(imps)(_.unfix.name)
           .iterator
           .map { case ((p, n), t) => ((Some(p), n), t) } ++

--- a/core/src/main/scala/org/bykn/bosatsu/PackageMap.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/PackageMap.scala
@@ -164,7 +164,7 @@ object PackageMap {
         case (p@Package(nm, imports, exports, (stmt, importMap)), recurse) =>
 
           def getImport[A, B](packF: Package.Inferred,
-            exMap: Map[String, NonEmptyList[ExportedName[A]]],
+            exMap: Map[Identifier, NonEmptyList[ExportedName[A]]],
             i: ImportedName[B]): ValidatedNel[PackageError, ImportedName[NonEmptyList[A]]] =
             exMap.get(i.originalName) match {
               case None =>
@@ -236,13 +236,13 @@ object PackageError {
 
   case class UnknownExport[A](ex: ExportedName[A],
     in: Package.PackageF2[Unit, (Statement, ImportMap[PackageName, Unit])],
-    lets: List[(String, RecursionKind, TypedExpr[Declaration])]) extends PackageError {
+    lets: List[(Identifier.Bindable, RecursionKind, TypedExpr[Declaration])]) extends PackageError {
     def message(sourceMap: Map[PackageName, (LocationMap, String)]) = {
       val (lm, sourceName) = sourceMap(in.name)
       val header =
         s"in $sourceName unknown export ${ex.name}"
       val candidates = lets
-        .map { case (n, _, expr) => (EditDistance.string(n, ex.name), n, HasRegion.region(expr)) }
+        .map { case (n, _, expr) => (EditDistance.string(n.asString, ex.name.asString), n, HasRegion.region(expr)) }
         .sorted
         .take(3)
         .map { case (_, n, r) =>
@@ -286,13 +286,15 @@ object PackageError {
           .lets
 
         val (_, sourceName) = sourceMap(in.name)
-        ls.iterator.map { case (n, _, d) => (n, d) }
+        ls.iterator.map { case (n, _, d) => (n: Identifier, d) }
           .toMap
           .get(iname.originalName) match {
             case Some(_) =>
               s"in $sourceName package: ${importing.name} has ${iname.originalName} but it is not exported. Add to exports"
             case None =>
-              val dist = Memoize.function[String, Int] { (s, _) => EditDistance(iname.originalName.toIterable, s.toIterable) }
+              val dist = Memoize.function[Identifier, Int] { (s, _) =>
+                EditDistance(iname.originalName.asString.toIterable, s.asString.toIterable)
+              }
               val nearest = ls.map { case (n, _, _) => (dist(n), n) }.sorted.take(3).map { case (_, n) => n }.mkString(", ")
               s"in $sourceName package: ${importing.name} does not have name ${iname.originalName}. Nearest: $nearest"
           }
@@ -312,13 +314,13 @@ object PackageError {
 
   case class CircularType[A](from: PackageName, path: NonEmptyList[rankn.DefinedType[A]]) extends PackageError {
     def message(sourceMap: Map[PackageName, (LocationMap, String)]) = {
-      s"circular types in ${from.asString} " + path.toList.reverse.map(_.name.asString).mkString(" -> ")
+      s"circular types in ${from.asString} " + path.toList.reverse.map(_.name.ident.asString).mkString(" -> ")
     }
   }
 
   case class VarianceInferenceFailure(from: PackageName, failed: NonEmptyList[rankn.DefinedType[Unit]]) extends PackageError {
     def message(sourceMap: Map[PackageName, (LocationMap, String)]) = {
-      s"failed to infer variance in ${from.asString} of " + failed.toList.map(_.name.asString).sorted.mkString(", ")
+      s"failed to infer variance in ${from.asString} of " + failed.toList.map(_.name.ident.asString).sorted.mkString(", ")
     }
   }
 
@@ -349,9 +351,9 @@ object PackageError {
             .iterator
             .collect { case (None, n) =>
               // we only print imported names, which are written with None
-              (EditDistance.string(name, n), n)
+              (EditDistance.string(name.asString, n.asString), n.asString)
             }
-            .filter(_._1 < name.length) // don't show things that require total edits
+            .filter(_._1 < name.asString.length) // don't show things that require total edits
             .toList
             .distinct
             .sortBy(_._1)

--- a/core/src/main/scala/org/bykn/bosatsu/Predef.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/Predef.scala
@@ -85,6 +85,7 @@ object Predef {
         "uncurry2",
         "uncurry3"
         )
+        .map(Identifier.unsafe(_))
         .map(ImportedName.OriginalName(_, ())))
 
   val jvmExternals: Externals =

--- a/core/src/main/scala/org/bykn/bosatsu/Program.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/Program.scala
@@ -82,14 +82,17 @@ object Program {
               (Nil, v)
             case _ =>
               val thisName = anonNames.next()
-              val v = Expr.Var(None, thisName, decl.tag)
+              val ident = Identifier.Name(thisName)
+              val v = Expr.Var(None, ident, decl.tag)
               ((thisName, decl) :: Nil, v)
           }
 
           val tail = complex.names.map { nm =>
             val pat = complex.filterVars(_ == nm)
+            // TODO, Pattern should use bindable name
+            val nmIdent = Identifier.Name(nm)
             (nm, Expr.Match(rightHandSide,
-              NonEmptyList.of((pat, Expr.Var(None, nm, decl.tag))), decl.tag))
+              NonEmptyList.of((pat, Expr.Var(None, nmIdent, decl.tag))), decl.tag))
           }
 
           def concat[A](ls: List[A], tail: NonEmptyList[A]): NonEmptyList[A] =

--- a/core/src/main/scala/org/bykn/bosatsu/Program.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/Program.scala
@@ -5,17 +5,19 @@ import cats.data.NonEmptyList
 
 import org.bykn.bosatsu.rankn.{Type, ParsedTypeEnv}
 
-case class Program[T, D, S](types: T, lets: List[(String, RecursionKind, D)], from: S) {
-  private[this] lazy val letMap: Map[String, (RecursionKind, D)] =
+import Identifier.{Bindable, Constructor}
+
+case class Program[T, D, S](types: T, lets: List[(Bindable, RecursionKind, D)], from: S) {
+  private[this] lazy val letMap: Map[Bindable, (RecursionKind, D)] =
     lets.iterator.map { case (n, r, d) => (n, (r, d)) }.toMap
 
-  def getLet(name: String): Option[(RecursionKind, D)] = letMap.get(name)
+  def getLet(name: Bindable): Option[(RecursionKind, D)] = letMap.get(name)
   /**
    * main is the thing we evaluate. It is the last thing defined
    */
-  def getMain[D1](fn: (String, D1, D1) => D1)(implicit ev: D Is Expr[D1]): Option[Expr[D1]] = {
+  def getMain[D1](fn: (Bindable, D1, D1) => D1)(implicit ev: D Is Expr[D1]): Option[Expr[D1]] = {
     @annotation.tailrec
-    def loop(ls: List[(String, RecursionKind, Expr[D1])], acc: Expr[D1]): Expr[D1] =
+    def loop(ls: List[(Bindable, RecursionKind, Expr[D1])], acc: Expr[D1]): Expr[D1] =
       ls match {
         case Nil => acc
         case (nm, rec, expr) :: tail =>
@@ -25,7 +27,7 @@ case class Program[T, D, S](types: T, lets: List[(String, RecursionKind, D)], fr
 
     lets.reverse match {
       case (_, _, h) :: tail =>
-        type L[X] = List[(String, RecursionKind, X)]
+        type L[X] = List[(Identifier.Bindable, RecursionKind, X)]
         Some(loop(ev.substitute[L](tail), ev.coerce(h)))
       case Nil =>
         None
@@ -34,7 +36,7 @@ case class Program[T, D, S](types: T, lets: List[(String, RecursionKind, D)], fr
 
   def getMainDecl(implicit ev: D Is Expr[Declaration]): Option[Expr[Declaration]] = {
 
-    val fn = { (nm: String, v: Declaration, in: Declaration) =>
+    val fn = { (nm: Bindable, v: Declaration, in: Declaration) =>
       val r = v.region + in.region
       Declaration.Binding(BindingStatement(Pattern.Var(nm), v, Padding(0, in)))(r)
     }
@@ -46,8 +48,8 @@ case class Program[T, D, S](types: T, lets: List[(String, RecursionKind, D)], fr
 object Program {
   def fromStatement(
     pn0: PackageName,
-    nameToType: String => Type.Const,
-    nameToCons: String => (PackageName, ConstructorName),
+    nameToType: Constructor => Type.Const,
+    nameToCons: Constructor => (PackageName, Constructor),
     stmt: Statement): Program[ParsedTypeEnv[Unit], Expr[Declaration], Statement] = {
 
     import Statement._
@@ -60,18 +62,28 @@ object Program {
       d: TypeDefinitionStatement): ParsedTypeEnv[Unit] =
       types.addDefinedType(d.toDefinition(pn0, nameToType))
 
-    val allNames = stmt.toStream.flatMap {
-      case Bind(BindingStatement(bound, _, _)) => bound.names
-      case _ => Nil
-    }.toSet
-
     // Each time we need a name, we can call anonNames.next()
     // it is mutable, but in a limited scope
-    val anonNames = rankn.Type.allBinders.iterator.map(_.name).filterNot(allNames)
+    val anonNames: Iterator[Bindable] = {
+      val allNames = stmt.toStream.flatMap {
+        case Bind(BindingStatement(bound, _, _)) => bound.names.map(_.asString) // TODO Keep identifiers
+        case _ => Nil
+      }.toSet
 
-    def bindings(b: Pattern[(PackageName, ConstructorName), Type], decl: Expr[Declaration]): NonEmptyList[(String, Expr[Declaration])] =
+      rankn.Type
+        .allBinders
+        .iterator
+        .map(_.name)
+        .filterNot(allNames)
+        .map(Identifier.Name(_))
+    }
+
+    def bindings(
+      b: Pattern[(PackageName, Constructor), Type],
+      decl: Expr[Declaration]): NonEmptyList[(Identifier.Bindable, Expr[Declaration])] =
       b match {
-        case Pattern.Var(nm) => NonEmptyList((nm, decl), Nil)
+        case Pattern.Var(nm) =>
+          NonEmptyList((nm, decl), Nil)
         case Pattern.Annotation(p, tpe) =>
           // we can just move the annotation to the expr:
           bindings(p, Expr.Annotation(decl, tpe, decl.tag))
@@ -81,18 +93,15 @@ object Program {
               // no need to make a new var to point to a var
               (Nil, v)
             case _ =>
-              val thisName = anonNames.next()
-              val ident = Identifier.Name(thisName)
+              val ident = anonNames.next()
               val v = Expr.Var(None, ident, decl.tag)
-              ((thisName, decl) :: Nil, v)
+              ((ident, decl) :: Nil, v)
           }
 
           val tail = complex.names.map { nm =>
             val pat = complex.filterVars(_ == nm)
-            // TODO, Pattern should use bindable name
-            val nmIdent = Identifier.Name(nm)
             (nm, Expr.Match(rightHandSide,
-              NonEmptyList.of((pat, Expr.Var(None, nmIdent, decl.tag))), decl.tag))
+              NonEmptyList.of((pat, Expr.Var(None, nm, decl.tag))), decl.tag))
           }
 
           def concat[A](ls: List[A], tail: NonEmptyList[A]): NonEmptyList[A] =

--- a/core/src/main/scala/org/bykn/bosatsu/Statement.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/Statement.scala
@@ -1,6 +1,6 @@
 package org.bykn.bosatsu
 
-import Parser.{ Combinators, Indy, lowerIdent, upperIdent, maybeSpace, spaces }
+import Parser.{ Combinators, Indy, lowerIdent, maybeSpace, spaces }
 import cats.Functor
 import cats.data.{ NonEmptyList, State }
 import cats.implicits._
@@ -10,6 +10,7 @@ import org.typelevel.paiges.{ Doc, Document }
 import org.bykn.fastparse_cats.StringInstances._
 
 import Indy.IndyMethods
+import Identifier.{Bindable, Constructor}
 
 case class CommentStatement[T](message: NonEmptyList[String], on: T)
 
@@ -47,7 +48,7 @@ object CommentStatement {
 }
 
 case class PackageStatement[T](name: String,
-  exports: List[String],
+  exports: List[Identifier],
   emptyLines: Int,
   contents: T)
 
@@ -86,12 +87,12 @@ sealed abstract class TypeDefinitionStatement extends Statement {
   /**
    * This is the name of the type being defined
    */
-  def name: String
+  def name: Constructor
 
   /**
    * here are the names of the constructors for this type
    */
-  def constructors: List[String] =
+  def constructors: List[Constructor] =
     this match {
       case Struct(nm, _, _) => nm :: Nil
       case Enum(_, items, _) =>
@@ -99,7 +100,7 @@ sealed abstract class TypeDefinitionStatement extends Statement {
       case ExternalStruct(_, _, _) => Nil
     }
 
-  def toDefinition(pname: PackageName, nameToType: String => rankn.Type.Const): rankn.DefinedType[Unit] = {
+  def toDefinition(pname: PackageName, nameToType: Constructor => rankn.Type.Const): rankn.DefinedType[Unit] = {
     import rankn.Type
 
     def typeVar(i: Long): Type.TyVar =
@@ -120,12 +121,12 @@ sealed abstract class TypeDefinitionStatement extends Statement {
         tv <- if (existing(candidate)) nextVar else add(candidate)
       } yield tv
 
-    def buildParam(p: (String, Option[Type])): VarState[(ParamName, Type)] =
+    def buildParam(p: (Bindable, Option[Type])): VarState[(Bindable, Type)] =
       p match {
         case (parname, Some(tpe)) =>
-          State.pure((ParamName(parname), tpe))
+          State.pure((parname, tpe))
         case (parname, None) =>
-          nextVar.map { v => (ParamName(parname), v) }
+          nextVar.map { v => (parname, v) }
       }
 
     def existingVars[A](ps: List[(A, Option[Type])]): List[Type.TyVar] = {
@@ -133,12 +134,12 @@ sealed abstract class TypeDefinitionStatement extends Statement {
       Type.freeTyVars(pt).map(Type.TyVar(_))
     }
 
-    def buildParams(args: List[(String, Option[Type])]): VarState[List[(ParamName, Type)]] =
+    def buildParams(args: List[(Bindable, Option[Type])]): VarState[List[(Bindable, Type)]] =
       args.traverse(buildParam _)
 
     this match {
       case Struct(nm, args, _) =>
-        val deep = Functor[List].compose(Functor[(String, ?)]).compose(Functor[Option])
+        val deep = Functor[List].compose(Functor[(Bindable, ?)]).compose(Functor[Option])
         val argsType = deep.map(args)(_.toType(nameToType))
         val initVars = existingVars(argsType)
         val initState = ((initVars.toSet, initVars.reverse), 0L)
@@ -161,16 +162,16 @@ sealed abstract class TypeDefinitionStatement extends Statement {
         rankn.DefinedType(pname,
           tname,
           typeParams.map((_, ())),
-          (ConstructorName(nm), params, consValueType) :: Nil)
+          (nm, params, consValueType) :: Nil)
       case Enum(nm, items, _) =>
-        val deep = Functor[List].compose(Functor[(String, ?)]).compose(Functor[Option])
+        val deep = Functor[List].compose(Functor[(Bindable, ?)]).compose(Functor[Option])
         val conArgs = items.get.map { case (nm, args) =>
           val argsType = deep.map(args)(_.toType(nameToType))
           (nm, argsType)
         }
         val constructorsS = conArgs.traverse { case (nm, argsType) =>
           buildParams(argsType).map { params =>
-            (ConstructorName(nm), params)
+            (nm, params)
           }
         }
         val initVars = existingVars(conArgs.toList.flatMap(_._2))
@@ -207,14 +208,14 @@ object Statement {
       case tds: TypeDefinitionStatement => tds
     }
 
-  case class Bind(bind: BindingStatement[Pattern[Option[String], TypeRef], Padding[Statement]]) extends Statement
+  case class Bind(bind: BindingStatement[Pattern.Parsed, Padding[Statement]]) extends Statement
   case class Comment(comment: CommentStatement[Padding[Statement]]) extends Statement
   case class Def(defstatement: DefStatement[(OptIndent[Declaration], Padding[Statement])]) extends Statement
-  case class Struct(name: String, args: List[(String, Option[TypeRef])], rest: Padding[Statement]) extends TypeDefinitionStatement
-  case class ExternalDef(name: String, params: List[(String, TypeRef)], result: TypeRef, rest: Padding[Statement]) extends Statement
-  case class ExternalStruct(name: String, typeArgs: List[TypeRef.TypeVar], rest: Padding[Statement]) extends TypeDefinitionStatement
-  case class Enum(name: String,
-    items: OptIndent[NonEmptyList[(String, List[(String, Option[TypeRef])])]],
+  case class Struct(name: Constructor, args: List[(Bindable, Option[TypeRef])], rest: Padding[Statement]) extends TypeDefinitionStatement
+  case class ExternalDef(name: Bindable, params: List[(Bindable, TypeRef)], result: TypeRef, rest: Padding[Statement]) extends Statement
+  case class ExternalStruct(name: Constructor, typeArgs: List[TypeRef.TypeVar], rest: Padding[Statement]) extends TypeDefinitionStatement
+  case class Enum(name: Constructor,
+    items: OptIndent[NonEmptyList[(Constructor, List[(Bindable, Option[TypeRef])])]],
     rest: Padding[Statement]) extends TypeDefinitionStatement
   case object EndOfFile extends Statement
 
@@ -225,7 +226,7 @@ object Statement {
     val bindingP = {
       val patP = Indy.lift(Pattern.parser)
       val bop = BindingStatement
-        .bindingParser[Pattern[Option[String], TypeRef], Padding[Statement]](
+        .bindingParser[Pattern[Option[Identifier.Constructor], TypeRef], Padding[Statement]](
           Declaration.parser, Indy.lift(maybeSpace ~ padding))("")
 
       (Pattern.parser ~ bop).map { case (p, fn) =>
@@ -240,7 +241,7 @@ object Statement {
 
     val end = P(End).map(_ => EndOfFile)
 
-    val constructorP = P(upperIdent ~ (DefStatement.argParser).list.parens.?)
+    val constructorP = P(Identifier.consParser ~ (DefStatement.argParser).list.parens.?)
       .map {
         case (n, None) => (n, Nil)
         case (n, Some(args)) => (n, args)
@@ -249,17 +250,17 @@ object Statement {
     val external = {
       val typeParams = Parser.nonEmptyListToList(lowerIdent.nonEmptyListSyntax)
       val externalStruct =
-        P("struct" ~/ spaces ~ upperIdent ~ typeParams ~ maybeSpace ~ Padding.parser(parser)).map {
+        P("struct" ~/ spaces ~ Identifier.consParser ~ typeParams ~ maybeSpace ~ Padding.parser(parser)).map {
           case (name, targs, rest) =>
             val tva = targs.map(TypeRef.TypeVar(_))
             ExternalStruct(name, tva, rest)
         }
 
       val externalDef = {
-        val argParser: P[(String, TypeRef)] = P(lowerIdent ~ ":" ~/ maybeSpace ~ TypeRef.parser)
+        val argParser: P[(Bindable, TypeRef)] = P(Identifier.bindableParser ~ ":" ~/ maybeSpace ~ TypeRef.parser)
         val args = P("(" ~ maybeSpace ~ argParser.nonEmptyList ~ maybeSpace ~ ")")
         val result = P(maybeSpace ~ "->" ~/ maybeSpace ~ TypeRef.parser ~ maybeSpace)
-        P("def" ~ spaces ~/ lowerIdent ~ args.? ~ result ~ maybeSpace ~ Padding.parser(parser))
+        P("def" ~ spaces ~/ Identifier.bindableParser ~ args.? ~ result ~ maybeSpace ~ Padding.parser(parser))
           .map {
             case (name, None, resType, res) => ExternalDef(name, Nil, resType, res)
             case (name, Some(args), resType, res) => ExternalDef(name, args.toList, resType, res)
@@ -277,7 +278,7 @@ object Statement {
       val variants = Indy.lift(constructorP ~ maybeSpace).nonEmptyList(sep)
 
       val nameVars = Indy.block(
-        Indy.lift(P("enum" ~ spaces ~/ upperIdent)),
+        Indy.lift(P("enum" ~ spaces ~/ Identifier.consParser)),
         variants).run("")
 
       (nameVars ~ padding)
@@ -290,15 +291,15 @@ object Statement {
     commentP | defP | struct | enum | external | bindingP | end
   }
 
-  private def constructor(name: String, args: List[(String, Option[TypeRef])]): Doc =
-    Doc.text(name) +
-      (if (args.nonEmpty) { Doc.char('(') + Doc.intercalate(Doc.text(", "), args.toList.map(TypeRef.argDoc _)) + Doc.char(')') }
+  private def constructor(name: Constructor, args: List[(Bindable, Option[TypeRef])]): Doc =
+    Document[Identifier].document(name) +
+      (if (args.nonEmpty) { Doc.char('(') + Doc.intercalate(Doc.text(", "), args.toList.map(TypeRef.argDoc[Bindable] _)) + Doc.char(')') }
       else Doc.empty)
 
   implicit lazy val document: Document[Statement] =
     Document.instance[Statement] {
       case Bind(bs) =>
-        Document[BindingStatement[Pattern[Option[String], TypeRef], Padding[Statement]]].document(bs)
+        Document[BindingStatement[Pattern.Parsed, Padding[Statement]]].document(bs)
       case Comment(cm) =>
         Document[CommentStatement[Padding[Statement]]].document(cm)
       case Def(d) =>
@@ -313,7 +314,7 @@ object Statement {
         Doc.text("struct ") + constructor(nm, args) +
           Document[Padding[Statement]].document(rest)
       case Enum(nm, parts, rest) =>
-        implicit val consDoc = Document.instance[(String, List[(String, Option[TypeRef])])] {
+        implicit val consDoc = Document.instance[(Constructor, List[(Bindable, Option[TypeRef])])] {
           case (nm, parts) => constructor(nm, parts)
         }
 
@@ -329,7 +330,7 @@ object Statement {
 
         val indentedCons = OptIndent.document(neDoc(consDoc)).document(parts)
 
-        Doc.text("enum ") + Doc.text(nm) + Doc.char(':') +
+        Doc.text("enum ") + Document[Constructor].document(nm) + Doc.char(':') +
           colonSep +
           indentedCons +
           Document[Padding[Statement]].document(rest)
@@ -339,11 +340,11 @@ object Statement {
           case Nil => Doc.empty
           case nonEmpty =>
             val da = Doc.intercalate(Doc.text(", "), nonEmpty.map { case (n, tr) =>
-              Doc.text(n) + Doc.text(": ") + tr.toDoc
+              Document[Bindable].document(n) + Doc.text(": ") + tr.toDoc
             })
             Doc.char('(') + da + Doc.char(')')
         }
-        Doc.text("external def ") + Doc.text(name) + argDoc + Doc.text(" -> ") + res.toDoc +
+        Doc.text("external def ") + Document[Bindable].document(name) + argDoc + Doc.text(" -> ") + res.toDoc +
           Document[Padding[Statement]].document(rest)
       case ExternalStruct(nm, targs, rest) =>
         val argsDoc = targs match {
@@ -352,7 +353,7 @@ object Statement {
             val params = nonEmpty.map { case TypeRef.TypeVar(v) => Doc.text(v) }
             Doc.char('[') + Doc.intercalate(Doc.text(", "), params) + Doc.char(']')
         }
-        Doc.text("external struct ") + Doc.text(nm) + argsDoc +
+        Doc.text("external struct ") + Document[Constructor].document(nm) + argsDoc +
           Document[Padding[Statement]].document(rest)
     }
 }

--- a/core/src/main/scala/org/bykn/bosatsu/TypeRecursionCheck.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/TypeRecursionCheck.scala
@@ -31,7 +31,7 @@ object TypeRecursionCheck {
       val depends = for {
         cons <- dt.constructors
         Type.Const.Defined(p, n) <- cons._2.flatMap { case (_, t) => Type.constantsOf(t) }
-        dt1 <- typeMap.get((p, TypeName(n))).toList // we only need edges into this package,
+        dt1 <- typeMap.get((p, n)).toList // we only need edges into this package,
       } yield dt1
 
       // we handle self loops separtely
@@ -49,7 +49,7 @@ object TypeRecursionCheck {
       }
 
     def getDT(dt: Type.Const.Defined): Option[DefinedType[Variance]] = {
-      val tn = TypeName(dt.name)
+      val tn = dt.name
       typeMap.get((dt.packageName, tn))
         .orElse(imports.getType(dt.packageName, tn))
     }

--- a/core/src/main/scala/org/bykn/bosatsu/TypedExpr.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/TypedExpr.scala
@@ -7,6 +7,8 @@ import cats.implicits._
 
 import org.bykn.bosatsu.rankn.Type
 
+import Identifier.{Bindable, Constructor}
+
 sealed abstract class TypedExpr[T] {
   import TypedExpr._
 
@@ -110,12 +112,12 @@ object TypedExpr {
    */
   case class Generic[T](typeVars: NonEmptyList[Type.Var.Bound], in: TypedExpr[T], tag: T) extends TypedExpr[T]
   case class Annotation[T](term: TypedExpr[T], coerce: Type, tag: T) extends TypedExpr[T]
-  case class AnnotatedLambda[T](arg: String, tpe: Type, expr: TypedExpr[T], tag: T) extends TypedExpr[T]
+  case class AnnotatedLambda[T](arg: Bindable, tpe: Type, expr: TypedExpr[T], tag: T) extends TypedExpr[T]
   case class Var[T](pack: Option[PackageName], name: Identifier, tpe: Type, tag: T) extends TypedExpr[T]
   case class App[T](fn: TypedExpr[T], arg: TypedExpr[T], result: Type, tag: T) extends TypedExpr[T]
-  case class Let[T](arg: String, expr: TypedExpr[T], in: TypedExpr[T], recursive: RecursionKind, tag: T) extends TypedExpr[T]
+  case class Let[T](arg: Bindable, expr: TypedExpr[T], in: TypedExpr[T], recursive: RecursionKind, tag: T) extends TypedExpr[T]
   case class Literal[T](lit: Lit, tpe: Type, tag: T) extends TypedExpr[T]
-  case class Match[T](arg: TypedExpr[T], branches: NonEmptyList[(Pattern[(PackageName, ConstructorName), Type], TypedExpr[T])], tag: T) extends TypedExpr[T]
+  case class Match[T](arg: TypedExpr[T], branches: NonEmptyList[(Pattern[(PackageName, Constructor), Type], TypedExpr[T])], tag: T) extends TypedExpr[T]
 
 
   type Coerce = FunctionK[TypedExpr, TypedExpr]
@@ -149,22 +151,22 @@ object TypedExpr {
   /**
    * Return the list of the free vars
    */
-  def freeVars[A](ts: List[TypedExpr[A]]): List[String] = {
+  def freeVars[A](ts: List[TypedExpr[A]]): List[Identifier] = {
 
     // usually we can recurse in a loop, but sometimes not
-    def cheat(te: TypedExpr[A], bound: Set[String], acc: List[String]): List[String] =
+    def cheat(te: TypedExpr[A], bound: Set[Identifier], acc: List[Identifier]): List[Identifier] =
       go(te :: Nil, bound, acc)
 
     @annotation.tailrec
-    def go(ts: List[TypedExpr[A]], bound: Set[String], acc: List[String]): List[String] =
+    def go(ts: List[TypedExpr[A]], bound: Set[Identifier], acc: List[Identifier]): List[Identifier] =
       ts match {
         case Nil => acc
         case Generic(_, expr, _) :: tail =>
           go(expr :: tail, bound, acc)
         case Annotation(t, _, _) :: tail =>
           go(t :: tail, bound, acc)
-        case Var(opt, ident, _, _) :: tail if bound(ident.asString) || opt.isDefined => go(tail, bound, acc)
-        case Var(None, name, _, _) :: tail => go(tail, bound, name.asString :: acc)
+        case Var(opt, ident, _, _) :: tail if bound(ident) || opt.isDefined => go(tail, bound, acc)
+        case Var(None, name, _, _) :: tail => go(tail, bound, name :: acc)
         case AnnotatedLambda(arg, _, res, _) :: tail =>
           val acc1 = cheat(res, bound + arg, acc)
           go(tail, bound, acc1)
@@ -201,9 +203,9 @@ object TypedExpr {
         /*
          * We have to be careful not to collide with the free vars in expr
          */
-        val free = freeVars(expr :: Nil).toSet
+        val free = freeVars(expr :: Nil).iterator.map(_.asString).toSet
         val name = Identifier.Name(Type.allBinders.iterator.map(_.name).filterNot(free).next)
-        AnnotatedLambda(name.asString, arg, cores(App(expr, coarg(Var(None, name, arg, expr.tag)), result, expr.tag)), expr.tag)
+        AnnotatedLambda(name, arg, cores(App(expr, coarg(Var(None, name, arg, expr.tag)), result, expr.tag)), expr.tag)
       }
     }
 

--- a/core/src/main/scala/org/bykn/bosatsu/VarianceFormula.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/VarianceFormula.scala
@@ -257,8 +257,7 @@ object VarianceFormula {
       def constructorVariance(tpe: Type): Stream[VarianceFormula] =
         tpe match {
           case FnType => Stream(Contravariant.toF, Covariant.toF)
-          case TyConst(Const.Defined(p, t)) =>
-            val tn = TypeName(t)
+          case TyConst(Const.Defined(p, tn)) =>
             // TODO need error handling if we don't know about this type
             val thisDt: DefinedType[VarianceFormula] =
               unknowns.get((p, tn))

--- a/core/src/main/scala/org/bykn/bosatsu/Wrappers.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/Wrappers.scala
@@ -3,22 +3,14 @@ package org.bykn.bosatsu
 import cats.Order
 import cats.implicits._
 
-case class ConstructorName(asString: String)
-
-object ConstructorName {
-  implicit val orderCN: Order[ConstructorName] = Order[String].contramap[ConstructorName](_.asString)
-  implicit val orderingCN: Ordering[ConstructorName] = orderCN.toOrdering
-}
-
-case class ParamName(asString: String)
-case class TypeName(asString: String)
+case class TypeName(ident: Identifier.Constructor)
 
 object TypeName {
   implicit val typeNameOrder: Order[TypeName] =
-    Order.by { tn: TypeName => tn.asString }
+    Order.by { tn: TypeName => tn.ident }
 
   implicit val typeNameOrdering: Ordering[TypeName] =
-    Ordering.by { tn: TypeName => tn.asString }
+    Ordering.by { tn: TypeName => tn.ident }
 }
 
 case class Unique(id: Long) {

--- a/core/src/main/scala/org/bykn/bosatsu/rankn/DefinedType.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/rankn/DefinedType.scala
@@ -1,16 +1,18 @@
 package org.bykn.bosatsu.rankn
 
 import cats.{Applicative, Eval, Traverse}
-import org.bykn.bosatsu.{ConstructorName, TypeName, PackageName, ParamName}
+import org.bykn.bosatsu.{TypeName, PackageName}
 import scala.collection.immutable.SortedMap
 
 import cats.implicits._
+
+import org.bykn.bosatsu.Identifier.{Bindable, Constructor}
 
 case class DefinedType[+A](
   packageName: PackageName,
   name: TypeName,
   annotatedTypeParams: List[(Type.Var.Bound, A)],
-  constructors: List[(ConstructorName, List[(ParamName, Type)], Type)]) {
+  constructors: List[(Constructor, List[(Bindable, Type)], Type)]) {
 
   val typeParams: List[Type.Var.Bound] =
     annotatedTypeParams.map(_._1)
@@ -38,7 +40,7 @@ case class DefinedType[+A](
 
 object DefinedType {
   def toTypeConst(pn: PackageName, nm: TypeName): Type.Const.Defined =
-    Type.Const.Defined(pn, nm.asString)
+    Type.Const.Defined(pn, nm)
 
   def constructorValueType(pn: PackageName, name: TypeName, tparams: List[Type.Var.Bound], fnParams: List[Type]): Type = {
     val tc: Type = Type.TyConst(toTypeConst(pn, name))

--- a/core/src/main/scala/org/bykn/bosatsu/rankn/Infer.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/rankn/Infer.scala
@@ -536,7 +536,7 @@ object Infer {
           instSigma(tpe, expect, region(term)).map(_(TypedExpr.Literal(lit, tpe, t)))
         case Var(optPack, name, tag) =>
           for {
-            vSigma <- lookupVarType((optPack, name), region(term))
+            vSigma <- lookupVarType((optPack, name.asString), region(term))
             coerce <- instSigma(vSigma, expect, region(term))
            } yield coerce(TypedExpr.Var(optPack, name, vSigma, tag))
         case App(fn, arg, tag) =>

--- a/core/src/main/scala/org/bykn/bosatsu/rankn/Infer.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/rankn/Infer.scala
@@ -4,9 +4,9 @@ import cats.data.{NonEmptyList, Writer}
 import cats.implicits._
 
 import org.bykn.bosatsu.{
-  ConstructorName,
   Expr,
   HasRegion,
+  Identifier,
   PackageName,
   Pattern => GenPattern,
   Region,
@@ -17,6 +17,8 @@ import org.bykn.bosatsu.{
 
 import HasRegion.region
 
+import Identifier.{Bindable, Constructor}
+
 sealed abstract class Infer[+A] {
   import Infer.Error
 
@@ -25,16 +27,16 @@ sealed abstract class Infer[+A] {
   final def flatMap[B](fn: A => Infer[B]): Infer[B] =
     Infer.Impl.FlatMap(this, fn)
 
-  final def runVar(v: Map[Infer.Name, Type], tpes: Map[(PackageName, ConstructorName), Infer.Cons]): RefSpace[Either[Error, A]] =
+  final def runVar(v: Map[Infer.Name, Type], tpes: Map[(PackageName, Constructor), Infer.Cons]): RefSpace[Either[Error, A]] =
     Infer.Env.init(v, tpes).flatMap(run(_))
 
-  final def runFully(v: Map[Infer.Name, Type], tpes: Map[(PackageName, ConstructorName), Infer.Cons]): Either[Error, A] =
+  final def runFully(v: Map[Infer.Name, Type], tpes: Map[(PackageName, Constructor), Infer.Cons]): Either[Error, A] =
     runVar(v, tpes).run.value
 }
 
 object Infer {
 
-  type Pattern = GenPattern[(PackageName, ConstructorName), Type]
+  type Pattern = GenPattern[(PackageName, Constructor), Type]
 
   // Import our private implementation functions
   import Impl._
@@ -56,18 +58,18 @@ object Infer {
    * the final is the defined type this creates
    */
   type Cons = (List[(Type.Var, Variance)], List[Type], Type.Const.Defined)
-  type Name = (Option[PackageName], String)
+  type Name = (Option[PackageName], Identifier)
 
-  def asFullyQualified(ns: Iterable[(String, Type)]): Map[Name, Type] =
+  def asFullyQualified(ns: Iterable[(Identifier, Type)]): Map[Name, Type] =
     ns.iterator.map { case (n, t) => ((None, n), t) }.toMap
 
   case class Env(
     uniq: Ref[Long],
     vars: Map[Name, Type],
-    typeCons: Map[(PackageName, ConstructorName), Cons])
+    typeCons: Map[(PackageName, Constructor), Cons])
 
   object Env {
-    def init(vars: Map[Name, Type], tpes: Map[(PackageName, ConstructorName), Cons]): RefSpace[Env] =
+    def init(vars: Map[Name, Type], tpes: Map[(PackageName, Constructor), Cons]): RefSpace[Env] =
       RefSpace.newRef(0L).map(Env(_, vars, tpes))
   }
 
@@ -149,11 +151,11 @@ object Infer {
       def message = s"unexpected bound ${v.name} in unification with $in"
     }
 
-    case class UnknownConstructor(name: (PackageName, ConstructorName), env: Env) extends NameError {
+    case class UnknownConstructor(name: (PackageName, Constructor), env: Env) extends NameError {
       def message = s"unknown Constructor $name. Known: ${env.typeCons.keys.toList.sorted}"
     }
 
-    case class UnionPatternBindMismatch(pattern: Pattern, names: List[List[String]]) extends NameError {
+    case class UnionPatternBindMismatch(pattern: Pattern, names: List[List[Identifier.Bindable]]) extends NameError {
       def message = s"$pattern doesn't bind the same names in all union branches: $names"
     }
 
@@ -214,7 +216,7 @@ object Infer {
       def run(env: Env) = RefSpace.pure(Right(env.vars))
     }
 
-    case class GetDataCons(fqn: (PackageName, ConstructorName)) extends Infer[Cons] {
+    case class GetDataCons(fqn: (PackageName, Constructor)) extends Infer[Cons] {
       def run(env: Env) =
         RefSpace.pure(
           env.typeCons.get(fqn) match {
@@ -536,7 +538,7 @@ object Infer {
           instSigma(tpe, expect, region(term)).map(_(TypedExpr.Literal(lit, tpe, t)))
         case Var(optPack, name, tag) =>
           for {
-            vSigma <- lookupVarType((optPack, name.asString), region(term))
+            vSigma <- lookupVarType((optPack, name), region(term))
             coerce <- instSigma(vSigma, expect, region(term))
            } yield coerce(TypedExpr.Var(optPack, name, vSigma, tag))
         case App(fn, arg, tag) =>
@@ -693,7 +695,7 @@ object Infer {
      *
      * TODO: Pattern needs to have a region for each part
      */
-    def typeCheckPattern(pat: Pattern, sigma: Expected[(Type, Region)], reg: Region): Infer[(Pattern, List[(String, Type)])] =
+    def typeCheckPattern(pat: Pattern, sigma: Expected[(Type, Region)], reg: Region): Infer[(Pattern, List[(Bindable, Type)])] =
       pat match {
         case GenPattern.WildCard => Infer.pure((pat, Nil))
         case GenPattern.Literal(lit) =>
@@ -743,7 +745,7 @@ object Infer {
           def checkEither(
             inner: Type,
             lst: Type,
-            e: Either[Option[String], Pattern]): Infer[(Either[Option[String], Pattern], List[(String, Type)])] =
+            e: Either[Option[Bindable], Pattern]): Infer[(Either[Option[Bindable], Pattern], List[(Bindable, Type)])] =
               e match {
                 case l@Left(None) =>
                   // this is *a pattern that has list type, and binds that type to the name
@@ -797,7 +799,7 @@ object Infer {
       }
 
     // Unions have to have identical bindings in all branches
-    def identicalBinds(u: Pattern, binds: NonEmptyList[List[(String, Type)]], reg: Region): Infer[Unit] =
+    def identicalBinds(u: Pattern, binds: NonEmptyList[List[(Bindable, Type)]], reg: Region): Infer[Unit] =
       binds.map(_.map(_._1)) match {
         case NonEmptyList(h, t) =>
           val bs = h.toSet
@@ -818,7 +820,7 @@ object Infer {
       }
 
     // TODO: we should be able to derive a region for any pattern
-    def checkPat(pat: Pattern, sigma: Type, reg: Region): Infer[(Pattern, List[(String, Type)])] =
+    def checkPat(pat: Pattern, sigma: Type, reg: Region): Infer[(Pattern, List[(Bindable, Type)])] =
       typeCheckPattern(pat, Expected.Check((sigma, reg)), reg)
 
     // TODO, Pattern should have a region
@@ -842,7 +844,7 @@ object Infer {
      *
      * Instantiation fills in all
      */
-    def instDataCon(consName: (PackageName, ConstructorName)): Infer[(List[Type], Type.Tau)] =
+    def instDataCon(consName: (PackageName, Constructor)): Infer[(List[Type], Type.Tau)] =
       GetDataCons(consName).flatMap {
         case (Nil, consParams, tpeName) =>
           Infer.pure((consParams, Type.TyConst(tpeName)))
@@ -901,7 +903,7 @@ object Infer {
       } yield expr
   }
 
-  def recursiveTypeCheck[A: HasRegion](name: String, expr: Expr[A]): Infer[TypedExpr[A]] =
+  def recursiveTypeCheck[A: HasRegion](name: Bindable, expr: Expr[A]): Infer[TypedExpr[A]] =
     newMetaType.flatMap { tpe =>
       extendEnv(name, tpe)(typeCheck(expr))
     }
@@ -949,17 +951,17 @@ object Infer {
   }
 
 
-  def extendEnv[A](varName: String, tpe: Type)(of: Infer[A]): Infer[A] =
+  def extendEnv[A](varName: Bindable, tpe: Type)(of: Infer[A]): Infer[A] =
     extendEnvList(List((varName, tpe)))(of)
 
-  def extendEnvList[A](bindings: List[(String, Type)])(of: Infer[A]): Infer[A] =
+  def extendEnvList[A](bindings: List[(Bindable, Type)])(of: Infer[A]): Infer[A] =
     Infer.Impl.ExtendEnvs(bindings.map { case (n, t) => ((None, n), t) }, of)
 
   /**
    * Packages are generally just lists of lets, this allows you to infer
    * the scheme for each in the context of the list
    */
-  def typeCheckLets[A: HasRegion](ls: List[(String, RecursionKind, Expr[A])]): Infer[List[(String, RecursionKind, TypedExpr[A])]] =
+  def typeCheckLets[A: HasRegion](ls: List[(Bindable, RecursionKind, Expr[A])]): Infer[List[(Bindable, RecursionKind, TypedExpr[A])]] =
     ls match {
       case Nil => Infer.pure(Nil)
       case (nm, rec, expr) :: tail =>

--- a/core/src/main/scala/org/bykn/bosatsu/rankn/ParsedTypeEnv.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/rankn/ParsedTypeEnv.scala
@@ -1,12 +1,14 @@
 package org.bykn.bosatsu.rankn
 
-import org.bykn.bosatsu.PackageName
+import org.bykn.bosatsu.{PackageName, Identifier}
 
-case class ParsedTypeEnv[+A](allDefinedTypes: List[DefinedType[A]], externalDefs: List[(PackageName, String, Type)]) {
+import Identifier.Bindable
+
+case class ParsedTypeEnv[+A](allDefinedTypes: List[DefinedType[A]], externalDefs: List[(PackageName, Bindable, Type)]) {
   def addDefinedType[A1 >: A](dt: DefinedType[A1]): ParsedTypeEnv[A1] =
     copy(allDefinedTypes = dt :: allDefinedTypes)
 
-  def addExternalValue(pn: PackageName, name: String, tpe: Type): ParsedTypeEnv[A] =
+  def addExternalValue(pn: PackageName, name: Bindable, tpe: Type): ParsedTypeEnv[A] =
     copy(externalDefs = (pn, name, tpe) :: externalDefs)
 }
 

--- a/core/src/main/scala/org/bykn/bosatsu/rankn/Type.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/rankn/Type.scala
@@ -4,6 +4,8 @@ import cats.data.NonEmptyList
 import cats.Eq
 import org.bykn.bosatsu.{PackageName, Lit}
 
+import org.bykn.bosatsu.{TypeName, Identifier}
+
 sealed abstract class Type
 
 object Type {
@@ -36,7 +38,7 @@ object Type {
           case (ForAll(_, _), _) => -1
           case (TyConst(Const.Defined(p0, n0)), TyConst(Const.Defined(p1, n1))) =>
             val c = Ordering[PackageName].compare(p0, p1)
-            if (c == 0) n0.compareTo(n1) else c
+            if (c == 0) Ordering[TypeName].compare(n0, n1) else c
           case (TyConst(_), ForAll(_, _)) => 1
           case (TyConst(_), _) => -1
           case (TyVar(v0), TyVar(v1)) =>
@@ -212,10 +214,10 @@ object Type {
 
   sealed abstract class Const
   object Const {
-    case class Defined(packageName: PackageName, name: String) extends Const
+    case class Defined(packageName: PackageName, name: TypeName) extends Const
 
     def predef(name: String): Defined =
-      Defined(PackageName.predef, name)
+      Defined(PackageName.predef, TypeName(Identifier.Constructor(name)))
   }
 
   sealed abstract class Var {

--- a/core/src/test/scala/org/bykn/bosatsu/ParserTest.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/ParserTest.scala
@@ -101,6 +101,9 @@ class ParserTest extends FunSuite {
         assert(idx == atIdx)
     }
 
+  def mkVar(n: String): Declaration.Var =
+    Declaration.Var(Identifier.Name(n))
+
   test("we can parse integers") {
     forAll { b: BigInt =>
       val bstr = b.toString
@@ -402,8 +405,8 @@ foo"""
       defWithComment,
       Declaration.DefFn(DefStatement("foo", List(("a", None)), None,
         (OptIndent.paddedIndented(1, 2, Declaration.Comment(CommentStatement(NonEmptyList.of(" comment here"),
-          Padding(0, Declaration.Var("a"))))),
-         Padding(0, Declaration.Var("foo"))))))
+          Padding(0, mkVar("a"))))),
+         Padding(0, mkVar("foo"))))))
 
     roundTrip(Declaration.parser(""), defWithComment)
 
@@ -437,29 +440,29 @@ x""")
 
     parseTestAll(parser(""),
       "x(f)",
-      Apply(Var("x"), NonEmptyList.of(Var("f")), false))
+      Apply(mkVar("x"), NonEmptyList.of(mkVar("f")), false))
 
     parseTestAll(parser(""),
       "f.x",
-      Apply(Var("x"), NonEmptyList.of(Var("f")), true))
+      Apply(mkVar("x"), NonEmptyList.of(mkVar("f")), true))
 
     parseTestAll(parser(""),
       "f(foo).x",
-      Apply(Var("x"), NonEmptyList.of(Apply(Var("f"), NonEmptyList.of(Var("foo")), false)), true))
+      Apply(mkVar("x"), NonEmptyList.of(Apply(mkVar("f"), NonEmptyList.of(mkVar("foo")), false)), true))
 
     parseTestAll(parser(""),
       "f.foo(x)", // foo(f, x)
-      Apply(Var("foo"), NonEmptyList.of(Var("f"), Var("x")), true))
+      Apply(mkVar("foo"), NonEmptyList.of(mkVar("f"), mkVar("x")), true))
 
     parseTestAll(parser(""),
       "(\\x -> x)(f)",
-      Apply(Parens(Lambda(NonEmptyList.of("x"), Var("x"))), NonEmptyList.of(Var("f")), false))
+      Apply(Parens(Lambda(NonEmptyList.of("x"), mkVar("x"))), NonEmptyList.of(mkVar("f")), false))
 
     parseTestAll(parser(""),
       "((\\x -> x)(f))",
-      Parens(Apply(Parens(Lambda(NonEmptyList.of("x"), Var("x"))), NonEmptyList.of(Var("f")), false)))
+      Parens(Apply(Parens(Lambda(NonEmptyList.of("x"), mkVar("x"))), NonEmptyList.of(mkVar("f")), false)))
 
-    val expected = Apply(Parens(Parens(Lambda(NonEmptyList.of("x"), Var("x")))), NonEmptyList.of(Var("f")), false)
+    val expected = Apply(Parens(Parens(Lambda(NonEmptyList.of("x"), mkVar("x")))), NonEmptyList.of(mkVar("f")), false)
     parseTestAll(parser(""),
       "((\\x -> x))(f)",
       expected)
@@ -528,19 +531,19 @@ x""")
     parseTestAll(parser(""),
       """x = 4
 x""",
-    Binding(BindingStatement(Pattern.Var("x"), Literal(Lit.fromInt(4)), Padding(0, Var("x")))))
+    Binding(BindingStatement(Pattern.Var("x"), Literal(Lit.fromInt(4)), Padding(0, mkVar("x")))))
 
     parseTestAll(parser(""),
       """x = foo(4)
 
 x""",
-    Binding(BindingStatement(Pattern.Var("x"), Apply(Var("foo"), NonEmptyList.of(Literal(Lit.fromInt(4))), false), Padding(1, Var("x")))))
+    Binding(BindingStatement(Pattern.Var("x"), Apply(mkVar("foo"), NonEmptyList.of(Literal(Lit.fromInt(4))), false), Padding(1, mkVar("x")))))
 
     parseTestAll(parser(""),
       """x = foo(4)
 # x is really great
 x""",
-    Binding(BindingStatement(Pattern.Var("x"),Apply(Var("foo"),NonEmptyList.of(Literal(Lit.fromInt(4))), false),Padding(0,Comment(CommentStatement(NonEmptyList.of(" x is really great"),Padding(0,Var("x"))))))))
+    Binding(BindingStatement(Pattern.Var("x"),Apply(mkVar("foo"),NonEmptyList.of(Literal(Lit.fromInt(4))), false),Padding(0,Comment(CommentStatement(NonEmptyList.of(" x is really great"),Padding(0,mkVar("x"))))))))
 
   }
 

--- a/core/src/test/scala/org/bykn/bosatsu/ParserTest.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/ParserTest.scala
@@ -316,9 +316,12 @@ class ParserTest extends FunSuite {
       ("block", OptIndent.paddedIndented(1, 2, sbRes)))
   }
 
+  def trName(s: String): TypeRef.TypeName =
+    TypeRef.TypeName(TypeName(Identifier.Constructor(s)))
+
   test("we can parse TypeRefs") {
     parseTestAll(TypeRef.parser, "foo", TypeRef.TypeVar("foo"))
-    parseTestAll(TypeRef.parser, "Foo", TypeRef.TypeName("Foo"))
+    parseTestAll(TypeRef.parser, "Foo", trName("Foo"))
 
     parseTestAll(TypeRef.parser, "forall a. a", TypeRef.TypeLambda(NonEmptyList.of(TypeRef.TypeVar("a")), TypeRef.TypeVar("a")))
     parseTestAll(TypeRef.parser, "forall a, b. f[a] -> f[b]",
@@ -330,12 +333,12 @@ class ParserTest extends FunSuite {
     roundTrip(TypeRef.parser, "(forall a, b. f[a]) -> f[b]")
     roundTrip(TypeRef.parser, "(forall a, b. f[a])[Int]") // apply a type
 
-    parseTestAll(TypeRef.parser, "Foo -> Bar", TypeRef.TypeArrow(TypeRef.TypeName("Foo"), TypeRef.TypeName("Bar")))
+    parseTestAll(TypeRef.parser, "Foo -> Bar", TypeRef.TypeArrow(trName("Foo"), trName("Bar")))
     parseTestAll(TypeRef.parser, "Foo -> Bar -> baz",
-      TypeRef.TypeArrow(TypeRef.TypeName("Foo"), TypeRef.TypeArrow(TypeRef.TypeName("Bar"), TypeRef.TypeVar("baz"))))
+      TypeRef.TypeArrow(trName("Foo"), TypeRef.TypeArrow(trName("Bar"), TypeRef.TypeVar("baz"))))
     parseTestAll(TypeRef.parser, "(Foo -> Bar) -> baz",
-      TypeRef.TypeArrow(TypeRef.TypeArrow(TypeRef.TypeName("Foo"), TypeRef.TypeName("Bar")), TypeRef.TypeVar("baz")))
-    parseTestAll(TypeRef.parser, "Foo[Bar]", TypeRef.TypeApply(TypeRef.TypeName("Foo"), NonEmptyList.of(TypeRef.TypeName("Bar"))))
+      TypeRef.TypeArrow(TypeRef.TypeArrow(trName("Foo"), trName("Bar")), TypeRef.TypeVar("baz")))
+    parseTestAll(TypeRef.parser, "Foo[Bar]", TypeRef.TypeApply(trName("Foo"), NonEmptyList.of(trName("Bar"))))
 
     forAll(Generators.typeRefGen) { tref =>
       parseTestAll(TypeRef.parser, tref.toDoc.render(80), tref)
@@ -403,7 +406,7 @@ foo"""
     parseTestAll(
       Declaration.parser(""),
       defWithComment,
-      Declaration.DefFn(DefStatement("foo", List(("a", None)), None,
+      Declaration.DefFn(DefStatement(Identifier.Name("foo"), List((Identifier.Name("a"), None)), None,
         (OptIndent.paddedIndented(1, 2, Declaration.Comment(CommentStatement(NonEmptyList.of(" comment here"),
           Padding(0, mkVar("a"))))),
          Padding(0, mkVar("foo"))))))
@@ -425,7 +428,7 @@ foo""")
       """foo = 5
 
 5""",
-    Declaration.Binding(BindingStatement(Pattern.Var("foo"), Declaration.Literal(Lit.fromInt(5)),
+    Declaration.Binding(BindingStatement(Pattern.Var(Identifier.Name("foo")), Declaration.Literal(Lit.fromInt(5)),
       Padding(1, Declaration.Literal(Lit.fromInt(5))))))
 
 
@@ -456,13 +459,13 @@ x""")
 
     parseTestAll(parser(""),
       "(\\x -> x)(f)",
-      Apply(Parens(Lambda(NonEmptyList.of("x"), mkVar("x"))), NonEmptyList.of(mkVar("f")), false))
+      Apply(Parens(Lambda(NonEmptyList.of(Identifier.Name("x")), mkVar("x"))), NonEmptyList.of(mkVar("f")), false))
 
     parseTestAll(parser(""),
       "((\\x -> x)(f))",
-      Parens(Apply(Parens(Lambda(NonEmptyList.of("x"), mkVar("x"))), NonEmptyList.of(mkVar("f")), false)))
+      Parens(Apply(Parens(Lambda(NonEmptyList.of(Identifier.Name("x")), mkVar("x"))), NonEmptyList.of(mkVar("f")), false)))
 
-    val expected = Apply(Parens(Parens(Lambda(NonEmptyList.of("x"), mkVar("x")))), NonEmptyList.of(mkVar("f")), false)
+    val expected = Apply(Parens(Parens(Lambda(NonEmptyList.of(Identifier.Name("x")), mkVar("x")))), NonEmptyList.of(mkVar("f")), false)
     parseTestAll(parser(""),
       "((\\x -> x))(f)",
       expected)
@@ -531,19 +534,19 @@ x""")
     parseTestAll(parser(""),
       """x = 4
 x""",
-    Binding(BindingStatement(Pattern.Var("x"), Literal(Lit.fromInt(4)), Padding(0, mkVar("x")))))
+    Binding(BindingStatement(Pattern.Var(Identifier.Name("x")), Literal(Lit.fromInt(4)), Padding(0, mkVar("x")))))
 
     parseTestAll(parser(""),
       """x = foo(4)
 
 x""",
-    Binding(BindingStatement(Pattern.Var("x"), Apply(mkVar("foo"), NonEmptyList.of(Literal(Lit.fromInt(4))), false), Padding(1, mkVar("x")))))
+    Binding(BindingStatement(Pattern.Var(Identifier.Name("x")), Apply(mkVar("foo"), NonEmptyList.of(Literal(Lit.fromInt(4))), false), Padding(1, mkVar("x")))))
 
     parseTestAll(parser(""),
       """x = foo(4)
 # x is really great
 x""",
-    Binding(BindingStatement(Pattern.Var("x"),Apply(mkVar("foo"),NonEmptyList.of(Literal(Lit.fromInt(4))), false),Padding(0,Comment(CommentStatement(NonEmptyList.of(" x is really great"),Padding(0,mkVar("x"))))))))
+    Binding(BindingStatement(Pattern.Var(Identifier.Name("x")),Apply(mkVar("foo"),NonEmptyList.of(Literal(Lit.fromInt(4))), false),Padding(0,Comment(CommentStatement(NonEmptyList.of(" x is really great"),Padding(0,mkVar("x"))))))))
 
   }
 

--- a/core/src/test/scala/org/bykn/bosatsu/PatternTest.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/PatternTest.scala
@@ -15,8 +15,9 @@ class PatternTest extends FunSuite {
   }
 
   test("filtering for names not in a pattern is unbind") {
-    forAll(patGen, Gen.listOf(Gen.identifier)) { (p, ids) =>
-      assert(p.unbind == p.filterVars(ids.toSet.filterNot(p.names.toSet)))
+    forAll(patGen, Gen.listOf(Gen.identifier)) { (p, ids0) =>
+      val ids = ids0.map(Identifier.unsafe(_))
+      assert(p.unbind == p.filterVars(ids.toSet.filterNot(p.names.toSet[Identifier])))
     }
   }
 
@@ -33,13 +34,16 @@ class PatternTest extends FunSuite {
   }
 
   test("substructures don't include total matches") {
-    assert(Pattern.Var("foo").substructures.isEmpty)
-    assert(Pattern.Annotation(Pattern.Var("foo"), "Type").substructures.isEmpty)
-    assert(Pattern.Union(Pattern.Var("foo"), NonEmptyList.of(Pattern.Var("bar"))).substructures.isEmpty)
+    val foo = Identifier.Name("foo")
+    val bar = Identifier.Name("bar")
+    assert(Pattern.Var(foo).substructures.isEmpty)
+    assert(Pattern.Annotation(Pattern.Var(foo), "Type").substructures.isEmpty)
+    assert(Pattern.Union(Pattern.Var(foo), NonEmptyList.of(Pattern.Var(bar))).substructures.isEmpty)
   }
 
   test("unions with total matches work correctly") {
-    val inner = Pattern.Var("foo")
+    val foo = Identifier.Name("foo")
+    val inner = Pattern.Var(foo)
     val struct = Pattern.PositionalStruct("Foo", inner :: Nil)
     // Note, foo can't be substructural because on the right it is total
     assert(Pattern.Union(struct, NonEmptyList.of(inner)).substructures.isEmpty)

--- a/core/src/test/scala/org/bykn/bosatsu/TestUtils.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/TestUtils.scala
@@ -13,11 +13,11 @@ object TestUtils {
 
   def typeEnvOf(pack: PackageName, str: String): TypeEnv[Unit] = {
 
-    val tpeFn: String => Type.Const =
-      { tpe => Type.Const.Defined(pack, tpe) }
+    val tpeFn: Identifier.Constructor => Type.Const =
+      { tpe => Type.Const.Defined(pack, TypeName(tpe)) }
 
-    val consFn: String => (PackageName, ConstructorName) =
-      { cons => (pack, ConstructorName(cons)) }
+    val consFn: Identifier.Constructor => (PackageName, Identifier.Constructor) =
+      { cons => (pack, cons) }
 
     val stmt = statementOf(pack, str)
     val prog = Program.fromStatement(
@@ -30,11 +30,11 @@ object TestUtils {
 
   def statementOf(pack: PackageName, str: String): Statement = {
 
-    val tpeFn: String => Type.Const =
-      { tpe => Type.Const.Defined(pack, tpe) }
+    val tpeFn: Identifier.Constructor => Type.Const =
+      { tpe => Type.Const.Defined(pack, TypeName(tpe)) }
 
-    val consFn: String => (PackageName, ConstructorName) =
-      { cons => (pack, ConstructorName(cons)) }
+    val consFn: Identifier.Constructor => (PackageName, Identifier.Constructor) =
+      { cons => (pack, cons) }
 
     Statement.parser.parse(str) match {
       case Parsed.Success(stmt, idx) =>

--- a/core/src/test/scala/org/bykn/bosatsu/TypeRefTest.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/TypeRefTest.scala
@@ -20,7 +20,7 @@ class TypeRefTest extends FunSuite {
   test("TypeRef -> Type -> TypeRef") {
     val pn = PackageName.parts("Test")
     forAll(typeRefGen) { tr =>
-      val tpe = tr.toType(Type.Const.Defined(pn, _))
+      val tpe = tr.toType { c => Type.Const.Defined(pn, TypeName(c)) }
       val tr1 = TypeRef.fromTypes(Some(pn), tpe :: Nil)(tpe)
       assert(tr1 == tr.normalizeForAll)
     }

--- a/core/src/test/scala/org/bykn/bosatsu/TypedExprTest.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/TypedExprTest.scala
@@ -4,13 +4,15 @@ import org.scalatest.FunSuite
 
 import TestUtils.checkLast
 
+import Identifier.Name
+
 class TypedExprTest extends FunSuite {
   test("freeVars on simple cases works") {
     checkLast("""#
 x = 1
 def id(x): x
 y = id(x)
-""") { te => assert(TypedExpr.freeVars(te :: Nil) == List("id", "x")) }
+""") { te => assert(TypedExpr.freeVars(te :: Nil) == List(Name("id"), Name("x"))) }
 
     checkLast("""#
 x = 1
@@ -20,7 +22,7 @@ x = 1
 struct Tup2(a, b)
 
 x = Tup2(1, 2)
-""") { te => assert(TypedExpr.freeVars(te :: Nil) == List("Tup2")) }
+""") { te => assert(TypedExpr.freeVars(te :: Nil) == List(Identifier.Constructor("Tup2"))) }
 
     checkLast("""#
 struct Tup2(a, b)
@@ -28,6 +30,6 @@ struct Tup2(a, b)
 x = Tup2(1, 2)
 y = match x:
   Tup2(a, _): a
-""") { te => assert(TypedExpr.freeVars(te :: Nil) == List("x")) }
+""") { te => assert(TypedExpr.freeVars(te :: Nil) == List(Name("x"))) }
   }
 }

--- a/core/src/test/scala/org/bykn/bosatsu/VarianceFormulaTest.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/VarianceFormulaTest.scala
@@ -12,7 +12,7 @@ class VarianceFormulaTest extends FunSuite {
       case Right(teVar) =>
         val teMap = DefinedType.listToMap(teVar)
         variances.foreach { case (n, vs) =>
-          val dt = teMap((Predef.packageName, TypeName(n)))
+          val dt = teMap((Predef.packageName, TypeName(Identifier.Constructor(n))))
           assert(dt.annotatedTypeParams.map(_._2) == vs)
         }
     }

--- a/core/src/test/scala/org/bykn/bosatsu/rankn/RankNInferTest.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/rankn/RankNInferTest.scala
@@ -79,10 +79,12 @@ class RankNInferTest extends FunSuite {
 
 
   def lit(i: Int): Expr[Unit] = Literal(Lit(i.toLong), ())
-  def lit(b: Boolean): Expr[Unit] = if (b) Var(None, "True", ()) else Var(None, "False", ())
+  def lit(b: Boolean): Expr[Unit] =
+    if (b) Var(None, Identifier.Constructor("True"), ())
+    else Var(None, Identifier.Constructor("False"), ())
   def let(n: String, expr: Expr[Unit], in: Expr[Unit]): Expr[Unit] = Let(n, expr, in, RecursionKind.NonRecursive, ())
   def lambda(arg: String, result: Expr[Unit]): Expr[Unit] = Lambda(arg, result, ())
-  def v(name: String): Expr[Unit] = Var(None, name, ())
+  def v(name: String): Expr[Unit] = Var(None, Identifier.unsafe(name), ())
   def ann(expr: Expr[Unit], t: Type): Expr[Unit] = Annotation(expr, t, ())
 
   def app(fn: Expr[Unit], arg: Expr[Unit]): Expr[Unit] = App(fn, arg, ())

--- a/core/src/test/scala/org/bykn/bosatsu/rankn/RankNInferTest.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/rankn/RankNInferTest.scala
@@ -11,18 +11,20 @@ import Type.ForAll
 
 import TestUtils.checkLast
 
+import Identifier.Constructor
+
 class RankNInferTest extends FunSuite {
 
   val emptyRegion: Region = Region(0, 0)
 
   implicit val unitRegion: HasRegion[Unit] = HasRegion.instance(_ => emptyRegion)
 
-  private def strToConst(str: String): Type.Const =
-    str match {
+  private def strToConst(str: Identifier.Constructor): Type.Const =
+    str.asString match {
       case "Int" => Type.Const.predef("Int")
       case "String" => Type.Const.predef("String")
       case s =>
-        Type.Const.Defined(PackageName.parts("Test"), s)
+        Type.Const.Defined(PackageName.parts("Test"), TypeName(str))
     }
 
   def typeFrom(str: String): Type =
@@ -48,16 +50,16 @@ class RankNInferTest extends FunSuite {
     assert(runUnify(left, right).isLeft, s"$left unexpectedly unifies with $right")
 
   def defType(n: String): Type.Const.Defined =
-    Type.Const.Defined(PackageName.parts("Test"), n)
+    Type.Const.Defined(PackageName.parts("Test"), TypeName(Identifier.Constructor(n)))
 
-  val withBools: Map[String, Type] =
+  val withBools: Map[Identifier, Type] =
     Map(
-      "True" -> Type.BoolType,
-      "False" -> Type.BoolType)
-  val boolTypes: Map[(PackageName, ConstructorName), Infer.Cons] =
+      Identifier.unsafe("True") -> Type.BoolType,
+      Identifier.unsafe("False") -> Type.BoolType)
+  val boolTypes: Map[(PackageName, Constructor), Infer.Cons] =
     Map(
-      ((Predef.packageName, ConstructorName("True")), (Nil, Nil, Type.Const.predef("Bool"))),
-      ((Predef.packageName, ConstructorName("False")), (Nil, Nil, Type.Const.predef("Bool"))))
+      ((Predef.packageName, Constructor("True")), (Nil, Nil, Type.Const.predef("Bool"))),
+      ((Predef.packageName, Constructor("False")), (Nil, Nil, Type.Const.predef("Bool"))))
 
   def testType[A: HasRegion](term: Expr[A], ty: Type) =
     Infer.typeCheck(term).runFully(Infer.asFullyQualified(withBools), boolTypes) match {
@@ -66,13 +68,13 @@ class RankNInferTest extends FunSuite {
     }
 
   def testLetTypes[A: HasRegion](terms: List[(String, Expr[A], Type)]) =
-    Infer.typeCheckLets(terms.map { case (k, v, _) => (k, RecursionKind.NonRecursive, v) })
+    Infer.typeCheckLets(terms.map { case (k, v, _) => (Identifier.Name(k), RecursionKind.NonRecursive, v) })
       .runFully(Infer.asFullyQualified(withBools), boolTypes) match {
         case Left(err) => assert(false, err)
         case Right(tpes) =>
           assert(tpes.size == terms.size)
           terms.zip(tpes).foreach { case ((n, exp, expt), (n1, _, te)) =>
-            assert(n == n1, s"the name changed: $n != $n1")
+            assert(n == n1.asString, s"the name changed: $n != $n1")
             assert(te.getType == expt, s"$n = $exp failed to typecheck to $expt, got ${te.getType}")
           }
       }
@@ -82,19 +84,22 @@ class RankNInferTest extends FunSuite {
   def lit(b: Boolean): Expr[Unit] =
     if (b) Var(None, Identifier.Constructor("True"), ())
     else Var(None, Identifier.Constructor("False"), ())
-  def let(n: String, expr: Expr[Unit], in: Expr[Unit]): Expr[Unit] = Let(n, expr, in, RecursionKind.NonRecursive, ())
-  def lambda(arg: String, result: Expr[Unit]): Expr[Unit] = Lambda(arg, result, ())
+  def let(n: String, expr: Expr[Unit], in: Expr[Unit]): Expr[Unit] =
+    Let(Identifier.Name(n), expr, in, RecursionKind.NonRecursive, ())
+  def lambda(arg: String, result: Expr[Unit]): Expr[Unit] =
+    Lambda(Identifier.Name(arg), result, ())
   def v(name: String): Expr[Unit] = Var(None, Identifier.unsafe(name), ())
   def ann(expr: Expr[Unit], t: Type): Expr[Unit] = Annotation(expr, t, ())
 
   def app(fn: Expr[Unit], arg: Expr[Unit]): Expr[Unit] = App(fn, arg, ())
-  def alam(arg: String, tpe: Type, res: Expr[Unit]): Expr[Unit] = AnnotatedLambda(arg, tpe, res, ())
+  def alam(arg: String, tpe: Type, res: Expr[Unit]): Expr[Unit] =
+    AnnotatedLambda(Identifier.Name(arg), tpe, res, ())
 
   def ife(cond: Expr[Unit], ift: Expr[Unit], iff: Expr[Unit]): Expr[Unit] = Expr.ifExpr(cond, ift, iff, ())
   def matche(arg: Expr[Unit], branches: NonEmptyList[(Pattern[String, Type], Expr[Unit])]): Expr[Unit] =
     Match(arg,
       branches.map { case (p, e) =>
-        val p1 = p.mapName { n => (PackageName.parts("Test"), ConstructorName(n)) }
+        val p1 = p.mapName { n => (PackageName.parts("Test"), Constructor(n)) }
         (p1, e)
       },
       ())
@@ -200,12 +205,12 @@ class RankNInferTest extends FunSuite {
 
     val pn = PackageName.parts("Test")
     val definedOption = Map(
-      ((pn, ConstructorName("Some")), (Nil, List(Type.IntType), optName)),
-      ((pn, ConstructorName("None")), (Nil, Nil, optName)))
+      ((pn, Constructor("Some")), (Nil, List(Type.IntType), optName)),
+      ((pn, Constructor("None")), (Nil, Nil, optName)))
 
     val definedOptionGen = Map(
-      ((pn, ConstructorName("Some")), (List((Bound("a"), Variance.co)), List(Type.TyVar(Bound("a"))), optName)),
-      ((pn, ConstructorName("None")), (List((Bound("a"), Variance.co)), Nil, optName)))
+      ((pn, Constructor("Some")), (List((Bound("a"), Variance.co)), List(Type.TyVar(Bound("a"))), optName)),
+      ((pn, Constructor("None")), (List((Bound("a"), Variance.co)), Nil, optName)))
   }
 
   test("match with custom non-generic types") {
@@ -215,7 +220,7 @@ class RankNInferTest extends FunSuite {
     import OptionTypes._
 
     val constructors = Map(
-      ("Some", Type.Fun(Type.IntType, optType))
+      (Identifier.unsafe("Some"), Type.Fun(Type.IntType, optType))
     )
 
     def testWithOpt[A: HasRegion](term: Expr[A], ty: Type) =
@@ -239,7 +244,7 @@ class RankNInferTest extends FunSuite {
     testWithOpt(
       matche(app(v("Some"), lit(1)),
         NonEmptyList.of(
-          (Pattern.PositionalStruct("Some", List(Pattern.Var("a"))), v("a")),
+          (Pattern.PositionalStruct("Some", List(Pattern.Var(Identifier.Name("a")))), v("a")),
           (Pattern.PositionalStruct("None", Nil), lit(42))
           )), Type.IntType)
 
@@ -257,8 +262,8 @@ class RankNInferTest extends FunSuite {
     import OptionTypes._
 
     val constructors = Map(
-      ("Some", Type.ForAll(NonEmptyList.of(b("a")), Type.Fun(tv("a"), Type.TyApply(optType, tv("a"))))),
-      ("None", Type.ForAll(NonEmptyList.of(b("a")), Type.TyApply(optType, tv("a"))))
+      (Identifier.unsafe("Some"), Type.ForAll(NonEmptyList.of(b("a")), Type.Fun(tv("a"), Type.TyApply(optType, tv("a"))))),
+      (Identifier.unsafe("None"), Type.ForAll(NonEmptyList.of(b("a")), Type.TyApply(optType, tv("a"))))
     )
 
     def testWithOpt[A: HasRegion](term: Expr[A], ty: Type) =
@@ -282,7 +287,7 @@ class RankNInferTest extends FunSuite {
     testWithOpt(
       matche(app(v("Some"), lit(1)),
         NonEmptyList.of(
-          (Pattern.PositionalStruct("Some", List(Pattern.Var("a"))), v("a")),
+          (Pattern.PositionalStruct("Some", List(Pattern.Var(Identifier.Name("a")))), v("a")),
           (Pattern.PositionalStruct("None", Nil), lit(42))
           )), Type.IntType)
 
@@ -290,7 +295,7 @@ class RankNInferTest extends FunSuite {
     testWithOpt(
       matche(app(v("Some"), app(v("Some"), lit(1))),
         NonEmptyList.of(
-          (Pattern.PositionalStruct("Some", List(Pattern.Var("a"))), v("a"))
+          (Pattern.PositionalStruct("Some", List(Pattern.Var(Identifier.Name("a")))), v("a"))
           )), Type.TyApply(optType, Type.IntType))
 
     failWithOpt(
@@ -314,18 +319,18 @@ class RankNInferTest extends FunSuite {
      * struct Pure(pure: forall a. a -> f[a])
      */
     val defined = Map(
-      ((pn, ConstructorName("Pure")), (List((b("f"), Variance.in)),
+      ((pn, Constructor("Pure")), (List((b("f"), Variance.in)),
         List(Type.ForAll(NonEmptyList.of(b("a")), Type.Fun(tv("a"), Type.TyApply(tv("f"), tv("a"))))),
         pureName)),
-      ((pn, ConstructorName("Some")), (List((b("a"), Variance.co)), List(tv("a")), optName)),
-      ((pn, ConstructorName("None")), (List((b("a"), Variance.co)), Nil, optName)))
+      ((pn, Constructor("Some")), (List((b("a"), Variance.co)), List(tv("a")), optName)),
+      ((pn, Constructor("None")), (List((b("a"), Variance.co)), Nil, optName)))
 
     val constructors = Map(
-      ("Pure", Type.ForAll(NonEmptyList.of(b("f")),
+      (Identifier.unsafe("Pure"), Type.ForAll(NonEmptyList.of(b("f")),
         Type.Fun(Type.ForAll(NonEmptyList.of(b("a")), Type.Fun(tv("a"), Type.TyApply(tv("f"), tv("a")))),
           Type.TyApply(Type.TyConst(pureName), tv("f")) ))),
-      ("Some", Type.ForAll(NonEmptyList.of(b("a")), Type.Fun(tv("a"), Type.TyApply(optType, tv("a"))))),
-      ("None", Type.ForAll(NonEmptyList.of(b("a")), Type.TyApply(optType, tv("a"))))
+      (Identifier.unsafe("Some"), Type.ForAll(NonEmptyList.of(b("a")), Type.Fun(tv("a"), Type.TyApply(optType, tv("a"))))),
+      (Identifier.unsafe("None"), Type.ForAll(NonEmptyList.of(b("a")), Type.TyApply(optType, tv("a"))))
     )
 
     def testWithTypes[A: HasRegion](term: Expr[A], ty: Type) =

--- a/core/src/test/scala/org/bykn/bosatsu/rankn/TypeTest.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/rankn/TypeTest.scala
@@ -9,7 +9,7 @@ import org.bykn.bosatsu.Generators
 object NTypeGen {
   val genRootType: Gen[Type] = {
     val genConst =
-      Gen.zip(Generators.packageNameGen, Generators.upperIdent)
+      Gen.zip(Generators.packageNameGen, Generators.typeNameGen)
         .map { case (p, n) => Type.TyConst(Type.Const.Defined(p, n)) }
 
     val genVar =


### PR DESCRIPTION
This was not a fun refactor, but it was real techdebt.

Previously, we were using `String` in many cases for identifiers. It is hard to refactor such code because we don't know which of those are referring to binding names, type names or Constructors.

This introduces Identifier which is intended to keep track of this and be clear that we are never recreating those strings after parsing.

This is related to #12 and #70 since both of those will need to touch how identifiers are delt with.