### PR TITLE
Add backtick escaping to allow any string as a binding

### DIFF
--- a/core/src/main/scala/org/bykn/bosatsu/Program.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/Program.scala
@@ -2,8 +2,8 @@ package org.bykn.bosatsu
 
 import cats.evidence.Is
 import cats.data.NonEmptyList
-
 import org.bykn.bosatsu.rankn.{Type, ParsedTypeEnv}
+import scala.collection.immutable.SortedSet
 
 import Identifier.{Bindable, Constructor}
 
@@ -65,17 +65,18 @@ object Program {
     // Each time we need a name, we can call anonNames.next()
     // it is mutable, but in a limited scope
     val anonNames: Iterator[Bindable] = {
-      val allNames = stmt.toStream.flatMap {
-        case Bind(BindingStatement(bound, _, _)) => bound.names.map(_.asString) // TODO Keep identifiers
-        case _ => Nil
-      }.toSet
+      val allNames =
+        SortedSet(stmt.toStream.flatMap {
+          case Bind(BindingStatement(bound, _, _)) => bound.names // TODO Keep identifiers
+          case _ => Nil
+        }: _*)
 
       rankn.Type
         .allBinders
         .iterator
         .map(_.name)
-        .filterNot(allNames)
         .map(Identifier.Name(_))
+        .filterNot(allNames)
     }
 
     def bindings(

--- a/core/src/main/scala/org/bykn/bosatsu/StringUtil.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/StringUtil.scala
@@ -42,10 +42,9 @@ abstract class GenericStringUtil {
     // We can ignore escaping the opposite character used for the string
     // x isn't escaped anyway and is kind of a hack here
     val ignoreEscape = if (quoteChar == '\'') '"' else if (quoteChar == '"') '\'' else 'x'
-    val tab = if (encodeTable.contains(quoteChar)) encodeTable else encodeTable.updated(quoteChar, s"\\$quoteChar")
     str.flatMap { c =>
       if (c == ignoreEscape) c.toString
-      else tab.get(c) match {
+      else encodeTable.get(c) match {
         case None =>
           if (c < ' ') nonPrintEscape(c.toInt)
           else c.toString
@@ -113,6 +112,7 @@ object StringUtil extends GenericStringUtil {
       ('\\', '\\'),
       ('\'', '\''),
       ('\"', '\"'),
+      ('`', '`'),
       ('a', 7.toChar), // bell
       ('b', 8.toChar), // backspace
       ('f', 12.toChar), // form-feed

--- a/core/src/main/scala/org/bykn/bosatsu/StringUtil.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/StringUtil.scala
@@ -12,7 +12,7 @@ abstract class GenericStringUtil {
       val strHex = c.toHexString
       val strPad = List.fill(4 - strHex.length)('0').mkString
       s"\\u$strPad$strHex"
-    }.toArray
+   }.toArray
 
   private val escapeString: P[Unit] = {
     val escapes = CharIn(decodeTable.keys.toSeq)
@@ -42,9 +42,10 @@ abstract class GenericStringUtil {
     // We can ignore escaping the opposite character used for the string
     // x isn't escaped anyway and is kind of a hack here
     val ignoreEscape = if (quoteChar == '\'') '"' else if (quoteChar == '"') '\'' else 'x'
+    val tab = if (encodeTable.contains(quoteChar)) encodeTable else encodeTable.updated(quoteChar, s"\\$quoteChar")
     str.flatMap { c =>
       if (c == ignoreEscape) c.toString
-      else encodeTable.get(c) match {
+      else tab.get(c) match {
         case None =>
           if (c < ' ') nonPrintEscape(c.toInt)
           else c.toString

--- a/core/src/main/scala/org/bykn/bosatsu/TypedExpr.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/TypedExpr.scala
@@ -4,8 +4,8 @@ import cats.Applicative
 import cats.arrow.FunctionK
 import cats.data.NonEmptyList
 import cats.implicits._
-
 import org.bykn.bosatsu.rankn.Type
+import scala.collection.immutable.SortedSet
 
 import Identifier.{Bindable, Constructor}
 
@@ -203,8 +203,8 @@ object TypedExpr {
         /*
          * We have to be careful not to collide with the free vars in expr
          */
-        val free = freeVars(expr :: Nil).iterator.map(_.asString).toSet
-        val name = Identifier.Name(Type.allBinders.iterator.map(_.name).filterNot(free).next)
+        val free = SortedSet(freeVars(expr :: Nil): _*)
+        val name = Type.allBinders.iterator.map { v => Identifier.Name(v.name) }.filterNot(free).next
         AnnotatedLambda(name, arg, cores(App(expr, coarg(Var(None, name, arg, expr.tag)), result, expr.tag)), expr.tag)
       }
     }

--- a/core/src/test/scala/org/bykn/bosatsu/EvaluationTest.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/EvaluationTest.scala
@@ -1114,4 +1114,24 @@ main = [Foo(1), Bar("1")]
       Json.JObject(
         List("bar" -> Json.JString("1"))))))
   }
+
+  test("json with backticks") {
+    evalTestJson(
+      List("""
+package Foo
+
+struct Foo(`struct`, `second key`, `enum`, `def`)
+
+`package` = 2
+
+main = Foo(1, `package`, 3, 4)
+"""), "Foo",
+  Json.JObject(
+    List(
+      ("struct" -> Json.JNumberStr("1")),
+      ("second key" -> Json.JNumberStr("2")),
+      ("enum" -> Json.JNumberStr("3")),
+      ("def" -> Json.JNumberStr("4")))
+    ))
+  }
 }

--- a/core/src/test/scala/org/bykn/bosatsu/Gen.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/Gen.scala
@@ -368,20 +368,14 @@ object Generators {
     Gen.oneOf(str, bi)
   }
 
-  val identBindableGen: Gen[Identifier.Bindable] =
-    lowerIdent.map { n => Identifier.Name(n) }
-
-  val identConsGen: Gen[Identifier.Constructor] =
-    upperIdent.map { n => Identifier.Constructor(n) }
-
   val identifierGen: Gen[Identifier] =
-    Gen.oneOf(identBindableGen, identConsGen)
+    Gen.oneOf(bindIdentGen, consIdentGen)
 
   val varGen: Gen[Declaration.Var] =
-    identBindableGen.map(Declaration.Var(_)(emptyRegion))
+    bindIdentGen.map(Declaration.Var(_)(emptyRegion))
 
   val consDeclGen: Gen[Declaration.Var] =
-    identConsGen.map(Declaration.Var(_)(emptyRegion))
+    consIdentGen.map(Declaration.Var(_)(emptyRegion))
 
   val unnestedDeclGen: Gen[Declaration] =
     Gen.frequency(

--- a/core/src/test/scala/org/bykn/bosatsu/Gen.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/Gen.scala
@@ -54,7 +54,11 @@ object Generators {
     } yield TypeRef.TypeLambda(nel, e)
 
   val bindIdentGen: Gen[Identifier.Bindable] =
-    lowerIdent.map { n => Identifier.Name(n) }
+    Gen.frequency(
+      (10, lowerIdent.map { n => Identifier.Name(n) }),
+      (1, Arbitrary.arbitrary[String].map { s =>
+        Identifier.Backticked(s)
+      }))
 
   val consIdentGen: Gen[Identifier.Constructor] =
     upperIdent.map { n => Identifier.Constructor(n) }

--- a/core/src/test/scala/org/bykn/bosatsu/ParserTest.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/ParserTest.scala
@@ -197,6 +197,15 @@ class ParserTest extends FunSuite {
     regressions.foreach { case (s, c) => law(s, c) }
   }
 
+  test("Identifier round trips") {
+    forAll(Generators.identifierGen)(law(Identifier.parser))
+
+    val examples = List("foo", "`bar`", "`bar foo`",
+      "`with \\`internal`")
+
+    examples.foreach(roundTrip(Identifier.parser, _))
+  }
+
   test("we can parse lists") {
     forAll { (ls: List[Long], spaceCnt0: Int) =>
       val spaceCount = spaceCnt0 & 7


### PR DESCRIPTION
close #70 

This is pretty easy after the #192 cleanup.

The JSON test shows the motivation: make objects with keys which are keywords in bosatsu.