### PR TITLE
allow newlines inside constructor and defs

### DIFF
--- a/core/src/main/scala/org/bykn/bosatsu/DefStatement.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/DefStatement.scala
@@ -61,9 +61,9 @@ object DefStatement {
      * The resultTParser should parse some indentation any newlines
      */
     def parser[T](resultTParser: P[T]): P[DefStatement[T]] = {
-      val args = argParser.nonEmptyList
+      val args = argParser.parensLines1
       val result = P(maybeSpace ~ "->" ~/ maybeSpace ~ TypeRef.parser).?
-      P("def" ~ spaces ~/ Identifier.bindableParser ~ ("(" ~ maybeSpace ~ args ~ maybeSpace ~ ")").? ~
+      P("def" ~ spaces ~/ Identifier.bindableParser ~ args.? ~
         result ~ maybeSpace ~ ":" ~/ resultTParser)
         .map {
           case (name, optArgs, resType, res) =>
@@ -76,5 +76,5 @@ object DefStatement {
     }
 
     val argParser: P[(Bindable, Option[TypeRef])] =
-      P(Identifier.bindableParser ~ (":" ~/ maybeSpace ~ TypeRef.parser).?)
+      P(Identifier.bindableParser ~ maybeSpace ~ (":" ~/ maybeSpace ~ TypeRef.parser).?)
 }

--- a/core/src/main/scala/org/bykn/bosatsu/Parser.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/Parser.scala
@@ -266,6 +266,11 @@ object Parser {
     def parens: P[T] =
       wrappedSpace("(", ")")
 
+    def parensLines1: P[NonEmptyList[T]] = {
+      val nel = item.nonEmptyListOfWs(maybeSpacesAndLines, 1)
+      P("(" ~ maybeSpacesAndLines ~ nel ~ maybeSpacesAndLines ~ ")")
+    }
+
     /**
      * Parse a python-like tuple or a parens
      */

--- a/core/src/main/scala/org/bykn/bosatsu/Statement.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/Statement.scala
@@ -241,10 +241,10 @@ object Statement {
 
     val end = P(End).map(_ => EndOfFile)
 
-    val constructorP = P(Identifier.consParser ~ (DefStatement.argParser).list.parens.?)
+    val constructorP = P(Identifier.consParser ~ (DefStatement.argParser).parensLines1.?)
       .map {
         case (n, None) => (n, Nil)
-        case (n, Some(args)) => (n, args)
+        case (n, Some(args)) => (n, args.toList)
       }
 
     val external = {

--- a/core/src/test/scala/org/bykn/bosatsu/ParserTest.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/ParserTest.scala
@@ -784,6 +784,22 @@ Pair(x, _) = Pair([], b)
 struct Monad(pure: forall a. a -> f[a], flatMap: forall a, b. f[a] -> (a -> f[b]) -> f[b])
 """)
 
+    // we can put new-lines in structs
+    roundTrip(Statement.parser,
+"""# MONADS!!!!
+struct Monad(
+  pure: forall a. a -> f[a],
+  flatMap: forall a, b. f[a] -> (a -> f[b]) -> f[b])
+""")
+
+    // we can put new-lines in defs
+    roundTrip(Statement.parser,
+"""#
+def foo(
+  x,
+  y: Int): x.add(y)
+""")
+
     roundTrip(Statement.parser, """enum Option: None, Some(a)""")
 
     roundTrip(Statement.parser,


### PR DESCRIPTION
close #17 

This allows newlines inside def and constructors. This makes longer lists of args more readable.