### PR TITLE
Add basic operator support

### DIFF
--- a/core/src/main/scala/org/bykn/bosatsu/Declaration.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/Declaration.scala
@@ -468,6 +468,11 @@ object Declaration {
             case _ => None
           }
         optParts.map(Pattern.ListPat(_))
+      case ApplyOp(left, Identifier.Operator("|"), right) =>
+        // this could be a pattern
+        (toPattern(left), toPattern(right)).mapN { (l, r) =>
+          Pattern.union(l, r :: Nil)
+        }
       case Apply(Var(nm@Identifier.Constructor(_)), args, ApplyKind.Parens) =>
         args.traverse(toPattern(_)).map { argPats =>
           Pattern.PositionalStruct(Some(nm), argPats.toList)

--- a/core/src/main/scala/org/bykn/bosatsu/Declaration.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/Declaration.scala
@@ -675,26 +675,24 @@ object Declaration {
       // now parse an operator apply
       val postOperators: P[Declaration] = {
 
-        def convert(form: Operators.Formula[(Region, Declaration)]): (Region, Declaration) =
+        def convert(form: Operators.Formula[Declaration]): Declaration =
           form match {
             case Operators.Formula.Sym(r) => r
             case Operators.Formula.Op(left, op, right) =>
-              val (leftr, leftD) = convert(left)
-              val (rightr, rightD) = convert(right)
-              val appRegion = leftr + rightr
-              val opRegion = Region(leftr.end, rightr.start)
+              val leftD = convert(left)
+              val rightD = convert(right)
               // `op`(l, r)
-              (appRegion, ApplyOp(leftD, Identifier.Operator(op), rightD))
+              ApplyOp(leftD, Identifier.Operator(op), rightD)
           }
 
         // one or more operators
-        val ops: P[((Region, Declaration)) => Operators.Formula[(Region, Declaration)]] =
-          Operators.Formula.infixOps1(applied.region)
+        val ops: P[Declaration => Operators.Formula[Declaration]] =
+          Operators.Formula.infixOps1(applied)
 
         // This already parses as many as it can, so we don't need repFn
         val form = ops.map { fn =>
 
-          { d: Declaration => convert(fn((d.region, d)))._2 }
+          { d: Declaration => convert(fn(d)) }
         }
 
         maybeAp(applied, form)

--- a/core/src/main/scala/org/bykn/bosatsu/Expr.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/Expr.scala
@@ -41,6 +41,17 @@ object Expr {
   def ifExpr[T](cond: Expr[T], ifTrue: Expr[T], ifFalse: Expr[T], tag: T): Expr[T] =
     Match(cond, NonEmptyList.of((TruePat, ifTrue), (FalsePat, ifFalse)), tag)
 
+  /**
+   * Build an apply expression by appling these args left to right
+   */
+  @annotation.tailrec
+  def buildApp[A](fn: Expr[A], args: List[Expr[A]], appTag: A): Expr[A] =
+    args match {
+      case Nil => fn
+      case h :: tail =>
+        buildApp(App(fn, h, appTag), tail, appTag)
+    }
+
   def traverseType[T, F[_]](expr: Expr[T], fn: rankn.Type => F[rankn.Type])(implicit F: Applicative[F]): F[Expr[T]] =
     expr match {
       case Annotation(e, tpe, a) =>

--- a/core/src/main/scala/org/bykn/bosatsu/Identifier.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/Identifier.scala
@@ -67,7 +67,7 @@ object Identifier {
    * raw operator tokens without an `operator` prefix
    */
   val rawOperator: P[Operator] =
-    Parser.operatorToken.map(Operator(_))
+    Operators.operatorToken.map(Operator(_))
 
   /**
    * the keyword operator preceding a rawOperator

--- a/core/src/main/scala/org/bykn/bosatsu/Operators.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/Operators.scala
@@ -87,7 +87,9 @@ object Operators {
           val c = compareOperator(op1, op2)
           if (c > 0) {
             // right binds tighter
-            // 1 + 2 * 3 .... => 1 + toFormula(2 * 3 ...)
+            // 1 + 2 * 3 .... => toFormula(1 + (2 * 3) ...)
+            // f2 is putting parents around (2 * 3)
+            // in this example, then starting again
             val f2 = Op(next1, op2, next2)
             toFormula(init, (op1, f2) :: tail)
           }

--- a/core/src/main/scala/org/bykn/bosatsu/Operators.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/Operators.scala
@@ -1,0 +1,123 @@
+package org.bykn.bosatsu
+
+import fastparse.all._
+
+object Operators {
+
+  // Longer strings bind tighter, so ** binds tighter than *
+  def compareOperator(left: String, right: String): Int = {
+    def loop(idx: Int): Int = {
+      val leftDone = left.length <= idx
+      val rightDone = right.length <= idx
+      (leftDone, rightDone) match {
+        case (true, true) => 0
+        case (true, false) => 1
+        case (false, true) => -1
+        case (false, false) =>
+          val lc = left.substring(idx, idx + 1)
+          val rc = right.substring(idx, idx + 1)
+          if (lc == rc) loop(idx + 1)
+          else {
+            Integer.compare(
+              priorityMap.getOrElse(lc, Int.MaxValue),
+              priorityMap.getOrElse(rc, Int.MaxValue))
+          }
+      }
+    }
+
+    if (left eq right) 0
+    else loop(0)
+  }
+
+  private val singleToks =
+    List(
+      "*", "/", "%",
+      "+", "-",
+      "<", ">",
+      "!", "$",
+      "&", "|", "^",
+      "?", "~").map(_.intern)
+
+  private val priorityMap: Map[String, Int] =
+    (singleToks ::: List("="))
+      .iterator
+      .zipWithIndex
+      .toMap
+
+  /**
+   * Here are a list of operators we allow
+   */
+  val operatorToken: P[String] = {
+    def from(strs: Iterable[String]): P[Unit] =
+      strs.map(P(_)).reduce(_ | _)
+
+    val singles = from(singleToks)
+    // = can appear with at least one other character
+    val withEqual = from("=" :: singleToks).rep(min = 2)
+    // we can also repeat core operators one or more times
+    val noEqual = singles.rep(min = 1)
+    (withEqual | noEqual).!.map(_.intern)
+  }
+
+  sealed abstract class Formula[+A] {
+    override def toString: String =
+      this match {
+        case Formula.Sym(a) => a.toString
+        case Formula.Op(a, op, b) =>
+          s"($a $op $b)"
+      }
+  }
+
+  object Formula {
+    case class Sym[A](value: A) extends Formula[A]
+    case class Op[A](left: Formula[A], op: String, right: Formula[A]) extends Formula[A]
+
+    /**
+     * 1 * 2 + 3 => (1 * 2) + 3
+     * 1 * 2 * 3 => ((1 * 2) * 3)
+     */
+    def toFormula[A](init: Formula[A], rest: List[(String, Formula[A])]): Formula[A] =
+      rest match {
+        case Nil => init
+        case (op, next) :: Nil => Op(init, op, next)
+        case (op1, next1) :: (right@((op2, next2) :: tail)) =>
+          val c = compareOperator(op1, op2)
+          if (c > 0) {
+            // right binds tighter
+            // 1 + 2 * 3 .... => 1 + toFormula(2 * 3 ...)
+            val f2 = Op(next1, op2, next2)
+            toFormula(init, (op1, f2) :: tail)
+          }
+          else {
+            // 1 + 2 + 3 => (1 + 2) + 3
+            // 1 * 2 + 3 => (1 * 2) + 3
+            toFormula(Op(init, op1, next1), right)
+          }
+      }
+
+    /**
+     * Parse a chain of at least 1 operator being applied
+     */
+    def infixOps1[A](p: P[A]): P[A => Formula[A]] = {
+      val chain: P[List[(String, A)]] =
+        P(Parser.maybeSpace ~ operatorToken ~ Parser.maybeSpacesAndLines ~ p)
+          .rep(min = 1)
+          .map(_.toList)
+
+      chain.map { rest =>
+
+        { a: A => toFormula(Sym(a), rest.map { case (o, s) => (o, Sym(s)) }) }
+      }
+    }
+    /**
+     * An a formula is a series of A's separated by spaces, with
+     * the correct parenthesis
+     */
+    def parser[A](p: P[A]): P[Formula[A]] =
+      (p ~ (infixOps1(p)).?)
+        .map {
+          case (a, None) => Sym(a)
+          case (a, Some(f)) => f(a)
+        }
+  }
+}

--- a/core/src/main/scala/org/bykn/bosatsu/Operators.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/Operators.scala
@@ -38,8 +38,11 @@ object Operators {
       "&", "|", "^",
       "?", "~").map(_.intern)
 
+  private val multiToks: List[String] =
+    ".".intern :: singleToks ::: List("=".intern)
+
   private val priorityMap: Map[String, Int] =
-    (singleToks ::: List("="))
+    multiToks
       .iterator
       .zipWithIndex
       .toMap
@@ -53,10 +56,10 @@ object Operators {
 
     val singles = from(singleToks)
     // = can appear with at least one other character
-    val withEqual = from("=" :: singleToks).rep(min = 2)
+    val twoOrMore: P[Unit] = from(multiToks).rep(min = 2)
     // we can also repeat core operators one or more times
-    val noEqual = singles.rep(min = 1)
-    (withEqual | noEqual).!.map(_.intern)
+    val singleP = singles.rep(min = 1)
+    (twoOrMore | singleP).!.map(_.intern)
   }
 
   sealed abstract class Formula[+A] {

--- a/core/src/main/scala/org/bykn/bosatsu/Operators.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/Operators.scala
@@ -29,7 +29,11 @@ object Operators {
     else loop(0)
   }
 
-  private val singleToks =
+  /**
+   * strings for operators allowed in single character
+   * operators (excludes = and .)
+   */
+  val singleToks =
     List(
       "*", "/", "%",
       "+", "-",
@@ -38,7 +42,11 @@ object Operators {
       "&", "|", "^",
       "?", "~").map(_.intern)
 
-  private val multiToks: List[String] =
+  /**
+   * strings for operators allowed in single character
+   * operators includes singleToks and . and =
+   */
+  val multiToks: List[String] =
     ".".intern :: singleToks ::: List("=".intern)
 
   private val priorityMap: Map[String, Int] =
@@ -102,6 +110,7 @@ object Operators {
 
     /**
      * Parse a chain of at least 1 operator being applied
+     * with the operator precedence handled by the formula
      */
     def infixOps1[A](p: P[A]): P[A => Formula[A]] = {
       val chain: P[List[(String, A)]] =

--- a/core/src/main/scala/org/bykn/bosatsu/Parser.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/Parser.scala
@@ -294,4 +294,24 @@ object Parser {
   }
 
   val toEOL: P[Unit] = P(maybeSpace ~ "\n")
+
+  /**
+   * Here are a list of operators we allow
+   */
+  val operatorToken: P[String] = {
+    def from(strs: Iterable[String]): P[Unit] =
+      strs.map(P(_)).reduce(_ | _)
+
+    val singleToks = List(
+      "+", "-", "*", "!", "$", "%",
+      "^", "&", "|", "?", "/", "<",
+      ">", "~")
+
+    val singles = from(singleToks)
+    // = can appear with at least one other character
+    val withEqual = from("=" :: singleToks).rep(min = 2)
+    // we can also repeat core operators one or more times
+    val noEqual = singles.rep(min = 1)
+    (withEqual | noEqual).!
+  }
 }

--- a/core/src/main/scala/org/bykn/bosatsu/Parser.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/Parser.scala
@@ -294,24 +294,4 @@ object Parser {
   }
 
   val toEOL: P[Unit] = P(maybeSpace ~ "\n")
-
-  /**
-   * Here are a list of operators we allow
-   */
-  val operatorToken: P[String] = {
-    def from(strs: Iterable[String]): P[Unit] =
-      strs.map(P(_)).reduce(_ | _)
-
-    val singleToks = List(
-      "+", "-", "*", "!", "$", "%",
-      "^", "&", "|", "?", "/", "<",
-      ">", "~")
-
-    val singles = from(singleToks)
-    // = can appear with at least one other character
-    val withEqual = from("=" :: singleToks).rep(min = 2)
-    // we can also repeat core operators one or more times
-    val noEqual = singles.rep(min = 1)
-    (withEqual | noEqual).!
-  }
 }

--- a/core/src/test/scala/org/bykn/bosatsu/EvaluationTest.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/EvaluationTest.scala
@@ -1134,4 +1134,15 @@ main = Foo(1, `package`, 3, 4)
       ("def" -> Json.JNumberStr("4")))
     ))
   }
+
+  test("test operators") {
+    evalTest(List("""
+package A
+
+operator + = add
+operator * = times
+
+main = 1 + 2 * 3
+"""), "A", VInt(7))
+  }
 }

--- a/core/src/test/scala/org/bykn/bosatsu/Gen.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/Gen.scala
@@ -434,6 +434,8 @@ object Generators {
           case Apply(fn, args, _) =>
             val next = fn #:: args.toList.toStream
             next.flatMap(apply _)
+          case ao@ApplyOp(left, op, right) =>
+            left #:: ao.opVar #:: right #:: Stream.empty
           case Binding(b) =>
             val next = b.value #:: b.in.padded #:: Stream.empty
             next #::: next.flatMap(apply _)

--- a/core/src/test/scala/org/bykn/bosatsu/Gen.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/Gen.scala
@@ -234,7 +234,7 @@ object Generators {
       useDot = dotApply && isVar(fn) // f.bar needs the fn to be a var
       argsGen = if (useDot) arg.map(NonEmptyList(_, Nil)) else nonEmpty(arg)
       args <- argsGen
-    } yield Apply(fn, args, false)(emptyRegion)) // TODO this should pass if we use `foo.bar(a, b)` syntax
+    } yield Apply(fn, args, ApplyKind.Parens)(emptyRegion)) // TODO this should pass if we use `foo.bar(a, b)` syntax
   }
 
   def bindGen[A, T](patGen: Gen[A], dec: Gen[Declaration], tgen: Gen[T]): Gen[BindingStatement[A, T]] =

--- a/core/src/test/scala/org/bykn/bosatsu/OperatorTest.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/OperatorTest.scala
@@ -1,0 +1,74 @@
+package org.bykn.bosatsu
+
+import org.typelevel.paiges.{ Doc, Document }
+import Parser.Combinators
+import fastparse.all._
+
+class OperatorTest extends ParserTestBase {
+
+  import Operators.Formula
+  import TestUtils.runBosatsuTest
+
+  sealed abstract class F {
+    def toFormula: Formula[String] =
+      this match {
+        case F.Num(s) => Formula.Sym(s)
+        case F.Form(Formula.Sym(n)) => n.toFormula
+        case F.Form(Formula.Op(left, op, right)) =>
+          Formula.Op(F.Form(left).toFormula, op, F.Form(right).toFormula)
+      }
+  }
+  object F {
+    case class Num(str: String) extends F
+    case class Form(toForm: Formula[F]) extends F
+  }
+
+  lazy val formP: Parser[F] =
+    Operators.Formula
+      .parser(Parser.integerString.map(F.Num(_)) |
+        P(formP.parens)).map(F.Form(_))
+
+  implicit val document: Document[Formula[String]] =
+    Document.instance[Formula[String]] {
+      case Formula.Sym(n) => Doc.text(n)
+      case Formula.Op(l, o, r) =>
+        document.document(l) + Doc.text(o) + document.document(r)
+    }
+
+  def parseSame(left: String, right: String) =
+    assert(parseUnsafe(formP, left).toFormula == parseUnsafe(formP, right).toFormula)
+
+  test("we can parse integer formulas") {
+    parseSame("1+2", "1 + 2")
+    parseSame("1+(2*3)", "1 + 2*3")
+    parseSame("1+2+3", "(1 + 2) + 3")
+    parseSame("1+2+3+4", "((1 + 2) + 3) + 4")
+    parseSame("1*2+3*4", "(1 * 2) + (3 * 4)")
+    parseSame("1&2|3&4", "(1 & 2) | (3 & 4)")
+    parseSame("1&2^3&4", "(1 & 2) ^ (3 & 4)")
+    parseSame("1 < 2 & 3 < 4", "(1 < 2) & (3 < 4)")
+    parseSame("1 <= 2 & 3 <= 4", "(1 <= 2) & (3 <= 4)")
+    parseSame("1 <= 2 < 3", "(1 <= 2) < 3")
+    parseSame("0 < 1 <= 2", "0 < (1 <= 2)")
+    parseSame("1 ** 2 * 3", "(1 ** 2) * 3")
+    parseSame("3 * 1 ** 2", "3 * (1 ** 2)")
+    parseSame("1 + 2 == 2 + 1", "(1 + 2) == (2 + 1)")
+    parseSame("1 + 2 * 3 == 1 + (2 * 3)", "(1 + (2*3)) == (1 + (2 * 3))")
+  }
+
+  test("test operator precedence in real programs") {
+    runBosatsuTest(List("""
+package Test
+
+operator + = add
+operator * = times
+operator == = eq_Int
+
+test = Test("precedence", [
+   Assertion(1 + 2 * 3 == 1 + (2 * 3), "p1"),
+   Assertion(1 + 2 * 3 == 1 + (2 * 3), "p1"),
+   Assertion(1 + 2 * 3 == 1 + (2 * 3), "p1")
+   ])
+"""), "Test", 3)
+  }
+}

--- a/core/src/test/scala/org/bykn/bosatsu/OperatorTest.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/OperatorTest.scala
@@ -116,4 +116,27 @@ test = Test("import export",
     Assertion(1 .+ 2 * 3 == (1 .+ 2) * 3, "p1") ])
 """), "T2", 2)
   }
+
+  test("test ternary operator precedence") {
+    runBosatsuTest(List("""
+package Test
+
+operator == = eq_Int
+operator + = add
+
+left1 = 1 + 2 if False else 4
+# should be 4 not 1 + 4
+right1 = 4
+
+left2 = 1 if True else 2 + 3
+# above should be 1 not (1 + 3)
+right2 = 1
+
+test = Test("precedence",
+  [
+    Assertion(left1 == right1, "p1"),
+    Assertion(left2 == right2, "p2"),
+  ])
+"""), "Test", 2)
+  }
 }

--- a/core/src/test/scala/org/bykn/bosatsu/OperatorTest.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/OperatorTest.scala
@@ -54,6 +54,8 @@ class OperatorTest extends ParserTestBase {
     parseSame("3 * 1 ** 2", "3 * (1 ** 2)")
     parseSame("1 + 2 == 2 + 1", "(1 + 2) == (2 + 1)")
     parseSame("1 + 2 * 3 == 1 + (2 * 3)", "(1 + (2*3)) == (1 + (2 * 3))")
+    parseSame("1 +. 2 * 3 == 1 +. (2 * 3)", "(1 +. (2*3)) == (1 +. (2 * 3))")
+    parseSame("1 .+ 2 * 3 == (1 .+ 2) * 3", "((1 .+ 2) *3) == ((1 .+ 2) * 3)")
   }
 
   test("test operator precedence in real programs") {
@@ -63,12 +65,36 @@ package Test
 operator + = add
 operator * = times
 operator == = eq_Int
+def operator %(a, b): mod_Int(a, b)
 
-test = Test("precedence", [
-   Assertion(1 + 2 * 3 == 1 + (2 * 3), "p1"),
-   Assertion(1 + 2 * 3 == 1 + (2 * 3), "p1"),
-   Assertion(1 + 2 * 3 == 1 + (2 * 3), "p1")
-   ])
+test = Test("precedence",
+  [
+    Assertion(1 + 2 * 3 == 1 + (2 * 3), "p1"),
+    Assertion(1 * 2 * 3 == (1 * 2) * 3, "p1"),
+    Assertion(1 + 2 % 3 == 1 + (2 % 3), "p1")
+  ])
 """), "Test", 3)
+
+    runBosatsuTest(List("""
+package T1
+
+export [ operator +, operator *, operator == ]
+
+operator + = add
+operator * = times
+operator == = eq_Int
+""",
+  """
+package T2
+
+import T1 [ operator + as operator ++, `*`, `==` ]
+
+`.+` = `++`
+`+.` = `++`
+
+test = Test("import export",
+  [ Assertion(1 +. (2 * 3) == 1 .+ (2 * 3), "p1"),
+    Assertion(1 .+ 2 * 3 == (1 .+ 2) * 3, "p1") ])
+"""), "T2", 2)
   }
 }

--- a/core/src/test/scala/org/bykn/bosatsu/OperatorTest.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/OperatorTest.scala
@@ -76,6 +76,25 @@ test = Test("precedence",
 """), "Test", 3)
 
     runBosatsuTest(List("""
+package Test
+
+# this is non-associative so we can test order
+operator *> = \x, y -> (x, y)
+
+operator == = \x, y ->
+  # kind of an interesting style to make local operators
+  `=*=` = eq_Int
+  `&` = \x, y -> y if x else False
+  (((a, b), c), ((d, e), f)) = (x, y)
+  (a =*= d) & (b =*= e) & (c =*= f)
+
+test = Test("precedence",
+  [
+    Assertion(1 *> 2 *> 3 == (1 *> 2) *> 3, "p1"),
+  ])
+"""), "Test", 1)
+
+    runBosatsuTest(List("""
 package T1
 
 export [ operator +, operator *, operator == ]

--- a/core/src/test/scala/org/bykn/bosatsu/ParserTest.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/ParserTest.scala
@@ -400,8 +400,8 @@ class SyntaxParseTest extends ParserTestBase {
 
   implicit val generatorDrivenConfig =
     //PropertyCheckConfiguration(minSuccessful = 5000)
-    //PropertyCheckConfiguration(minSuccessful = 300)
-    PropertyCheckConfiguration(minSuccessful = 5)
+    PropertyCheckConfiguration(minSuccessful = 300)
+    //PropertyCheckConfiguration(minSuccessful = 5)
 
   def mkVar(n: String): Declaration.Var =
     Declaration.Var(Identifier.Name(n))

--- a/core/src/test/scala/org/bykn/bosatsu/ParserTest.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/ParserTest.scala
@@ -386,10 +386,10 @@ class ParserTest extends ParserTestBase {
     val allLen3 = (allLen2, withEq).mapN(_ + _)
 
     (singleToks ::: allLen2 ::: allLen3).foreach { opStr =>
-      roundTrip(Parser.operatorToken, opStr)
+      roundTrip(Operators.operatorToken, opStr)
     }
 
-    expectFail(Parser.operatorToken, "=", 0)
+    expectFail(Operators.operatorToken, "=", 0)
   }
 }
 

--- a/core/src/test/scala/org/bykn/bosatsu/ParserTest.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/ParserTest.scala
@@ -534,7 +534,7 @@ x""")
   }
 
   test("Declaration.toPattern works for all Pattern-like declarations") {
-    forAll(Generators.patternDecl(5)) { dec =>
+    def law1(dec: Declaration) = {
       Declaration.toPattern(dec) match {
         case None => fail("expected to convert to pattern")
         case Some(pat) =>
@@ -543,6 +543,15 @@ x""")
           val parsePat = parseUnsafe(Pattern.parser, decStr)
           assert(pat == parsePat)
       }
+    }
+    forAll(Generators.patternDecl(5))(law1(_))
+
+    {
+      import Declaration._
+      import Identifier.{Name, Operator}
+      // this operator application can be a pattern
+      val regression = ApplyOp(Var(Name("q")),Operator("|"),Var(Name("npzma")))
+      law1(regression)
     }
 
     // for all Declarations, either it parses like a pattern or toPattern is None


### PR DESCRIPTION
Implement the proposal from #12 

- [x] make Gen emit operators both in Var and applying form
- [x] consider a more constrained Declaration than Apply, which can't prove it has the right shape.
- [x] use operators in more tests and examples
- [x] exercise imports of operators in tests
- [x] implement prioritization so that `*` is applied before `+` and `&` is applied before `|` and `^`.

cc @snoble 