### PR TITLE
Add support to run bosatsu tests inside scala tests

### DIFF
--- a/core/src/main/scala/org/bykn/bosatsu/Test.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/Test.scala
@@ -2,7 +2,21 @@ package org.bykn.bosatsu
 
 import org.typelevel.paiges.Doc
 
-sealed abstract class Test
+sealed abstract class Test {
+  def assertions: Int =
+    Test.assertions(this)
+
+  def failures: Option[Test] =
+    this match {
+      case Test.Assertion(true, _) => None
+      case f@Test.Assertion(false, _) => Some(f)
+      case Test.Suite(nm, ts) => {
+        val innerFails = ts.flatMap(_.failures.toList)
+        if (innerFails.isEmpty) None
+        else Some(Test.Suite(nm, innerFails))
+      }
+    }
+}
 
 object Test {
   case class Assertion(value: Boolean, message: String) extends Test


### PR DESCRIPTION
The idea here is to:

1. exercise the built in testing code in predef more.
2. write more tests fully in bosatsu vs having to encode the results as Value.
3. make it easier to have many assertions in a single test.
4. increase test coverage since we weren't exercising the Evaluation test support in scalatest tests.