### PR TITLE
Issue with metavariables not fully inferred

### DIFF
--- a/core/src/main/scala/org/bykn/bosatsu/PackageMap.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/PackageMap.scala
@@ -62,7 +62,7 @@ object PackageMap {
       Statement
     ]
   ]
-  
+
   type Inferred = Typed[Declaration]
 
   /**
@@ -397,10 +397,16 @@ object PackageError {
 
   case class TotalityCheckError(pack: PackageName, err: TotalityCheck.ExprError[Declaration]) extends PackageError {
     def message(sourceMap: Map[PackageName, (LocationMap, String)]) = {
-      val (lm, sourceName) = sourceMap(pack)
+      val (lm, sourceName) = sourceMap.get(pack) match {
+        case None => (LocationMap(""), "<unknown source>")
+        case Some(found) => found
+      }
       val teMessage = err.toString
+      val region = err.matchExpr.tag.region
+      val context1 =
+        lm.showRegion(region).getOrElse(region.toString) // we should highlight the whole region
       // TODO use the sourceMap/regions in Infer.Error
-      s"in file: $sourceName, package ${pack.asString}, $teMessage"
+      s"in file: $sourceName, package ${pack.asString}\n$context1"
     }
   }
 

--- a/core/src/main/scala/org/bykn/bosatsu/TotalityCheck.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/TotalityCheck.scala
@@ -20,7 +20,9 @@ object TotalityCheck {
   case class UnknownConstructor(cons: Cons, in: Pattern[Cons, Type], env: TypeEnv[Any]) extends Error
   case class MultipleSplicesInPattern(pat: ListPat[Cons, Type], env: TypeEnv[Any]) extends Error
 
-  sealed abstract class ExprError[A]
+  sealed abstract class ExprError[A] {
+    def matchExpr: Expr.Match[A]
+  }
   case class NonTotalMatch[A](matchExpr: Expr.Match[A], missing: NonEmptyList[Pattern[Cons, Type]]) extends ExprError[A]
   case class InvalidPattern[A](matchExpr: Expr.Match[A], err: Error) extends ExprError[A]
 }

--- a/core/src/main/scala/org/bykn/bosatsu/rankn/Infer.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/rankn/Infer.scala
@@ -945,7 +945,12 @@ object Infer {
 
       // todo this should be a law...
     res.map { te =>
-      scala.Predef.require(Type.freeTyVars(te.getType :: Nil).isEmpty, te.getType.toString)
+      val tp = te.getType
+      lazy val teStr = TypeRef.fromTypes(None, tp :: Nil)(tp).toDoc.render(80)
+      scala.Predef.require(Type.freeTyVars(tp :: Nil).isEmpty, s"illegal inferred type: $teStr")
+
+      scala.Predef.require(Type.innerMetas(tp).isEmpty,
+        s"illegal inferred type: $teStr")
       te
     }
   }

--- a/core/src/main/scala/org/bykn/bosatsu/rankn/Infer.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/rankn/Infer.scala
@@ -430,7 +430,7 @@ object Infer {
       ty2 match {
         case Type.TyMeta(m2) =>
           readMeta(m2).flatMap {
-            case Some(ty2) => unify(Type.TyMeta(m), ty2, right, left)
+            case Some(ty2) => unify(Type.TyMeta(m), ty2, left, right)
             case None => writeMeta(m, ty2)
           }
         case nonMeta =>

--- a/core/src/main/scala/org/bykn/bosatsu/rankn/Infer.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/rankn/Infer.scala
@@ -3,6 +3,8 @@ import cats.Monad
 import cats.data.{NonEmptyList, Writer}
 import cats.implicits._
 
+import scala.collection.immutable.SortedSet
+
 import org.bykn.bosatsu.{
   Expr,
   HasRegion,
@@ -147,8 +149,8 @@ object Infer {
     }
 
     // This could be a user error if we don't check scoping before typing
-    case class UnexpectedBound(v: Type.Var.Bound, in: Type) extends NameError {
-      def message = s"unexpected bound ${v.name} in unification with $in"
+    case class UnexpectedBound(v: Type.Var.Bound, in: Type, rb: Region, rt: Region) extends NameError {
+      def message = s"unexpected bound ${v.name} at $rb in unification with $in at $rt"
     }
 
     case class UnknownConstructor(name: (PackageName, Constructor), env: Env) extends NameError {
@@ -163,8 +165,8 @@ object Infer {
      * These can only happen if the compiler has bugs at some point
      */
     sealed abstract class InternalError extends Error
-    case class UnexpectedMeta(m: Type.Meta, in: Type) extends InternalError {
-      def message = s"meta $m occurs in $in and should not"
+    case class UnexpectedMeta(m: Type.Meta, in: Type, left: Region, right: Region) extends InternalError {
+      def message = s"meta $m at $left occurs in $in at $right and should not. This implies an infinite type."
     }
 
     // This is a logic error which should never happen
@@ -248,7 +250,7 @@ object Infer {
     /**
      * Meta vars point to unknown instantiated parametric types
      */
-    def getMetaTyVars(tpes: List[Type]): Infer[Set[Type.Meta]] =
+    def getMetaTyVars(tpes: List[Type]): Infer[SortedSet[Type.Meta]] =
       tpes.traverse(zonkType).map(Type.metaTvs(_))
 
     /**
@@ -423,21 +425,18 @@ object Infer {
           } yield (argT, resT)
       }
 
-    def occursCheckErr(m: Type.Meta, t: Type): Infer[Unit] =
-      fail(Error.UnexpectedMeta(m, t))
-
     // invariant the flexible type variable tv1 is not bound
     def unifyUnboundVar(m: Type.Meta, ty2: Type.Tau, left: Region, right: Region): Infer[Unit] =
       ty2 match {
         case Type.TyMeta(m2) =>
           readMeta(m2).flatMap {
-            case Some(ty2) => unify(Type.TyMeta(m), ty2, left, right)
+            case Some(ty2) => unify(Type.TyMeta(m), ty2, right, left)
             case None => writeMeta(m, ty2)
           }
         case nonMeta =>
           getMetaTyVars(List(nonMeta))
             .flatMap { tvs2 =>
-              if (tvs2(m)) occursCheckErr(m, nonMeta)
+              if (tvs2(m)) fail(Error.UnexpectedMeta(m, nonMeta, left, right))
               else writeMeta(m, nonMeta)
             }
       }
@@ -451,9 +450,9 @@ object Infer {
     def unify(t1: Type.Tau, t2: Type.Tau, r1: Region, r2: Region): Infer[Unit] =
       (t1, t2) match {
         case (Type.TyVar(b@Type.Var.Bound(_)), _) =>
-          fail(Error.UnexpectedBound(b, t2))
+          fail(Error.UnexpectedBound(b, t2, r1, r2))
         case (_, Type.TyVar(b@Type.Var.Bound(_))) =>
-          fail(Error.UnexpectedBound(b, t1))
+          fail(Error.UnexpectedBound(b, t1, r2, r1))
         // the only vars that should appear are skolem variables, we check here
         case (Type.TyVar(v1), Type.TyVar(v2)) if v1 == v2 => unit
         case (Type.TyMeta(m1), Type.TyMeta(m2)) if m1.id == m2.id => unit
@@ -605,9 +604,10 @@ object Infer {
                   for {
                     // the type variable needs to be unified with varT
                     // note, varT could be a sigma type, it is not a Tau or Rho
-                    typedRhs <- inferSigmaMeta(rhs, Some((rhsTpe, region(rhs))))
+                    typedRhs <- inferSigmaMeta(rhs, Some((name, rhsTpe, region(rhs))))
                     varT = typedRhs.getType
-                    typedBody <- typeCheckRho(body, expect)
+                    // we need to overwrite the metavariable now with the full type
+                    typedBody <- extendEnv(name, varT)(typeCheckRho(body, expect))
                     // TODO: a more efficient algorithm would do this top down
                     // for each top level TypedExpr and build it bottom up.
                     // we could do this after all typechecking is done
@@ -862,17 +862,21 @@ object Infer {
     def inferSigma[A: HasRegion](e: Expr[A]): Infer[TypedExpr[A]] =
       inferSigmaMeta(e, None)
 
-    def inferSigmaMeta[A: HasRegion](e: Expr[A], meta: Option[(Type.TyMeta, Region)]): Infer[TypedExpr[A]] =
+    def inferSigmaMeta[A: HasRegion](e: Expr[A], meta: Option[(Identifier, Type.TyMeta, Region)]): Infer[TypedExpr[A]] =
       for {
         rho <- inferRho(e)
         expTy = rho.getType
         _ <- meta match {
-          case None => pure(())
-          case Some((m, r)) => unify(expTy, m, region(e), r)
+          case None =>
+            pure(())
+          case Some((_, m, r)) =>
+            unify(expTy, m, region(e), r)
         }
-        envTys <- getEnv
+        envTys0 <- getEnv
+        // we have to remove the recursive binding from the environment
+        envTys = envTys0 -- meta.toList.map { case (i, _, _) => (None, i) }
         envTypeVars <- getMetaTyVars(envTys.values.toList)
-        resTypeVars <- getMetaTyVars(List(expTy))
+        resTypeVars <- getMetaTyVars(expTy :: Nil)
         forAllTvs = resTypeVars -- envTypeVars
         q <- quantify(forAllTvs.toList, rho)
       } yield q
@@ -905,13 +909,16 @@ object Infer {
 
   def recursiveTypeCheck[A: HasRegion](name: Bindable, expr: Expr[A]): Infer[TypedExpr[A]] =
     newMetaType.flatMap { tpe =>
-      extendEnv(name, tpe)(typeCheck(expr))
+      extendEnv(name, tpe)(typeCheckMeta(expr, Some((name, tpe, region(expr)))))
     }
 
 
-  def typeCheck[A: HasRegion](t: Expr[A]): Infer[TypedExpr[A]] = {
-    // TODO handle rec
-    def run(t: Expr[A]) = inferSigma(t).flatMap(zonkTypedExpr _)
+  def typeCheck[A: HasRegion](t: Expr[A]): Infer[TypedExpr[A]] =
+    typeCheckMeta(t, None)
+
+
+  private def typeCheckMeta[A: HasRegion](t: Expr[A], optMeta: Option[(Identifier, Type.TyMeta, Region)]): Infer[TypedExpr[A]] = {
+    def run(t: Expr[A]) = inferSigmaMeta(t, optMeta).flatMap(zonkTypedExpr _)
     /*
      * This is a deviation from the paper.
      * We are allowing a syntax like:
@@ -949,7 +956,7 @@ object Infer {
       lazy val teStr = TypeRef.fromTypes(None, tp :: Nil)(tp).toDoc.render(80)
       scala.Predef.require(Type.freeTyVars(tp :: Nil).isEmpty, s"illegal inferred type: $teStr")
 
-      scala.Predef.require(Type.innerMetas(tp).isEmpty,
+      scala.Predef.require(Type.metaTvs(tp :: Nil).isEmpty,
         s"illegal inferred type: $teStr")
       te
     }

--- a/core/src/main/scala/org/bykn/bosatsu/rankn/Type.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/rankn/Type.scala
@@ -134,6 +134,13 @@ object Type {
       case TyConst(_) | TyVar(_) | TyMeta(_) => t
     }
 
+  def innerMetas(t: Type): List[Meta] =
+    t match {
+      case TyMeta(m) => m :: Nil
+      case TyVar(_) | TyConst(_) => Nil
+      case ForAll(_, r) => innerMetas(r)
+      case TyApply(l, r) => innerMetas(l) ::: innerMetas(r)
+    }
   /**
    * Return the Bound and Skolem variables that
    * are free in the given list of types

--- a/core/src/test/scala/org/bykn/bosatsu/Regressions.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/Regressions.scala
@@ -1,0 +1,100 @@
+package org.bykn.bosatsu
+
+import org.scalatest.FunSuite
+
+class Regressions extends FunSuite {
+  import TestUtils._
+  import Evaluation.Value._
+
+  test("example from https://github.com/johnynek/bosatsu/issues/196") {
+    evalTestJson(
+      List(
+"""package Example/Resuitset
+
+struct Resultset(data, fields)
+
+struct Field(name: String, accessor: a -> b)
+
+struct Row(firstName: String, lastName: String, age: Int)
+
+def firstName(row: Row) -> String:
+  Row(result, _, _) = row
+  result
+
+def lastName(row: Row) -> String:
+  Row(_, result, _) = row
+  result
+
+def age(row: Row) -> Int:
+  Row(_, _, result) = row
+  result
+
+fields = (Field("first", firstName),
+  Some((Field("last", lastName),
+    Some((Field("age", age),
+      None)))))
+
+rs = Resultset([Row("a", "b", 1), Row("c", "d", 2)], fields)
+
+def applyFields(fields, row):
+  recur fields:
+    (field, Some(s)):
+      Field(_, fn) = field
+      (fn(row), Some(applyFields(s, row)))
+    (field, None):
+      Field(_, fn) = field
+      (fn(row), None)
+
+def materialize(rs):
+  Resultset(rows, fields) = rs
+  #[applyFields(fields, row) for row in rows]
+  rows.map_List(\row -> applyFields(fields, row))
+
+def addField(resultset, name: String, fn: a -> b):
+  Resultset(old_data, old_fields) = resultset
+  new_fields = (Field(name, fn), Some(old_fields))
+  Resultset(old_data, new_fields)
+
+def filterRecords(records, fn: a -> Bool):
+  records.flat_map_List(\row ->
+    keep = fn(row)
+    match keep:
+      True: [row]
+      False: [])
+
+def filter(rs, fn: a -> Bool):
+  Resultset(old_records, same_fields) = rs
+  new_records = filterRecords(old_records, fn)
+  Resultset(new_records, same_fields)
+
+def new_age(row):
+  row.age.add(10)
+
+new_resultset = rs.addField("newAge", new_age)
+filtered_resultset = new_resultset.filter(\row -> eq_Int(row.new_age, 11))
+
+out = materialize(filtered_resultset)
+"""), "Example/Resuitset", Json.JString("foo"))
+  }
+
+  test("test complex recursion case from #196") {
+    evalTest(List("""
+package Foo
+
+struct Field(name: String, extract: a -> b)
+
+def applyFields(fields, row):
+  recur fields:
+    (f, Some(s)):
+      Field(_, fn) = f
+      rec = applyFields(s, row)
+      (fn(row), Some(rec))
+    (f, None):
+      Field(_, fn) = f
+      (fn(row), None)
+
+hlist = (Field("a", \x -> "a"), Some((Field("b", \x -> "b"), None)))
+main = applyFields(hlist, 1)
+"""), "Foo", VInt(42))
+  }
+}

--- a/core/src/test/scala/org/bykn/bosatsu/Regressions.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/Regressions.scala
@@ -4,81 +4,9 @@ import org.scalatest.FunSuite
 
 class Regressions extends FunSuite {
   import TestUtils._
-  import Evaluation.Value._
-
-  test("example from https://github.com/johnynek/bosatsu/issues/196") {
-    evalTestJson(
-      List(
-"""package Example/Resuitset
-
-struct Resultset(data, fields)
-
-struct Field(name: String, accessor: a -> b)
-
-struct Row(firstName: String, lastName: String, age: Int)
-
-def firstName(row: Row) -> String:
-  Row(result, _, _) = row
-  result
-
-def lastName(row: Row) -> String:
-  Row(_, result, _) = row
-  result
-
-def age(row: Row) -> Int:
-  Row(_, _, result) = row
-  result
-
-fields = (Field("first", firstName),
-  Some((Field("last", lastName),
-    Some((Field("age", age),
-      None)))))
-
-rs = Resultset([Row("a", "b", 1), Row("c", "d", 2)], fields)
-
-def applyFields(fields, row):
-  recur fields:
-    (field, Some(s)):
-      Field(_, fn) = field
-      (fn(row), Some(applyFields(s, row)))
-    (field, None):
-      Field(_, fn) = field
-      (fn(row), None)
-
-def materialize(rs):
-  Resultset(rows, fields) = rs
-  #[applyFields(fields, row) for row in rows]
-  rows.map_List(\row -> applyFields(fields, row))
-
-def addField(resultset, name: String, fn: a -> b):
-  Resultset(old_data, old_fields) = resultset
-  new_fields = (Field(name, fn), Some(old_fields))
-  Resultset(old_data, new_fields)
-
-def filterRecords(records, fn: a -> Bool):
-  records.flat_map_List(\row ->
-    keep = fn(row)
-    match keep:
-      True: [row]
-      False: [])
-
-def filter(rs, fn: a -> Bool):
-  Resultset(old_records, same_fields) = rs
-  new_records = filterRecords(old_records, fn)
-  Resultset(new_records, same_fields)
-
-def new_age(row):
-  row.age.add(10)
-
-new_resultset = rs.addField("newAge", new_age)
-filtered_resultset = new_resultset.filter(\row -> eq_Int(row.new_age, 11))
-
-out = materialize(filtered_resultset)
-"""), "Example/Resuitset", Json.JString("foo"))
-  }
 
   test("test complex recursion case from #196") {
-    evalTest(List("""
+    evalFail(List("""
 package Foo
 
 struct Field(name: String, extract: a -> b)
@@ -95,6 +23,6 @@ def applyFields(fields, row):
 
 hlist = (Field("a", \x -> "a"), Some((Field("b", \x -> "b"), None)))
 main = applyFields(hlist, 1)
-"""), "Foo", VInt(42))
+"""), "Foo") { case PackageError.TypeErrorIn(_, _) => () }
   }
 }

--- a/core/src/test/scala/org/bykn/bosatsu/TestUtils.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/TestUtils.scala
@@ -101,10 +101,15 @@ object TestUtils {
         ev.evaluateLast(mainPack) match {
           case None => fail("found no main expression")
           case Some((eval, schm)) =>
+            val typeStr = TypeRef.fromTypes(Some(mainPack), schm :: Nil)(schm).toDoc.render(80)
             expected match {
-              case EvaluationMode.EvalMode(exp) => assert(eval.value == exp)
+              case EvaluationMode.EvalMode(exp) =>
+                val left = eval.value
+                assert(left == exp,
+                  s"failed: for type: $typeStr, ${left} != $exp")
               case EvaluationMode.JsonMode(json) =>
-                assert(ev.toJson(eval.value, schm) == Some(json))
+                val leftJson = ev.toJson(eval.value, schm)
+                assert(leftJson == Some(json), s"type: $typeStr, $leftJson != $json")
               case EvaluationMode.TestMode(cnt) =>
                 ev.evalTest(mainPack) match {
                   case None => fail(s"$mainPack had no tests evaluted")

--- a/core/src/test/scala/org/bykn/bosatsu/TestUtils.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/TestUtils.scala
@@ -64,8 +64,7 @@ object TestUtils {
   object EvaluationMode {
     case class JsonMode(expected: Json) extends EvaluationMode[Json]
     case class EvalMode(expected: Evaluation.Value) extends EvaluationMode[Evaluation.Value]
-    case class TestMode(expected: Int) extends EvaluationMode[Int] {
-    }
+    case class TestMode(expected: Int) extends EvaluationMode[Int]
   }
 
   def evalTest(packages: List[String], mainPackS: String, expected: Evaluation.Value, extern: Externals = Externals.empty) =


### PR DESCRIPTION
I added a requirement (which I thought was there) that metas never escape. It's not cool to have that requirement, but it does show that there are a few places with this bug currently.

this was discovered in #196 

I guess we are missing a call to quantify/zonk...

However, if that were the case, those shoudn't cause anything to not typecheck. I think this is also related to recursive methods. I think all the current examples of failures are recursive methods.