### PR TITLE
Support patterns in def args

### DIFF
--- a/core/src/main/scala/org/bykn/bosatsu/DefStatement.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/DefStatement.scala
@@ -1,30 +1,27 @@
 package org.bykn.bosatsu
 
 import Parser.{ Combinators, maybeSpace, spaces }
-import cats.Functor
 import cats.data.NonEmptyList
 import cats.implicits._
 import fastparse.all._
 import org.bykn.fastparse_cats.StringInstances._
 import org.typelevel.paiges.{ Doc, Document }
 
-import Identifier.Bindable
+import Identifier.{Bindable, Constructor}
 
-case class DefStatement[T](
+case class DefStatement[A, B](
   name: Bindable,
-  args: List[(Bindable, Option[TypeRef])],
-  retType: Option[TypeRef], result: T) {
+  args: List[A],
+  retType: Option[TypeRef], result: B) {
 
-
-  def map[A](fn: T => A): DefStatement[A] =
-    copy(result = fn(result))
   /**
    * This ignores the name completely and just returns the lambda expression here
    *
    * This could be a traversal: TypeRef => F[rankn.Type] for an Applicative F[_]
    */
-  def toLambdaExpr[A](resultExpr: Expr[A], tag: A)(trFn: TypeRef => rankn.Type): Expr[A] = {
-    val unTypedBody = resultExpr
+  def toLambdaExpr[C](resultExpr: B => Expr[C],
+    tag: C)(argFn: A => Pattern[(PackageName, Constructor), rankn.Type], trFn: TypeRef => rankn.Type): Expr[C] = {
+    val unTypedBody = resultExpr(result)
     val bodyExp =
       retType.fold(unTypedBody) { t =>
         Expr.Annotation(unTypedBody, trFn(t), tag)
@@ -32,8 +29,8 @@ case class DefStatement[T](
     NonEmptyList.fromList(args) match {
       case None => bodyExp
       case Some(neargs) =>
-        val deepFunctor = Functor[NonEmptyList].compose[(Bindable, ?)].compose[Option]
-        Expr.buildLambda(deepFunctor.map(neargs)(trFn), bodyExp, tag)
+        val mappedArgs = neargs.map(argFn)
+        Expr.buildPatternLambda(mappedArgs, bodyExp, tag)
     }
   }
 }
@@ -41,26 +38,27 @@ case class DefStatement[T](
 object DefStatement {
   private[this] val defDoc = Doc.text("def ")
 
-  implicit def document[T: Document]: Document[DefStatement[T]] =
-    Document.instance[DefStatement[T]] { defs =>
+  implicit def document[A: Document, B: Document]: Document[DefStatement[A, B]] =
+    Document.instance[DefStatement[A, B]] { defs =>
       import defs._
       val res = retType.fold(Doc.empty) { t => Doc.text(" -> ") + t.toDoc }
       val argDoc =
         if (args.isEmpty) Doc.empty
         else {
+          val docA = Document[A]
           Doc.char('(') +
-            Doc.intercalate(Doc.text(", "), args.map(TypeRef.argDoc[Bindable] _)) +
+            Doc.intercalate(Doc.text(", "), args.map(docA.document(_))) +
             Doc.char(')')
         }
       val line0 = defDoc + Document[Bindable].document(name) + argDoc + res + Doc.text(":")
 
-      line0 + Document[T].document(result)
+      line0 + Document[B].document(result)
     }
 
     /**
      * The resultTParser should parse some indentation any newlines
      */
-    def parser[T](resultTParser: P[T]): P[DefStatement[T]] = {
+    def parser[A, B](argParser: P[A], resultTParser: P[B]): P[DefStatement[A, B]] = {
       val args = argParser.parensLines1
       val result = P(maybeSpace ~ "->" ~/ maybeSpace ~ TypeRef.parser).?
       P("def" ~ spaces ~/ Identifier.bindableParser ~ args.? ~
@@ -74,7 +72,4 @@ object DefStatement {
             DefStatement(name, args, resType, res)
         }
     }
-
-    val argParser: P[(Bindable, Option[TypeRef])] =
-      P(Identifier.bindableParser ~ maybeSpace ~ (":" ~/ maybeSpace ~ TypeRef.parser).?)
 }

--- a/core/src/main/scala/org/bykn/bosatsu/Expr.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/Expr.scala
@@ -177,17 +177,6 @@ object Expr {
         }
     }
 
-  def buildLambda[A](args: NonEmptyList[(Bindable, Option[rankn.Type])], body: Expr[A], outer: A): Expr[A] =
-    args match {
-      case NonEmptyList((arg, None), Nil) =>
-        Expr.Lambda(arg, body, outer)
-      case NonEmptyList((arg, Some(tpe)), Nil) =>
-        Expr.AnnotatedLambda(arg, tpe, body, outer)
-      case NonEmptyList(arg, h :: tail) =>
-        val body1 = buildLambda(NonEmptyList(h, tail), body, outer)
-        buildLambda(NonEmptyList.of(arg), body1, outer)
-    }
-
   def buildPatternLambda[A](
     args: NonEmptyList[Pattern[(PackageName, Constructor), rankn.Type]],
     body: Expr[A],

--- a/core/src/main/scala/org/bykn/bosatsu/Pattern.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/Pattern.scala
@@ -324,8 +324,8 @@ object Pattern {
         Doc.intercalate(Doc.text(" | "), (head :: rest.toList).map(doc(_)))
     }
 
-  val pwild = P("_").map(_ => WildCard)
-  val plit = Lit.parser.map(Literal(_))
+  private[this] val pwild = P("_").map(_ => WildCard)
+  private[this] val plit = Lit.parser.map(Literal(_))
 
   /**
    * This does not allow a top-level type annotation which would be ambiguous

--- a/core/src/main/scala/org/bykn/bosatsu/Program.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/Program.scala
@@ -136,11 +136,12 @@ object Program {
         case Comment(CommentStatement(_, Padding(_, on))) =>
           loop(on).copy(from = s)
         case Def(defstmt@DefStatement(_, _, _, _)) =>
-          val (lam, Program(te, binds, _)) = defstmt.result match {
-            case (body, Padding(_, in)) =>
-              // using body for the outer here is a bummer, but not really a good outer otherwise
-              val l = defstmt.toLambdaExpr(declToE(body.get), body.get)(_.toType(nameToType))
-              (l, loop(in))
+          // using body for the outer here is a bummer, but not really a good outer otherwise
+          val lam = defstmt.toLambdaExpr({ res => declToE(res._1.get) },
+            defstmt.result._1.get)(Declaration.unTuplePattern(_, nameToType, nameToCons), _.toType(nameToType))
+
+          val Program(te, binds, _) = defstmt.result match {
+            case (_, Padding(_, in)) => loop(in)
           }
           Program(te, (defstmt.name, RecursionKind.Recursive, lam) :: binds, stmt)
         case s@Struct(_, _, Padding(_, rest)) =>

--- a/core/src/test/scala/org/bykn/bosatsu/EvaluationTest.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/EvaluationTest.scala
@@ -1102,10 +1102,13 @@ main = 1 + 2 * 3
     runBosatsuTest(List("""
 package A
 
-# for an unknown reason, removing the ( ) breaks the following
-inc = \(x: Int) -> x.add(1)
+# you can't write \x: Int -> x.add(1)
+# since Int -> looks like a type
+# you need to protect it in a ( )
+inc: Int -> Int = \x -> x.add(1)
+inc2: Int -> Int = \(x: Int) -> x.add(1)
 
-test = Assertion(inc(1).eq_Int(2), "inc(1) == 2")
+test = Assertion(inc(1).eq_Int(inc2(1)), "inc(1) == 2")
 """), "A", 1)
 
     runBosatsuTest(List("""

--- a/core/src/test/scala/org/bykn/bosatsu/EvaluationTest.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/EvaluationTest.scala
@@ -1102,7 +1102,16 @@ main = 1 + 2 * 3
     runBosatsuTest(List("""
 package A
 
+# for an unknown reason, removing the ( ) breaks the following
 inc = \(x: Int) -> x.add(1)
+
+test = Assertion(inc(1).eq_Int(2), "inc(1) == 2")
+"""), "A", 1)
+
+    runBosatsuTest(List("""
+package A
+
+def inc(x: Int): x.add(1)
 
 test = Assertion(inc(1).eq_Int(2), "inc(1) == 2")
 """), "A", 1)
@@ -1130,6 +1139,35 @@ test4 = Assertion(inc3((B(1), Foo(1))).eq_Int(2), "inc3((B(1), Foo(1))) == 2")
 # with a custom struct
 struct Pair(x, y)
 inc4 = \Pair(F(x) | B(x), Foo(y)) -> x.add(y)
+test5 = Assertion(inc4(Pair(F(1), Foo(1))).eq_Int(2), "inc4(Pair(F(1), Foo(1))) == 2")
+test6 = Assertion(inc4(Pair(B(1), Foo(1))).eq_Int(2), "inc4(Pair(B(1), Foo(1))) == 2")
+
+suite = Test("match tests", [test0, test1, test2, test3, test4, test5, test6])
+"""), "A", 7)
+
+    runBosatsuTest(List("""
+package A
+
+struct Foo(v)
+
+def inc(Foo(x)): x.add(1)
+
+test0 = Assertion(inc(Foo(1)).eq_Int(2), "inc(Foo(1)) == 2")
+
+enum FooBar: F(x), B(x)
+
+def inc2(F(x) | B(x), Foo(y)): x.add(y)
+test1 = Assertion(inc2(F(1), Foo(1)).eq_Int(2), "inc2(F(1), Foo(1)) == 2")
+test2 = Assertion(inc2(B(1), Foo(1)).eq_Int(2), "inc2(B(1), Foo(1)) == 2")
+
+# with an outer tuple wrapping
+def inc3((F(x) | B(x), Foo(y))): x.add(y)
+test3 = Assertion(inc3((F(1), Foo(1))).eq_Int(2), "inc3((F(1), Foo(1))) == 2")
+test4 = Assertion(inc3((B(1), Foo(1))).eq_Int(2), "inc3((B(1), Foo(1))) == 2")
+
+# with a custom struct
+struct Pair(x, y)
+def inc4(Pair(F(x) | B(x), Foo(y))): x.add(y)
 test5 = Assertion(inc4(Pair(F(1), Foo(1))).eq_Int(2), "inc4(Pair(F(1), Foo(1))) == 2")
 test6 = Assertion(inc4(Pair(B(1), Foo(1))).eq_Int(2), "inc4(Pair(B(1), Foo(1))) == 2")
 

--- a/core/src/test/scala/org/bykn/bosatsu/Gen.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/Gen.scala
@@ -146,13 +146,19 @@ object Generators {
       t <- Gen.option(typeRefGen)
     } yield (arg, t)
 
-  def defGen[T](dec: Gen[T]): Gen[DefStatement[T]] =
+  def argToPat(arg: (Identifier.Bindable, Option[TypeRef])): Pattern.Parsed =
+    arg match {
+      case (bn, None) => Pattern.Var(bn)
+      case (bn, Some(t)) => Pattern.Annotation(Pattern.Var(bn), t)
+    }
+
+  def defGen[T](dec: Gen[T]): Gen[DefStatement[Pattern.Parsed, T]] =
     for {
       name <- bindIdentGen
       args <- Gen.listOf(argGen)
       retType <- Gen.option(typeRefGen)
       body <- dec
-    } yield DefStatement(name, args, retType, body)
+    } yield DefStatement(name, args.map(argToPat), retType, body)
 
   def genSpliceOrItem[A](spliceGen: Gen[A], itemGen: Gen[A]): Gen[ListLang.SpliceOrItem[A]] =
     Gen.oneOf(spliceGen.map(ListLang.SpliceOrItem.Splice(_)),

--- a/core/src/test/scala/org/bykn/bosatsu/TotalityTest.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/TotalityTest.scala
@@ -59,7 +59,7 @@ struct TupleCons(fst, snd)
 """)
 
   def patterns(str: String): List[Pattern[(PackageName, Constructor), Type]] =
-    Pattern.parser.listSyntax.parse(str) match {
+    Pattern.matchParser.listSyntax.parse(str) match {
       case Parsed.Success(pats, idx) =>
         pats.map(parsedToExpr _)
       case Parsed.Failure(exp, idx, extra) =>


### PR DESCRIPTION
close #211 

which seems like we need to have to be consistent between lambdas and defs, and to emphasize the importance of patterns in bosatsu.

It seems like this *should* close #212 but for a reason I don't yet understand, I can't yet parse `\x: Int -> x` we need to have `\(x: Int) -> x` despite bare type annotations working for defs. I'll debug that in a separate PR.

cc @snoble 