### PR TITLE
use bosatsu to generate dependencies.yaml

### DIFF
--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -1,99 +1,147 @@
-options:
-  buildHeader: [ "load(\"@io_bazel_rules_scala//scala:scala_import.bzl\", \"scala_import\")" ]
-  languages: [ "java", "scala:2.11.11" ]
-  resolvers: 
-    - id: "mavencentral"
-      type: "default"
-      url: https://repo.maven.apache.org/maven2/
-  transitivity: runtime_deps
-  resolverType: coursier
-  versionConflictPolicy: highest
-
-dependencies:
-  com.lihaoyi:
-    fastparse:
-      modules: ["", "utils"]
-      lang: scala
-      version: "1.0.0"
-      exports:
-        - "com.lihaoyi:sourcecode"
-
-    sourcecode:
-      lang: scala
-      version: "0.1.4"
-  
-  com.monovore:
-    decline:
-      lang: scala
-      version: "0.4.2"
-  
-  com.stripe:
-    dagon-core:
-      lang: scala
-      version: "0.2.2"
-  
-  org.bykn:
-    fastparse-cats-core:
-      lang: scala
-      version: "0.1.0"
-
-  org.scala-lang.modules:
-    scala-xml:
-      lang: scala
-      version: "1.0.6"
-  
-  org.scalacheck:
-    scalacheck:
-      lang: scala
-      version: "1.13.5"
-  
-  org.scalactic:
-    scalactic:
-      lang: scala
-      version: "3.0.1"
-  
-  org.scalatest:
-    scalatest:
-      exports: 
-        - "org.scalactic:scalactic"
-      lang: scala
-      version: "3.0.1"
-  
-  org.spire-math:
-    kind-projector:
-      lang: scala
-      version: "0.9.4"
-  
-  org.typelevel:
-    alleycats:
-      lang: scala
-      modules: [ "core" ]
-      version: "1.4.0"
-    cats:
-      lang: scala
-      modules: [ "core", "free", "kernel", "macros" ]
-      version: "1.4.0"
-    paiges-core:
-      lang: scala
-      version: "0.2.1"
-
-replacements:
-  org.scala-lang:
-    scala-compiler:
-      lang: scala/unmangled
-      target: "@io_bazel_rules_scala_scala_compiler//:io_bazel_rules_scala_scala_compiler"
-    scala-library:
-      lang: scala/unmangled
-      target: "@io_bazel_rules_scala_scala_library//:io_bazel_rules_scala_scala_library"
-    scala-reflect:
-      lang: scala/unmangled
-      target: "@io_bazel_rules_scala_scala_reflect//:io_bazel_rules_scala_scala_reflect"
-
-  org.scala-lang.modules:
-    scala-parser-combinators:
-      lang: scala
-      target:
-        "@io_bazel_rules_scala_scala_parser_combinators//:io_bazel_rules_scala_scala_parser_combinators"
-    scala-xml:
-      lang: scala
-      target: "@io_bazel_rules_scala_scala_xml//:io_bazel_rules_scala_scala_xml"
+{
+  "options": {
+      "buildHeader": [
+          "load(\"@io_bazel_rules_scala//scala:scala_import.bzl\", \"scala_import\")" ],
+      "languages": [ "java", "scala:2.11.11" ],
+      "resolvers": [
+          {
+            "id": "mavencentral",
+            "type": "default",
+            "url": "https://repo.maven.apache.org/maven2/"
+          } ],
+      "transitivity": "runtime_deps",
+      "resolverType": "coursier",
+      "versionConflictPolicy": "highest"
+    },
+  "dependencies": {
+      "com.lihaoyi": {
+          "fastparse": {
+              "modules": [ "", "utils" ],
+              "lang": "scala",
+              "version": "1.0.0",
+              "exports": [ "com.lihaoyi:sourcecode" ]
+            },
+          "sourcecode": {
+              "modules": [ ],
+              "lang": "scala",
+              "version": "0.1.4",
+              "exports": [ ]
+            }
+        },
+      "com.monovore": {
+          "decline": {
+              "modules": [ ],
+              "lang": "scala",
+              "version": "0.4.2",
+              "exports": [ ]
+            }
+        },
+      "com.stripe": {
+          "dagon-core": {
+              "modules": [ ],
+              "lang": "scala",
+              "version": "0.2.2",
+              "exports": [ ]
+            }
+        },
+      "org.bykn": {
+          "fastparse-cats-core": {
+              "modules": [ ],
+              "lang": "scala",
+              "version": "0.1.0",
+              "exports": [ ]
+            }
+        },
+      "org.scala-lang.modules": {
+          "scala-xml": {
+              "modules": [ ],
+              "lang": "scala",
+              "version": "1.0.6",
+              "exports": [ ]
+            }
+        },
+      "org.scalacheck": {
+          "scalacheck": {
+              "modules": [ ],
+              "lang": "scala",
+              "version": "1.13.5",
+              "exports": [ ]
+            }
+        },
+      "org.scalactic": {
+          "scalactic": {
+              "modules": [ ],
+              "lang": "scala",
+              "version": "3.0.1",
+              "exports": [ ]
+            }
+        },
+      "org.scalatest": {
+          "scalatest": {
+              "modules": [ "" ],
+              "lang": "scala",
+              "version": "3.0.1",
+              "exports": [ "org.scalactic:scalactic" ]
+            }
+        },
+      "org.spire-math": {
+          "kind-projector": {
+              "modules": [ ],
+              "lang": "scala",
+              "version": "0.9.4",
+              "exports": [ ]
+            }
+        },
+      "org.typelevel": {
+          "alleycats-core": {
+              "modules": [ ],
+              "lang": "scala",
+              "version": "1.4.0",
+              "exports": [ ]
+            },
+          "cats": {
+              "modules": [ "core", "free", "kernel", "macros" ],
+              "lang": "scala",
+              "version": "1.4.0",
+              "exports": [ ]
+            },
+          "paiges-core": {
+              "modules": [ ],
+              "lang": "scala",
+              "version": "0.2.1",
+              "exports": [ ]
+            }
+        }
+    },
+  "replacements": {
+      "org.scala-lang": {
+          "scala-compiler": {
+              "lang": "scala/unmangled",
+              "target":
+                "@io_bazel_rules_scala_scala_compiler//:io_bazel_rules_scala_scala_compiler"
+            },
+          "scala-library": {
+              "lang": "scala/unmangled",
+              "target":
+                "@io_bazel_rules_scala_scala_library//:io_bazel_rules_scala_scala_library"
+            },
+          "scala-reflect": {
+              "lang": "scala/unmangled",
+              "target":
+                "@io_bazel_rules_scala_scala_reflect//:io_bazel_rules_scala_scala_reflect"
+            }
+        },
+      "org.scala-lang.modules": {
+          "scala-parser-combinators": {
+              "lang": "scala",
+              "target":
+                "@io_bazel_rules_scala_scala_parser_combinators//:io_bazel_rules_scala_scala_parser_combinators"
+            },
+          "scala-xml": {
+              "lang": "scala",
+              "target":
+                "@io_bazel_rules_scala_scala_xml//:io_bazel_rules_scala_scala_xml"
+            }
+        }
+    }
+}

--- a/test_workspace/BUILD
+++ b/test_workspace/BUILD
@@ -60,12 +60,17 @@ bosatsu_test(
     size = "medium")
 
 bosatsu_library(
+    name = "dict_tools",
+    srcs = ["dicttools.bosatsu"])
+
+bosatsu_library(
     name = "bazel_deps_api",
+    deps = ["dict_tools"],
     srcs = ["bazel_deps_api.bosatsu"],
     )
 
 bosatsu_json(
     name ="gen_deps",
     srcs = ["gen_deps.bosatsu"],
-    deps = [":bazel_deps_api"],
+    deps = [":bazel_deps_api", ":dict_tools"],
     package = "GenDeps")

--- a/test_workspace/BUILD
+++ b/test_workspace/BUILD
@@ -58,3 +58,14 @@ bosatsu_test(
     name = "euler7",
     srcs = ["euler7.bosatsu"],
     size = "medium")
+
+bosatsu_library(
+    name = "bazel_deps_api",
+    srcs = ["bazel_deps_api.bosatsu"],
+    )
+
+bosatsu_json(
+    name ="gen_deps",
+    srcs = ["gen_deps.bosatsu"],
+    deps = [":bazel_deps_api"],
+    package = "GenDeps")

--- a/test_workspace/bazel_deps_api.bosatsu
+++ b/test_workspace/bazel_deps_api.bosatsu
@@ -5,7 +5,7 @@ import DictTools [ merge as merge_Dict ]
 export [
   Artifact(), Config(), Resolver(), Replacement(), maven_central,
   default_options_with_scala, scala_dep, scala_dep_modules,
-  merge_deps, merge_dep_List ]
+  merge_deps, merge_dep_List, standard_scala_replacements ]
 
 struct Resolver(id: String, type: String, url: String)
 
@@ -50,3 +50,26 @@ def merge_deps(left: Dict[String, Dict[String, Artifact]], right: Dict[String, D
   merge_Dict(left, right, merge_inner)
 
 def merge_dep_List(deps): deps.foldLeft({}, merge_deps)
+
+standard_scala_replacements = {
+  'org.scala-lang': {
+    'scala-compiler': Replacement(
+        'scala/unmangled',
+        '@io_bazel_rules_scala_scala_compiler//:io_bazel_rules_scala_scala_compiler'),
+    'scala-library': Replacement(
+        'scala/unmangled',
+        '@io_bazel_rules_scala_scala_library//:io_bazel_rules_scala_scala_library'),
+    'scala-reflect': Replacement(
+        'scala/unmangled',
+        '@io_bazel_rules_scala_scala_reflect//:io_bazel_rules_scala_scala_reflect'),
+    },
+  'org.scala-lang.modules': {
+    'scala-parser-combinators': Replacement(
+        'scala', 
+        '@io_bazel_rules_scala_scala_parser_combinators//:io_bazel_rules_scala_scala_parser_combinators'),
+    'scala-xml': Replacement(
+        'scala',
+        '@io_bazel_rules_scala_scala_xml//:io_bazel_rules_scala_scala_xml')
+  }
+}
+

--- a/test_workspace/bazel_deps_api.bosatsu
+++ b/test_workspace/bazel_deps_api.bosatsu
@@ -1,6 +1,11 @@
 package BazelDepsApi
 
-export [Artifact(), Config(), Resolver(), maven_central, default_options_with_scala, scala_dep ]
+import DictTools [ merge as merge_Dict ]
+
+export [
+  Artifact(), Config(), Resolver(), Replacement(), maven_central,
+  default_options_with_scala, scala_dep, scala_dep_modules,
+  merge_deps, merge_dep_List ]
 
 struct Resolver(id: String, type: String, url: String)
 
@@ -22,7 +27,26 @@ default_options_with_scala = Options(
 
 struct Artifact(modules: List[String], lang: String, version: String, exports: List[String])
 
-struct Config(options: Options, dependencies: Dict[String, Dict[String, Artifact]])
+struct Replacement(lang: String, target: String)
+
+struct Config(
+  options: Options,
+  dependencies: Dict[String, Dict[String, Artifact]],
+  replacements: Dict[String, Dict[String, Replacement]])
 
 def scala_dep(orgname: String, artifact: String, version: String) -> Dict[String, Dict[String, Artifact]]:
   { orgname: { artifact: Artifact([], "scala", version, []) } }
+
+def scala_dep_modules(orgname: String, artifact: String, modules, version: String, exports) -> Dict[String, Dict[String, Artifact]]:
+  { orgname: { artifact: Artifact(modules, "scala", version, exports) } }
+
+def merge_artifact(left: Artifact, right: Artifact):
+  Artifact(lm, _, _, le) = left
+  Artifact(rm, rr, rv, re) = right
+  Artifact(lm.concat(rm), rr, rv, le.concat(re))
+
+def merge_deps(left: Dict[String, Dict[String, Artifact]], right: Dict[String, Dict[String, Artifact]]):
+  merge_inner = \l, r -> merge_Dict(l, r, merge_artifact)
+  merge_Dict(left, right, merge_inner)
+
+def merge_dep_List(deps): deps.foldLeft({}, merge_deps)

--- a/test_workspace/bazel_deps_api.bosatsu
+++ b/test_workspace/bazel_deps_api.bosatsu
@@ -1,0 +1,28 @@
+package BazelDepsApi
+
+export [Artifact(), Config(), Resolver(), maven_central, default_options_with_scala, scala_dep ]
+
+struct Resolver(id: String, type: String, url: String)
+
+struct Options(buildHeader: List[String], languages: List[String],
+  resolvers: List[Resolver],
+  transitivity: String,
+  resolverType: String,
+  versionConflictPolicy: String)
+
+maven_central = Resolver("mavencentral", "default", "https://repo.maven.apache.org/maven2/")
+
+default_options_with_scala = Options(
+  [ 'load("@io_bazel_rules_scala//scala:scala_import.bzl", "scala_import")' ],
+  [ "java", "scala:2.11.11" ],
+  [ maven_central ],
+  "runtime_deps",
+  "coursier",
+  "highest")
+
+struct Artifact(modules: List[String], lang: String, version: String, exports: List[String])
+
+struct Config(options: Options, dependencies: Dict[String, Dict[String, Artifact]])
+
+def scala_dep(orgname: String, artifact: String, version: String) -> Dict[String, Dict[String, Artifact]]:
+  { orgname: { artifact: Artifact([], "scala", version, []) } }

--- a/test_workspace/dicttools.bosatsu
+++ b/test_workspace/dicttools.bosatsu
@@ -1,0 +1,10 @@
+package DictTools
+
+export [ merge ]
+
+def merge(left: Dict[k, v], right: Dict[k, v], fn: v -> v -> v) -> Dict[k, v]:
+  right.items.foldLeft(left, \d, (k, v) ->
+    match d.get_key(k):
+      None:     d.add_key(k, v)
+      Some(v0): d.add_key(k, fn(v0, v))
+  )

--- a/test_workspace/gen_deps.bosatsu
+++ b/test_workspace/gen_deps.bosatsu
@@ -1,6 +1,61 @@
 package GenDeps
 
-import BazelDepsApi [ Config, Artifact, default_options_with_scala ]
+import BazelDepsApi [
+  Config, Artifact, Replacement, default_options_with_scala, merge_dep_List, scala_dep, scala_dep_modules ]
 
-main = Config(default_options_with_scala,
-  { "org.typelevel": { "cats-core": Artifact(["", "core"], "scala", "1.0.0", []) } })
+replacements = {
+  'org.scala-lang': {
+    'scala-compiler': Replacement(
+        'scala/unmangled',
+        '@io_bazel_rules_scala_scala_compiler//:io_bazel_rules_scala_scala_compiler'),
+    'scala-library': Replacement(
+        'scala/unmangled',
+        '@io_bazel_rules_scala_scala_library//:io_bazel_rules_scala_scala_library'),
+    'scala-reflect': Replacement(
+        'scala/unmangled',
+        '@io_bazel_rules_scala_scala_reflect//:io_bazel_rules_scala_scala_reflect'),
+    },
+  'org.scala-lang.modules': {
+    'scala-parser-combinators': Replacement(
+        'scala', 
+        '@io_bazel_rules_scala_scala_parser_combinators//:io_bazel_rules_scala_scala_parser_combinators'),
+    'scala-xml': Replacement(
+        'scala',
+        '@io_bazel_rules_scala_scala_xml//:io_bazel_rules_scala_scala_xml')
+  }
+}
+cats_version = '1.4.0'
+dagon_version = '0.2.2'
+decline_version = '0.4.2'
+fastparse_cats_version = '0.1.0'
+fastparse_version = '1.0.0'
+kind_projector_version = '0.9.4'
+paiges_version = '0.2.1'
+scala_xml_version = '1.0.6'
+scalacheck_version = '1.13.5'
+scalatest_version = '3.0.1'
+sourcecode_version = '0.1.4'
+
+operator ++ = concat
+main = Config(
+  default_options_with_scala,
+  merge_dep_List(
+    [ scala_dep(o, a, v) for (o, a, v) in [
+        ('com.lihaoyi', 'fastparse', fastparse_version),
+        ('com.lihaoyi', 'fastparse-utils', fastparse_version),
+        ('com.lihaoyi', 'sourcecode', sourcecode_version),
+        ('com.monovore', 'decline', decline_version),
+        ('com.stripe', 'dagon-core', dagon_version),
+        ('org.bykn', 'fastparse-cats-core', fastparse_cats_version),
+        ('org.scala-lang.modules', 'scala-xml', scala_xml_version),
+        ('org.scalacheck', 'scalacheck', scalacheck_version),
+        ('org.scalactic', 'scalactic', scalatest_version),
+        ('org.spire-math', 'kind-projector', kind_projector_version),
+        ('org.typelevel', 'alleycats-core', cats_version),
+        ('org.typelevel', 'paiges-core', paiges_version),
+      ]
+    ] ++ [
+        scala_dep_modules('org.scalatest', 'scalatest', [''], scalatest_version, ['org.scalactic:scalactic']),
+        scala_dep_modules('org.typelevel', 'cats', ['core', 'free', 'kernel', 'macros'], cats_version, []),
+      ]
+  ), replacements)

--- a/test_workspace/gen_deps.bosatsu
+++ b/test_workspace/gen_deps.bosatsu
@@ -1,7 +1,8 @@
 package GenDeps
 
 import BazelDepsApi [
-  Config, Artifact, Replacement, default_options_with_scala, merge_dep_List, scala_dep, scala_dep_modules ]
+  Config, Artifact, Replacement, default_options_with_scala, merge_dep_List, scala_dep,
+  scala_dep_modules, standard_scala_replacements ]
 
 cats_version = '1.4.0'
 dagon_version = '0.2.2'
@@ -14,28 +15,6 @@ scala_xml_version = '1.0.6'
 scalacheck_version = '1.13.5'
 scalatest_version = '3.0.1'
 sourcecode_version = '0.1.4'
-
-replacements = {
-  'org.scala-lang': {
-    'scala-compiler': Replacement(
-        'scala/unmangled',
-        '@io_bazel_rules_scala_scala_compiler//:io_bazel_rules_scala_scala_compiler'),
-    'scala-library': Replacement(
-        'scala/unmangled',
-        '@io_bazel_rules_scala_scala_library//:io_bazel_rules_scala_scala_library'),
-    'scala-reflect': Replacement(
-        'scala/unmangled',
-        '@io_bazel_rules_scala_scala_reflect//:io_bazel_rules_scala_scala_reflect'),
-    },
-  'org.scala-lang.modules': {
-    'scala-parser-combinators': Replacement(
-        'scala', 
-        '@io_bazel_rules_scala_scala_parser_combinators//:io_bazel_rules_scala_scala_parser_combinators'),
-    'scala-xml': Replacement(
-        'scala',
-        '@io_bazel_rules_scala_scala_xml//:io_bazel_rules_scala_scala_xml')
-  }
-}
 
 operator ++ = concat
 
@@ -59,4 +38,4 @@ main = Config(
         scala_dep_modules('org.typelevel', 'cats', ['core', 'free', 'kernel', 'macros'], cats_version, []),
         scala_dep_modules('com.lihaoyi', 'fastparse', ['', 'utils'], fastparse_version, ['com.lihaoyi:sourcecode']),
       ]
-  ), replacements)
+  ), standard_scala_replacements)

--- a/test_workspace/gen_deps.bosatsu
+++ b/test_workspace/gen_deps.bosatsu
@@ -3,6 +3,18 @@ package GenDeps
 import BazelDepsApi [
   Config, Artifact, Replacement, default_options_with_scala, merge_dep_List, scala_dep, scala_dep_modules ]
 
+cats_version = '1.4.0'
+dagon_version = '0.2.2'
+decline_version = '0.4.2'
+fastparse_cats_version = '0.1.0'
+fastparse_version = '1.0.0'
+kind_projector_version = '0.9.4'
+paiges_version = '0.2.1'
+scala_xml_version = '1.0.6'
+scalacheck_version = '1.13.5'
+scalatest_version = '3.0.1'
+sourcecode_version = '0.1.4'
+
 replacements = {
   'org.scala-lang': {
     'scala-compiler': Replacement(
@@ -24,25 +36,13 @@ replacements = {
         '@io_bazel_rules_scala_scala_xml//:io_bazel_rules_scala_scala_xml')
   }
 }
-cats_version = '1.4.0'
-dagon_version = '0.2.2'
-decline_version = '0.4.2'
-fastparse_cats_version = '0.1.0'
-fastparse_version = '1.0.0'
-kind_projector_version = '0.9.4'
-paiges_version = '0.2.1'
-scala_xml_version = '1.0.6'
-scalacheck_version = '1.13.5'
-scalatest_version = '3.0.1'
-sourcecode_version = '0.1.4'
 
 operator ++ = concat
+
 main = Config(
   default_options_with_scala,
   merge_dep_List(
     [ scala_dep(o, a, v) for (o, a, v) in [
-        ('com.lihaoyi', 'fastparse', fastparse_version),
-        ('com.lihaoyi', 'fastparse-utils', fastparse_version),
         ('com.lihaoyi', 'sourcecode', sourcecode_version),
         ('com.monovore', 'decline', decline_version),
         ('com.stripe', 'dagon-core', dagon_version),
@@ -57,5 +57,6 @@ main = Config(
     ] ++ [
         scala_dep_modules('org.scalatest', 'scalatest', [''], scalatest_version, ['org.scalactic:scalactic']),
         scala_dep_modules('org.typelevel', 'cats', ['core', 'free', 'kernel', 'macros'], cats_version, []),
+        scala_dep_modules('com.lihaoyi', 'fastparse', ['', 'utils'], fastparse_version, ['com.lihaoyi:sourcecode']),
       ]
   ), replacements)

--- a/test_workspace/gen_deps.bosatsu
+++ b/test_workspace/gen_deps.bosatsu
@@ -1,0 +1,6 @@
+package GenDeps
+
+import BazelDepsApi [ Config, Artifact, default_options_with_scala ]
+
+main = Config(default_options_with_scala,
+  { "org.typelevel": { "cats-core": Artifact(["", "core"], "scala", "1.0.0", []) } })

--- a/update_deps.sh
+++ b/update_deps.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+bazel build test_workspace:gen_deps
+cp bazel-bin/test_workspace/gen_deps.json dependencies.yaml
+cd ../bazel-deps
+bazel run :parse -- generate -r ~/oss/bosatsu/ --deps dependencies.yaml -s 3rdparty/workspace.bzl
+cd ../bosatsu


### PR DESCRIPTION
close #205 
related to #21 

This is a start of using bosatsu to generate the depedencies.yaml file in this repo. It is a good dog-fooding exercise as I've already hit two issues:

0. you can't get the ordering out of an existing map. This makes it more painful to make new maps.
1. no merge function on maps and hard to write due to the above.
2. lack of both type-aliases the default rules for Json conversion is pretty painful. It means you often have to work with big types. I think type aliases probably make sense, or the approach of making 1 item structs not use object wrapping...
3. new-lines between keys and values in literal dicts don't work, which is annoying.

I'm a bit concerned the single way of constructing Json from types will turn out to be very restrictive and require two sets of types: the real types, then the Json facade that you convert into.

Here is an example output:
```json
{
  "options": {
      "buildHeader": [
          "load(\"@io_bazel_rules_scala//scala:scala_import.bzl\", \"scala_import\")" ],
      "languages": [ "java", "scala:2.11.11" ],
      "resolvers": [
          {
            "id": "mavencentral",
            "type": "default",
            "url": "https://repo.maven.apache.org/maven2/"
          } ],
      "transitivity": "runtime_deps",
      "resolverType": "coursier",
      "versionConflictPolicy": "highest"
    },
  "dependencies": {
      "org.typelevel": {
          "cats-core": {
              "modules": [ "", "core" ],
              "lang": "scala",
              "version": "1.0.0",
              "exports": [ ]
            }
        }
    }
}
```