### PR TITLE
Improve parsing of statements

### DIFF
--- a/core/src/main/scala/org/bykn/bosatsu/Padding.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/Padding.scala
@@ -13,8 +13,14 @@ object Padding {
       Doc.line.repeat(padding.lines) + Document[T].document(padding.padded)
     }
 
+  def parseFn[A]: P[A => Padding[A]] =
+    // if we have a P[Unit] then rep() is also P[Unit] due to weird shit
+    P((maybeSpace ~ "\n").map(_ => 0).rep()).map { vec =>
+      { a => Padding(vec.size, a) }
+    }
+
   def parser[T](p: P[T]): P[Padding[T]] =
-    P((maybeSpace ~ "\n").!.rep() ~ p).map { case (vec, t) => Padding(vec.size, t) }
+    (parseFn[T] ~ p).map { case (fn, t) => fn(t) }
 
   def parser1[T](p: P[T]): P[Padding[T]] =
     P((maybeSpace ~ "\n").!.rep(1) ~ p).map { case (vec, t) => Padding(vec.size, t) }

--- a/core/src/main/scala/org/bykn/bosatsu/Parser.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/Parser.scala
@@ -294,4 +294,22 @@ object Parser {
   }
 
   val toEOL: P[Unit] = P(maybeSpace ~ "\n")
+
+  /**
+   * If we have a list like structure where
+   * we parse the function to add something
+   * to the head, we can use this
+   */
+  def chained[A](p: P[A => A], end: P[A]): P[A] = {
+    (p.rep() ~ end).map { case (fns, a) =>
+      @annotation.tailrec
+      def loop(revFn: List[A => A], a: A): A =
+        revFn match {
+          case Nil => a
+          case h :: t => loop(t, h(a))
+        }
+
+      loop(fns.toList.reverse, a)
+    }
+  }
 }

--- a/core/src/test/scala/org/bykn/bosatsu/ParserTest.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/ParserTest.scala
@@ -936,6 +936,15 @@ foo = 1
     forAll(Generators.packageGen(5))(law(Package.parser))
   }
 
+  test("parse errors point near where they occur") {
+    expectFail(Statement.parser,
+      """x = 1
+z = 3
+z = 4
+y = {'x': 'x' : 'y'}
+""", 18)
+  }
+
   test("we can parse Externals") {
     parseTestAll(Externals.parser,
 """


### PR DESCRIPTION
previously, we fail to parse any statement if any item in the linked list that forms the top statement fails.

This is obviously terrible.

This PR fixes it taking the approach suggested in:

https://github.com/johnynek/bosatsu/issues/90#issuecomment-480527578

I need to do the same with Declaration.

Note the test I added originally failed at index 0 which is to say it never parsed anything. Now it fails at the statement that can't be parsed. Ideally we would point at the dictionary, but this is an improvement.