### PR TITLE
Remove duplication of type substitution

### DIFF
--- a/core/src/main/scala/org/bykn/bosatsu/Evaluation.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/Evaluation.scala
@@ -796,7 +796,7 @@ case class Evaluation[T](pm: PackageMap.Typed[T], externals: Externals) {
         (vp, optDt).mapN { case ((variant, prod), dt) =>
           val cons = dt.constructors
           val (_, targs) = Type.applicationArgs(tpe)
-          val replaceMap = dt.typeParams.zip(targs).toMap
+          val replaceMap = dt.typeParams.zip(targs).toMap[Type.Var, Type]
           cons.lift(variant).flatMap { case (_, params, _) =>
             prod.toList.zip(params).traverse { case (a1, (pn, t)) =>
               toJson(a1, Type.substituteVar(t, replaceMap)).map((pn.asString, _))

--- a/core/src/main/scala/org/bykn/bosatsu/rankn/Infer.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/rankn/Infer.scala
@@ -330,21 +330,8 @@ object Infer {
       lift(RefSpace.newRef[Either[Error, A]](Left(err)))
 
     def substTy(keys: NonEmptyList[Type.Var], vals: NonEmptyList[Type], t: Type): Type = {
-
-      def subst(env: Map[Type.Var, Type], t: Type): Type =
-        t match {
-          case Type.TyApply(on, arg) => Type.TyApply(subst(env, on), subst(env, arg))
-          case v@Type.TyVar(n) => env.getOrElse(n, v)
-          case Type.ForAll(ns, rho) =>
-            val boundSet: Set[Type.Var] = ns.toList.toSet
-            val env1 = env.filterKeys { v => !boundSet(v) }
-            Type.ForAll(ns, subst(env1, rho))
-          case m@Type.TyMeta(_) => m
-          case c@Type.TyConst(_) => c
-        }
-
       val env = keys.toList.iterator.zip(vals.toList.iterator).toMap
-      subst(env, t)
+      Type.substituteVar(t, env)
     }
 
     def substExpr[A](keys: NonEmptyList[Type.Var], vals: NonEmptyList[Type], expr: Expr[A]): Expr[A] = {

--- a/core/src/main/scala/org/bykn/bosatsu/rankn/Type.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/rankn/Type.scala
@@ -121,14 +121,19 @@ object Type {
 
   def substituteVar(t: Type, env: Map[Type.Var, Type]): Type =
     t match {
-      case Type.TyApply(on, arg) => Type.TyApply(substituteVar(on, env), substituteVar(arg, env))
-      case v@Type.TyVar(n) => env.getOrElse(n, v)
-      case Type.ForAll(ns, rho) =>
-        val boundSet: Set[Type.Var] = ns.toList.toSet
+      case TyApply(on, arg) => TyApply(substituteVar(on, env), substituteVar(arg, env))
+      case v@TyVar(n) => env.getOrElse(n, v)
+      case ForAll(ns, rho) =>
+        val boundSet: Set[Var] = ns.toList.toSet
         val env1 = env.filterKeys { v => !boundSet(v) }
-        Type.ForAll(ns, substituteVar(rho, env1))
-      case m@Type.TyMeta(_) => m
-      case c@Type.TyConst(_) => c
+        substituteVar(rho, env1) match {
+          case ForAll(ns1, r1) =>
+            ForAll(ns ::: ns1, r1)
+          case notForAll =>
+            ForAll(ns, notForAll)
+        }
+      case m@TyMeta(_) => m
+      case c@TyConst(_) => c
     }
 
   /**

--- a/core/src/main/scala/org/bykn/bosatsu/rankn/Type.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/rankn/Type.scala
@@ -119,18 +119,16 @@ object Type {
     loop(t, Nil)
   }
 
-  def substituteVar(t: Type, replace: Map[Var.Bound, Type]): Type =
+  def substituteVar(t: Type, env: Map[Type.Var, Type]): Type =
     t match {
-      case v@TyVar(b@Var.Bound(_)) =>
-        replace.get(b) match {
-          case None => v
-          case Some(t) => t
-        }
-      case ForAll(bs, r) =>
-        forAll(bs.toList, substituteVar(r, replace -- bs.toList))
-      case TyApply(l, r) =>
-        TyApply(substituteVar(l, replace), substituteVar(r, replace))
-      case TyConst(_) | TyVar(_) | TyMeta(_) => t
+      case Type.TyApply(on, arg) => Type.TyApply(substituteVar(on, env), substituteVar(arg, env))
+      case v@Type.TyVar(n) => env.getOrElse(n, v)
+      case Type.ForAll(ns, rho) =>
+        val boundSet: Set[Type.Var] = ns.toList.toSet
+        val env1 = env.filterKeys { v => !boundSet(v) }
+        Type.ForAll(ns, substituteVar(rho, env1))
+      case m@Type.TyMeta(_) => m
+      case c@Type.TyConst(_) => c
     }
 
   /**

--- a/core/src/test/scala/org/bykn/bosatsu/rankn/TypeTest.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/rankn/TypeTest.scala
@@ -140,9 +140,9 @@ class TypeTest extends FunSuite {
     }
   }
 
-  def genSubs(depth: Int): Gen[Map[Type.Var.Bound, Type]] = {
+  def genSubs(depth: Int): Gen[Map[Type.Var, Type]] = {
     val pair = Gen.zip(
-      Gen.identifier.map(Type.Var.Bound(_)),
+      Gen.identifier.map(Type.Var.Bound(_): Type.Var),
       NTypeGen.genDepth(depth))
     Gen.mapOf(pair)
   }
@@ -163,7 +163,7 @@ class TypeTest extends FunSuite {
   }
 
   test("after substitution, none of the keys are free") {
-    def law(t: Type, subs: Map[Type.Var.Bound, Type]) = {
+    def law(t: Type, subs: Map[Type.Var, Type]) = {
       // don't substitute back onto the keys
       val subs1 = subs.filter { case (_, v) =>
         (Type.freeBoundTyVars(v :: Nil).toSet & subs.keySet).isEmpty


### PR DESCRIPTION
We had implemented type substitution twice, since I forgot it was hiding inside Infer. This moves the infer version into Type and adjusts some type parameters to use it.

Infer needs to be able to substitute skolem vars, not just bound vars, so the type was broadened.

