### PR TITLE
Use variance in skolemization and substitution

### DIFF
--- a/core/src/main/scala/org/bykn/bosatsu/rankn/Infer.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/rankn/Infer.scala
@@ -550,7 +550,7 @@ object Infer {
         case (Type.TyApply(a1, b1), Type.TyApply(a2, b2)) =>
           unify(a1, a2, r1, r2) *> unify(b1, b2, r1, r2)
         case (Type.TyConst(c1), Type.TyConst(c2)) if c1 == c2 => unit
-        // these shouldn't be reachable since we have Tau types, but they are reachable
+        // these shouldn't be reachable since we have Tau types, but may be reachable
         // case (Type.ForAll(_, _), _) =>
         //   sys.error(s"expected tau type: $t1, $t2")
         // case (_, Type.ForAll(_, _)) =>

--- a/core/src/test/scala/org/bykn/bosatsu/TestUtils.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/TestUtils.scala
@@ -50,7 +50,8 @@ object TestUtils {
     Statement.parser.parse(statement) match {
       case Parsed.Success(stmt, _) =>
         Package.inferBody(PackageName.parts("Test"), Nil, stmt) match {
-          case Validated.Invalid(errs) => fail(errs.toList.map(_.message(Map.empty)).mkString("\n"))
+          case Validated.Invalid(errs) =>
+            fail("inference failure: " + errs.toList.map(_.message(Map.empty)).mkString("\n"))
           case Validated.Valid((_, lets)) =>
             fn(lets.last._3)
         }

--- a/core/src/test/scala/org/bykn/bosatsu/rankn/RankNInferTest.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/rankn/RankNInferTest.scala
@@ -723,7 +723,7 @@ enum Opt: Nope, Yep(a)
 struct FnWrapper(fn: a -> b)
 
 # TODO: this should pass because FnWrapper is covariant, but skolemization ignores custom types
-#(producer: FnWrapper[Foo, forall a. Opt[a]]) = FnWrapper(\x -> Nope)
+(producer: FnWrapper[Foo, forall a. Opt[a]]) = FnWrapper(\x -> Nope)
 # in the covariant position, we can substitute
 #(producer1: FnWrapper[Foo, Opt[Foo]]) = producer
 (consumer: FnWrapper[Opt[Foo], Foo]) = FnWrapper(\x -> Foo)

--- a/core/src/test/scala/org/bykn/bosatsu/rankn/RankNInferTest.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/rankn/RankNInferTest.scala
@@ -659,8 +659,8 @@ struct Cont(cont: (b -> a) -> a)
 (baz41: Cont[Foo, Foo]) = baz1
 (baz42: Cont[Foo, Foo]) = baz2
 # Cont is covariant in a, this should be allowed
-# (baz43: Cont[Foo, Foo]) = baz3
-# (baz43: Cont[Foo, Foo]) = baz3
+(baz43: Cont[Foo, Foo]) = baz3
+(baz43: Cont[Foo, Foo]) = baz3
 
 (producer: Foo -> (forall a. Cont[Foo, a])) = \x -> bar1
 # in the covariant position, we can substitute
@@ -722,15 +722,12 @@ enum Opt: Nope, Yep(a)
 
 struct FnWrapper(fn: a -> b)
 
-# TODO: this should pass because FnWrapper is covariant, but skolemization ignores custom types
 (producer: FnWrapper[Foo, forall a. Opt[a]]) = FnWrapper(\x -> Nope)
 # in the covariant position, we can substitute
-#(producer1: FnWrapper[Foo, Opt[Foo]]) = producer
+(producer1: FnWrapper[Foo, Opt[Foo]]) = producer
 (consumer: FnWrapper[Opt[Foo], Foo]) = FnWrapper(\x -> Foo)
 # in the contravariant position, we can generalize
-# TODO: this should pass because FnWrapper is contravariant in the first type
-# but subsCheck only knows about contravariance in the Fn type
-#(consumer1: FnWrapper[forall a. Opt[a], Foo]) = consumer
+(consumer1: FnWrapper[forall a. Opt[a], Foo]) = consumer
 
 main = Foo
 """, "Foo")


### PR DESCRIPTION
part of #225 

This seems to solve the open problems. This approach exposes an issue in this approach: if we have unknown types in an apply, we should really introduce variables to track what final variance is substituted in. This does not do that, and instead falls back on a worse case of invariance.