### PR TITLE
Add two data structure examples: Queue, TreeList

### DIFF
--- a/test_workspace/BUILD
+++ b/test_workspace/BUILD
@@ -74,3 +74,25 @@ bosatsu_json(
     srcs = ["gen_deps.bosatsu"],
     deps = [":bazel_deps_api", ":dict_tools"],
     package = "GenDeps")
+
+bosatsu_library(
+    name = "queue",
+    srcs = ["Queue.bosatsu"],
+    )
+
+# todo we need to be able to test a library without recompiling it
+bosatsu_test(
+    name = "queue_test",
+    srcs = ["Queue.bosatsu"],
+    )
+
+bosatsu_library(
+    name = "treelist",
+    srcs = ["TreeList.bosatsu"],
+    )
+
+# todo we need to be able to test a library without recompiling it
+bosatsu_test(
+    name = "treelist_test",
+    srcs = ["TreeList.bosatsu"],
+    )

--- a/test_workspace/Queue.bosatsu
+++ b/test_workspace/Queue.bosatsu
@@ -1,8 +1,8 @@
 package Queue
 
 export [ Queue,
-  empty_Queue, fold_Queue, push, pop, pop_value, pop_Queue, reverse_Queue, eq_Queue,
-  queue_to_List,
+  empty_Queue, fold_Queue, push, unpush, pop_value, pop, reverse_Queue, eq_Queue,
+  to_List, from_List
 ]
 
 struct Queue(front: List[a], back: List[a])
@@ -12,14 +12,13 @@ empty_Queue: forall a. Queue[a] = Queue([], [])
 # convenient local alias
 empty = empty_Queue
 
-def queue_from_List(list: List[a]) -> Queue[a]:
+def from_List(list: List[a]) -> Queue[a]:
   Queue(list, [])
 
-def push(queue: Queue[a], item: a) -> Queue[a]:
-  Queue(f, b) = queue
+def push(Queue(f, b): Queue[a], item: a) -> Queue[a]:
   Queue(f, [item, *b])
 
-def pop(queue: Queue[a]) -> Option[(a, Queue[a])]:
+def unpush(queue: Queue[a]) -> Option[(a, Queue[a])]:
   match queue:
     Queue([h, *t], b): Some((h, Queue(t, b)))
     Queue([], b):
@@ -28,23 +27,21 @@ def pop(queue: Queue[a]) -> Option[(a, Queue[a])]:
         [h, *t]: Some((h, Queue(t, [])))
 
 def pop_value(queue: Queue[a]) -> Option[a]:
-  match pop(queue):
+  match unpush(queue):
     Some((a, _)): Some(a)
     None: None
 
 # drop an item off and return the rest, or empty
-def pop_Queue(queue: Queue[a]) -> Queue[a]:
-  match pop(queue):
+def pop(queue: Queue[a]) -> Queue[a]:
+  match unpush(queue):
     Some((_, queue)): queue
     None: empty
 
-def fold_Queue(queue: Queue[a], init: b, fn: b -> a -> b) -> b:
-  Queue(f, b) = queue
+def fold_Queue(Queue(f, b): Queue[a], init: b, fn: b -> a -> b) -> b:
   front = f.foldLeft(init, fn)
   b.reverse.foldLeft(front, fn)
 
-def reverse_Queue(queue: Queue[a]) -> Queue[a]:
-  Queue(f, b) = queue
+def reverse_Queue(Queue(f, b): Queue[a]) -> Queue[a]:
   Queue(b.reverse, f.reverse)
 
 def eq_Queue(eq_fn: a -> a -> Bool, left: Queue[a], right: Queue[a]) -> Bool:
@@ -52,15 +49,14 @@ def eq_Queue(eq_fn: a -> a -> Bool, left: Queue[a], right: Queue[a]) -> Bool:
     match g:
       False: (False, empty)
       True:
-        match pop(right):
+        match unpush(right):
           None: (False, empty)
           Some((ar, right)):
             (eq_fn(al, ar), right)
     )
   res
 
-def queue_to_List(q: Queue[a]) -> List[a]:
-  Queue(f, b) = q
+def to_List(Queue(f, b): Queue[a]) -> List[a]:
   f.concat(b.reverse)
 
 ########
@@ -69,10 +65,9 @@ def queue_to_List(q: Queue[a]) -> List[a]:
 
 def eq_Opt(fn, a, b):
   match (a, b):
-    (None, None): True
-    (None, Some(_)): False
-    (Some(_), None): False
     (Some(a), Some(b)): fn(a, b)
+    (None, None): True
+    _: False
 
 def eq_List(fn, a, b):
   (res, _) = a.foldLeft((True, b), \current, h ->
@@ -97,11 +92,11 @@ tests = Test("queue tests", [
   Assertion(q12.fold_Queue(0,\_, x -> x).eq_Int(2), "take the second"),
   Assertion(q12.fold_Queue(0,\x, _ -> x).eq_Int(0), "take the first"),
   Assertion(q12.reverse_Queue.reverse_Queue.eq_qi(q12), "reverse is idempotent"),
-  Assertion(q12.eq_qi(queue_from_List([1, 2])), "from list [1, 2]"),
-  Assertion(q12.push(3).eq_qi(queue_from_List([1, 2, 3])), "from list [1, 2, 3]"),
-  Assertion(empty_Queue.eq_qi(queue_from_List([])), "empty_Queue == queue_from_List([])"),
-  Assertion(q12.eq_qi(queue_from_List([1, 2, 3])), "from list [1, 2, 3]"),
-  Assertion(queue_from_List([1, 2, 3]).pop_Queue.pop_Queue.pop_Queue.eq_qi(empty), "pop to empty"),
-  Assertion(empty.pop_Queue.eq_qi(empty), "pop empty is okay"),
-  Assertion(queue_to_List(queue_from_List([1, 1, 2, 2, 3, 3])).eq_li([1, 1, 2, 2, 3, 3]), "to/from List"),
+  Assertion(q12.eq_qi(from_List([1, 2])), "from list [1, 2]"),
+  Assertion(q12.push(3).eq_qi(from_List([1, 2, 3])), "from list [1, 2, 3]"),
+  Assertion(empty_Queue.eq_qi(from_List([])), "empty_Queue == from_List([])"),
+  Assertion(q12.eq_qi(from_List([1, 2, 3])), "from list [1, 2, 3]"),
+  Assertion(from_List([1, 2, 3]).pop.pop.pop.eq_qi(empty), "pop to empty"),
+  Assertion(empty.pop.eq_qi(empty), "pop empty is okay"),
+  Assertion(to_List(from_List([1, 1, 2, 2, 3, 3])).eq_li([1, 1, 2, 2, 3, 3]), "to/from List"),
 ])

--- a/test_workspace/Queue.bosatsu
+++ b/test_workspace/Queue.bosatsu
@@ -1,0 +1,107 @@
+package Queue
+
+export [ Queue,
+  empty_Queue, fold_Queue, push, pop, pop_value, pop_Queue, reverse_Queue, eq_Queue,
+  queue_to_List,
+]
+
+struct Queue(front: List[a], back: List[a])
+
+empty_Queue: forall a. Queue[a] = Queue([], [])
+
+# convenient local alias
+empty = empty_Queue
+
+def queue_from_List(list: List[a]) -> Queue[a]:
+  Queue(list, [])
+
+def push(queue: Queue[a], item: a) -> Queue[a]:
+  Queue(f, b) = queue
+  Queue(f, [item, *b])
+
+def pop(queue: Queue[a]) -> Option[(a, Queue[a])]:
+  match queue:
+    Queue([h, *t], b): Some((h, Queue(t, b)))
+    Queue([], b):
+      match b.reverse:
+        []: None
+        [h, *t]: Some((h, Queue(t, [])))
+
+def pop_value(queue: Queue[a]) -> Option[a]:
+  match pop(queue):
+    Some((a, _)): Some(a)
+    None: None
+
+# drop an item off and return the rest, or empty
+def pop_Queue(queue: Queue[a]) -> Queue[a]:
+  match pop(queue):
+    Some((_, queue)): queue
+    None: empty
+
+def fold_Queue(queue: Queue[a], init: b, fn: b -> a -> b) -> b:
+  Queue(f, b) = queue
+  front = f.foldLeft(init, fn)
+  b.reverse.foldLeft(front, fn)
+
+def reverse_Queue(queue: Queue[a]) -> Queue[a]:
+  Queue(f, b) = queue
+  Queue(b.reverse, f.reverse)
+
+def eq_Queue(eq_fn: a -> a -> Bool, left: Queue[a], right: Queue[a]) -> Bool:
+  (res, _) = left.fold_Queue((True, right), \(g, right), al ->
+    match g:
+      False: (False, empty)
+      True:
+        match pop(right):
+          None: (False, empty)
+          Some((ar, right)):
+            (eq_fn(al, ar), right)
+    )
+  res
+
+def queue_to_List(q: Queue[a]) -> List[a]:
+  Queue(f, b) = q
+  f.concat(b.reverse)
+
+########
+## Tests below
+########
+
+def eq_Opt(fn, a, b):
+  match (a, b):
+    (None, None): True
+    (None, Some(_)): False
+    (Some(_), None): False
+    (Some(a), Some(b)): fn(a, b)
+
+def eq_List(fn, a, b):
+  (res, _) = a.foldLeft((True, b), \current, h ->
+    match current:
+      (True, [hb, *tb]):
+        if fn(h, hb): (True, tb)
+        else: (False, [])
+      (_, []): (False, [])
+      (False, _): current
+  )
+  res
+
+eq_oi = eq_Opt(eq_Int)
+eq_qi = eq_Queue(eq_Int)
+eq_li = eq_List(eq_Int)
+
+q12 = empty.push(1).push(2)
+
+tests = Test("queue tests", [
+  Assertion(eq_oi(q12.pop_value, Some(1)), "1"),
+  Assertion(q12.fold_Queue(0,add).eq_Int(3), "fold_Queue add"),
+  Assertion(q12.fold_Queue(0,\_, x -> x).eq_Int(2), "take the second"),
+  Assertion(q12.fold_Queue(0,\x, _ -> x).eq_Int(0), "take the first"),
+  Assertion(q12.reverse_Queue.reverse_Queue.eq_qi(q12), "reverse is idempotent"),
+  Assertion(q12.eq_qi(queue_from_List([1, 2])), "from list [1, 2]"),
+  Assertion(q12.push(3).eq_qi(queue_from_List([1, 2, 3])), "from list [1, 2, 3]"),
+  Assertion(empty_Queue.eq_qi(queue_from_List([])), "empty_Queue == queue_from_List([])"),
+  Assertion(q12.eq_qi(queue_from_List([1, 2, 3])), "from list [1, 2, 3]"),
+  Assertion(queue_from_List([1, 2, 3]).pop_Queue.pop_Queue.pop_Queue.eq_qi(empty), "pop to empty"),
+  Assertion(empty.pop_Queue.eq_qi(empty), "pop empty is okay"),
+  Assertion(queue_to_List(queue_from_List([1, 1, 2, 2, 3, 3])).eq_li([1, 1, 2, 2, 3, 3]), "to/from List"),
+])

--- a/test_workspace/TreeList.bosatsu
+++ b/test_workspace/TreeList.bosatsu
@@ -27,9 +27,8 @@ empty: forall a. TreeList[a] = TreeList([])
 
 operator + = add
 
-def cons(head: a, tail: TreeList[a]) -> TreeList[a]:
-  TreeList(trees) = tail
-  match trees:
+def cons(head: a, TreeList(tail): TreeList[a]) -> TreeList[a]:
+  match tail:
     []: TreeList([Single(head)])
     [s1 @ Single(_)]:
       TreeList([Single(head), s1])
@@ -46,10 +45,9 @@ def cons(head: a, tail: TreeList[a]) -> TreeList[a]:
       if (eq_Int(s1, s2)):
         TreeList([Branch(s1 + s2 + 1, head, b1, b2), *t])
       else:
-        TreeList([Single(head), *trees])
+        TreeList([Single(head), *tail])
 
-def decons(tail: TreeList[a]) -> Option[(a, TreeList[a])]:
-  TreeList(trees) = tail
+def decons(TreeList(trees): TreeList[a]) -> Option[(a, TreeList[a])]:
   match trees:
     []: None
     [Single(h), *t]: Some((h, TreeList(t)))
@@ -63,9 +61,7 @@ def head(tl: TreeList[a]) -> Option[a]:
 operator + = add
 operator - = sub
 
-#def int_loop(intValue: Int, state: a, fn: Int -> a -> (Int, a)) -> a
-def get(tl: TreeList[a], idx: Int) -> Option[a]:
-  TreeList(trees) = tl
+def get(TreeList(trees): TreeList[a], idx: Int) -> Option[a]:
   # since int_loop stops at 0, we use 1 based indexing here
   (_, item) = int_loop(idx + 1, (trees, None), \idx, (trees, _) ->
     if eq_Int(idx, 1): (0, ([], head(TreeList(trees))))
@@ -86,8 +82,7 @@ def get(tl: TreeList[a], idx: Int) -> Option[a]:
 def from_List(list: List[a]) -> TreeList[a]:
   list.reverse.foldLeft(empty, \lst, h -> cons(h, lst))
 
-def fold(tl: TreeList[a], init: b, fn: b -> a -> b) -> b:
-  TreeList(trees) = tl
+def fold(TreeList(trees): TreeList[a], init: b, fn: b -> a -> b) -> b:
   def loop(trees, init):
     recur trees:
       []: init
@@ -123,10 +118,9 @@ def eq_List(fn, a, b):
 
 def eq_Opt(fn, a, b):
   match (a, b):
-    (None, None): True
-    (None, Some(_)): False
-    (Some(_), None): False
     (Some(a), Some(b)): fn(a, b)
+    (None, None): True
+    _: False
 
 eq_oi = eq_Opt(eq_Int)
 eq_ti = eq_TreeList(eq_Int)

--- a/test_workspace/TreeList.bosatsu
+++ b/test_workspace/TreeList.bosatsu
@@ -1,0 +1,152 @@
+package TreeList
+
+export [ TreeList, empty, cons, decons, head, get, fold, eq_TreeList ]
+
+# implementation of O(1) cons/uncons O(log N) list-like data structure
+
+enum Tree:
+  Single(a: a)
+  Branch(size: Int, head: a, left: Tree[a], right: Tree[a])
+
+def foldTree(t: Tree[a], init: b, fn: b -> a -> b) -> b:
+  # performance is better if we minimize the scope.
+  # this is a good candidate for optimization to fix
+  # this issue...
+  def loop(t: Tree[a], init: b) -> b:
+    recur t:
+      Single(a): fn(init, a)
+      Branch(_, h, l, r):
+        init = fn(init, h)
+        init = loop(l, init)
+        loop(r, init)
+  loop(t, init)
+
+struct TreeList(trees: List[Tree[a]])
+
+empty: forall a. TreeList[a] = TreeList([])
+
+operator + = add
+
+def cons(head: a, tail: TreeList[a]) -> TreeList[a]:
+  TreeList(trees) = tail
+  match trees:
+    []: TreeList([Single(head)])
+    [s1 @ Single(_)]:
+      TreeList([Single(head), s1])
+    [s1 @ Single(_), b1 @Branch(_, _, _, _), *t]:
+      TreeList([Single(head), b1, *t])
+    [s1 @ Single(_), s2 @ Single(_), *t]:
+      TreeList([Branch(3, head, s1, s2), *t])
+    [Branch(_, _, _, _), Single(_), *t]:
+      # illegal state, we can just return empty
+      empty
+    [branch @ Branch(_, _, _, _)]: TreeList([Single(head), branch])
+    [Branch(_, _, _, _), Single(_), *t]: empty
+    [b1@Branch(s1, _, _, _), b2@Branch(s2, _, _, _), *t]:
+      if (eq_Int(s1, s2)):
+        TreeList([Branch(s1 + s2 + 1, head, b1, b2), *t])
+      else:
+        TreeList([Single(head), *trees])
+
+def decons(tail: TreeList[a]) -> Option[(a, TreeList[a])]:
+  TreeList(trees) = tail
+  match trees:
+    []: None
+    [Single(h), *t]: Some((h, TreeList(t)))
+    [Branch(_, h, b1, b2), *t]: Some((h, TreeList([b1, b2, *t])))
+
+def head(tl: TreeList[a]) -> Option[a]:
+  match decons(tl):
+    Some((h, _)): Some(h)
+    None: None
+
+operator + = add
+operator - = sub
+
+#def int_loop(intValue: Int, state: a, fn: Int -> a -> (Int, a)) -> a
+def get(tl: TreeList[a], idx: Int) -> Option[a]:
+  TreeList(trees) = tl
+  # since int_loop stops at 0, we use 1 based indexing here
+  (_, item) = int_loop(idx + 1, (trees, None), \idx, (trees, _) ->
+    if eq_Int(idx, 1): (0, ([], head(TreeList(trees))))
+    else:
+      match trees:
+        []: (0, ([], None))
+        [Single(h), *rest]:
+          if eq_Int(idx, 1): (0, ([], Some(h)))
+          else: (idx - 1, (rest, None))
+        [Branch(s, _, t1, t2), *rest]:
+          # we can either skip just one, or skip the entire Tree
+          match cmp_Int(idx, s):
+            LT | EQ: (idx - 1, ([t1, t2, *rest], None))
+            _: (idx - s, (rest, None))
+  )
+  item
+
+def from_List(list: List[a]) -> TreeList[a]:
+  list.reverse.foldLeft(empty, \lst, h -> cons(h, lst))
+
+def fold(tl: TreeList[a], init: b, fn: b -> a -> b) -> b:
+  TreeList(trees) = tl
+  def loop(trees, init):
+    recur trees:
+      []: init
+      [h, *t]:
+        loop(t, h.foldTree(init, fn))
+  loop(trees, init)
+
+def to_List(list: TreeList[a]) -> List[a]:
+  fold(list, [], \l, h -> [h, *l]).reverse
+
+def eq_TreeList(fn, a, b):
+  (res, _) = a.fold((True, b), \(current, b), h ->
+    if current:
+      match b.decons:
+        None: (False, empty)
+        Some((hb, tb)):
+          if fn(h, hb): (True, tb)
+          else: (False, empty)
+    else: (False, empty)
+  )
+  res
+
+def eq_List(fn, a, b):
+  (res, _) = a.foldLeft((True, b), \current, h ->
+    match current:
+      (True, [hb, *tb]):
+        if fn(h, hb): (True, tb)
+        else: (False, [])
+      (_, []): (False, [])
+      (False, _): current
+  )
+  res
+
+def eq_Opt(fn, a, b):
+  match (a, b):
+    (None, None): True
+    (None, Some(_)): False
+    (Some(_), None): False
+    (Some(a), Some(b)): fn(a, b)
+
+eq_oi = eq_Opt(eq_Int)
+eq_ti = eq_TreeList(eq_Int)
+eq_li = eq_List(eq_Int)
+
+operator +/ = cons
+
+tl12 = 2 +/ (1 +/ empty)
+
+list14 = from_List([1, 2, 3, 4])
+cons14 = 1 +/ ( 2 +/ ( 3 +/ ( 4 +/ empty ) ) )
+
+tests = Test("TreeList tests", [
+  Assertion(tl12.get(0).eq_oi(Some(2)), "get 0 == 2"),
+  Assertion(tl12.get(1).eq_oi(Some(1)), "get 1 == 1"),
+  Assertion(tl12.get(2).eq_oi(None), "get 2 == None"),
+  Assertion(list14.get(0).eq_oi(Some(1)), "[1, 2, 3, 4] get 0"),
+  Assertion(list14.get(1).eq_oi(Some(2)), "[1, 2, 3, 4] get 1"),
+  Assertion(list14.get(2).eq_oi(Some(3)), "[1, 2, 3, 4] get 2"),
+  Assertion(list14.get(3).eq_oi(Some(4)), "[1, 2, 3, 4] get 3"),
+  Assertion(list14.fold(0, `+`).eq_Int(10), "fold to 10"),
+  Assertion(eq_ti(list14, cons14), "fromList matches building by cons"),
+])


### PR DESCRIPTION
This adds two implementations of potentially useful libraries as bosatsu examples, and immutable Queue and TreeList both originally described by Chris Okasaki.

This is the first "library code" I've ever actually written in bosatsu, and I really liked it. I think there are still patterns to be learned in the language, but I'm pretty happy living without typeclasses actually and just manually passing functions around. In this example I wrote `eq_Queue` and `eq_TreeList` which each themselves take functions to check equality on items, and returns a function to check equality on the data structure. This is exactly writing the `Eq` instances by hand, but it really doesn't seem very painful in this case to do so.

I am exploring a kind of strange style lately: actively using shadowing in order to prevent the possibility of accidentally using the wrong variable later. Some think shadowing is bad, but one upside of shadowing means the original value isn't able to be used, which can be a similar benefit to linear types: you can't accidentally reuse the wrong one later. Maybe it will be a stylistic dead-end, but I played with it a bit here.

cc @snoble if you want to do any style review.