### PR TITLE
Allow struct and enum to have explicit type arguments

### DIFF
--- a/core/src/main/scala/org/bykn/bosatsu/DefRecursionCheck.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/DefRecursionCheck.scala
@@ -49,13 +49,13 @@ object DefRecursionCheck {
         checkStatement(cs.on.padded)
       case Def(defn) =>
         checkDef(TopLevel, defn) *> checkStatement(defn.result._2.padded)
-      case Struct(_, _, rest) =>
+      case Struct(_, _, _, rest) =>
         checkStatement(rest.padded)
       case ExternalDef(_, _, _, rest) =>
         checkStatement(rest.padded)
       case ExternalStruct(_, _, rest) =>
         checkStatement(rest.padded)
-      case Enum(_, _, rest) =>
+      case Enum(_, _, _, rest) =>
         checkStatement(rest.padded)
       case EndOfFile =>
         unitValid

--- a/core/src/main/scala/org/bykn/bosatsu/Program.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/Program.scala
@@ -144,10 +144,10 @@ object Program {
             case (_, Padding(_, in)) => loop(in)
           }
           Program(te, (defstmt.name, RecursionKind.Recursive, lam) :: binds, stmt)
-        case s@Struct(_, _, Padding(_, rest)) =>
+        case s@Struct(_, _, _, Padding(_, rest)) =>
           val p = loop(rest)
           p.copy(types = defToT(p.types, s), from = s)
-        case e@Enum(_, _, Padding(_, rest)) =>
+        case e@Enum(_, _, _, Padding(_, rest)) =>
           val p = loop(rest)
           p.copy(types = defToT(p.types, e), from = e)
         case ExternalDef(name, params, result, Padding(_, rest)) =>

--- a/core/src/main/scala/org/bykn/bosatsu/TypeRef.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/TypeRef.scala
@@ -106,7 +106,9 @@ object TypeRef {
       case (s, Some(tr)) => Document[A].document(s) + colonSpace + (tr.toDoc)
     }
 
-  case class TypeVar(asString: String) extends TypeRef
+  case class TypeVar(asString: String) extends TypeRef {
+    def toBoundVar: Type.Var.Bound = Type.Var.Bound(asString)
+  }
   case class TypeName(name: Name) extends TypeRef
   case class TypeArrow(from: TypeRef, to: TypeRef) extends TypeRef
   case class TypeApply(of: TypeRef, args: NonEmptyList[TypeRef]) extends TypeRef

--- a/core/src/test/scala/org/bykn/bosatsu/ParserTest.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/ParserTest.scala
@@ -861,6 +861,14 @@ struct Monad(
   flatMap: forall a, b. f[a] -> (a -> f[b]) -> f[b])
 """)
 
+    // we can put type params in
+    roundTrip(Statement.parser,
+"""# MONADS!!!!
+struct Monad[f](
+  pure: forall a. a -> f[a],
+  flatMap: forall a, b. f[a] -> (a -> f[b]) -> f[b])
+""")
+
     // we can put new-lines in defs
     roundTrip(Statement.parser,
 """#
@@ -871,10 +879,17 @@ def foo(
 
     roundTrip(Statement.parser, """enum Option: None, Some(a)""")
 
+    roundTrip(Statement.parser, """enum Option[a]: None, Some(a: a)""")
+
     roundTrip(Statement.parser,
 """enum Option:
   None
   Some(a)""")
+
+    roundTrip(Statement.parser,
+"""enum Option[a]:
+  None
+  Some(a: a)""")
 
     roundTrip(Statement.parser,
 """enum Option:


### PR DESCRIPTION
close #83 

This is pretty easy it turns out, but since we have no errors allowed going from syntax into types, it means we have coerce anything into something meaningful. Two error conditions that are ignored currently:

1. duplicating type parameters shouldn't be allowed (similarly with value parameters)
2. I think we want type parameters to be a superset of the free type parameters in the args.

I think the right way to deal with these two cases are lints that run on the source code that give warnings or errors (depending on the package's source defined strictness, see #241 ), but we want to give the user as much feedback as possible, so it is good to be able to run the typechecker on the sanest interpretation of the input.

What do you think @snoble ?