### PR TITLE
Move CommentStatement to a separate file

### DIFF
--- a/core/src/main/scala/org/bykn/bosatsu/CommentStatement.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/CommentStatement.scala
@@ -1,0 +1,48 @@
+package org.bykn.bosatsu
+
+import cats.data.NonEmptyList
+import cats.implicits._
+import fastparse.all._
+import org.typelevel.paiges.{ Doc, Document }
+
+import org.bykn.fastparse_cats.StringInstances._
+
+/**
+ * Represents a commented thing. Commented[A] would probably
+ * be a better name
+ */
+final case class CommentStatement[T](message: NonEmptyList[String], on: T)
+
+object CommentStatement {
+  type Maybe[T] = Either[T, CommentStatement[T]]
+
+  implicit def document[T: Document]: Document[CommentStatement[T]] =
+    Document.instance[CommentStatement[T]] { comment =>
+      import comment._
+      val block = Doc.intercalate(Doc.line, message.toList.map { mes => Doc.char('#') + Doc.text(mes) })
+      block + Doc.line + Document[T].document(on)
+    }
+
+  implicit def maybeDocument[T: Document]: Document[Maybe[T]] = {
+    val docT = Document[T]
+    Document.instance[Maybe[T]] {
+      case Left(t) => docT.document(t)
+      case Right(c) => document[T](docT).document(c)
+    }
+  }
+
+  /** on should make sure indent is matching
+   * this is to allow a P[Unit] that does nothing for testing or other applications
+   */
+  def parser[T](onP: Parser.Indy[T]): Parser.Indy[CommentStatement[T]] = Parser.Indy { indent =>
+    val commentBlock: P[NonEmptyList[String]] =
+      P(commentPart ~ ("\n" ~ indent ~ commentPart).rep() ~ ("\n" | End))
+        .map { case (c1, cs) => NonEmptyList(c1, cs.toList) }
+
+    P(commentBlock ~ onP(indent))
+      .map { case (m, on) => CommentStatement(m, on) }
+  }
+
+  val commentPart: P[String] = P("#" ~/ CharsWhile(_ != '\n').?.!)
+}
+

--- a/core/src/main/scala/org/bykn/bosatsu/Statement.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/Statement.scala
@@ -12,46 +12,6 @@ import org.bykn.fastparse_cats.StringInstances._
 import Indy.IndyMethods
 import Identifier.{Bindable, Constructor}
 
-case class CommentStatement[T](message: NonEmptyList[String], on: T)
-
-object CommentStatement {
-  type Maybe[T] = Either[T, CommentStatement[T]]
-
-  implicit def document[T: Document]: Document[CommentStatement[T]] =
-    Document.instance[CommentStatement[T]] { comment =>
-      import comment._
-      val block = Doc.intercalate(Doc.line, message.toList.map { mes => Doc.char('#') + Doc.text(mes) })
-      block + Doc.line + Document[T].document(on)
-    }
-
-  implicit def maybeDocument[T: Document]: Document[Maybe[T]] = {
-    val docT = Document[T]
-    Document.instance[Maybe[T]] {
-      case Left(t) => docT.document(t)
-      case Right(c) => document[T](docT).document(c)
-    }
-  }
-
-  /** on should make sure indent is matching
-   * this is to allow a P[Unit] that does nothing for testing or other applications
-   */
-  def parser[T](onP: Parser.Indy[T]): Parser.Indy[CommentStatement[T]] = Parser.Indy { indent =>
-    val commentBlock: P[NonEmptyList[String]] =
-      P(commentPart ~ ("\n" ~ indent ~ commentPart).rep() ~ ("\n" | End))
-        .map { case (c1, cs) => NonEmptyList(c1, cs.toList) }
-
-    P(commentBlock ~ onP(indent))
-      .map { case (m, on) => CommentStatement(m, on) }
-  }
-
-  val commentPart: P[String] = P("#" ~/ CharsWhile(_ != '\n').?.!)
-}
-
-case class PackageStatement[T](name: String,
-  exports: List[Identifier],
-  emptyLines: Int,
-  contents: T)
-
 sealed abstract class Statement {
 
   def toStream: Stream[Statement] = {


### PR DESCRIPTION
minor code cleanup.

I want to get back to the style of one top-level name per scala file. I've been slack in some cases, and that makes the code harder to navigate.