### PR TITLE
More Evaluation optimizations

### DIFF
--- a/core/src/main/scala/org/bykn/bosatsu/Evaluation.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/Evaluation.scala
@@ -203,11 +203,9 @@ object Evaluation {
         }
       }
 
-    def asLambda(name: Bindable, set: Set[Identifier]): Scoped =
-      fromFn { env0 =>
+    def asLambda(name: Bindable): Scoped =
+      fromFn { env =>
         import cats.Now
-        // we can remove anything not captured by the closure
-        val env = env0.filter { case (k, _) => set(k) }
         val fn =
           FnValue {
             case n@Now(v) =>
@@ -225,7 +223,7 @@ object Evaluation {
 
     def applyArg(arg: Scoped): Scoped =
       fromFn { env =>
-        val fnE = inEnv(env)
+        val fnE = inEnv(env).memoize
         val argE = arg.inEnv(env)
         fnE.flatMap { fn =>
           // safe because we typecheck
@@ -244,7 +242,7 @@ object Evaluation {
     def recursive(name: Bindable, item: Scoped): Scoped = {
       fromFn { env =>
         lazy val env1: Map[Identifier, Eval[Value]] =
-          env + (name -> Eval.defer(item.inEnv(env1)).memoize)
+          env.updated(name, Eval.defer(item.inEnv(env1)).memoize)
         item.inEnv(env1)
       }
     }
@@ -621,9 +619,7 @@ case class Evaluation[T](pm: PackageMap.Typed[T], externals: Externals) {
          efn.applyArg(earg)
        case a@AnnotatedLambda(name, _, expr, _) =>
          val inner = recurse((p, Right(expr)))._1
-
-         val freeVars = TypedExpr.freeVars(a :: Nil).toSet
-         inner.asLambda(name, freeVars)
+         inner.asLambda(name)
        case Let(arg, e, in, rec, _) =>
          val e0 = recurse((p, Right(e)))._1
          val eres =
@@ -702,8 +698,9 @@ case class Evaluation[T](pm: PackageMap.Typed[T], externals: Externals) {
         if (singleItemStruct) prod
         else SumValue(enum, prod)
       }
-      else FnValue { ea =>
-        ea.map { a => loop(param - 1, a :: args) }.memoize
+      else FnValue {
+        case cats.Now(a) => cats.Now(loop(param - 1, a :: args))
+        case ea => ea.map { a => loop(param - 1, a :: args) }.memoize
       }
 
     Eval.now(loop(arity, Nil))

--- a/core/src/main/scala/org/bykn/bosatsu/Identifier.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/Identifier.scala
@@ -18,7 +18,7 @@ sealed abstract class Identifier {
       case _ => false
     }
 
-  override def hashCode: Int = asString.hashCode
+  override val hashCode: Int = asString.hashCode
 
   def toBindable: Option[Identifier.Bindable] =
     this match {
@@ -57,17 +57,17 @@ object Identifier {
     }
 
   val nameParser: P[Name] =
-    lowerIdent.map(Name(_))
+    lowerIdent.map { n => Name(n.intern) }
 
   val consParser: P[Constructor] =
-    upperIdent.map(Constructor(_))
+    upperIdent.map { c => Constructor(c.intern) }
 
   /**
    * This is used to apply operators, it is the
    * raw operator tokens without an `operator` prefix
    */
   val rawOperator: P[Operator] =
-    Operators.operatorToken.map(Operator(_))
+    Operators.operatorToken.map { op => Operator(op.intern) }
 
   /**
    * the keyword operator preceding a rawOperator
@@ -80,7 +80,7 @@ object Identifier {
    */
   val bindableParser: P[Bindable] =
     // operator has to come first to not look like a Name
-    operator | nameParser | Parser.escapedString('`').map(Backticked(_))
+    operator | nameParser | Parser.escapedString('`').map { b => Backticked(b.intern) }
 
   val parser: P[Identifier] =
     bindableParser | consParser

--- a/core/src/main/scala/org/bykn/bosatsu/Predef.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/Predef.scala
@@ -179,11 +179,13 @@ object PredefImpl {
   //def intLoop(intValue: Int, state: a, fn: Int -> a -> TupleCons[Int, TupleCons[a, Unit]]) -> a
   final def intLoop(intValue: Value, state: Value, fn: Value): Value = {
     val fnT = fn.asFn
+
     @annotation.tailrec
     def loop(biValue: Value, bi: BigInteger, state: Value): Value =
       if (bi.compareTo(BigInteger.ZERO) <= 0) state
       else {
-        fnT(biValue).flatMap(_.asFn(state)).value match {
+        val fn0 = fnT(biValue).value.asFn
+        fn0(state).value match {
           case ConsValue(nextI, ConsValue(ConsValue(nextA, _), _)) =>
             val n = i(nextI)
             if (n.compareTo(bi) >= 0) {


### PR DESCRIPTION
Gets almost 2x better. Not the 100x we got in #247 but still an improvement.

1. adds a benchmark of the slowest Euler problem and used that with jstack to look for cheap wins
2. the "optimization" of cleaning the Env in closures was hurting, not helping, so that was removed.
3. interning Identifiers and caching the hashCode was somewhat helpful
4. a few changes in memoization helped.

before:
```
[info] Benchmark          Mode  Cnt      Score     Error  Units   
[info] TestBench.bench0  thrpt    5  12098.270 ± 739.487  ops/s   
[info] TestBench.bench1  thrpt    5   8311.776 ± 400.025  ops/s   
[info] TestBench.bench2  thrpt    5      1.719 ±   0.115  ops/s~
```
after:
```
[info] Benchmark          Mode  Cnt      Score     Error  Units                             
[info] TestBench.bench0  thrpt    5  20597.788 ± 666.883  ops/s    
[info] TestBench.bench1  thrpt    5  13273.263 ± 306.294  ops/s    
[info] TestBench.bench2  thrpt    5      3.069 ±   0.286  ops/s
```