### PR TITLE
Add conversion to and from protobuf for Type

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -21,9 +21,15 @@ scala_repositories()
 load("@io_bazel_rules_scala//scala:toolchains.bzl", "scala_register_toolchains")
 scala_register_toolchains()
 
+load("@io_bazel_rules_scala//scala_proto:scala_proto.bzl", "scala_proto_repositories")
+scala_proto_repositories()
+
 load("//3rdparty:workspace.bzl", "maven_dependencies")
 
 maven_dependencies()
 
 bind(name = 'io_bazel_rules_scala/dependency/scalatest/scalatest', actual = '//3rdparty/jvm/org/scalatest')
 
+register_toolchains(
+  "//cli/src/main/protobuf/bosatsu:scalapb_toolchain"
+)

--- a/build.sbt
+++ b/build.sbt
@@ -92,8 +92,11 @@ lazy val cli = (project in file("cli")).
       Seq(
         jawnParser.value % Test,
         jawnAst.value % Test
-      )
-  ).dependsOn(coreJVM)
+      ),
+    PB.targets in Compile := Seq(
+     scalapb.gen() -> (sourceManaged in Compile).value
+   )
+  ).dependsOn(coreJVM % "compile->compile;test->test")
 
 lazy val core = (crossProject(JSPlatform, JVMPlatform).crossType(CrossType.Pure) in file("core")).
   settings(

--- a/cli/src/main/protobuf/bosatsu/BUILD
+++ b/cli/src/main/protobuf/bosatsu/BUILD
@@ -1,0 +1,24 @@
+load("@io_bazel_rules_scala//scala_proto:scala_proto.bzl", "scalapb_proto_library")
+load("@io_bazel_rules_scala//scala_proto:scala_proto_toolchain.bzl", "scala_proto_toolchain")
+
+scala_proto_toolchain(
+    name = "scala_proto_toolchain_configuration",
+    with_grpc = False,
+)
+
+toolchain(
+    name = "scalapb_toolchain",
+    toolchain = ":scala_proto_toolchain_configuration",
+    toolchain_type = "@io_bazel_rules_scala//scala_proto:toolchain_type",
+    visibility = ["//visibility:public"],
+)
+
+proto_library(
+    name = "bosatsu_proto",
+    srcs = ["TypedAst.proto"],
+    )
+
+scalapb_proto_library(
+    name = "bosatsu",
+    deps = [":bosatsu_proto"],
+    )

--- a/cli/src/main/protobuf/bosatsu/BUILD
+++ b/cli/src/main/protobuf/bosatsu/BUILD
@@ -1,6 +1,8 @@
 load("@io_bazel_rules_scala//scala_proto:scala_proto.bzl", "scalapb_proto_library")
 load("@io_bazel_rules_scala//scala_proto:scala_proto_toolchain.bzl", "scala_proto_toolchain")
 
+package(default_visibility = ["//visibility:public"])
+
 scala_proto_toolchain(
     name = "scala_proto_toolchain_configuration",
     with_grpc = False,

--- a/cli/src/main/protobuf/bosatsu/TypedAst.proto
+++ b/cli/src/main/protobuf/bosatsu/TypedAst.proto
@@ -1,0 +1,33 @@
+syntax = "proto3";
+
+package bosatsu;
+
+message TypeConst {
+  string packageName = 1;
+  string typeName = 2;
+}
+
+message TypeVar {
+  string varName = 1;
+}
+
+message TypeForAll {
+  repeated string varNames = 1;
+  Type typeValue = 2;
+}
+
+// represents left[right] type application
+message TypeApply {
+  Type left = 1;
+  Type right = 2;
+}
+
+message Type {
+  oneof value {
+    TypeConst typeConst = 1;
+    TypeVar typeVar = 2;
+    TypeForAll typeForAll = 3;
+    TypeApply typeApply = 4;
+  }
+}
+

--- a/cli/src/main/scala/org/bykn/bosatsu/BUILD
+++ b/cli/src/main/scala/org/bykn/bosatsu/BUILD
@@ -20,7 +20,7 @@ common_deps = [
 scala_library(
     name = "bosatsu",
     srcs = glob(["**/*.scala"], exclude=["Main.scala"]),
-    deps = common_deps)
+    deps = common_deps + ["//cli/src/main/protobuf/bosatsu"])
 
 scala_binary(
     name = "bosatsu_main",

--- a/cli/src/main/scala/org/bykn/bosatsu/TypedExprToProto.scala
+++ b/cli/src/main/scala/org/bykn/bosatsu/TypedExprToProto.scala
@@ -1,0 +1,72 @@
+package org.bykn.bosatsu
+
+import _root_.bosatsu.TypedAst.{Type => ProtoType}
+import org.bykn.bosatsu.rankn.Type
+import scala.util.{Failure, Success, Try}
+
+import cats.implicits._
+/**
+ * convert TypedExpr to and from Protobuf representation
+ */
+object ProtoConverter {
+  def typeFromProto(p: ProtoType): Try[Type] = {
+    import ProtoType.Value
+    import bosatsu.TypedAst.{Type => _, _}
+
+    def bound(n: String): Type.Var.Bound =
+      Type.Var.Bound(n)
+
+    p.value match {
+      case Value.Empty =>
+        Failure(new Exception("empty type found"))
+      case Value.TypeConst(TypeConst(pack, t)) =>
+        PackageName.parse(pack) match {
+          case None =>
+            Failure(new Exception(s"invalid package name: $pack, in $p"))
+          case Some(pack) =>
+            Try {
+              val cons = Identifier.unsafeParse(Identifier.consParser, t)
+              Type.TyConst(Type.Const.Defined(pack, TypeName(cons)))
+            }
+        }
+      case Value.TypeVar(TypeVar(nm)) =>
+        Success(Type.TyVar(bound(nm)))
+      case Value.TypeForAll(TypeForAll(args, in)) =>
+        in match {
+          case None => Failure(new Exception(s"invalid: ForAll($args, $in)"))
+          case Some(tpe) =>
+            typeFromProto(tpe).map { in =>
+              val boundArgs = args.iterator.map(bound).toList
+              Type.forAll(boundArgs, in)
+            }
+        }
+      case Value.TypeApply(TypeApply(left, right)) =>
+        left.product(right) match {
+          case None => Failure(new Exception(s"invalid TypeApply($left, $right)"))
+          case Some((l, r)) =>
+            (typeFromProto(l), typeFromProto(r)).mapN(Type.TyApply(_, _))
+        }
+    }
+  }
+  def typeToProto(p: Type): Try[ProtoType] = {
+    import ProtoType.Value
+    import bosatsu.TypedAst.{Type => _, _}
+
+    p match {
+      case Type.ForAll(bs, t) =>
+        typeToProto(t).map { pt =>
+          ProtoType(Value.TypeForAll(TypeForAll(bs.toList.map(_.name), Some(pt))))
+        }
+      case Type.TyApply(on, arg) =>
+        (typeToProto(on), typeToProto(arg)).mapN { (o, a) =>
+          ProtoType(Value.TypeApply(TypeApply(Some(o), Some(a))))
+        }
+      case Type.TyConst(Type.Const.Defined(p, n)) =>
+        Success(ProtoType(Value.TypeConst(TypeConst(p.asString, n.ident.asString))))
+      case Type.TyVar(Type.Var.Bound(n)) =>
+        Success(ProtoType(Value.TypeVar(TypeVar(n))))
+      case Type.TyVar(Type.Var.Skolem(_, _)) | Type.TyMeta(_) =>
+        Failure(new Exception(s"invalid type to serialize: $p"))
+    }
+  }
+}

--- a/cli/src/test/scala/org/bykn/bosatsu/TestProtoType.scala
+++ b/cli/src/test/scala/org/bykn/bosatsu/TestProtoType.scala
@@ -1,0 +1,26 @@
+package org.bykn.bosatsu
+
+import org.bykn.bosatsu.rankn.NTypeGen
+import org.scalatest.prop.PropertyChecks.{ forAll, PropertyCheckConfiguration }
+import org.scalatest.FunSuite
+
+class TestProtoType extends FunSuite {
+  implicit val generatorDrivenConfig =
+    //PropertyCheckConfiguration(minSuccessful = 5000)
+    PropertyCheckConfiguration(minSuccessful = 500)
+    //PropertyCheckConfiguration(minSuccessful = 5)
+
+  test("we can roundtrip through proto") {
+    forAll(NTypeGen.genDepth03) { tpe =>
+      val maybeProto = ProtoConverter.typeToProto(tpe)
+      assert(maybeProto.isSuccess, maybeProto.toString)
+      val proto = maybeProto.get
+
+      val maybeBack = ProtoConverter.typeFromProto(proto)
+      assert(maybeBack.isSuccess, maybeBack.toString)
+      val orig = maybeBack.get
+
+      assert(tpe == orig)
+    }
+  }
+}

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -11,6 +11,6 @@ object Dependencies {
   lazy val jawnParser = Def.setting("org.typelevel" %%% "jawn-parser" % "0.14.1")
   lazy val jawnAst = Def.setting("org.typelevel" %%% "jawn-ast" % "0.14.1")
   lazy val paiges = Def.setting("org.typelevel" %%% "paiges-core" % "0.2.0")
-  lazy val scalaTest = Def.setting("org.scalatest" %%% "scalatest" % "3.0.3")
   lazy val scalaCheck = Def.setting("org.scalacheck" %%% "scalacheck" % "1.13.5")
+  lazy val scalaTest = Def.setting("org.scalatest" %%% "scalatest" % "3.0.3")
 }

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,9 +1,13 @@
 addSbtPlugin("com.dwijnand" % "sbt-travisci" % "1.2.0")
-addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.5.1")
-addSbtPlugin("io.get-coursier" % "sbt-coursier" % "1.0.3")
 addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.14.9")
-addSbtPlugin("org.portable-scala" % "sbt-scalajs-crossproject" % "0.6.0")
+addSbtPlugin("com.thesamet" % "sbt-protoc" % "0.99.20")
+addSbtPlugin("io.get-coursier" % "sbt-coursier" % "1.0.3")
 addSbtPlugin("org.portable-scala" % "sbt-scala-native-crossproject" % "0.6.0")
+addSbtPlugin("org.portable-scala" % "sbt-scalajs-crossproject" % "0.6.0")
 addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.27")
 addSbtPlugin("org.scala-native" % "sbt-scala-native" % "0.3.9")
+addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.5.1")
 addSbtPlugin("pl.project13.scala" % "sbt-jmh" % "0.3.6")
+
+// This is adding this compiler plugin as a dependency for the build, not the code itself
+libraryDependencies += "com.thesamet.scalapb" %% "compilerplugin" % "0.8.4"


### PR DESCRIPTION
This adds a protobuf representation of `rankn.Type`. This is kind of a bottom up approach. The top is Package.Interface and Package.Typed that we want to serialize.

I have bad internet currently and I can't download the dependencies to get the bazel proto build working locally. I will need to do that before merging, but I may press on in a series of PRs that I fix up after the fact.