### PR TITLE
Add Proto version of package interfaces

### DIFF
--- a/cli/src/main/protobuf/bosatsu/TypedAst.proto
+++ b/cli/src/main/protobuf/bosatsu/TypedAst.proto
@@ -89,3 +89,7 @@ message Interface {
   repeated DefinedType definedTypes = 2;
   repeated ExportedName exports = 3;
 }
+
+message Interfaces {
+  repeated Interface interfaces = 1;
+}

--- a/cli/src/main/protobuf/bosatsu/TypedAst.proto
+++ b/cli/src/main/protobuf/bosatsu/TypedAst.proto
@@ -31,3 +31,61 @@ message Type {
   }
 }
 
+enum Variance {
+  Phantom = 0;
+  Covariant = 1;
+  Contravariant = 2;
+  Invariant = 3;
+}
+
+message TypeParam {
+  TypeVar typeVar = 1;
+  Variance variance = 2;
+}
+
+message FnParam {
+  string name = 1;
+  Type typeOf = 2;
+}
+
+message ConstructorFn {
+  string name = 1;
+  repeated FnParam params = 2;
+}
+
+message DefinedType {
+  TypeConst typeConst = 1;
+  repeated TypeParam typeParams = 2;
+  repeated ConstructorFn constructors = 3;
+}
+
+message ConstructorPtr {
+  int32 definedTypePtr = 1; /* 1-based pointer into the list of types */
+  int32 constructorPtr = 2; /* 1-based pointer into the list of constructors for this type */
+}
+
+message Referant {
+  oneof referant {
+    Type value = 1; /* an exported value which has a given type */
+    int32 definedTypePtr = 2; /* 1-based pointer into the list of types */
+    ConstructorPtr constructor = 3; /* an exported constructor */
+  }
+}
+
+message ExportedName {
+  oneof kind {
+    string binding = 1;
+    string typeName = 2;
+    string constructorName = 3;
+  }
+  Referant referant = 4;
+}
+
+/*
+ * This is an interface of a package: all public types, and the type of all exported values
+ */
+message Interface {
+  string packageName = 1;
+  repeated DefinedType definedTypes = 2;
+  repeated ExportedName exports = 3;
+}

--- a/cli/src/main/scala/org/bykn/bosatsu/BUILD
+++ b/cli/src/main/scala/org/bykn/bosatsu/BUILD
@@ -25,7 +25,10 @@ scala_library(
 scala_binary(
     name = "bosatsu_main",
     srcs = ["Main.scala"],
-    deps = [":bosatsu"] + common_deps,
+    deps = [
+        ":bosatsu",
+        "//cli/src/main/protobuf/bosatsu",
+    ] + common_deps,
     runtime_deps = [],
     main_class = "org.bykn.bosatsu.Main",
     scalacopts = strict_scalacopts(),

--- a/cli/src/main/scala/org/bykn/bosatsu/TypedExprToProto.scala
+++ b/cli/src/main/scala/org/bykn/bosatsu/TypedExprToProto.scala
@@ -1,42 +1,56 @@
 package org.bykn.bosatsu
 
-import _root_.bosatsu.TypedAst.{Type => ProtoType}
-import org.bykn.bosatsu.rankn.Type
+import _root_.bosatsu.{TypedAst => proto}
+import org.bykn.bosatsu.rankn.{Type, DefinedType}
 import scala.util.{Failure, Success, Try}
 
 import cats.implicits._
+
 /**
  * convert TypedExpr to and from Protobuf representation
  */
 object ProtoConverter {
-  def typeFromProto(p: ProtoType): Try[Type] = {
-    import ProtoType.Value
-    import bosatsu.TypedAst.{Type => _, _}
+  def typeConstFromProto(p: proto.TypeConst): Try[Type.Const.Defined] = {
+    val proto.TypeConst(pack, t) = p
+    PackageName.parse(pack) match {
+      case None =>
+        Failure(new Exception(s"invalid package name: $pack, in $p"))
+      case Some(pack) =>
+        Try {
+          val cons = Identifier.unsafeParse(Identifier.consParser, t)
+          Type.Const.Defined(pack, TypeName(cons))
+        }
+    }
+  }
 
-    def bound(n: String): Type.Var.Bound =
-      Type.Var.Bound(n)
+  def typeConstToProto(tc: Type.Const): proto.TypeConst =
+    tc match {
+      case Type.Const.Defined(p, n) =>
+        proto.TypeConst(p.asString, n.ident.asString)
+    }
+
+  def typeVarBoundToProto(tvb: Type.Var.Bound): proto.TypeVar =
+    proto.TypeVar(tvb.name)
+
+  def typeVarBoundFromProto(tv: proto.TypeVar): Type.Var.Bound =
+    Type.Var.Bound(tv.varName)
+
+  def typeFromProto(p: proto.Type): Try[Type] = {
+    import proto.Type.Value
+    import bosatsu.TypedAst.{Type => _, _}
 
     p.value match {
       case Value.Empty =>
         Failure(new Exception("empty type found"))
-      case Value.TypeConst(TypeConst(pack, t)) =>
-        PackageName.parse(pack) match {
-          case None =>
-            Failure(new Exception(s"invalid package name: $pack, in $p"))
-          case Some(pack) =>
-            Try {
-              val cons = Identifier.unsafeParse(Identifier.consParser, t)
-              Type.TyConst(Type.Const.Defined(pack, TypeName(cons)))
-            }
-        }
-      case Value.TypeVar(TypeVar(nm)) =>
-        Success(Type.TyVar(bound(nm)))
+      case Value.TypeConst(tc) => typeConstFromProto(tc).map(Type.TyConst(_))
+      case Value.TypeVar(tv) =>
+        Success(Type.TyVar(typeVarBoundFromProto(tv)))
       case Value.TypeForAll(TypeForAll(args, in)) =>
         in match {
           case None => Failure(new Exception(s"invalid: ForAll($args, $in)"))
           case Some(tpe) =>
             typeFromProto(tpe).map { in =>
-              val boundArgs = args.iterator.map(bound).toList
+              val boundArgs = args.iterator.map(Type.Var.Bound(_)).toList
               Type.forAll(boundArgs, in)
             }
         }
@@ -48,25 +62,232 @@ object ProtoConverter {
         }
     }
   }
-  def typeToProto(p: Type): Try[ProtoType] = {
-    import ProtoType.Value
+  def typeToProto(p: Type): Try[proto.Type] = {
+    import proto.Type.Value
     import bosatsu.TypedAst.{Type => _, _}
 
     p match {
       case Type.ForAll(bs, t) =>
         typeToProto(t).map { pt =>
-          ProtoType(Value.TypeForAll(TypeForAll(bs.toList.map(_.name), Some(pt))))
+          proto.Type(Value.TypeForAll(TypeForAll(bs.toList.map(_.name), Some(pt))))
         }
       case Type.TyApply(on, arg) =>
         (typeToProto(on), typeToProto(arg)).mapN { (o, a) =>
-          ProtoType(Value.TypeApply(TypeApply(Some(o), Some(a))))
+          proto.Type(Value.TypeApply(TypeApply(Some(o), Some(a))))
         }
-      case Type.TyConst(Type.Const.Defined(p, n)) =>
-        Success(ProtoType(Value.TypeConst(TypeConst(p.asString, n.ident.asString))))
+      case Type.TyConst(tcd) =>
+        Success(proto.Type(Value.TypeConst(typeConstToProto(tcd))))
       case Type.TyVar(Type.Var.Bound(n)) =>
-        Success(ProtoType(Value.TypeVar(TypeVar(n))))
+        Success(proto.Type(Value.TypeVar(TypeVar(n))))
       case Type.TyVar(Type.Var.Skolem(_, _)) | Type.TyMeta(_) =>
         Failure(new Exception(s"invalid type to serialize: $p"))
     }
   }
+
+  def varianceToProto(v: Variance): proto.Variance =
+    v match {
+      case Variance.Phantom => proto.Variance.Phantom
+      case Variance.Covariant => proto.Variance.Covariant
+      case Variance.Contravariant => proto.Variance.Contravariant
+      case Variance.Invariant => proto.Variance.Invariant
+    }
+
+  def varianceFromProto(p: proto.Variance): Try[Variance] =
+    p match {
+      case proto.Variance.Phantom => Success(Variance.Phantom)
+      case proto.Variance.Covariant => Success(Variance.Covariant)
+      case proto.Variance.Contravariant => Success(Variance.Contravariant)
+      case proto.Variance.Invariant => Success(Variance.Invariant)
+      case proto.Variance.Unrecognized(value) => Failure(new Exception(s"unrecognized value for variance: $value"))
+    }
+
+  def definedTypeToProto(d: DefinedType[Variance]): Try[proto.DefinedType] = {
+    val tc = typeConstToProto(d.toTypeConst)
+    def paramToProto(tv: (Type.Var.Bound, Variance)): proto.TypeParam =
+      proto.TypeParam(Some(typeVarBoundToProto(tv._1)), varianceToProto(tv._2))
+
+    val protoTypeParams: List[proto.TypeParam] = d.annotatedTypeParams.map(paramToProto)
+
+    val constructors: Try[List[proto.ConstructorFn]] =
+      d.constructors.traverse { case (c, tp, _) =>
+        tp.traverse { case (b, t) =>
+          typeToProto(t).map { tpe =>
+            proto.FnParam(b.asString, Some(tpe))
+          }
+        }
+        .map { params =>
+          proto.ConstructorFn(c.asString, params)
+        }
+      }
+
+    constructors.map(proto.DefinedType(Some(tc), protoTypeParams, _))
+  }
+
+  def definedTypeFromProto(pdt: proto.DefinedType): Try[DefinedType[Variance]] = {
+    def paramFromProto(tp: proto.TypeParam): Try[(Type.Var.Bound, Variance)] =
+      tp.typeVar match {
+        case None => Failure(new Exception(s"expected type variable in $tp"))
+        case Some(tv) =>
+          varianceFromProto(tp.variance).map { v =>
+            val tvb = typeVarBoundFromProto(tv)
+            (tvb, v)
+          }
+      }
+
+    def fnParamFromProto(p: proto.FnParam): Try[(Identifier.Bindable, Type)] =
+      p.typeOf match {
+        case None => Failure(new Exception(s"invalid FnParam, missing typeOf: $p"))
+        case Some(tpe) =>
+          Try(Identifier.unsafeParse(Identifier.bindableParser, p.name))
+            .product(typeFromProto(tpe))
+      }
+
+    def consFromProto(tc: Type.Const.Defined, tp: List[Type.Var.Bound], c: proto.ConstructorFn): Try[(Identifier.Constructor, List[(Identifier.Bindable, Type)], Type)] = {
+      Try(Identifier.unsafeParse(Identifier.consParser, c.name)).flatMap { cname =>
+        //def
+        c.params.toList.traverse(fnParamFromProto)
+          .map { fnParams =>
+            val fnType = DefinedType.constructorValueType(tc.packageName, tc.name, tp, fnParams.map(_._2))
+            (cname, fnParams, fnType)
+          }
+      }
+    }
+
+    pdt.typeConst match {
+      case None => Failure(new Exception(s"missing typeConst: $pdt"))
+      case Some(tc) =>
+        for {
+          tconst <- typeConstFromProto(tc)
+          tparams <- pdt.typeParams.toList.traverse(paramFromProto)
+          cons <- pdt.constructors.toList.traverse(consFromProto(tconst, tparams.map(_._1), _))
+        } yield DefinedType(tconst.packageName, tconst.name, tparams, cons)
+    }
+  }
+
+  def interfaceToProto(iface: Package.Interface): Try[proto.Interface] = {
+    val allDts = DefinedType.listToMap(
+      iface.exports.flatMap { ex =>
+        ex.tag match {
+          case Referant.Value(_) => Nil
+          case Referant.DefinedT(dt) => dt :: Nil
+          case Referant.Constructor(_, dt, _, _) => dt :: Nil
+        }
+      }).mapWithIndex { (dt, idx) => (dt, idx) }
+
+    val tryProtoDts = allDts
+      .traverse { case (dt, _) => definedTypeToProto(dt) }
+      .map(_.iterator.map(_._2).toList)
+
+    def expNameToProto(e: ExportedName[Referant[Variance]]): Try[proto.ExportedName] = {
+      val protoRef =
+        e.tag match {
+          case Referant.Value(t) =>
+            typeToProto(t).map { pt =>
+              proto.Referant(proto.Referant.Referant.Value(pt))
+            }
+          case Referant.DefinedT(dt) =>
+            val key = (dt.packageName, dt.name)
+            allDts.get(key) match {
+              case Some((_, idx)) =>
+                Success(
+                  proto.Referant(proto.Referant.Referant.DefinedTypePtr(idx + 1))
+                )
+              case None => Failure(new Exception(s"missing defined type for $key in $e"))
+            }
+          case Referant.Constructor(nm, dt, _, _) =>
+            val key = (dt.packageName, dt.name)
+            allDts.get(key) match {
+              case Some((dtV, dtIdx)) =>
+                val cIdx = dtV.constructors.indexWhere { case (c, _, _) => c == nm }
+                if (cIdx >= 0) {
+                  Success(
+                    proto.Referant(
+                      proto.Referant.Referant.Constructor(
+                        proto.ConstructorPtr(dtIdx + 1, cIdx + 1))))
+                }
+                else Failure(new Exception(s"missing contructor for type $key, $nm, with local: $dt"))
+              case None => Failure(new Exception(s"missing defined type for $key in $e"))
+            }
+        }
+      val exKind = e match {
+        case ExportedName.Binding(b, _) => proto.ExportedName.Kind.Binding(b.asString)
+        case ExportedName.TypeName(n, _) => proto.ExportedName.Kind.TypeName(n.asString)
+        case ExportedName.Constructor(n, _) => proto.ExportedName.Kind.ConstructorName(n.asString)
+      }
+
+      protoRef.map { ref => proto.ExportedName(Some(ref), exKind) }
+    }
+
+    val tryExports = iface.exports.traverse(expNameToProto)
+
+    (tryProtoDts, tryExports).mapN { (dts, exps) =>
+      proto.Interface(iface.name.asString, dts, exps)
+    }
+  }
+
+  private def referantFromProto[A](dts: Vector[DefinedType[A]], ref: proto.Referant): Try[Referant[A]] = {
+    def getDt(idx: Int): Try[DefinedType[A]] = {
+      // idx is 1 based:
+      val fixedIdx = idx - 1
+      if ((fixedIdx < 0) || (fixedIdx >= dts.size))
+        Failure(new Exception(s"invalid index: $idx in $ref, size: ${dts.size}"))
+      else Success(dts(fixedIdx))
+    }
+
+    ref.referant match {
+      case proto.Referant.Referant.Value(t) =>
+        typeFromProto(t).map(Referant.Value(_))
+      case proto.Referant.Referant.DefinedTypePtr(idx) =>
+        getDt(idx).map(Referant.DefinedT(_))
+      case proto.Referant.Referant.Constructor(proto.ConstructorPtr(dtIdx, cIdx)) =>
+        getDt(dtIdx).flatMap { dt =>
+          // cIdx is 1 based:
+          val fixedIdx = cIdx - 1
+          dt.constructors.get(fixedIdx.toLong) match {
+            case None =>
+              Failure(new Exception(s"invalid constructor index: $cIdx in: $dt"))
+            case Some((c, a, t)) =>
+              Success(Referant.Constructor(c, dt, a, t))
+          }
+        }
+      case proto.Referant.Referant.Empty => Failure(new Exception(s"empty referant found: $ref"))
+    }
+  }
+
+  private def exportedNameFromProto[A](dts: Vector[DefinedType[A]], en: proto.ExportedName): Try[ExportedName[Referant[A]]] = {
+    val tryRef = en.referant match {
+      case Some(r) => referantFromProto(dts, r)
+      case None => Failure(new Exception(s"missing referant in $en"))
+    }
+
+    tryRef.flatMap { ref =>
+      en.kind match {
+        case proto.ExportedName.Kind.Binding(s) =>
+          Try(ExportedName.Binding(Identifier.unsafeParse(Identifier.bindableParser, s), ref))
+        case proto.ExportedName.Kind.TypeName(n) =>
+          Try(ExportedName.TypeName(Identifier.unsafeParse(Identifier.consParser, n), ref))
+        case proto.ExportedName.Kind.ConstructorName(n) =>
+          Try(ExportedName.Constructor(Identifier.unsafeParse(Identifier.consParser, n), ref))
+        case proto.ExportedName.Kind.Empty => Failure(new Exception(s"empty exported name kind found in $ref"))
+      }
+    }
+  }
+
+  def interfaceFromProto(protoIface: proto.Interface): Try[Package.Interface] =
+    PackageName.parse(protoIface.packageName) match {
+      case None => Failure(new Exception(s"bad package name in: $protoIface"))
+      case Some(pn) =>
+        protoIface
+          .definedTypes
+          .toVector
+          .traverse(definedTypeFromProto)
+          .flatMap { dtVect =>
+            val exports: Try[List[ExportedName[Referant[Variance]]]] =
+              protoIface.exports.toList.traverse(exportedNameFromProto(dtVect, _))
+
+            exports.map { exports =>
+              Package(pn, Nil, exports, ())
+            }
+          }
+    }
 }

--- a/cli/src/main/scala/org/bykn/bosatsu/TypedExprToProto.scala
+++ b/cli/src/main/scala/org/bykn/bosatsu/TypedExprToProto.scala
@@ -112,7 +112,7 @@ object ProtoConverter {
       d.constructors.traverse { case (c, tp, _) =>
         tp.traverse { case (b, t) =>
           typeToProto(t).map { tpe =>
-            proto.FnParam(b.asString, Some(tpe))
+            proto.FnParam(b.sourceCodeRepr, Some(tpe))
           }
         }
         .map { params =>
@@ -210,7 +210,8 @@ object ProtoConverter {
             }
         }
       val exKind = e match {
-        case ExportedName.Binding(b, _) => proto.ExportedName.Kind.Binding(b.asString)
+        case ExportedName.Binding(b, _) =>
+          proto.ExportedName.Kind.Binding(b.sourceCodeRepr)
         case ExportedName.TypeName(n, _) => proto.ExportedName.Kind.TypeName(n.asString)
         case ExportedName.Constructor(n, _) => proto.ExportedName.Kind.ConstructorName(n.asString)
       }

--- a/cli/src/test/scala/org/bykn/bosatsu/TestProtoType.scala
+++ b/cli/src/test/scala/org/bykn/bosatsu/TestProtoType.scala
@@ -1,9 +1,11 @@
 package org.bykn.bosatsu
 
+import cats.Eq
 import org.bykn.bosatsu.rankn.NTypeGen
 import org.scalatest.prop.PropertyChecks.{ forAll, PropertyCheckConfiguration }
 import org.scalatest.FunSuite
 import scala.util.Try
+import cats.implicits._
 
 class TestProtoType extends FunSuite {
   implicit val generatorDrivenConfig =
@@ -11,7 +13,7 @@ class TestProtoType extends FunSuite {
     PropertyCheckConfiguration(minSuccessful = 500)
     //PropertyCheckConfiguration(minSuccessful = 5)
 
-  def law[A, B](a: A, fn: A => Try[B], gn: B => Try[A]) = {
+  def law[A: Eq, B](a: A, fn: A => Try[B], gn: B => Try[A]) = {
     val maybeProto = fn(a)
     assert(maybeProto.isSuccess, maybeProto.toString)
     val proto = maybeProto.get
@@ -20,18 +22,40 @@ class TestProtoType extends FunSuite {
     assert(maybeBack.isSuccess, maybeBack.toString)
     val orig = maybeBack.get
 
-    assert(a == orig)
+    // lazy val diffIdx =
+    //   a.toString
+    //     .zip(orig.toString)
+    //     .zipWithIndex
+    //     .dropWhile { case ((a, b), _) => a == b }
+    //     .headOption.map(_._2)
+    //     .getOrElse(0)
+
+    //assert(Eq[A].eqv(a, orig), s"${a.toString.drop(diffIdx).take(20)} != ${orig.toString.drop(diffIdx).take(20)}")
+    assert(Eq[A].eqv(a, orig))
   }
 
   test("we can roundtrip types through proto") {
     forAll(NTypeGen.genDepth03) { tpe =>
-      law(tpe, ProtoConverter.typeToProto _, ProtoConverter.typeFromProto _)
+      law(tpe, ProtoConverter.typeToProto _, ProtoConverter.typeFromProto _)(Eq.fromUniversalEquals)
+    }
+  }
+
+  test("we can roundtrip interface through proto") {
+    forAll(Generators.interfaceGen) { iface =>
+      law(iface, ProtoConverter.interfaceToProto _, ProtoConverter.interfaceFromProto _)(Eq.fromUniversalEquals)
     }
   }
 
   test("we can roundtrip interfaces through proto") {
-    forAll(Generators.interfaceGen) { iface =>
-      law(iface, ProtoConverter.interfaceToProto _, ProtoConverter.interfaceFromProto _)
+    forAll(Generators.smallList(Generators.interfaceGen)) { ifaces =>
+      val sortedEq: Eq[List[Package.Interface]] =
+        new Eq[List[Package.Interface]] {
+          def eqv(l: List[Package.Interface], r: List[Package.Interface]) =
+            // we are only sorting the left because we expect the right
+            // to come out sorted
+            l.sortBy(_.name.asString) == r
+        }
+      law(ifaces, ProtoConverter.interfacesToProto[List] _, ProtoConverter.interfacesFromProto _)(sortedEq)
     }
   }
 }

--- a/cli/src/test/scala/org/bykn/bosatsu/TestProtoType.scala
+++ b/cli/src/test/scala/org/bykn/bosatsu/TestProtoType.scala
@@ -3,6 +3,7 @@ package org.bykn.bosatsu
 import org.bykn.bosatsu.rankn.NTypeGen
 import org.scalatest.prop.PropertyChecks.{ forAll, PropertyCheckConfiguration }
 import org.scalatest.FunSuite
+import scala.util.Try
 
 class TestProtoType extends FunSuite {
   implicit val generatorDrivenConfig =
@@ -10,17 +11,27 @@ class TestProtoType extends FunSuite {
     PropertyCheckConfiguration(minSuccessful = 500)
     //PropertyCheckConfiguration(minSuccessful = 5)
 
-  test("we can roundtrip through proto") {
+  def law[A, B](a: A, fn: A => Try[B], gn: B => Try[A]) = {
+    val maybeProto = fn(a)
+    assert(maybeProto.isSuccess, maybeProto.toString)
+    val proto = maybeProto.get
+
+    val maybeBack = gn(proto)
+    assert(maybeBack.isSuccess, maybeBack.toString)
+    val orig = maybeBack.get
+
+    assert(a == orig)
+  }
+
+  test("we can roundtrip types through proto") {
     forAll(NTypeGen.genDepth03) { tpe =>
-      val maybeProto = ProtoConverter.typeToProto(tpe)
-      assert(maybeProto.isSuccess, maybeProto.toString)
-      val proto = maybeProto.get
+      law(tpe, ProtoConverter.typeToProto _, ProtoConverter.typeFromProto _)
+    }
+  }
 
-      val maybeBack = ProtoConverter.typeFromProto(proto)
-      assert(maybeBack.isSuccess, maybeBack.toString)
-      val orig = maybeBack.get
-
-      assert(tpe == orig)
+  test("we can roundtrip interfaces through proto") {
+    forAll(Generators.interfaceGen) { iface =>
+      law(iface, ProtoConverter.interfaceToProto _, ProtoConverter.interfaceFromProto _)
     }
   }
 }

--- a/core/src/main/scala/org/bykn/bosatsu/Codegen.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/Codegen.scala
@@ -64,7 +64,7 @@ trait CodeGen {
                 case None =>
                   Monad[Output].pure(())
                 case Some(n) =>
-                  tell(Doc.text("import static ") + Doc.text(toPackage(pack.unfix.name)) +
+                  tell(Doc.text("import static ") + Doc.text(toPackage(pack.name)) +
                     Doc.text(".Values.") + Doc.text(n) + Doc.char(';') + Doc.line)
               }).map(_ => None)
             }
@@ -87,7 +87,7 @@ trait CodeGen {
       Foldable[List].foldMap(ls) { case (p, orig, local) =>
         val priv = if (isExported(local)) "public " else "private "
         Doc.text(priv) + Doc.text("final static Object ") + Doc.text(toExportedName(local)) + Doc.text(" = ") +
-          Doc.text(toPackage(p.unfix.name)) + Doc.text(".Values.") + Doc.text(toExportedName(orig)) + Doc.text(";") + Doc.line
+          Doc.text(toPackage(p.name)) + Doc.text(".Values.") + Doc.text(toExportedName(orig)) + Doc.text(";") + Doc.line
       }
 
     val internalImports = List("Fn", "EnumValue")

--- a/core/src/main/scala/org/bykn/bosatsu/Evaluation.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/Evaluation.scala
@@ -665,7 +665,7 @@ case class Evaluation[T](pm: PackageMap.Typed[T], externals: Externals) {
           case Some(NameKind.Constructor(cn, _, dt, tpe)) =>
             (Scoped.const(constructor(cn, dt)), tpe)
           case Some(NameKind.Import(from, orig)) =>
-            val infFrom = pm.toMap(from.unfix.name)
+            val infFrom = pm.toMap(from.name)
             val other = recurse((infFrom, Left(orig)))
 
             // we reset the environment in the other package

--- a/core/src/main/scala/org/bykn/bosatsu/ExportedName.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/ExportedName.scala
@@ -79,11 +79,11 @@ object ExportedName {
    *   1. a type
    *   2. a value (e.g. a let or a constructor function)
    */
-  def buildExports[E, V](
+  def buildExports[E, V, R, D](
     nm: PackageName,
     exports: List[ExportedName[E]],
     typeEnv: rankn.TypeEnv[V],
-    lets: List[(Identifier.Bindable, RecursionKind, TypedExpr[Declaration])]): ValidatedNel[ExportedName[E], List[ExportedName[Referant[V]]]] = {
+    lets: List[(Identifier.Bindable, R, TypedExpr[D])]): ValidatedNel[ExportedName[E], List[ExportedName[Referant[V]]]] = {
 
      val letMap = lets.iterator.map { case (n, _, t) => (n, t) }.toMap
 

--- a/core/src/main/scala/org/bykn/bosatsu/Identifier.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/Identifier.scala
@@ -11,6 +11,9 @@ import cats.implicits._
 sealed abstract class Identifier {
   def asString: String
 
+  def sourceCodeRepr: String =
+    Identifier.document.document(this).renderWideStream.mkString
+
   override def equals(that: Any): Boolean =
     that match {
       case ident: Identifier =>

--- a/core/src/main/scala/org/bykn/bosatsu/Normalization.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/Normalization.scala
@@ -246,7 +246,7 @@ object Normalization {
         }
 
         maybeIdx match {
-          case None => 
+          case None =>
             // this is a struct, which means we expect it
             { (arg: NormalExpression, acc: PatternEnv) =>
               arg match {
@@ -255,7 +255,7 @@ object Normalization {
                 case _ =>
                   NotProvable
               }
-            } 
+            }
 
           case Some(idx) =>
             // we don't check if idx < 0, because if we compiled, it can't be
@@ -422,7 +422,7 @@ case class NormalizePackageMap(pm: PackageMap.Inferred) {
         a.copy(term=term, tag=tag)
       }
 
-  def normalizeGeneric(g: Generic[Declaration], env: Env, p: Package.Inferred): 
+  def normalizeGeneric(g: Generic[Declaration], env: Env, p: Package.Inferred):
     NormState[TypedExpr[(Declaration, NormalExpressionTag)]] =
       normalizeExpr(g.in, env, p).map { in =>
         val neTag = in.tag._2
@@ -549,7 +549,7 @@ case class NormalizePackageMap(pm: PackageMap.Inferred) {
 
   def normalizeProgram(pkgName: PackageName, pack: Package.Inferred): NormState[
     Program[TypeEnv[Variance], TypedExpr[(Declaration, Normalization.NormalExpressionTag)], Statement]] = {
-    for { 
+    for {
       lets <- pack.program.lets.map {
         case (name, recursive, expr) => normalizeNameKindLet(name, recursive, expr, pack, (Map(), Nil)).map((name, recursive, _))
       }.sequence
@@ -587,7 +587,7 @@ case class NormalizePackageMap(pm: PackageMap.Inferred) {
         case NameKind.Import(from, orig) =>
           // we reset the environment in the other package
           for {
-            imported <- norm(pm.toMap(from.unfix.name), orig, t, (Map.empty, Nil))
+            imported <- norm(pm.toMap(from.name), orig, t, (Map.empty, Nil))
             neTag = getTag(imported)._2
           } yield Left((item, (t, neTag)))
         case NameKind.ExternalDef(pn, n, scheme) =>
@@ -601,7 +601,7 @@ case class NormalizePackageMap(pm: PackageMap.Inferred) {
       lookup <- State.inspect {
         lets: Map[(PackageName, Identifier), TypedExpr[(Declaration, NormalExpressionTag)]] =>
           lets.get((pack.name, name))
-        } 
+        }
       outExpr  <- lookup match {
         case Some(res) =>
           State.pure(res): NormState[TypedExpr[(Declaration, NormalExpressionTag)]]

--- a/core/src/test/scala/org/bykn/bosatsu/Gen.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/Gen.scala
@@ -1,5 +1,6 @@
 package org.bykn.bosatsu
 
+import org.bykn.bosatsu.rankn.NTypeGen
 import cats.data.NonEmptyList
 import org.scalacheck.{Arbitrary, Gen, Shrink}
 import cats.implicits._
@@ -636,13 +637,68 @@ object Generators {
       consIdentGen.map(ExportedName.TypeName(_, ())),
       consIdentGen.map(ExportedName.Constructor(_, ())))
 
+  def smallList[A](g: Gen[A]): Gen[List[A]] =
+    Gen.choose(0, 8).flatMap(Gen.listOfN(_, g))
+
   def packageGen(depth: Int): Gen[Package.Parsed] =
     for {
       p <- packageNameGen
-      ic <- Gen.choose(0, 8)
       ec <- Gen.choose(0, 10)
-      imports <- Gen.listOfN(ic, importGen)
+      imports <- smallList(importGen)
       exports <- Gen.listOfN(ec, exportedNameGen)
       body <- genStatement(depth)
     } yield Package(p, imports, exports, body)
+
+
+  def genDefinedType[A](inner: Gen[A]): Gen[rankn.DefinedType[A]] =
+    for {
+      p <- packageNameGen
+      t <- typeNameGen
+      params0 <- smallList(Gen.zip(NTypeGen.genBound, inner))
+      params = params0.toMap.toList // don't generate duplicate type parameters
+      genCons: Gen[(Identifier.Constructor, List[(Identifier.Bindable, rankn.Type)], rankn.Type)] =
+        for {
+          cons <- consIdentGen
+          ps <- smallList(Gen.zip(bindIdentGen, NTypeGen.genDepth03))
+          res = rankn.DefinedType.constructorValueType(p, t, params.map(_._1), ps.map(_._2))
+        } yield (cons, ps, res)
+      cons <- smallList(genCons)
+    } yield rankn.DefinedType(p, t, params, cons)
+
+  def typeEnvGen[A](inner: Gen[A]): Gen[rankn.TypeEnv[A]] =
+    smallList(genDefinedType(inner)).map(rankn.TypeEnv.fromDefinitions(_))
+
+  def exportGen[A](te: rankn.TypeEnv[A]): Gen[ExportedName[Referant[A]]] = {
+    def bind(genTpe: Gen[rankn.Type]) = for {
+      n <- bindIdentGen
+      t <- genTpe
+    } yield ExportedName.Binding(n, Referant.Value(t))
+
+    te.allDefinedTypes match {
+      case Nil => bind(NTypeGen.genDepth03)
+      case dts =>
+        val b = bind(Gen.oneOf(NTypeGen.genDepth03, Gen.oneOf(dts).map(_.toTypeTyConst)))
+        val genExpT = Gen.oneOf(dts)
+          .map { dt =>
+            ExportedName.TypeName(dt.name.ident, Referant.DefinedT(dt))
+          }
+
+        dts.filter(_.constructors.nonEmpty) match {
+          case Nil => Gen.oneOf(b, genExpT)
+          case nonEmpty =>
+            val c = for {
+              dt <- Gen.oneOf(nonEmpty)
+              (c, ps, tpe) <- Gen.oneOf(dt.constructors)
+            } yield ExportedName.Constructor(c, Referant.Constructor(c, dt, ps, tpe))
+            Gen.oneOf(b, genExpT, c)
+        }
+    }
+  }
+
+  val interfaceGen: Gen[Package.Interface] =
+    for {
+      p <- packageNameGen
+      te <- typeEnvGen(Gen.oneOf(Variance.co, Variance.phantom, Variance.contra, Variance.in))
+      exs <- smallList(exportGen(te))
+    } yield Package(p, Nil, exs, ())
 }

--- a/core/src/test/scala/org/bykn/bosatsu/rankn/NTypeGen.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/rankn/NTypeGen.scala
@@ -1,0 +1,39 @@
+package org.bykn.bosatsu.rankn
+
+import org.scalacheck.Gen
+import org.bykn.bosatsu.Generators
+
+object NTypeGen {
+  val genRootType: Gen[Type] = {
+    val genConst =
+      Gen.zip(Generators.packageNameGen, Generators.typeNameGen)
+        .map { case (p, n) => Type.TyConst(Type.Const.Defined(p, n)) }
+
+    val genVar =
+      Generators.lowerIdent.map { v => Type.TyVar(Type.Var.Bound(v)) }
+
+    Gen.oneOf(genVar, genConst)
+  }
+
+  val genBound: Gen[Type.Var.Bound] =
+    Generators.lowerIdent.map { v => Type.Var.Bound(v) }
+
+  def genDepth(d: Int): Gen[Type] =
+    if (d <= 0) genRootType
+    else {
+      val recurse = Gen.lzy(genDepth(d - 1))
+      val genForAll =
+        for {
+          c <- Gen.choose(1, 5)
+          as <- Gen.listOfN(c, genBound)
+          in <- recurse
+        } yield Type.forAll(as, in)
+
+      val genApply = Gen.zip(recurse, recurse).map { case (a, b) => Type.TyApply(a, b) }
+
+      Gen.oneOf(recurse, genApply, genForAll)
+    }
+
+
+  val genDepth03: Gen[Type] = Gen.choose(0, 3).flatMap(genDepth(_))
+}

--- a/core/src/test/scala/org/bykn/bosatsu/rankn/TypeTest.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/rankn/TypeTest.scala
@@ -6,38 +6,6 @@ import org.scalatest.prop.PropertyChecks.{ forAll, PropertyCheckConfiguration }
 import org.scalatest.FunSuite
 import org.bykn.bosatsu.Generators
 
-object NTypeGen {
-  val genRootType: Gen[Type] = {
-    val genConst =
-      Gen.zip(Generators.packageNameGen, Generators.typeNameGen)
-        .map { case (p, n) => Type.TyConst(Type.Const.Defined(p, n)) }
-
-    val genVar =
-      Generators.lowerIdent.map { v => Type.TyVar(Type.Var.Bound(v)) }
-
-    Gen.oneOf(genVar, genConst)
-  }
-
-  def genDepth(d: Int): Gen[Type] =
-    if (d <= 0) genRootType
-    else {
-      val recurse = Gen.lzy(genDepth(d - 1))
-      val args = Generators.lowerIdent.map { v => Type.Var.Bound(v) }
-      val genForAll =
-        for {
-          c <- Gen.choose(1, 5)
-          as <- Gen.listOfN(c, args)
-          in <- recurse
-        } yield Type.forAll(as, in)
-
-      val genApply = Gen.zip(recurse, recurse).map { case (a, b) => Type.TyApply(a, b) }
-
-      Gen.oneOf(recurse, genApply, genForAll)
-    }
-
-
-  val genDepth03: Gen[Type] = Gen.choose(0, 3).flatMap(genDepth(_))
-}
 
 class TypeTest extends FunSuite {
   implicit val generatorDrivenConfig =

--- a/tools/bosatsu.bzl
+++ b/tools/bosatsu.bzl
@@ -33,8 +33,9 @@ def _bosatsu_library_impl(ctx):
   args = ["type-check"]
   for f in all_inputs:
     args += ["--input", f.path]
-  for f in provider.transitive_sigs:
-    args += ["--interface", f.path]
+  # TODO: This is not yet supported
+  # for f in provider.transitive_sigs:
+  #   args += ["--interface", f.path]
 
   args += ["--output", ctx.outputs.interface.path]
 

--- a/tools/bosatsu.bzl
+++ b/tools/bosatsu.bzl
@@ -18,8 +18,8 @@ def _collect_deps(ctx):
 
 def _add_self(ctx, prov):
   outs = []
-  if hasattr(ctx.outputs, "signature"):
-    outs += [ctx.outputs.signature]
+  if hasattr(ctx.outputs, "interface"):
+    outs += [ctx.outputs.interface]
   if hasattr(ctx.outputs, "json"):
     outs += [ctx.outputs.json]
 
@@ -34,13 +34,13 @@ def _bosatsu_library_impl(ctx):
   for f in all_inputs:
     args += ["--input", f.path]
   for f in provider.transitive_sigs:
-    args += ["--signature", f.path]
+    args += ["--interface", f.path]
 
-  args += ["--output", ctx.outputs.signature.path]
+  args += ["--output", ctx.outputs.interface.path]
 
   ctx.action(
-      inputs = all_inputs + provider.transitive_sigs, # TODO only use signatures of dependencies
-      outputs = [ctx.outputs.signature],
+      inputs = all_inputs + provider.transitive_sigs, # TODO only use interface of dependencies
+      outputs = [ctx.outputs.interface],
       executable = ctx.executable._bosatsu_main,
       mnemonic = "Bosatsu",
       progress_message = "bosatsu %s (%s files)" % (ctx.label, len(ctx.files.srcs)),
@@ -57,7 +57,7 @@ bosatsu_library = rule(
         "_bosatsu_main": attr.label(executable=True, cfg="host", default=Label("//cli/src/main/scala/org/bykn/bosatsu:bosatsu_main")),
     },
     outputs = {
-      "signature": "%{name}.bosatsig",
+      "interface": "%{name}.bosatsig",
     },
 )
 
@@ -69,13 +69,13 @@ def _bosatsu_json_impl(ctx):
   for f in all_inputs:
     args += ["--input", f.path]
   for f in provider.transitive_sigs:
-    args += ["--signature", f.path]
+    args += ["--interface", f.path]
 
   args += ["--output", ctx.outputs.json.path]
   args += ["--main", ctx.attr.package]
 
   ctx.action(
-      inputs = all_inputs + provider.transitive_sigs, # TODO only use signatures of dependencies
+      inputs = all_inputs + provider.transitive_sigs, # TODO only use interface of dependencies
       outputs = [ctx.outputs.json],
       executable = ctx.executable._bosatsu_main,
       mnemonic = "Bosatsu",


### PR DESCRIPTION
part of #54 

This adds proto serialization of interfaces, but does not yet use them.

The idea is to allow the CLI to depend on proto interfaces and avoid having to transitively recompile code in order to use dependencies. We should also emit proto interfaces when we compile. Lastly, we need to make the bazel rules aware of these so it can plumb them through correctly. That will be in follow up PRs.