### PR TITLE
Use interface files in bosatsu_library

### DIFF
--- a/bench/src/main/scala/org/bykn/bosatsu/TestBench.scala
+++ b/bench/src/main/scala/org/bykn/bosatsu/TestBench.scala
@@ -26,7 +26,7 @@ class TestBench {
         sys.error("failed to parse") //errs.toString)
     }
 
-    PackageMap.resolveThenInfer(Predef.withPredefA(("predef", LocationMap("")), parsedPaths)) match {
+    PackageMap.resolveThenInfer(Predef.withPredefA(("predef", LocationMap("")), parsedPaths), Nil) match {
       case (dups, Validated.Valid(packMap)) if dups.isEmpty =>
         (packMap, mainPack)
       case other => sys.error(s"expected clean compilation: $other")

--- a/core/src/main/scala/org/bykn/bosatsu/Package.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/Package.scala
@@ -55,15 +55,22 @@ final case class Package[A, B, C, D](
 }
 
 object Package {
-  type FixPackage[B, C, D] = Fix[Lambda[a => Package[a, B, C, D]]]
-  type PackageF[A, B, C] = Package[FixPackage[A, B, C], A, B, C]
+  type Interface = Package[Nothing, Nothing, Referant[Variance], Unit]
+  /**
+   * This is a package whose import type is Either:
+   * 1 a package of the same kind
+   * 2 an interface
+   */
+  type FixPackage[B, C, D] = Fix[Lambda[a => Either[Interface, Package[a, B, C, D]]]]
+  type PackageF[A, B, C] = Either[Interface, Package[FixPackage[A, B, C], A, B, C]]
   type PackageF2[A, B] = PackageF[A, A, B]
   type Parsed = Package[PackageName, Unit, Unit, Statement]
   type Resolved = FixPackage[Unit, Unit, (Statement, ImportMap[PackageName, Unit])]
-  type Interface = Package[Nothing, Nothing, Referant[Variance], Unit]
   type Typed[T] = Package[Interface, NonEmptyList[Referant[Variance]], Referant[Variance], Program[TypeEnv[Variance], TypedExpr[T], Statement]]
   type Inferred = Typed[Declaration]
 
+  def fix[A, B, C](p: PackageF[A, B, C]): FixPackage[A, B, C] =
+    Fix[Lambda[a => Either[Interface, Package[a, A, B, C]]]](p)
   /**
    * build a Parsed Package from a Statement. This is useful for testing or
    * library usages.

--- a/core/src/main/scala/org/bykn/bosatsu/PackageMap.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/PackageMap.scala
@@ -48,7 +48,7 @@ object PackageMap {
         else Left((bad, good))
     }
 
-  import Package.{ FixPackage, PackageF2 }
+  import Package.FixPackage
 
   type MapF3[A, B, C] = PackageMap[FixPackage[A, B, C], A, B, C]
   type MapF2[A, B] = MapF3[A, A, B]
@@ -71,14 +71,25 @@ object PackageMap {
    * This builds a DAG of actual packages where names have been replaced by the fully resolved
    * packages
    */
-  def resolvePackages[A, B, C](map: PackageMap[PackageName, A, B, C]): ValidatedNel[PackageError, MapF3[A, B, C]] = {
-    def getPackage(i: Import[PackageName, A], from: Package[PackageName, A, B, C]): ValidatedNel[PackageError, Import[Package[PackageName, A, B, C], A]] =
-      map.toMap.get(i.pack) match {
-        case None => Validated.invalidNel(PackageError.UnknownImportPackage(i.pack, from))
-        case Some(pack) => Validated.valid(Import(pack, i.items))
-      }
+  def resolvePackages[A, B, C](map: PackageMap[PackageName, A, B, C], ifs: List[Package.Interface]): ValidatedNel[PackageError, MapF3[A, B, C]] = {
+    val interfaceMap = ifs.iterator.map { iface => (iface.name, iface) }.toMap
 
-    def step(p: Package[PackageName, A, B, C]): ReaderT[Either[NonEmptyList[PackageError], ?], List[PackageName], Package[FixPackage[A, B, C], A, B, C]] = {
+    def getPackage(
+      i: Import[PackageName, A],
+      from: Package[PackageName, A, B, C]): ValidatedNel[PackageError, Import[Either[Package.Interface, Package[PackageName, A, B, C]], A]] =
+        map.toMap.get(i.pack) match {
+          case Some(pack) => Validated.valid(Import(Right(pack), i.items))
+          case None =>
+            interfaceMap.get(i.pack) match {
+              case Some(iface) =>
+                Validated.valid(Import(Left(iface), i.items))
+              case None =>
+                Validated.invalidNel(PackageError.UnknownImportPackage(i.pack, from))
+            }
+        }
+
+    type RightPackageF = Right[Package.Interface, Package[FixPackage[A, B, C], A, B, C]]
+    def step(p: Package[PackageName, A, B, C]): ReaderT[Either[NonEmptyList[PackageError], ?], List[PackageName], RightPackageF] = {
       val edeps = ReaderT.ask[Either[NonEmptyList[PackageError], ?], List[PackageName]]
         .flatMapF {
           case nonE@(h :: tail) if nonE.contains(p.name) =>
@@ -89,29 +100,48 @@ object PackageMap {
         }
 
       edeps
-        .flatMap { deps =>
+        .flatMap { deps: List[Import[Either[Package.Interface, Package[PackageName, A, B, C]], A]] =>
           deps.traverse { i =>
-            step(i.pack)
-              .local[List[PackageName]](p.name :: _) // add this package into the path of all the deps
-              .map { p => Import(Fix[Lambda[a => Package[a, A, B, C]]](p), i.items) }
+            i.pack match {
+              case Right(pack) =>
+                step(pack)
+                  .local[List[PackageName]](p.name :: _) // add this package into the path of all the deps
+                  .map { p => Import(Package.fix[A, B, C](p), i.items) }
+              case Left(iface) =>
+                ReaderT.pure[
+                  Either[NonEmptyList[PackageError], ?],
+                  List[PackageName],
+                  Import[FixPackage[A, B, C], A]](Import(Package.fix[A, B, C](Left(iface)), i.items))
+            }
           }
           .map { imports =>
-            Package(p.name, imports, p.exports, p.program)
+            Right(Package(p.name, imports, p.exports, p.program))
           }
         }
     }
 
-    type M = Map[PackageName, Package[FixPackage[A, B, C], A, B, C]]
+    type M = Map[PackageName, RightPackageF]
     val r: ReaderT[Either[NonEmptyList[PackageError], ?], List[PackageName], M] =
       map.toMap.traverse(step)
     val m: Either[NonEmptyList[PackageError], M] = r.run(Nil)
-    m.map(PackageMap(_)).toValidated
+
+    def unright[L, R](r: Right[L, R]): R =
+      r match {
+        case Right(a) => a
+      }
+    m.map { map =>
+      val m1 =
+        map.iterator.map { case (k, v) =>
+          (k, unright(v))
+        }.toMap
+      PackageMap(m1)
+    }.toValidated
   }
 
   /**
    * Convenience method to create a PackageMap then resolve it
    */
-  def resolveAll[A](ps: List[(A, Package.Parsed)]): (Map[PackageName, ((A, Package.Parsed), NonEmptyList[(A, Package.Parsed)])], ValidatedNel[PackageError, Resolved]) = {
+  def resolveAll[A](ps: List[(A, Package.Parsed)], ifs: List[Package.Interface]): (Map[PackageName, ((A, Package.Parsed), NonEmptyList[(A, Package.Parsed)])], ValidatedNel[PackageError, Resolved]) = {
 
     type AP = (A, Package.Parsed)
     val (nonUnique, unique): (Map[PackageName, (AP, NonEmptyList[AP])], Map[PackageName, AP]) =
@@ -126,11 +156,10 @@ object PackageMap {
         Package[PackageName, Unit, Unit, (Statement, ImportMap[PackageName, Unit])]) = {
 
       val (errs0, imap) = ImportMap.fromImports(p.imports)
-      val errs = errs0 match {
-        case Nil => None
-        case h :: tail =>
-          Some(PackageError.DuplicatedImport(NonEmptyList(h, tail)))
-      }
+      val errs =
+        NonEmptyList.fromList(errs0)
+          .map(PackageError.DuplicatedImport)
+
       (errs, p.mapProgram((_, imap)))
     }
 
@@ -147,7 +176,7 @@ object PackageMap {
     }
 
     val (errs, pmap) = foldMap(unique)
-    val res = resolvePackages(pmap)
+    val res = resolvePackages(pmap, ifs)
     // combine the import errors now:
     val check =
       errs match {
@@ -166,7 +195,11 @@ object PackageMap {
   def inferAll(ps: Resolved): ValidatedNel[PackageError, Inferred] = {
 
     // This is unfixed resolved
-    type ResolvedU = PackageF2[Unit, (Statement, ImportMap[PackageName, Unit])]
+    type ResolvedU = Package[
+      FixPackage[Unit, Unit, (Statement, ImportMap[PackageName, Unit])],
+      Unit,
+      Unit,
+      (Statement, ImportMap[PackageName, Unit])]
     /*
      * We memoize this function to avoid recomputing diamond dependencies
      */
@@ -174,7 +207,7 @@ object PackageMap {
       Memoize.function[ResolvedU, ValidatedNel[PackageError, Package.Inferred]] {
         // TODO, we ignore importMap here, we only check earlier we don't
         // have duplicate imports
-        case (p@Package(nm, imports, exports, (stmt, importMap)), recurse) =>
+        case (Package(nm, imports, exports, (stmt, importMap)), recurse) =>
 
           def getImport[A, B](packF: Package.Inferred,
             exMap: Map[Identifier, NonEmptyList[ExportedName[A]]],
@@ -183,7 +216,21 @@ object PackageMap {
               case None =>
                 Validated.invalidNel(
                   PackageError.UnknownImportName(
-                    p, packF, i,
+                    nm, packF, i,
+                    exMap.iterator.flatMap(_._2.toList).toList))
+              case Some(exps) =>
+                val bs = exps.map(_.tag)
+                Validated.valid(i.map(_ => bs))
+            }
+
+          def getImportIface[A, B](packF: Package.Interface,
+            exMap: Map[Identifier, NonEmptyList[ExportedName[A]]],
+            i: ImportedName[B]): ValidatedNel[PackageError, ImportedName[NonEmptyList[A]]] =
+            exMap.get(i.originalName) match {
+              case None =>
+                Validated.invalidNel(
+                  PackageError.UnknownImportFromInterface(
+                    nm, packF, i,
                     exMap.iterator.flatMap(_._2.toList).toList))
               case Some(exps) =>
                 val bs = exps.map(_.tag)
@@ -200,11 +247,24 @@ object PackageMap {
           def stepImport(i: Import[Package.Resolved, Unit]):
             ValidatedNel[PackageError, Import[Package.Interface, NonEmptyList[Referant[Variance]]]] = {
             val Import(fixpack, items) = i
-            recurse(fixpack.unfix).andThen { packF =>
-              val packInterface = Package.interfaceOf(packF)
-              val exMap = ExportedName.buildExportMap(packF.exports)
-              items.traverse(getImport(packF, exMap, _))
-                .map(Import(packInterface, _))
+            fixpack.unfix match {
+              case Right(p) =>
+                /*
+                 * Here we have a source we need to fully resolve
+                 */
+                recurse(p).andThen { packF =>
+                  val packInterface = Package.interfaceOf(packF)
+                  val exMap = ExportedName.buildExportMap(packF.exports)
+                  items.traverse(getImport(packF, exMap, _))
+                    .map(Import(packInterface, _))
+                }
+              case Left(iface) =>
+                /*
+                 * this import is already an interface, we can stop here
+                 */
+                val exMap = ExportedName.buildExportMap(iface.exports)
+                items.traverse(getImportIface(iface, exMap, _))
+                  .map(Import(iface, _))
             }
           }
 
@@ -221,7 +281,7 @@ object PackageMap {
                 }
                 .leftMap { badPackages =>
                   badPackages.map { n =>
-                    PackageError.UnknownExport(n, p, lets)
+                    PackageError.UnknownExport(n, nm, lets)
                   }
                 }
             }
@@ -231,8 +291,9 @@ object PackageMap {
   }
 
   def resolveThenInfer[A](
-    ps: List[(A, Package.Parsed)]): (Map[PackageName, ((A, Package.Parsed), NonEmptyList[(A, Package.Parsed)])], ValidatedNel[PackageError, Inferred]) = {
-      val (bad, good) = resolveAll(ps)
+    ps: List[(A, Package.Parsed)],
+    ifs: List[Package.Interface]): (Map[PackageName, ((A, Package.Parsed), NonEmptyList[(A, Package.Parsed)])], ValidatedNel[PackageError, Inferred]) = {
+      val (bad, good) = resolveAll(ps, ifs)
       (bad, good.andThen(inferAll(_)))
     }
 
@@ -267,10 +328,10 @@ object PackageError {
       .map { case (i, _, a) => (i, a) }
 
   case class UnknownExport[A](ex: ExportedName[A],
-    in: Package.PackageF2[Unit, (Statement, ImportMap[PackageName, Unit])],
+    in: PackageName,
     lets: List[(Identifier.Bindable, RecursionKind, TypedExpr[Declaration])]) extends PackageError {
     def message(sourceMap: Map[PackageName, (LocationMap, String)]) = {
-      val (lm, sourceName) = sourceMap(in.name)
+      val (lm, sourceName) = sourceMap(in)
       val header =
         s"in $sourceName unknown export ${ex.name}"
       val candidateMap: Map[Identifier, Region] =
@@ -310,7 +371,7 @@ object PackageError {
 
   // We could check if we forgot to export the name in the package and give that error
   case class UnknownImportName[A, B](
-    in: Package.PackageF2[Unit, (Statement, ImportMap[PackageName, Unit])],
+    in: PackageName,
     importing: Package.Inferred,
     iname: ImportedName[A],
     exports: List[ExportedName[B]]) extends PackageError {
@@ -319,7 +380,7 @@ object PackageError {
           .program
           .lets
 
-        val (_, sourceName) = sourceMap(in.name)
+        val (_, sourceName) = sourceMap(in)
         val letMap = ls.iterator.map { case (n, _, _) => (n: Identifier, ()) }.toMap
         letMap
           .get(iname.originalName) match {
@@ -333,6 +394,23 @@ object PackageError {
           }
       }
     }
+
+  case class UnknownImportFromInterface[A, B](
+    in: PackageName,
+    importing: Package.Interface,
+    iname: ImportedName[A],
+    exports: List[ExportedName[B]]) extends PackageError {
+      def message(sourceMap: Map[PackageName, (LocationMap, String)]) = {
+
+        val (_, sourceName) = sourceMap(in)
+        val exportMap = importing.exports.map { e => (e.name, ()) }.toMap
+        val near = nearest(iname.originalName, exportMap, 3)
+          .map { case (n, _) => n.asString }
+          .mkString(" Nearest: ", ", ", "")
+        s"in $sourceName package: ${importing.name} does not have name ${iname.originalName}.$near"
+      }
+    }
+
   case class CircularDependency[A, B, C](from: Package[PackageName, A, B, C], path: NonEmptyList[PackageName]) extends PackageError {
     def message(sourceMap: Map[PackageName, (LocationMap, String)]) = {
       val packs = from.name :: (path.toList)

--- a/core/src/test/scala/org/bykn/bosatsu/CodegenTest.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/CodegenTest.scala
@@ -11,7 +11,7 @@ class CodegenTest extends FunSuite {
     val validated =
       ss.traverse(Parser.parse(Package.parser, _))
         .andThen { parsed =>
-          PackageMap.resolveThenInfer(parsed)._2
+          PackageMap.resolveThenInfer(parsed, Nil)._2
         }
 
     validated match {

--- a/core/src/test/scala/org/bykn/bosatsu/PackageTest.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/PackageTest.scala
@@ -7,7 +7,7 @@ import org.scalatest.FunSuite
 class PackageTest extends FunSuite {
 
   def resolveThenInfer(ps: Iterable[Package.Parsed]): ValidatedNel[PackageError, PackageMap.Inferred] =
-    PackageMap.resolveThenInfer(ps.toList.map { p => ((), p) })._2
+    PackageMap.resolveThenInfer(ps.toList.map { p => ((), p) }, Nil)._2
 
   def parse(s: String): Package.Parsed =
     Package.parser.parse(s) match {

--- a/core/src/test/scala/org/bykn/bosatsu/TestUtils.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/TestUtils.scala
@@ -128,7 +128,7 @@ object TestUtils {
         sys.error("failed to parse") //errs.toString)
     }
 
-    PackageMap.resolveThenInfer(Predef.withPredefA(("predef", LocationMap("")), parsedPaths)) match {
+    PackageMap.resolveThenInfer(Predef.withPredefA(("predef", LocationMap("")), parsedPaths), Nil) match {
       case (dups, Validated.Valid(packMap)) if dups.isEmpty =>
         inferredHandler(packMap, mainPack)
 
@@ -199,7 +199,7 @@ object TestUtils {
     }
 
     val withPre = Predef.withPredefA(("predef", LocationMap("")), parsedPaths)
-    PackageMap.resolveThenInfer(withPre) match {
+    PackageMap.resolveThenInfer(withPre, Nil) match {
       case (_, Validated.Valid(_)) =>
         fail("expected to fail type checking")
 

--- a/tools/bosatsu.bzl
+++ b/tools/bosatsu.bzl
@@ -29,19 +29,18 @@ def _add_self(ctx, prov):
 def _bosatsu_library_impl(ctx):
   provider = _collect_deps(ctx)
 
-  all_inputs = provider.transitive_deps + ctx.files.srcs
   args = ["type-check"]
-  for f in all_inputs:
+  for f in ctx.files.srcs:
     args += ["--input", f.path]
-  # TODO: This is not yet supported
-  # for f in provider.transitive_sigs:
-  #   args += ["--interface", f.path]
+  for f in provider.transitive_sigs:
+    args += ["--interface", f.path]
 
-  args += ["--output", ctx.outputs.interface.path]
+  args += ["--interface_out", ctx.outputs.interface.path]
+  args += ["--output", ctx.outputs.info_out.path]
 
   ctx.action(
-      inputs = all_inputs + provider.transitive_sigs, # TODO only use interface of dependencies
-      outputs = [ctx.outputs.interface],
+      inputs = depset(ctx.files.srcs, transitive=[provider.transitive_sigs]),
+      outputs = [ctx.outputs.interface, ctx.outputs.info_out],
       executable = ctx.executable._bosatsu_main,
       mnemonic = "Bosatsu",
       progress_message = "bosatsu %s (%s files)" % (ctx.label, len(ctx.files.srcs)),
@@ -59,6 +58,7 @@ bosatsu_library = rule(
     },
     outputs = {
       "interface": "%{name}.bosatsig",
+      "info_out": "%{name}.info_out",
     },
 )
 


### PR DESCRIPTION
This changes the type-check command to emit protobuf interface files and consume those from dependencies rather than recompiling the full source.

This is only useful to improve the speed of `bosatsu_library` it does not help `bosatsu_test` because that has to evaluate the code, and we have not yet implemented a full serialized typechecked package.

part of #54 

The format of the protobuf still probably needs work: the assumption that types are small seems false so we probably want to build a full type table and reference those as integers so we don't declare them over and over, and also probably the same for package names.

one issue is that the version of protobuf we are pulling in gives this warning:
```
WARNING: An illegal reflective access operation has occurred                                                                         
WARNING: Illegal reflective access by com.google.protobuf.UnsafeUtil (file:/home/oscarboykin/.cache/bazel/_bazel_oscarboykin/59ac5359
049e5a9d2939770b3c14229a/execroot/org_bykn_bosatsu/bazel-out/host/bin/external/com_google_protobuf/libprotobuf_java.jar) to field jav
a.nio.Buffer.address                                                                                                                 
WARNING: Please consider reporting this to the maintainers of com.google.protobuf.UnsafeUtil               
WARNING: Use --illegal-access=warn to enable warnings of further illegal reflective access operations
WARNING: All illegal access operations will be denied in a future release  
```