### PR TITLE
Put external defs in Program

### DIFF
--- a/core/src/main/scala/org/bykn/bosatsu/NameKind.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/NameKind.scala
@@ -47,15 +47,7 @@ object NameKind {
       }
 
     def getExternal: Option[NameKind[T]] =
-      // there should not be duplicate top level names TODO lint for this
-      prog.externalDefs.collectFirst {
-        case n if n == item =>
-          // The type could be an import, so we need to check for the type
-          // in the TypeEnv
-          val pn = from.name
-          val tpe = prog.types.getValue(pn, n).get
-          ExternalDef(pn, item, tpe)
-      }
+      externals(from).find(_.defName == item)
 
     getLet
       .orElse(getConstructor)

--- a/core/src/main/scala/org/bykn/bosatsu/NameKind.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/NameKind.scala
@@ -15,13 +15,12 @@ object NameKind {
 
   def externals[T](from: Package.Typed[T]): Stream[ExternalDef[T]] = {
     val prog = from.program
-    prog.from.toStream.collect {
-      case Statement.ExternalDef(n, _, _, _) =>
-        // The type could be an import, so we need to check for the type
-        // in the TypeEnv
-        val pn = from.name
-        val tpe = prog.types.getValue(pn, n).get
-        ExternalDef[T](pn, n, tpe)
+    prog.externalDefs.toStream.map { n =>
+      // The type could be an import, so we need to check for the type
+      // in the TypeEnv
+      val pn = from.name
+      val tpe = prog.types.getValue(pn, n).get
+      ExternalDef[T](pn, n, tpe)
     }
   }
 
@@ -49,8 +48,8 @@ object NameKind {
 
     def getExternal: Option[NameKind[T]] =
       // there should not be duplicate top level names TODO lint for this
-      prog.from.toStream.collectFirst {
-        case Statement.ExternalDef(n, _, _, _) if n == item =>
+      prog.externalDefs.collectFirst {
+        case n if n == item =>
           // The type could be an import, so we need to check for the type
           // in the TypeEnv
           val pn = from.name

--- a/core/src/main/scala/org/bykn/bosatsu/Normalization.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/Normalization.scala
@@ -548,7 +548,7 @@ case class NormalizePackageMap(pm: PackageMap.Inferred) {
   }
 
   def normalizeProgram(pkgName: PackageName, pack: Package.Inferred): NormState[
-    Program[TypeEnv[Variance], TypedExpr[(Declaration, Normalization.NormalExpressionTag)], Statement]] = {
+    Program[TypeEnv[Variance], TypedExpr[(Declaration, Normalization.NormalExpressionTag)], Any]] = {
     for {
       lets <- pack.program.lets.map {
         case (name, recursive, expr) => normalizeNameKindLet(name, recursive, expr, pack, (Map(), Nil)).map((name, recursive, _))

--- a/core/src/main/scala/org/bykn/bosatsu/PackageMap.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/PackageMap.scala
@@ -61,7 +61,7 @@ object PackageMap {
     Program[
       TypeEnv[Variance],
       TypedExpr[T],
-      Statement
+      Any
     ]
   ]
 
@@ -274,10 +274,10 @@ object PackageMap {
               Package.inferBody(nm, imps, stmt)
                 .map((imps, _))
             }
-            .andThen { case (imps, (types, lets)) =>
+            .andThen { case (imps, (types, extDefs, lets)) =>
               ExportedName.buildExports(nm, exports, types, lets)
                 .map { exps =>
-                  Package(nm, imps, exps, Program(types, lets, stmt))
+                  Package(nm, imps, exps, Program(types, lets, extDefs, stmt))
                 }
                 .leftMap { badPackages =>
                   badPackages.map { n =>

--- a/core/src/main/scala/org/bykn/bosatsu/PackageMap.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/PackageMap.scala
@@ -274,15 +274,14 @@ object PackageMap {
               Package.inferBody(nm, imps, stmt)
                 .map((imps, _))
             }
-            .andThen { case (imps, (types, extDefs, lets)) =>
-              ExportedName.buildExports(nm, exports, types, lets)
-                .map { exps =>
-                  Package(nm, imps, exps, Program(types, lets, extDefs, stmt))
-                }
-                .leftMap { badPackages =>
-                  badPackages.map { n =>
+            .andThen { case (imps, program@Program(types, lets, _, _)) =>
+              ExportedName.buildExports(nm, exports, types, lets) match {
+                case Validated.Valid(exps) =>
+                  Validated.valid(Package(nm, imps, exps, program))
+                case Validated.Invalid(badPackages) =>
+                  Validated.invalid(badPackages.map { n =>
                     PackageError.UnknownExport(n, nm, lets)
-                  }
+                  })
                 }
             }
         }

--- a/core/src/test/scala/org/bykn/bosatsu/TestUtils.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/TestUtils.scala
@@ -52,7 +52,7 @@ object TestUtils {
         Package.inferBody(PackageName.parts("Test"), Nil, stmt) match {
           case Validated.Invalid(errs) =>
             fail("inference failure: " + errs.toList.map(_.message(Map.empty)).mkString("\n"))
-          case Validated.Valid((_, lets)) =>
+          case Validated.Valid((_, _, lets)) =>
             fn(lets.last._3)
         }
       case Parsed.Failure(exp, idx, extra) =>

--- a/core/src/test/scala/org/bykn/bosatsu/TestUtils.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/TestUtils.scala
@@ -52,8 +52,8 @@ object TestUtils {
         Package.inferBody(PackageName.parts("Test"), Nil, stmt) match {
           case Validated.Invalid(errs) =>
             fail("inference failure: " + errs.toList.map(_.message(Map.empty)).mkString("\n"))
-          case Validated.Valid((_, _, lets)) =>
-            fn(lets.last._3)
+          case Validated.Valid(program) =>
+            fn(program.lets.last._3)
         }
       case Parsed.Failure(exp, idx, extra) =>
         fail(s"failed to parse: $statement: $exp at $idx with trace: ${extra.traced.trace}")

--- a/core/src/test/scala/org/bykn/bosatsu/rankn/RankNInferTest.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/rankn/RankNInferTest.scala
@@ -122,8 +122,8 @@ class RankNInferTest extends FunSuite {
       case Parsed.Success(stmt, _) =>
         Package.inferBody(PackageName.parts("Test"), Nil, stmt) match {
           case Validated.Invalid(_) => assert(true)
-          case Validated.Valid((tpeEnv, _, lets)) =>
-            fail(lets.toString)
+          case Validated.Valid(program) =>
+            fail(program.lets.toString)
         }
       case Parsed.Failure(exp, idx, extra) =>
         fail(s"failed to parse: $statement: $exp at $idx with trace: ${extra.traced.trace}")

--- a/core/src/test/scala/org/bykn/bosatsu/rankn/RankNInferTest.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/rankn/RankNInferTest.scala
@@ -122,7 +122,7 @@ class RankNInferTest extends FunSuite {
       case Parsed.Success(stmt, _) =>
         Package.inferBody(PackageName.parts("Test"), Nil, stmt) match {
           case Validated.Invalid(_) => assert(true)
-          case Validated.Valid((tpeEnv, lets)) =>
+          case Validated.Valid((tpeEnv, _, lets)) =>
             fail(lets.toString)
         }
       case Parsed.Failure(exp, idx, extra) =>


### PR DESCRIPTION
To serialize compiled packages, we don't want to serialize the source ADTs (I don't think). But currently, evaluation actually reaches all the way back to the source to get the list of external defs. If we need them, we should explicitly put them on Program. That's what this PR does.