### PR TITLE
Fix forall arg in function

### DIFF
--- a/core/src/main/scala/org/bykn/bosatsu/rankn/Infer.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/rankn/Infer.scala
@@ -437,29 +437,17 @@ object Infer {
         case (fa@Type.ForAll(_, _), rho) =>
           // Rule SPEC
           instantiate(fa).flatMap(subsCheckRho(_, rho, left, right))
-        case (Type.Fun(fa@Type.ForAll(vars, _), r1), rho2) =>
-          unifyFnForAllArg(rho2, vars, right, left).flatMap { case (a2, r2) =>
-            instantiate(fa).flatMap { instA1 =>
-              subsCheckFn(instA1, r1, a2, r2, left, right)
-            }
-          }
-        case (rho, Type.Fun(fa@Type.ForAll(vars, _), r1)) =>
-          unifyFnForAllArg(rho, vars, right, left).flatMap { case (a2, r2) =>
-            instantiate(fa).flatMap { instA1 =>
-              subsCheckFn(a2, r2, instA1, r1, left, right)
-            }
-          }
         case (rho1, Type.Fun(a2, r2)) =>
           // Rule FUN
           unifyFn(rho1, left, right).flatMap {
             case (a1, r1) =>
-              subsCheckFn(a1, r1, a2, r2, left, right)
+              subsCheckFn(a2, r2, a1, r1, left, right)
           }
         case (Type.Fun(a1, r1), rho2) =>
           // Rule FUN
           unifyFn(rho2, right, left).flatMap {
             case (a2, r2) =>
-              subsCheckFn(a1, r1, a2, r2, left, right)
+              subsCheckFn(a2, r2, a1, r1, left, right)
           }
         case (rho1, Type.TyApply(l2, r2)) =>
           unifyTyApp(rho1, left, right).flatMap {
@@ -519,16 +507,6 @@ object Infer {
             argT <- newMetaType
             resT <- newMetaType
             _ <- unify(tau, Type.Fun(argT, resT), fnRegion, evidenceRegion)
-          } yield (argT, resT)
-      }
-    def unifyFnForAllArg(fnType: Type, vars: NonEmptyList[Type.Var.Bound], fnRegion: Region, evidenceRegion: Region): Infer[(Type, Type)] =
-      fnType match {
-        case Type.Fun(Type.ForAll(vars2, arg), res) => pure((arg, res))
-        case tau =>
-          for {
-            argT <- newMetaType
-            resT <- newMetaType
-            _ <- unify(tau, Type.Fun(Type.ForAll(vars, argT), resT), fnRegion, evidenceRegion)
           } yield (argT, resT)
       }
 

--- a/core/src/main/scala/org/bykn/bosatsu/rankn/Infer.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/rankn/Infer.scala
@@ -437,6 +437,18 @@ object Infer {
         case (fa@Type.ForAll(_, _), rho) =>
           // Rule SPEC
           instantiate(fa).flatMap(subsCheckRho(_, rho, left, right))
+        case (Type.Fun(fa@Type.ForAll(vars, _), r1), rho2) =>
+          unifyFnForAllArg(rho2, vars, right, left).flatMap { case (a2, r2) =>
+            instantiate(fa).flatMap { instA1 =>
+              subsCheckFn(instA1, r1, a2, r2, left, right)
+            }
+          }
+        case (rho, Type.Fun(fa@Type.ForAll(vars, _), r1)) =>
+          unifyFnForAllArg(rho, vars, right, left).flatMap { case (a2, r2) =>
+            instantiate(fa).flatMap { instA1 =>
+              subsCheckFn(a2, r2, instA1, r1, left, right)
+            }
+          }
         case (rho1, Type.Fun(a2, r2)) =>
           // Rule FUN
           unifyFn(rho1, left, right).flatMap {
@@ -507,6 +519,16 @@ object Infer {
             argT <- newMetaType
             resT <- newMetaType
             _ <- unify(tau, Type.Fun(argT, resT), fnRegion, evidenceRegion)
+          } yield (argT, resT)
+      }
+    def unifyFnForAllArg(fnType: Type, vars: NonEmptyList[Type.Var.Bound], fnRegion: Region, evidenceRegion: Region): Infer[(Type, Type)] =
+      fnType match {
+        case Type.Fun(Type.ForAll(vars2, arg), res) => pure((arg, res))
+        case tau =>
+          for {
+            argT <- newMetaType
+            resT <- newMetaType
+            _ <- unify(tau, Type.Fun(Type.ForAll(vars, argT), resT), fnRegion, evidenceRegion)
           } yield (argT, resT)
       }
 

--- a/core/src/test/scala/org/bykn/bosatsu/rankn/RankNInferTest.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/rankn/RankNInferTest.scala
@@ -869,34 +869,37 @@ main = bar(5)
     parseProgram("""#
 struct Wrap[bbbb](y1: bbbb)
 struct Foo[cccc](y2: cccc)
+struct Nil
 
-def foo(cra_fn: Wrap[(forall ssss. Foo[ssss]) -> Int]):
+def foo(cra_fn: Wrap[(forall ssss. Foo[ssss]) -> Nil]):
   Wrap(_) = cra_fn
-  2
+  Nil
 
 main = foo
-""", "Wrap[(forall ssss. Foo[ssss]) -> Int] -> Int")
+""", "Wrap[(forall ssss. Foo[ssss]) -> Nil] -> Nil")
   }
 
   test("nested ForAll as function arg") {
     parseProgram("""#
 struct Wrap[bbbb](y1: bbbb)
 struct Foo[cccc](y2: cccc)
+struct Nil
 
-def foo(cra_fn: Wrap[Foo[forall ssss. Foo[ssss]] -> Int]):
+def foo(cra_fn: Wrap[Foo[forall ssss. Foo[ssss]] -> Nil]):
   Wrap(_) = cra_fn
-  2
+  Nil
 
 main = foo
-""", "Wrap[Foo[forall ssss. Foo[ssss]] -> Int] -> Int")
+""", "Wrap[Foo[forall ssss. Foo[ssss]] -> Nil] -> Nil")
   }
 
   test("ForAll as function arg called with bad arg") {
     parseProgramIllTyped("""#
 struct Wrap[bbbb](y1: bbbb)
 struct Foo[cccc](y2: cccc)
+struct Nil
 
-def foo(cra_fn: Wrap[(forall ssss. Foo[ssss]) -> Int]):
+def foo(cra_fn: Wrap[(forall ssss. Foo[ssss]) -> Nil]):
   Wrap(_) = cra_fn
   2
 

--- a/core/src/test/scala/org/bykn/bosatsu/rankn/RankNInferTest.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/rankn/RankNInferTest.scala
@@ -878,6 +878,19 @@ main = foo
 """, "Wrap[(forall ssss. Foo[ssss]) -> Int] -> Int")
   }
 
+  test("nested ForAll as function arg") {
+    parseProgram("""#
+struct Wrap[bbbb](y1: bbbb)
+struct Foo[cccc](y2: cccc)
+
+def foo(cra_fn: Wrap[Foo[forall ssss. Foo[ssss]] -> Int]):
+  Wrap(_) = cra_fn
+  2
+
+main = foo
+""", "Wrap[Foo[forall ssss. Foo[ssss]) -> Int] -> Int")
+  }
+
   test("ForAll as function arg called with bad arg") {
     parseProgramIllTyped("""#
 struct Wrap[bbbb](y1: bbbb)

--- a/core/src/test/scala/org/bykn/bosatsu/rankn/RankNInferTest.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/rankn/RankNInferTest.scala
@@ -864,4 +864,30 @@ def bar(x):
 main = bar(5)
 """, "Pair[Int, Int]")
   }
+
+  test("ForAll as function arg") {
+    parseProgram("""#
+struct Wrap[bbbb](y1: bbbb)
+struct Foo[cccc](y2: cccc)
+
+def foo(cra_fn: Wrap[(forall ssss. Foo[ssss]) -> Int]):
+  Wrap(_) = cra_fn
+  2
+
+main = foo
+""", "Wrap[(forall ssss. Foo[ssss]) -> Int] -> Int")
+  }
+
+  test("ForAll as function arg called with bad arg") {
+    parseProgramIllTyped("""#
+struct Wrap[bbbb](y1: bbbb)
+struct Foo[cccc](y2: cccc)
+
+def foo(cra_fn: Wrap[(forall ssss. Foo[ssss]) -> Int]):
+  Wrap(_) = cra_fn
+  2
+
+main = foo(Wrap(\Foo(x) -> x))
+""")
+  }
 }

--- a/core/src/test/scala/org/bykn/bosatsu/rankn/RankNInferTest.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/rankn/RankNInferTest.scala
@@ -901,7 +901,7 @@ struct Nil
 
 def foo(cra_fn: Wrap[(forall ssss. Foo[ssss]) -> Nil]):
   Wrap(_) = cra_fn
-  2
+  Nil
 
 main = foo(Wrap(\Foo(x) -> x))
 """)

--- a/core/src/test/scala/org/bykn/bosatsu/rankn/RankNInferTest.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/rankn/RankNInferTest.scala
@@ -888,7 +888,7 @@ def foo(cra_fn: Wrap[Foo[forall ssss. Foo[ssss]] -> Int]):
   2
 
 main = foo
-""", "Wrap[Foo[forall ssss. Foo[ssss]) -> Int] -> Int")
+""", "Wrap[Foo[forall ssss. Foo[ssss]] -> Int] -> Int")
   }
 
   test("ForAll as function arg called with bad arg") {


### PR DESCRIPTION
Trying to fix #267 

This doesn't quite work yet. somehow ended up with `PackageName(NonEmptyList(Test)),TypeName(Constructor(Int))` in one of the test results which makes no sense.

Also regressed on another test.

Finally I suspect this doesn't work if the `forall` is nested inside a `struct` in an arg. I think the real answer has to do with the variance of meta. But this is sort of informative at least
