### PR TITLE
Make Type.Rho a real type, not an alias

### DIFF
--- a/core/src/main/scala/org/bykn/bosatsu/rankn/Infer.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/rankn/Infer.scala
@@ -197,6 +197,9 @@ object Infer {
     case class InferIncomplete(method: String, term: Expr[_]) extends InternalError {
       def message = s"$method not complete for $term"
     }
+    case class ExpectedRho(tpe: Type, context: String) extends InternalError {
+      def message = s"expected $tpe to be a Type.Rho, at $context"
+    }
   }
 
 
@@ -331,6 +334,9 @@ object Infer {
      * and then skolemizes recurses on the substituted value
      *
      * otherwise we return the type.
+     *
+     * The returned type is in weak-prenex form: all ForAlls have
+     * been floated up over covariant parameters
      */
     def skolemize(t: Type): Infer[(List[Type.Var.Skolem], Type.Rho)] =
       t match {
@@ -356,7 +362,7 @@ object Infer {
                 // otherwise, we don't skolemize the right
                 pure((sksl, Type.TyApply(sl, right)))
             }
-        case other =>
+        case other: Type.Rho =>
           // Rule PRMONO
           pure((Nil, other))
       }
@@ -370,8 +376,13 @@ object Infer {
      */
     def zonkType(t: Type): Infer[Type] =
       t match {
+        case rho: Type.Rho => zonkRho(rho)
         case Type.ForAll(ns, ty) =>
-          zonkType(ty).map(Type.ForAll(ns, _))
+          zonkRho(ty).map(Type.ForAll(ns, _))
+      }
+
+    def zonkRho(t: Type.Rho): Infer[Type.Rho] =
+      t match {
         case Type.TyApply(on, arg) =>
           (zonkType(on), zonkType(arg)).mapN(Type.TyApply(_, _))
         case c@Type.TyConst(_) => pure(c)
@@ -380,7 +391,7 @@ object Infer {
           readMeta(m).flatMap {
             case None => pure(t)
             case Some(ty) =>
-              zonkType(ty).flatMap { ty1 =>
+              zonkRho(ty).flatMap { ty1 =>
                 // short out multiple hops (I guess an optimization?)
                 writeMeta(m, ty1) *> pure(ty1)
               }
@@ -414,42 +425,82 @@ object Infer {
       expr.traverseType[cats.Id](fn)
     }
 
-    // Return a Rho type (not a Forall)
+    /*
+     * This asserts that a given Type must be a Rho. We have some
+     * invariants we can't track with the type system, so we dynamically
+     * check those here
+     *
+     * An alternative to calling this method is instantiate, which assigns
+     * new meta variables for each bound variable in ForAll or skolemize
+     * which replaces the ForAll variables with skolem variables
+     */
+    def assertRho(t: Type, context: => String): Infer[Type.Rho] =
+      t match {
+        case r: Type.Rho => pure(r)
+        case notRho => fail(Error.ExpectedRho(t, context))
+      }
+
+    /*
+     * Return a Rho type (not a Forall), by assigning
+     * new meta variables for each of the outer ForAll variables
+     */
     def instantiate(t: Type): Infer[Type.Rho] =
       t match {
         case Type.ForAll(vars, ty) =>
           for {
             vars1T <- vars.traverse(_ => newMetaType)
-          } yield substTy(vars, vars1T, ty)
-        case rho => pure(rho)
+            subs = substTy(vars, vars1T, ty)
+            rho <- assertRho(subs, "instantiate")
+          } yield rho
+        case rho: Type.Rho => pure(rho)
       }
 
+    /*
+     * Invariant: r2 needs to be in weak prenex form
+     */
     def subsCheckFn(a1: Type, r1: Type.Rho, a2: Type, r2: Type.Rho, left: Region, right: Region): Infer[TypedExpr.Coerce] =
       // note due to contravariance in input, we reverse the order there
       for {
         coarg <- subsCheck(a2, a1, left, right)
+        // r2 is already in weak-prenex form
         cores <- subsCheckRho(r1, r2, left, right)
       } yield TypedExpr.coerceFn(a1, r2, coarg, cores)
 
-    // invariant: second argument is in weak prenex form
+    /*
+     * invariant: second argument is in weak prenex form, which means that all
+     * the covariant positions have lifted the ForAlls out, e.g.
+     * forall a. a -> (forall b. b -> b)
+     * was rewritten to:
+     * forall a, b. a -> (b -> b)
+     */
     def subsCheckRho(t: Type, rho: Type.Rho, left: Region, right: Region): Infer[TypedExpr.Coerce] =
       (t, rho) match {
         case (fa@Type.ForAll(_, _), rho) =>
           // Rule SPEC
           instantiate(fa).flatMap(subsCheckRho(_, rho, left, right))
-        case (rho1, Type.Fun(a2, r2)) =>
+        case (rho1: Type.Rho, Type.Fun(a2, r2)) =>
           // Rule FUN
-          unifyFn(rho1, left, right).flatMap {
-            case (a1, r1) =>
-              subsCheckFn(a1, r1, a2, r2, left, right)
-          }
+          for {
+            a1r1 <- unifyFn(rho1, left, right)
+            (a1, r1) = a1r1
+            rhor1 <- instantiate(r1)
+            rhor2 <- assertRho(r2, s"subsCheckRho($t, $rho, $left, $right), line 462")
+            // since rho is in weak prenex form, and Fun is covariant on r2, we know
+            // r2 is in weak-prenex form
+            coerce <- subsCheckFn(a1, rhor1, a2, rhor2, left, right)
+          } yield coerce
         case (Type.Fun(a1, r1), rho2) =>
           // Rule FUN
-          unifyFn(rho2, right, left).flatMap {
-            case (a2, r2) =>
-              subsCheckFn(a1, r1, a2, r2, left, right)
-          }
-        case (rho1, Type.TyApply(l2, r2)) =>
+          for {
+            a2r2 <- unifyFn(rho2, right, left)
+            (a2, r2) = a2r2
+            rhor1 <- instantiate(r1)
+            // since rho is in weak prenex form, and Fun is covariant on r2, we know
+            // r2 is in weak-prenex form
+            rhor2 <- assertRho(r2, s"subsCheckRho($t, $rho, $left, $right), line 471")
+            coerce <- subsCheckFn(a1, rhor1, a2, rhor2, left, right)
+          } yield coerce
+        case (rho1: Type.Rho, Type.TyApply(l2, r2)) =>
           unifyTyApp(rho1, left, right).flatMap {
             case (l1, r1) =>
               val check2 = varianceOf2(l1, l2).flatMap {
@@ -461,12 +512,16 @@ object Infer {
                   // this doesn't matter
                   pure(())
                 case None | Some(Variance.Invariant) =>
-                  unify(r1, r2, left, right).void
+                  for {
+                    rho1 <- instantiate(r1)
+                    rho2 <- assertRho(r2, s"subsCheckRho($t, $rho, $left, $right), line 488")
+                    _ <- unify(rho1, rho2, left, right)
+                  } yield ()
               }
               // should we coerce to t2? Seems like... but copying previous code
-              (subsCheck(l1, l2, left, right) *> check2).as(TypedExpr.coerceRho(t))
+              (subsCheck(l1, l2, left, right) *> check2).as(TypedExpr.coerceRho(rho1))
           }
-        case (Type.TyApply(l1, r1), rho2) =>
+        case (ta@Type.TyApply(l1, r1), rho2) =>
           unifyTyApp(rho2, left, right).flatMap {
             case (l2, r2) =>
               val check2 = varianceOf2(l1, l2).flatMap {
@@ -478,19 +533,27 @@ object Infer {
                   // this doesn't matter
                   pure(())
                 case None | Some(Variance.Invariant) =>
-                  unify(r1, r2, left, right).void
+                  for {
+                    rho1 <- instantiate(r1)
+                    rho2 <- assertRho(r2, s"subsCheckRho($t, $rho, $left, $right), line 488")
+                    _ <- unify(rho1, rho2, left, right)
+                  } yield ()
               }
               // should we coerce to t2? Seems like... but copying previous code
-              (subsCheck(l1, l2, left, right) *> check2).as(TypedExpr.coerceRho(t))
+              (subsCheck(l1, l2, left, right) *> check2).as(TypedExpr.coerceRho(ta))
           }
-        case (t1, t2) =>
+        case (t1: Type.Rho, t2) =>
           // rule: MONO
           unify(t1, t2, left, right).as(TypedExpr.coerceRho(t1)) // TODO this coerce seems right, since we have unified
       }
 
+    /*
+     * Invariant: if the second argument is (Check rho) then rho is in weak prenex form
+     */
     def instSigma(sigma: Type, expect: Expected[(Type.Rho, Region)], r: Region): Infer[TypedExpr.Coerce] =
       expect match {
         case Expected.Check((t, tr)) =>
+          // note t is in weak-prenex form
           subsCheckRho(sigma, t, r, tr)
         case infer@Expected.Inf(_) =>
           for {
@@ -499,7 +562,7 @@ object Infer {
           } yield TypedExpr.coerceRho(rho)
       }
 
-    def unifyFn(fnType: Type, fnRegion: Region, evidenceRegion: Region): Infer[(Type, Type)] =
+    def unifyFn(fnType: Type.Rho, fnRegion: Region, evidenceRegion: Region): Infer[(Type, Type)] =
       fnType match {
         case Type.Fun(arg, res) => pure((arg, res))
         case tau =>
@@ -510,7 +573,7 @@ object Infer {
           } yield (argT, resT)
       }
 
-    def unifyTyApp(apType: Type, apRegion: Region, evidenceRegion: Region): Infer[(Type, Type)] =
+    def unifyTyApp(apType: Type.Rho, apRegion: Region, evidenceRegion: Region): Infer[(Type, Type)] =
       apType match {
         case Type.TyApply(left, right) => pure((left, right))
         case notApply =>
@@ -555,17 +618,18 @@ object Infer {
         case (Type.TyMeta(m), tpe) => unifyVar(m, tpe, r1, r2)
         case (tpe, Type.TyMeta(m)) => unifyVar(m, tpe, r2, r1)
         case (Type.TyApply(a1, b1), Type.TyApply(a2, b2)) =>
-          unify(a1, a2, r1, r2) *> unify(b1, b2, r1, r2)
+          unifyType(a1, a2, r1, r2) *> unifyType(b1, b2, r1, r2)
         case (Type.TyConst(c1), Type.TyConst(c2)) if c1 == c2 => unit
-        // these shouldn't be reachable since we have Tau types, but may be reachable
-        // case (Type.ForAll(_, _), _) =>
-        //   sys.error(s"expected tau type: $t1, $t2")
-        // case (_, Type.ForAll(_, _)) =>
-        //   sys.error(s"expected tau type: $t1, $t2")
         case (left, right) =>
           fail(Error.NotUnifiable(left, right, r1, r2))
       }
 
+    def unifyType(t1: Type, t2: Type, r1: Region, r2: Region): Infer[Unit] =
+      for {
+        rho1 <- assertRho(t1, s"unifyType($t1, $t2, $r1, $r2)")
+        rho2 <- assertRho(t2, s"unifyType($t1, $t2, $r1, $r2)")
+        _ <- unify(rho1, rho2, r1, r2)
+      } yield ()
     /**
      * Allocate a new Meta variable which
      * will point to a Tau (no forall anywhere) type
@@ -576,7 +640,7 @@ object Infer {
     def newMetaType: Infer[Type.TyMeta] =
       for {
         id <- nextId
-        ref <- lift(RefSpace.newRef[Option[Type]](None))
+        ref <- lift(RefSpace.newRef[Option[Type.Tau]](None))
       } yield Type.TyMeta(Type.Meta(id, ref))
 
     def newSkolemTyVar(tv: Type.Var): Infer[Type.Var.Skolem] =
@@ -619,6 +683,7 @@ object Infer {
       for {
         skolRho <- skolemize(declared)
         (skolTvs, rho2) = skolRho
+        // note: we need rho2 in weak prenex form, but skolemize does this
         coerce <- subsCheckRho(inferred, rho2, left, right)
         escTvs <- getFreeTyVars(List(inferred, declared))
         _ <- NonEmptyList.fromList(skolTvs.filter(escTvs)) match {
@@ -646,7 +711,8 @@ object Infer {
            for {
              typedFn <- inferRho(fn)
              fnT = typedFn.getType
-             argRes <- unifyFn(fnT, region(fn), region(term))
+             fnTRho <- assertRho(fnT, s"must be rho since we inferRho($fn): on $typedFn")
+             argRes <- unifyFn(fnTRho, region(fn), region(term))
              (argT, resT) = argRes
              typedArg <- checkSigma(arg, argT)
              coerce <- instSigma(resT, expect, region(term))
@@ -656,9 +722,12 @@ object Infer {
             case Expected.Check((expTy, rr)) =>
               for {
                 vb <- unifyFn(expTy, rr, region(term))
+                // we know expTy is in weak-prenex form, and since Fn is covariant, bodyT must be
+                // in weak prenex form
                 (varT, bodyT) = vb
+                bodyTRho <- assertRho(bodyT, s"expect a rho type in $vb from $expTy at $rr")
                 typedBody <- extendEnv(name, varT) {
-                    checkRho(result, bodyT)
+                    checkRho(result, bodyTRho)
                   }
               } yield TypedExpr.AnnotatedLambda(name, varT, typedBody, tag)
             case infer@Expected.Inf(_) =>
@@ -674,12 +743,20 @@ object Infer {
             case Expected.Check((expTy, rr)) =>
               for {
                 vb <- unifyFn(expTy, rr, region(term))
+                // we know expTy is in weak-prenex form, and since Fn is covariant, bodyT must be
+                // in weak prenex form
                 (varT, bodyT) = vb
+                bodyTRho <- assertRho(bodyT, s"expect a rho type in $vb from $expTy at $rr")
                 typedBody <- extendEnv(name, varT) {
                     // TODO we are ignoring the result of subsCheck here
                     // should we be coercing a var?
-                    subsCheck(tpe, varT, region(term), rr) *>
-                      checkRho(result, bodyT)
+                    //
+                    // this comes from page 54 of the paper, but I can't seem to find examples
+                    // where this will fail if we reverse (as we had for a long time), which
+                    // indicates the testing coverage is incomplete
+                    subsCheck(varT, tpe, region(term), rr) *>
+                      // bodyTRho is in reach prenex form due to above
+                      checkRho(result, bodyTRho)
                   }
               } yield TypedExpr.AnnotatedLambda(name, varT /* or tpe? */, typedBody, tag)
             case infer@Expected.Inf(_) =>
@@ -755,6 +832,7 @@ object Infer {
               for {
                 tsigma <- inferSigma(term)
                 tbranches <- branches.traverse { case (p, r) =>
+                  // note, resT is in weak-prenex form, so this call is permitted
                   checkBranch(p, Expected.Check((tsigma.getType, region(term))), r, resT)
                 }
               } yield TypedExpr.Match(tsigma, tbranches, tag)
@@ -771,13 +849,18 @@ object Infer {
                   // we do N^2 subsCheck, which to coerce with, composed?
                   case ((t0, r0), (t1, r1)) => subsCheck(t0, t1, r0, r1)
                 }
-                _ <- infer.set(resT.head)
+                // Should this be instantiate? Maybe?
+                resTRho <- assertRho(resT.head._1, s"infer on match ${tbranches.head}")
+                _ <- infer.set((resTRho, resT.head._2))
               } yield TypedExpr.Match(tsigma, tbranches, tag)
           }
       }
     }
 
-    def checkBranch[A: HasRegion](p: Pattern, sigma: Expected[(Type, Region)], res: Expr[A], resT: Type): Infer[(Pattern, TypedExpr[A])] =
+    /*
+     * we require resT in weak prenex form because we call checkRho with it
+     */
+    def checkBranch[A: HasRegion](p: Pattern, sigma: Expected[(Type, Region)], res: Expr[A], resT: Type.Rho): Infer[(Pattern, TypedExpr[A])] =
       for {
         patBind <- typeCheckPattern(p, sigma, region(res))
         (pattern, bindings) = patBind
@@ -802,7 +885,11 @@ object Infer {
         case GenPattern.WildCard => Infer.pure((pat, Nil))
         case GenPattern.Literal(lit) =>
           val tpe = Type.getTypeOf(lit)
-          instSigma(tpe, sigma, reg).as((pat, Nil))
+          val check = sigma match {
+            case Expected.Check((t, tr)) => subsCheck(tpe, t, reg, tr)
+            case infer@Expected.Inf(_) => infer.set((tpe, reg))
+          }
+          check.as((pat, Nil))
         case GenPattern.Var(n) =>
           // We always return an annotation here, which is the only
           // place we need to be careful
@@ -914,7 +1001,8 @@ object Infer {
               val tpe = bmh(v)
               bmt.traverse_ { m2 =>
                 val tpe2 = m2(v)
-                unify(tpe, tpe2, reg, reg)
+                // TODO: forall in patterns are not supported by this
+                unifyType(tpe, tpe2, reg, reg)
               }
             }
           }
@@ -956,7 +1044,7 @@ object Infer {
           vars.traverse(_ => newMetaType)
             .map { vars1T =>
               val params1 = consParams.map(substTy(vars, vars1T, _))
-              val res = vars1T.foldLeft(Type.TyConst(tpeName): Type)(Type.TyApply(_, _))
+              val res = vars1T.foldLeft(Type.TyConst(tpeName): Type.Tau)(Type.TyApply(_, _))
               (params1, res)
             }
       }
@@ -969,7 +1057,7 @@ object Infer {
         meta match {
           case None => getEnv
           case Some((nm, m, r)) =>
-            (unify(tpe, m, region(e), r) *> getEnv).map { envTys =>
+            (unifyType(tpe, m, region(e), r) *> getEnv).map { envTys =>
               // we have to remove the recursive binding from the environment
               envTys - ((None, nm))
             }
@@ -990,6 +1078,7 @@ object Infer {
       for {
         skolRho <- skolemize(tpe)
         (skols, rho) = skolRho
+        // we need rho in weak-prenex form, but skolemize does this
         te <- checkRho(t, rho)
         envTys <- getEnv
         escTvs <- getFreeTyVars(tpe :: envTys.values.toList)
@@ -997,6 +1086,9 @@ object Infer {
         _ <- require(badTvs.isEmpty, Error.NotPolymorphicEnough(tpe, t, NonEmptyList.fromListUnsafe(badTvs), region(t)))
       } yield te // should be fine since the everything after te is just checking
 
+    /**
+     * invariant: rho needs to be in weak-prenex form
+     */
     def checkRho[A: HasRegion](t: Expr[A], rho: Type.Rho): Infer[TypedExpr[A]] =
       typeCheckRho(t, Expected.Check((rho, region(t))))
 

--- a/core/src/main/scala/org/bykn/bosatsu/rankn/Type.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/rankn/Type.scala
@@ -133,6 +133,14 @@ object Type {
       case c@TyConst(_) => c
     }
 
+  def substituteRhoVar(t: Type.Rho, env: Map[Type.Var, Type.Rho]): Type.Rho =
+    t match {
+      case TyApply(on, arg) => TyApply(substituteVar(on, env), substituteVar(arg, env))
+      case v@TyVar(n) => env.getOrElse(n, v)
+      case m@TyMeta(_) => m
+      case c@TyConst(_) => c
+    }
+
   /**
    * Return the Bound and Skolem variables that
    * are free in the given list of types

--- a/core/src/main/scala/org/bykn/bosatsu/rankn/Type.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/rankn/Type.scala
@@ -8,19 +8,17 @@ import scala.collection.immutable.SortedSet
 sealed abstract class Type
 
 object Type {
-  type Rho = Type // no top level ForAll
-  type Tau = Type // no forall anywhere
+  /**
+   * A type with no top level ForAll
+   */
+  sealed abstract class Rho extends Type
+  type Tau = Rho // no forall anywhere
 
-  case class ForAll(vars: NonEmptyList[Var.Bound], in: Rho) extends Type {
-    in match {
-      case ForAll(_, _) => sys.error(s"invalid nested ForAll")
-      case _ => ()
-    }
-  }
-  case class TyConst(tpe: Const) extends Type
-  case class TyVar(toVar: Var) extends Type
-  case class TyMeta(toMeta: Meta) extends Type
-  case class TyApply(on: Type, arg: Type) extends Type
+  case class ForAll(vars: NonEmptyList[Var.Bound], in: Rho) extends Type
+  case class TyConst(tpe: Const) extends Rho
+  case class TyVar(toVar: Var) extends Rho
+  case class TyMeta(toMeta: Meta) extends Rho
+  case class TyApply(on: Type, arg: Type) extends Rho
 
   implicit val typeOrdering: Ordering[Type] =
     new Ordering[Type] {
@@ -78,8 +76,8 @@ object Type {
       case Nil => in
       case ne@(h :: tail) =>
         in match {
+          case rho: Rho => Type.ForAll(NonEmptyList(h, tail), rho)
           case Type.ForAll(nes, tt) => forAll(ne ::: nes.toList, tt)
-          case notForAll => Type.ForAll(NonEmptyList(h, tail), notForAll)
         }
     }
 
@@ -129,7 +127,7 @@ object Type {
         substituteVar(rho, env1) match {
           case ForAll(ns1, r1) =>
             ForAll(ns ::: ns1, r1)
-          case notForAll =>
+          case notForAll: Rho =>
             ForAll(ns, notForAll)
         }
       case m@TyMeta(_) => m
@@ -201,7 +199,7 @@ object Type {
         case _ => None
       }
 
-    def apply(from: Type, to: Type): Type =
+    def apply(from: Type, to: Type): Type.Rho =
       TyApply(TyApply(FnType, from), to)
   }
 
@@ -298,7 +296,7 @@ object Type {
     NonEmptyList((items.head, bs.head), items.tail.zip(bs.tail))
   }
 
-  case class Meta(id: Long, ref: Ref[Option[Type]])
+  case class Meta(id: Long, ref: Ref[Option[Type.Tau]])
 
   object Meta {
     implicit val orderingMeta: Ordering[Meta] =

--- a/core/src/main/scala/org/bykn/bosatsu/rankn/Type.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/rankn/Type.scala
@@ -70,14 +70,13 @@ object Type {
       case fa@ForAll(_, _) => freeTyVars(fa :: Nil).isEmpty
     }
 
-  @annotation.tailrec
   final def forAll(vars: List[Var.Bound], in: Type): Type =
-    vars match {
-      case Nil => in
-      case ne@(h :: tail) =>
+    NonEmptyList.fromList(vars) match {
+      case None => in
+      case Some(ne) =>
         in match {
-          case rho: Rho => Type.ForAll(NonEmptyList(h, tail), rho)
-          case Type.ForAll(nes, tt) => forAll(ne ::: nes.toList, tt)
+          case rho: Rho => Type.ForAll(ne, rho)
+          case Type.ForAll(ne1, rho) => Type.ForAll(ne ::: ne1, rho)
         }
     }
 

--- a/core/src/test/scala/org/bykn/bosatsu/rankn/RankNInferTest.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/rankn/RankNInferTest.scala
@@ -133,6 +133,12 @@ class RankNInferTest extends FunSuite {
     assertTypesUnify("forall a. a", "forall b. b")
     assertTypesUnify("forall a. a", "Int")
     assertTypesUnify("forall a, b. a -> b", "forall b. b -> Int")
+    assertTypesUnify("forall a, b. a -> b", "forall a. a -> (forall b. b -> b)")
+    assertTypesUnify("(forall a. a) -> Int", "(forall a. a) -> Int")
+    assertTypesUnify("(forall a. a -> Int) -> Int", "(forall a. a -> Int) -> Int")
+    assertTypesUnify("forall a, b. a -> b -> b", "forall a. a -> a -> a")
+    // these aren't disjoint but the right is more polymorphic
+    assertTypesDisjoint("forall a. a -> a -> a", "forall a, b. a -> b -> b")
     assertTypesUnify("forall a, b. a -> b", "forall b, c. b -> (c -> Int)")
     // assertTypesUnify("(forall a. a)[Int]", "Int")
     // assertTypesUnify("(forall a. Int)[b]", "Int")


### PR DESCRIPTION
related to #267 and #269 

Before this PR, `Rho` was a type alias for `Type` as in the paper. Scala's subtyping allows us to define it as a real type, and let the compiler check some of the invariants we claim. Doing this didn't seem to uncover any new bugs, but seems valuable for safety.

There are two other invariants not checked:
1. Type.Tau: no ForAll anywhere. For instance `(forall a. a) -> Foo` is a Rho type, but not a Tau type.
2. weak-prenex form: this means we have moved all the ForAlls up as far as possible using covariance.

While doing this, I added a variant of the tests in #269. I think at least part of our issue is around pattern matches. Currently, we would do a subsCheck eventually on a meta variable, against an annotated `forall` type, and that will always fail if the type. By contrast, Expr.Annotation leads to a checkSigma, which will skolemize the forall and has a separate code path that is not subsCheck. This seems related to the issue since all the forms in #269 are using pattern matching under the hood.

cc @snoble