### PR TITLE
WIP: extend paper to support higher rank type parameters on data constructors

### DIFF
--- a/core/src/test/scala/org/bykn/bosatsu/rankn/RankNInferTest.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/rankn/RankNInferTest.scala
@@ -899,10 +899,14 @@ struct Nil
 #Wrap(_: ((forall x. Foo[x]) -> Nil)) = cra_fn
 #def foo(cra_fn: Wrap[(forall ssss. ssss) -> Nil]):
 # Wrap(_: ((forall x. x) -> Nil)) = cra_fn
+#(_: Wrap[(forall x. Foo[x]) -> Nil]): Nil
 #Nil
-def foo(cra_fn: Wrap[(forall ssss. Foo[ssss]) -> Nil]):
-  match cra_fn:
-    (_: Wrap[(forall x. Foo[x]) -> Nil]): Nil
+# def foo(cra_fn: Wrap[(forall ssss. Foo[ssss]) -> Nil]):
+#   Wrap(fn: ((forall x. Foo[x]) -> Nil)) = cra_fn
+#   fn(Foo(1))
+def foo(cra_fn: Wrap[(forall ssss. Foo[ssss] -> s)]):
+  Wrap(fn: ((forall x. Foo[x] -> x))) = cra_fn
+  fn(Foo(1))
 main = foo
 """, "Wrap[(forall ssss. Foo[ssss]) -> Nil] -> Nil")
   }


### PR DESCRIPTION
related to #267 #269 

In this comment: https://github.com/johnynek/bosatsu/pull/269#issuecomment-497995921

While rereading the paper I am using, they state this limitation, though I had forgotten: type constructors are all monotyped in this typesystem.

So, the kind of code that we are trying to write in #267 and #269 isn't supported. The main issue is that we always use inference on type constructor parameters, and inference always infers monotypes.

An idea I had to extend the algorithm to support this is to look to see if there are any annotations of polytypes in a data constructor, and if there, in some limited cases, we could infer a polytype (namely, if the constructor is tuple-like and has a free type parameter in one position).

This may cause other problems and it doesn't quite work, but I'm putting it up here as a sketch of an idea.