### PR TITLE
Improve Pattern compilation in expressions

### DIFF
--- a/core/src/main/scala/org/bykn/bosatsu/Declaration.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/Declaration.scala
@@ -128,16 +128,32 @@ sealed abstract class Declaration {
         case ao@ApplyOp(left, op, right) =>
           val opVar: Expr[Declaration] = Expr.Var(None, op, ao.opVar)
           Expr.buildApp(opVar, loop(left) :: loop(right) :: Nil, decl)
-        case Binding(BindingStatement(pat, value, Padding(_, rest))) =>
-          pat match {
-            case Pattern.Var(arg) =>
-              Expr.Let(arg, loop(value), loop(rest), RecursionKind.NonRecursive, decl)
-            case pat =>
-              val newPattern = unTuplePattern(pat, nameToType, nameToCons)
-              val res = loop(rest)
-              val expBranches = NonEmptyList.of((newPattern, res))
-              Expr.Match(loop(value), expBranches, decl)
-          }
+        case Binding(BindingStatement(pat, value, prest@Padding(_, rest))) =>
+          val erest = loop(rest)
+
+          def solvePat(pat: Pattern.Parsed): Expr[Declaration] => Expr[Declaration] =
+            pat match {
+              case Pattern.Var(arg) =>
+                { rhs => Expr.Let(arg, rhs, erest, RecursionKind.NonRecursive, decl) }
+              case Pattern.Annotation(pat, tpe) =>
+                val inner = solvePat(pat)
+                val realTpe = tpe.toType(nameToType)
+
+                // move the annotation to the right
+                { rhs => inner(Expr.Annotation(rhs, realTpe, decl)) }
+              case Pattern.Named(nm, p) =>
+                 val inner = solvePat(p)
+
+                 // this is the same as creating a let nm = value first
+                 { rhs => Expr.Let(nm, rhs, inner(rhs), RecursionKind.NonRecursive, decl) }
+              case pat =>
+                val newPattern = unTuplePattern(pat, nameToType, nameToCons)
+                val expBranches = NonEmptyList.of((newPattern, erest))
+
+                { rhs => Expr.Match(rhs, expBranches, decl) }
+            }
+
+          solvePat(pat)(loop(value))
         case Comment(CommentStatement(_, Padding(_, decl))) =>
           loop(decl).map(_ => decl)
         case DefFn(defstmt@DefStatement(_, _, _, _)) =>

--- a/core/src/test/scala/org/bykn/bosatsu/rankn/RankNInferTest.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/rankn/RankNInferTest.scala
@@ -906,4 +906,22 @@ def foo(cra_fn: Wrap[(forall ssss. Foo[ssss]) -> Nil]):
 main = foo
 """, "Wrap[(forall ssss. Foo[ssss]) -> Nil] -> Nil")
   }
+
+  test("use a type annotation inside a def") {
+    parseProgram("""#
+struct Foo
+struct Bar
+def add(x):
+  (y: Foo) = x
+  Bar
+""", "Foo -> Bar")
+
+    parseProgram("""#
+struct Foo
+struct Bar(f: Foo)
+def add(x):
+  (b@(y: Foo)) = x
+  Bar(b)
+""", "Foo -> Bar")
+  }
 }


### PR DESCRIPTION
this improves compilations of `pattern = foo` bindings inside expressions. The goal is to minimize the use of Match, which is more expensive in that we have to check those for totality. This instead uses `Expr.Annotation` and `Expr.Let` in two cases, allowing more patterns to avoid a single arm match.