### PR TITLE
Snoble/recordset

### DIFF
--- a/test_workspace/BUILD
+++ b/test_workspace/BUILD
@@ -114,5 +114,5 @@ bosatsu_test(
     name = "recordset",
     deps = [],
     srcs = ["recordset.bosatsu"],
-    packages = ["RecordSet"],
+    packages = ["RecordSet/Library"],
     )

--- a/test_workspace/recordset.bosatsu
+++ b/test_workspace/recordset.bosatsu
@@ -1,17 +1,17 @@
 package RecordSet
 
-enum RowEntry:
-  REBool(value: Bool)
-  REInt(value: Int)
-  REString(value: String)
+enum RowEntry[w]:
+  REBool(value: w[Bool])
+  REInt(value: w[Int])
+  REString(value: w[String])
 
-struct RecordField[t](name: String, toValue: t -> RowEntry)
+struct RecordField[t](name: String, to_entry: forall w. w[t] -> RowEntry[w])
 struct RecordValue[t](value: t)
 
-struct RecordSet[shape](fields: shape[RecordField], rows: List[shape[RecordValue]])
+struct RecordSet[shape](fields: shape[RecordField], rows: List[shape[RecordValue]], to_row: forall w. shape[w] -> List[RowEntry[w]])
 
-def restructure(RecordSet(fields, rows), f: forall w. shape1[w] -> shape2[w]) -> RecordSet[shape2]:
-  RecordSet(f(fields), rows.map_List(f))
+def restructure(RecordSet(fields, rows), f: forall w. shape1[w] -> shape2[w], to_row: forall w. shape2[w] -> List[RowEntry[w]]) -> RecordSet[shape2]:
+  RecordSet(f(fields), rows.map_List(f), to_row)
 
 struct IntShape[w](int: w[Int])
 struct PairShape[shape1,shape2,w](left: shape1[w], right: shape2[w])
@@ -22,8 +22,12 @@ def make_pair_int_shape(rest: shape[w], i: w[Int]) -> PairShape[shape,IntShape,w
 # def add_shape(RecordSet(fields1, rows): RecordSet[shape1], fields2: shape2[RecordField[String], RecordField[Int], RecordField[Bool]], f: shape1[String, Int, Bool] -> shape2[String, Int, Bool]) -> RecordSet[PairShape[shape1, shape2]]:
 #  RecordSet(PairShape(fields1, fields2), rows.map_List(\row -> PairShape(row, f(row))))
 
-def add_int_field(RecordSet(fields, rows): RecordSet[shape1], name: String, f: shape1[RecordValue] -> Int) -> RecordSet[PairShape[shape1, IntShape]]:
-  RecordSet(make_pair_int_shape(fields, RecordField(name, REInt)), rows.map_List(\row -> make_pair_int_shape(row, RecordValue(f(row)))))
+def add_int_field(RecordSet(fields, rows, to_row): RecordSet[shape1], name: String, f: shape1[RecordValue] -> Int) -> RecordSet[PairShape[shape1, IntShape]]:
+  RecordSet(
+    make_pair_int_shape(fields, RecordField(name, REInt)),
+    rows.map_List(\row -> make_pair_int_shape(row, RecordValue(f(row)))),
+    \PairShape(sh1, IntShape(int)) -> to_row(sh1).concat([REInt(int)])
+  )
 
 ##################################################
 
@@ -33,12 +37,13 @@ struct Shape3[w](f1: w[String], f2: w[Bool], f3: w[Int], f4: w[Int])
 
 rs = RecordSet(
   Shape1(RecordField("String", REString), RecordField("Int", REInt), RecordField("Bool", REBool)),
-  [Shape1(RecordValue("a"), RecordValue(1), RecordValue(True))]
+  [Shape1(RecordValue("a"), RecordValue(1), RecordValue(True))],
+  \Shape1(f1, f2, f3) -> [REString(f1), REInt(f2), REBool(f3)]
 )
 
-rs0 = rs.restructure(\Shape1(a,b,c) -> Shape2(a,c,b))
+rs0 = rs.restructure(\Shape1(a,b,c) -> Shape2(a,c,b), \Shape2(f1,f2,f3) -> [REString(f1), REBool(f2), REInt(f3)])
 rs1 = rs0.add_int_field("Second Int", \Shape2(_,_,RecordValue(x)) -> x.add(4))
-rs2 = rs1.restructure(\PairShape(Shape2(a,b,c), IntShape(i)) -> Shape3(a,b,c,i))
+rs2 = rs1.restructure(\PairShape(Shape2(a,b,c), IntShape(i)) -> Shape3(a,b,c,i), \Shape3(f1,f2,f3,f4) -> [REString(f1), REBool(f2), REInt(f3), REInt(f4)])
 
 ##################################################
 
@@ -70,9 +75,19 @@ def equal_List(is_equal, l1, l2):
 def compare_shape3((compare1, compare2, compare3), Shape3(RecordValue(x1), RecordValue(x2), RecordValue(x3), RecordValue(x4)), Shape3(RecordValue(y1), RecordValue(y2), RecordValue(y3), RecordValue(y4))):
   compare1.equals(x1, y1) && compare2.equals(x2, y2) && compare3.equals(x3, y3) && compare3.equals(x4, y4)
 
-RecordSet(_, rows) = rs2
+def equal_RowEntry(re1, re2):
+  match (re1, re2):
+    (REBool(RecordValue(x1)), REBool(RecordValue(x2))): cmp_Bool.equals(x1, x2)
+    (REInt(RecordValue(x1)), REInt(RecordValue(x2))): cmp_Int.equals(x1, x2)
+    (REString(RecordValue(x1)), REString(RecordValue(x2))): string_Order_fn.equals(x1, x2)
+    _: False
+
+def equal_rows(row1, row2):
+  equal_RowEntry.equal_List(row1, row2)
+
+RecordSet(_, rows, to_row) = rs2
 tests = Test("reordering",
   [
-    Assertion((string_Order_fn, cmp_Bool, cmp_Int).compare_shape3.equal_List(rows, [Shape3(RecordValue("a"), RecordValue(True), RecordValue(1), RecordValue(5))]), "swap")
+    Assertion(equal_rows.equal_List(rows.map_List(to_row), [[REString(RecordValue("a")), REBool(RecordValue(True)), REInt(RecordValue(1)), REInt(RecordValue(5))]]), "swap")
   ]
 )

--- a/test_workspace/recordset.bosatsu
+++ b/test_workspace/recordset.bosatsu
@@ -113,8 +113,7 @@ def equal_RowEntry(re1, re2):
     (REString(RecordValue(x1)), REString(RecordValue(x2))): string_Order_fn.equals(x1, x2)
     _: False
 
-def equal_rows(row1, row2):
-  equal_RowEntry.equal_List(row1, row2)
+equal_rows = equal_List(equal_RowEntry)
 
 ##################################################
 

--- a/test_workspace/recordset.bosatsu
+++ b/test_workspace/recordset.bosatsu
@@ -11,21 +11,20 @@ struct RecordGetter[shape, t](f: forall w. shape[w] -> w[t])
 
 struct RecordSet[shape](fields: shape[RecordField], rows: List[shape[RecordValue]], getters: shape[RecordGetter[shape]])
 
-# , forall w1, w2. shape2[w1] -> (forall s. w1[s] -> w2[s]) -> shape2[w2])) -> RecordSet[shape2]:
-def restructure(RecordSet(fields, rows, getters): RecordSet[shape1], f: shape1[RecordGetter[shape1]] -> (forall w. shape1[w] -> shape2[w], shape2[RecordGetter[shape2]])) -> RecordSet[shape2]:
-  (reshaper1, new_getters) = f(getters)
-  (reshaper2, _) = f(getters)
+def restructure(RecordSet(fields, rows, getters): RecordSet[shape1], f: shape1[RecordGetter[shape1]] -> (forall w. shape1[w] -> shape2[w], shape2[RecordGetter[shape2]], forall w1, w2. shape2[w1] -> (forall s. w1[s] -> w2[s]) -> shape2[w2])) -> RecordSet[shape2]:
+  (reshaper1, new_getters, _) = f(getters)
+  (reshaper2, _, _) = f(getters)
   RecordSet(reshaper1(fields), rows.map_List(reshaper2), new_getters)
 
 struct NilShape[w]
 struct IntShape[w](int: w[Int])
 struct PS[t,shape2,w](left: w[t], right: shape2[w])
 
-#    \PS(x, _), g -> PS(g(x), NilShape)
-def s(RecordGetter(f)):
+def s(RecordGetter(f): RecordGetter[shape, t]) -> (forall w. shape[w] -> PS[t,NilShape,w], PS[t,NilShape,RecordGetter[PS[t,NilShape]]], forall w1,w2. PS[t,NilShape,w1] -> (forall s. w1[s] -> w2[s]) -> PS[t,NilShape,w2]):
   (
     \x -> PS(f(x),NilShape),
-    PS(RecordGetter(\PS(x, _) -> x), NilShape)
+    PS(RecordGetter(\PS(x, _) -> x), NilShape),
+    \PS(x, _), g -> PS(g(x), NilShape)
   )
 
 # def ps(RecordGetter(f): RecordGetter[shapae1, t], (g, sh2, traverse): (forall w. shape1[w] -> shape2[w], shape2[RecordGetter[shape2]], forall w1,w2. shape2[w1] -> (forall s. w1[s] -> w2[s]) -> shape2[w2] )):

--- a/test_workspace/recordset.bosatsu
+++ b/test_workspace/recordset.bosatsu
@@ -11,22 +11,29 @@ struct RecordGetter[shape, t](f: forall w. shape[w] -> w[t])
 
 struct RecordSet[shape](fields: shape[RecordField], rows: List[shape[RecordValue]], getters: shape[RecordGetter[shape]])
 
-def restructure(RecordSet(fields, rows, getters), f: shape1[RecordGetter[shape1]] -> (forall w. shape1[w] -> shape2[w], forall w. shape1[w] -> shape2[w], shape2[RecordGetter[shape2]])) -> RecordSet[shape2]:
-  (reshaper1, reshaper2, new_getters) = f(getters)
+# , forall w1, w2. shape2[w1] -> (forall s. w1[s] -> w2[s]) -> shape2[w2])) -> RecordSet[shape2]:
+def restructure(RecordSet(fields, rows, getters): RecordSet[shape1], f: shape1[RecordGetter[shape1]] -> (forall w. shape1[w] -> shape2[w], shape2[RecordGetter[shape2]])) -> RecordSet[shape2]:
+  (reshaper1, new_getters) = f(getters)
+  (reshaper2, _) = f(getters)
   RecordSet(reshaper1(fields), rows.map_List(reshaper2), new_getters)
-
 
 struct NilShape[w]
 struct IntShape[w](int: w[Int])
 struct PS[t,shape2,w](left: w[t], right: shape2[w])
 
-def s(getter):
-  RecordGetter(f) = getter
+#    \PS(x, _), g -> PS(g(x), NilShape)
+def s(RecordGetter(f)):
   (
-    \x -> PS(f(x),NilShape),
     \x -> PS(f(x),NilShape),
     PS(RecordGetter(\PS(x, _) -> x), NilShape)
   )
+
+# def ps(RecordGetter(f): RecordGetter[shapae1, t], (g, sh2, traverse): (forall w. shape1[w] -> shape2[w], shape2[RecordGetter[shape2]], forall w1,w2. shape2[w1] -> (forall s. w1[s] -> w2[s]) -> shape2[w2] )):
+#  (
+#    \sh1 -> PS(f(sh1), g(sh1)),
+#    PS(RecordGetter(\PS(x,_) -> x), sh2.traverse(\RecordGetter(f1) -> RecordGetter(\PS(_, sh2) -> f1(sh2)))),
+#    \PS(x, sh2), g -> PS(g(x), sh2.traverse(g))
+#  )
 
 ##################################################
 

--- a/test_workspace/recordset.bosatsu
+++ b/test_workspace/recordset.bosatsu
@@ -11,6 +11,7 @@ struct RecordGetter[shape, t](
   field: shape[RecordField] -> RecordField[t],
   value: shape[RecordValue] -> RecordValue[t]
 )
+struct RecordRowEntry[w, t](row_entry: RowEntry[w])
 
 struct RecordSet[shape](
   fields: shape[RecordField],
@@ -22,21 +23,27 @@ def get(sh: shape[RecordValue], RecordGetter(_, getter): RecordGetter[shape, t])
   RecordValue(result) = sh.getter
   result
 
-def createField(rf: RecordField[t], fn: shape[RecordValue] -> t):
+def create_field(rf: RecordField[t], fn: shape[RecordValue] -> t):
   RecordGetter(\sh -> rf, \sh -> RecordValue(fn(sh)))
 
 struct RestructureOutput[shape1, shape2](
   reshaperFields: shape1[RecordField] -> shape2[RecordField],
   reshaperValues: shape1[RecordValue] -> shape2[RecordValue],
   getters: shape2[RecordGetter[shape2]],
-  traverse: (forall w1,w2. shape2[w1] -> (forall ss. w1[ss] -> w2[ss]) -> shape2[w2])
+  traverse: (forall w1,w2. shape2[w1] -> (forall ss. w1[ss] -> w2[ss]) -> shape2[w2]),
+  record_to_list: (forall w. shape2[RecordRowEntry[w]] -> List[RowEntry[w]])
 )
 def restructure(RecordSet(fields, rows, getters): RecordSet[shape1], f: shape1[RecordGetter[shape1]] -> RestructureOutput[shape1, shape2]) -> RecordSet[shape2]:
-  RestructureOutput(reshaperF, reshaperV, new_getters, _) = f(getters)
+  RestructureOutput(reshaperF, reshaperV, new_getters, _, _) = f(getters)
   RecordSet(reshaperF(fields), rows.map_List(reshaperV), new_getters)
+
+def concat_records(RecordSet(fields, rows, getters), more_rows):
+  RecordSet(fields, rows.concat(more_rows), getters)
 
 struct NilShape[w]
 struct PS[t,rest,w](left: w[t], right: rest[w])
+
+new_record_set = RecordSet(NilShape, [], NilShape)
 
 def s(RecordGetter(f1, v1)):
   def traverse(PS(x, _), g):
@@ -45,27 +52,25 @@ def s(RecordGetter(f1, v1)):
     \x -> PS(f1(x),NilShape),
     \x -> PS(v1(x),NilShape),
     PS(RecordGetter(\PS(x, _) -> x, \PS(x, _) -> x), NilShape),
-    traverse
+    traverse,
+    \PS(RecordRowEntry(row_entry), _) -> [row_entry]
   )
 
 def ps(
   RecordGetter(fF, fV): RecordGetter[shape1, t],
-  RestructureOutput(reshaper1F, reshaper1V, getters1, traverse1): RestructureOutput[shape1, shape2]):
+  RestructureOutput(reshaper1F, reshaper1V, getters1, traverse1, record_to_list1): RestructureOutput[shape1, shape2]):
   getters2 = getters1.traverse1(\RecordGetter(f1, v1) -> RecordGetter(\PS(_, sh2) -> f1(sh2), \PS(_, sh2) -> v1(sh2)))
   RestructureOutput(
     \sh1 -> PS(fF(sh1), reshaper1F(sh1)),
     \sh1 -> PS(fV(sh1), reshaper1V(sh1)),
     PS(RecordGetter(\PS(x,_) -> x, \PS(x,_) -> x), getters2),
-    \PS(x, sh2), g -> PS(g(x), sh2.traverse1(g))
+    \PS(x, sh2), g -> PS(g(x), sh2.traverse1(g)),
+    \PS(RecordRowEntry(row_entry), sh2) -> [row_entry].concat(record_to_list1(sh2))
   )
 
 ##################################################
 
-rs = RecordSet(
-  PS(RecordField("String", REString), PS(RecordField("Int", REInt), PS(RecordField("Bool", REBool), NilShape))),
-  [PS(RecordValue("a"), PS(RecordValue(1), PS(RecordValue(True), NilShape)))],
-  PS(RecordGetter(\PS(x,_) -> x, \PS(x,_) -> x), PS(RecordGetter(\PS(_, PS(x, _)) -> x, \PS(_, PS(x, _)) -> x), PS(RecordGetter(\PS(_, PS(_, PS(x, _))) -> x, \PS(_, PS(_, PS(x, _))) -> x), NilShape)))
-)
+rs = new_record_set.restructure(\ns -> ps(RecordField("String", REString).create_field(\_ -> ""), ps(RecordField("Int", REInt).create_field(\_ -> 0), s(RecordField("Bool", REBool).create_field(\_ -> True))))).concat_records([PS(RecordValue("a"), PS(RecordValue(1), PS(RecordValue(False), NilShape)))])
 
 rs0 = rs.restructure(\PS(a, PS(b, PS(c, _))) -> ps(c,ps(a,s(b))))
 

--- a/test_workspace/recordset.bosatsu
+++ b/test_workspace/recordset.bosatsu
@@ -17,7 +17,8 @@ struct RecordSet[shape](
   fields: shape[RecordField],
   rows: List[shape[RecordValue]],
   getters: shape[RecordGetter[shape]],
-  traverse: forall w1,w2. shape[w1] -> (forall ss. w1[ss] -> w2[ss]) -> shape[w2]
+  traverse: forall w1,w2. shape[w1] -> (forall ss. w1[ss] -> w2[ss]) -> shape[w2],
+  record_to_list: forall w. shape[RecordRowEntry[w]] -> List[RowEntry[w]]
 )
 
 def get(sh: shape[RecordValue], RecordGetter(_, getter): RecordGetter[shape, t]) -> t:
@@ -34,17 +35,17 @@ struct RestructureOutput[shape1, shape2](
   traverse: forall w1,w2. shape2[w1] -> (forall ss. w1[ss] -> w2[ss]) -> shape2[w2],
   record_to_list: forall w. shape2[RecordRowEntry[w]] -> List[RowEntry[w]]
 )
-def restructure(RecordSet(fields, rows, getters, _): RecordSet[shape1], f: shape1[RecordGetter[shape1]] -> RestructureOutput[shape1, shape2]) -> RecordSet[shape2]:
-  RestructureOutput(reshaperF, reshaperV, new_getters, traverse, _) = f(getters)
-  RecordSet(reshaperF(fields), rows.map_List(reshaperV), new_getters, traverse)
+def restructure(RecordSet(fields, rows, getters, _, _): RecordSet[shape1], f: shape1[RecordGetter[shape1]] -> RestructureOutput[shape1, shape2]) -> RecordSet[shape2]:
+  RestructureOutput(reshaperF, reshaperV, new_getters, traverse, record_to_list) = f(getters)
+  RecordSet(reshaperF(fields), rows.map_List(reshaperV), new_getters, traverse, record_to_list)
 
-def concat_records(RecordSet(fields, rows, getters, traverse), more_rows):
-  RecordSet(fields, rows.concat(more_rows), getters, traverse)
+def concat_records(RecordSet(fields, rows, getters, traverse, record_to_list), more_rows):
+  RecordSet(fields, rows.concat(more_rows), getters, traverse, record_to_list)
 
 struct NilShape[w]
 struct PS[t,rest,w](left: w[t], right: rest[w])
 
-new_record_set = RecordSet(NilShape, [], NilShape, \NilShape,fn -> NilShape)
+new_record_set = RecordSet(NilShape, [], NilShape, \NilShape,fn -> NilShape, \NilShape -> [])
 
 def s(RecordGetter(f1, v1)):
   def traverse(PS(x, _), g):

--- a/test_workspace/recordset.bosatsu
+++ b/test_workspace/recordset.bosatsu
@@ -11,7 +11,7 @@ struct RecordGetter[shape, t](f: forall w. shape[w] -> w[t])
 
 struct RecordSet[shape](fields: shape[RecordField], rows: List[shape[RecordValue]], getters: shape[RecordGetter[shape]])
 
-def restructure(RecordSet(fields, rows, getters): RecordSet[shape1], f: shape1[RecordGetter[shape1]] -> (forall w. shape1[w] -> shape2[w], shape2[RecordGetter[shape2]], forall w1, w2. shape2[w1] -> (forall s. w1[s] -> w2[s]) -> shape2[w2])) -> RecordSet[shape2]:
+def restructure(RecordSet(fields, rows, getters): RecordSet[shape1], f: shape1[RecordGetter[shape1]] -> ((forall w. shape1[w] -> shape2[w]), shape2[RecordGetter[shape2]], (forall w1,w2. shape2[w1] -> (forall ss. w1[ss] -> w2[ss]) -> shape2[w2]))) -> RecordSet[shape2]:
   (reshaper1, new_getters, _) = f(getters)
   (reshaper2, _, _) = f(getters)
   RecordSet(reshaper1(fields), rows.map_List(reshaper2), new_getters)
@@ -20,11 +20,14 @@ struct NilShape[w]
 struct IntShape[w](int: w[Int])
 struct PS[t,shape2,w](left: w[t], right: shape2[w])
 
-def s(RecordGetter(f): RecordGetter[shape, t]) -> (forall w. shape[w] -> PS[t,NilShape,w], PS[t,NilShape,RecordGetter[PS[t,NilShape]]], forall w1,w2. PS[t,NilShape,w1] -> (forall s. w1[s] -> w2[s]) -> PS[t,NilShape,w2]):
+def s(rg):
+  RecordGetter(f) = rg
+  def traverse(PS(x, _), g):
+    PS(g(x), NilShape)
   (
     \x -> PS(f(x),NilShape),
     PS(RecordGetter(\PS(x, _) -> x), NilShape),
-    \PS(x, _), g -> PS(g(x), NilShape)
+    traverse
   )
 
 # def ps(RecordGetter(f): RecordGetter[shapae1, t], (g, sh2, traverse): (forall w. shape1[w] -> shape2[w], shape2[RecordGetter[shape2]], forall w1,w2. shape2[w1] -> (forall s. w1[s] -> w2[s]) -> shape2[w2] )):

--- a/test_workspace/recordset.bosatsu
+++ b/test_workspace/recordset.bosatsu
@@ -16,7 +16,8 @@ struct RecordRowEntry[w, t](row_entry: RowEntry[w])
 struct RecordSet[shape](
   fields: shape[RecordField],
   rows: List[shape[RecordValue]],
-  getters: shape[RecordGetter[shape]]
+  getters: shape[RecordGetter[shape]],
+  traverse: forall w1,w2. shape[w1] -> (forall ss. w1[ss] -> w2[ss]) -> shape[w2]
 )
 
 def get(sh: shape[RecordValue], RecordGetter(_, getter): RecordGetter[shape, t]) -> t:
@@ -30,20 +31,20 @@ struct RestructureOutput[shape1, shape2](
   reshaperFields: shape1[RecordField] -> shape2[RecordField],
   reshaperValues: shape1[RecordValue] -> shape2[RecordValue],
   getters: shape2[RecordGetter[shape2]],
-  traverse: (forall w1,w2. shape2[w1] -> (forall ss. w1[ss] -> w2[ss]) -> shape2[w2]),
-  record_to_list: (forall w. shape2[RecordRowEntry[w]] -> List[RowEntry[w]])
+  traverse: forall w1,w2. shape2[w1] -> (forall ss. w1[ss] -> w2[ss]) -> shape2[w2],
+  record_to_list: forall w. shape2[RecordRowEntry[w]] -> List[RowEntry[w]]
 )
-def restructure(RecordSet(fields, rows, getters): RecordSet[shape1], f: shape1[RecordGetter[shape1]] -> RestructureOutput[shape1, shape2]) -> RecordSet[shape2]:
-  RestructureOutput(reshaperF, reshaperV, new_getters, _, _) = f(getters)
-  RecordSet(reshaperF(fields), rows.map_List(reshaperV), new_getters)
+def restructure(RecordSet(fields, rows, getters, _): RecordSet[shape1], f: shape1[RecordGetter[shape1]] -> RestructureOutput[shape1, shape2]) -> RecordSet[shape2]:
+  RestructureOutput(reshaperF, reshaperV, new_getters, traverse, _) = f(getters)
+  RecordSet(reshaperF(fields), rows.map_List(reshaperV), new_getters, traverse)
 
-def concat_records(RecordSet(fields, rows, getters), more_rows):
-  RecordSet(fields, rows.concat(more_rows), getters)
+def concat_records(RecordSet(fields, rows, getters, traverse), more_rows):
+  RecordSet(fields, rows.concat(more_rows), getters, traverse)
 
 struct NilShape[w]
 struct PS[t,rest,w](left: w[t], right: rest[w])
 
-new_record_set = RecordSet(NilShape, [], NilShape)
+new_record_set = RecordSet(NilShape, [], NilShape, \NilShape,fn -> NilShape)
 
 def s(RecordGetter(f1, v1)):
   def traverse(PS(x, _), g):

--- a/test_workspace/recordset.bosatsu
+++ b/test_workspace/recordset.bosatsu
@@ -28,6 +28,14 @@ def get(sh: shape[RecordValue], RecordGetter(_, getter): RecordGetter[shape, t])
 def create_field(rf: RecordField[t], fn: shape[RecordValue] -> t):
   RecordGetter(\sh -> rf, \sh -> RecordValue(fn(sh)))
 
+def list_of_rows(RecordSet(fields, rows, getters, traverse, record_to_list): RecordSet[shape]):
+  def getter_to_row_entry(row: shape[RecordValue]):
+    (result_fn: forall tt. RecordGetter[shape, tt] -> RecordRowEntry[RecordValue, tt]) = \RecordGetter(get_field, get_value) ->
+      RecordField(name, to_entry) = get_field(fields)
+      RecordRowEntry(to_entry(get_value(row)))
+    result_fn
+  rows.map_List(\row -> record_to_list(getters.traverse(getter_to_row_entry(row))))
+
 struct RestructureOutput[shape1, shape2](
   reshaperFields: shape1[RecordField] -> shape2[RecordField],
   reshaperValues: shape1[RecordValue] -> shape2[RecordValue],
@@ -70,11 +78,15 @@ def ps(
     \PS(RecordRowEntry(row_entry), sh2) -> [row_entry].concat(record_to_list1(sh2))
   )
 
+def string_field(name, fn: shape[RecordValue] -> String): RecordField(name, REString).create_field(fn)
+def int_field(name, fn: shape[RecordValue] -> Int): RecordField(name, REInt).create_field(fn)
+def bool_field(name, fn: shape[RecordValue] -> Bool): RecordField(name, REBool).create_field(fn)
 ##################################################
 
-rs = new_record_set.restructure(\ns -> ps(RecordField("String", REString).create_field(\_ -> ""), ps(RecordField("Int", REInt).create_field(\_ -> 0), s(RecordField("Bool", REBool).create_field(\_ -> True))))).concat_records([PS(RecordValue("a"), PS(RecordValue(1), PS(RecordValue(False), NilShape)))])
+rs_empty = new_record_set.restructure(\ns -> ps("String field".string_field(\_ -> ""), ps("Int field".int_field(\_ -> 0), s("Bool field".bool_field(\_ -> True)))))
+rs = rs_empty.concat_records([PS(RecordValue("a"), PS(RecordValue(1), PS(RecordValue(False), NilShape)))])
 
-rs0 = rs.restructure(\PS(a, PS(b, PS(c, _))) -> ps(c,ps(a,s(b))))
+rs0 = rs.restructure(\PS(a, PS(b, PS(c, _))) -> ps(c, ps(b, ps(a, s("Plus 2".int_field( \r -> r.get(b).add(2) ))))))
 
 ##################################################
 
@@ -113,14 +125,11 @@ def equal_RowEntry(re1, re2):
 def equal_rows(row1, row2):
   equal_RowEntry.equal_List(row1, row2)
 
-RecordSet(_, rows, _) = rs0
-
-def to_row(PS(RecordValue(x), _)):
-  [REInt(RecordValue(1))]
+rows = rs0.list_of_rows
 
 tests = Test("reordering",
   [
-    Assertion(equal_rows.equal_List(rows.map_List(to_row), [[REInt(RecordValue(1))]]), "swap")
+    Assertion(equal_rows.equal_List(rows, [[REBool(RecordValue(False)), REInt(RecordValue(1)), REString(RecordValue("a")), REInt(RecordValue(3))]]), "swap")
   ]
 )
 

--- a/test_workspace/recordset.bosatsu
+++ b/test_workspace/recordset.bosatsu
@@ -1,22 +1,28 @@
 package RecordSet
 
-enum RecordValue:
-  RVBool(value: Bool)
-  RVInt(value: Int)
-  RVString(value: String)
-struct Field[t](name: String, toValue: t -> RecordValue)
-struct RecordSet[shape](fields: shape[Field[String], Field[Int], Field[Bool]], rows: List[shape[String,Int, Bool]])
+enum RowEntry:
+  REBool(value: Bool)
+  REInt(value: Int)
+  REString(value: String)
+
+struct RecordField[t](name: String, toValue: t -> RowEntry)
+
+struct RecordSet[shape](fields: shape[RecordField[String], RecordField[Int], RecordField[Bool]], rows: List[shape[String,Int, Bool]])
 
 def restructure(RecordSet(fields, rows), f: forall string,int,bool. shape1[string, int, bool] -> shape2[string, int, bool]) -> RecordSet[shape2]:
   RecordSet(f(fields), rows.map_List(f))
 
 struct IntShape[string,int,bool](int: int)
-struct PairShape[shape,t,string,int,bool](left: t[string,int,bool], right: shape[string, int, bool])
+struct PairShape[shape1,shape2,string,int,bool](left: shape1[string,int,bool], right: shape2[string, int, bool])
+
 def make_pair_int_shape(rest: shape[string,int,bool], i: int) -> PairShape[shape,IntShape,string,int,bool]:
-  PairShape(IntShape(i), rest)
+  PairShape(rest, IntShape(i))
+
+# def add_shape(RecordSet(fields1, rows): RecordSet[shape1], fields2: shape2[RecordField[String], RecordField[Int], RecordField[Bool]], f: shape1[String, Int, Bool] -> shape2[String, Int, Bool]) -> RecordSet[PairShape[shape1, shape2]]:
+#  RecordSet(PairShape(fields1, fields2), rows.map_List(\row -> PairShape(row, f(row))))
 
 def add_int_field(RecordSet(fields, rows): RecordSet[shape1], name: String, f: shape1[String, Int, Bool] -> Int) -> RecordSet[PairShape[shape1, IntShape]]:
-  RecordSet(make_pair_int_shape(fields, Field(name, RVInt)), rows.map_List(\row -> make_pair_int_shape(row, f(row))))
+  RecordSet(make_pair_int_shape(fields, RecordField(name, REInt)), rows.map_List(\row -> make_pair_int_shape(row, f(row))))
 
 ##################################################
 
@@ -25,13 +31,13 @@ struct Shape2[string,int,bool](f1: string, f2: bool, f3: int)
 struct Shape3[string,int,bool](f1: string, f2: bool, f3: int, f4: int)
 
 rs = RecordSet(
-  Shape1(Field("String", RVString), Field("Int", RVInt), Field("Bool", RVBool)),
+  Shape1(RecordField("String", REString), RecordField("Int", REInt), RecordField("Bool", REBool)),
   [Shape1("a", 1, True)]
 )
 
 rs0 = rs.restructure(\Shape1(a,b,c) -> Shape2(a,c,b))
 rs1 = rs0.add_int_field("Second Int", \Shape2(_,_,x) -> x.add(4))
-rs2 = rs1.restructure(\PairShape(IntShape(i), Shape2(a,b,c)) -> Shape3(a,b,c,i))
+rs2 = rs1.restructure(\PairShape(Shape2(a,b,c), IntShape(i)) -> Shape3(a,b,c,i))
 
 ##################################################
 

--- a/test_workspace/recordset.bosatsu
+++ b/test_workspace/recordset.bosatsu
@@ -6,37 +6,38 @@ enum RowEntry:
   REString(value: String)
 
 struct RecordField[t](name: String, toValue: t -> RowEntry)
+struct RecordValue[t](value: t)
 
-struct RecordSet[shape](fields: shape[RecordField[String], RecordField[Int], RecordField[Bool]], rows: List[shape[String,Int, Bool]])
+struct RecordSet[shape](fields: shape[RecordField], rows: List[shape[RecordValue]])
 
-def restructure(RecordSet(fields, rows), f: forall string,int,bool. shape1[string, int, bool] -> shape2[string, int, bool]) -> RecordSet[shape2]:
+def restructure(RecordSet(fields, rows), f: forall w. shape1[w] -> shape2[w]) -> RecordSet[shape2]:
   RecordSet(f(fields), rows.map_List(f))
 
-struct IntShape[string,int,bool](int: int)
-struct PairShape[shape1,shape2,string,int,bool](left: shape1[string,int,bool], right: shape2[string, int, bool])
+struct IntShape[w](int: w[Int])
+struct PairShape[shape1,shape2,w](left: shape1[w], right: shape2[w])
 
-def make_pair_int_shape(rest: shape[string,int,bool], i: int) -> PairShape[shape,IntShape,string,int,bool]:
+def make_pair_int_shape(rest: shape[w], i: w[Int]) -> PairShape[shape,IntShape,w]:
   PairShape(rest, IntShape(i))
 
 # def add_shape(RecordSet(fields1, rows): RecordSet[shape1], fields2: shape2[RecordField[String], RecordField[Int], RecordField[Bool]], f: shape1[String, Int, Bool] -> shape2[String, Int, Bool]) -> RecordSet[PairShape[shape1, shape2]]:
 #  RecordSet(PairShape(fields1, fields2), rows.map_List(\row -> PairShape(row, f(row))))
 
-def add_int_field(RecordSet(fields, rows): RecordSet[shape1], name: String, f: shape1[String, Int, Bool] -> Int) -> RecordSet[PairShape[shape1, IntShape]]:
-  RecordSet(make_pair_int_shape(fields, RecordField(name, REInt)), rows.map_List(\row -> make_pair_int_shape(row, f(row))))
+def add_int_field(RecordSet(fields, rows): RecordSet[shape1], name: String, f: shape1[RecordValue] -> Int) -> RecordSet[PairShape[shape1, IntShape]]:
+  RecordSet(make_pair_int_shape(fields, RecordField(name, REInt)), rows.map_List(\row -> make_pair_int_shape(row, RecordValue(f(row)))))
 
 ##################################################
 
-struct Shape1[string,int,bool](f1: string, f2: int, f3: bool)
-struct Shape2[string,int,bool](f1: string, f2: bool, f3: int)
-struct Shape3[string,int,bool](f1: string, f2: bool, f3: int, f4: int)
+struct Shape1[w](f1: w[String], f2: w[Int], f3: w[Bool])
+struct Shape2[w](f1: w[String], f2: w[Bool], f3: w[Int])
+struct Shape3[w](f1: w[String], f2: w[Bool], f3: w[Int], f4: w[Int])
 
 rs = RecordSet(
   Shape1(RecordField("String", REString), RecordField("Int", REInt), RecordField("Bool", REBool)),
-  [Shape1("a", 1, True)]
+  [Shape1(RecordValue("a"), RecordValue(1), RecordValue(True))]
 )
 
 rs0 = rs.restructure(\Shape1(a,b,c) -> Shape2(a,c,b))
-rs1 = rs0.add_int_field("Second Int", \Shape2(_,_,x) -> x.add(4))
+rs1 = rs0.add_int_field("Second Int", \Shape2(_,_,RecordValue(x)) -> x.add(4))
 rs2 = rs1.restructure(\PairShape(Shape2(a,b,c), IntShape(i)) -> Shape3(a,b,c,i))
 
 ##################################################
@@ -66,12 +67,12 @@ def equal_List(is_equal, l1, l2):
       []: False
       [h2, *r2]: is_equal(h1, h2) && equal_List(is_equal, r1, r2)
 
-def compare_shape3((compare1, compare2, compare3), Shape3(x1, x2, x3, x4), Shape3(y1, y2, y3, y4)):
+def compare_shape3((compare1, compare2, compare3), Shape3(RecordValue(x1), RecordValue(x2), RecordValue(x3), RecordValue(x4)), Shape3(RecordValue(y1), RecordValue(y2), RecordValue(y3), RecordValue(y4))):
   compare1.equals(x1, y1) && compare2.equals(x2, y2) && compare3.equals(x3, y3) && compare3.equals(x4, y4)
 
 RecordSet(_, rows) = rs2
 tests = Test("reordering",
   [
-    Assertion((string_Order_fn, cmp_Bool, cmp_Int).compare_shape3.equal_List(rows, [Shape3("a", True, 1, 5)]), "swap")
+    Assertion((string_Order_fn, cmp_Bool, cmp_Int).compare_shape3.equal_List(rows, [Shape3(RecordValue("a"), RecordValue(True), RecordValue(1), RecordValue(5))]), "swap")
   ]
 )

--- a/test_workspace/recordset.bosatsu
+++ b/test_workspace/recordset.bosatsu
@@ -7,43 +7,36 @@ enum RowEntry[w]:
 
 struct RecordField[t](name: String, to_entry: forall w. w[t] -> RowEntry[w])
 struct RecordValue[t](value: t)
+struct RecordGetter[shape, t](f: forall w. shape[w] -> w[t])
 
-struct RecordSet[shape](fields: shape[RecordField], rows: List[shape[RecordValue]], to_row: forall w. shape[w] -> List[RowEntry[w]])
+struct RecordSet[shape](fields: shape[RecordField], rows: List[shape[RecordValue]], getters: shape[RecordGetter[shape]])
 
-def restructure(RecordSet(fields, rows), f: forall w. shape1[w] -> shape2[w], to_row: forall w. shape2[w] -> List[RowEntry[w]]) -> RecordSet[shape2]:
-  RecordSet(f(fields), rows.map_List(f), to_row)
+def restructure(RecordSet(fields, rows, getters), f: shape1[RecordGetter[shape1]] -> (forall w. shape1[w] -> shape2[w], forall w. shape1[w] -> shape2[w], shape2[RecordGetter[shape2]])) -> RecordSet[shape2]:
+  (reshaper1, reshaper2, new_getters) = f(getters)
+  RecordSet(reshaper1(fields), rows.map_List(reshaper2), new_getters)
 
+
+struct NilShape[w]
 struct IntShape[w](int: w[Int])
-struct PairShape[shape1,shape2,w](left: shape1[w], right: shape2[w])
+struct PS[t,shape2,w](left: w[t], right: shape2[w])
 
-def make_pair_int_shape(rest: shape[w], i: w[Int]) -> PairShape[shape,IntShape,w]:
-  PairShape(rest, IntShape(i))
-
-# def add_shape(RecordSet(fields1, rows): RecordSet[shape1], fields2: shape2[RecordField[String], RecordField[Int], RecordField[Bool]], f: shape1[String, Int, Bool] -> shape2[String, Int, Bool]) -> RecordSet[PairShape[shape1, shape2]]:
-#  RecordSet(PairShape(fields1, fields2), rows.map_List(\row -> PairShape(row, f(row))))
-
-def add_int_field(RecordSet(fields, rows, to_row): RecordSet[shape1], name: String, f: shape1[RecordValue] -> Int) -> RecordSet[PairShape[shape1, IntShape]]:
-  RecordSet(
-    make_pair_int_shape(fields, RecordField(name, REInt)),
-    rows.map_List(\row -> make_pair_int_shape(row, RecordValue(f(row)))),
-    \PairShape(sh1, IntShape(int)) -> to_row(sh1).concat([REInt(int)])
+def s(getter):
+  RecordGetter(f) = getter
+  (
+    \x -> PS(f(x),NilShape),
+    \x -> PS(f(x),NilShape),
+    PS(RecordGetter(\PS(x, _) -> x), NilShape)
   )
 
 ##################################################
 
-struct Shape1[w](f1: w[String], f2: w[Int], f3: w[Bool])
-struct Shape2[w](f1: w[String], f2: w[Bool], f3: w[Int])
-struct Shape3[w](f1: w[String], f2: w[Bool], f3: w[Int], f4: w[Int])
-
 rs = RecordSet(
-  Shape1(RecordField("String", REString), RecordField("Int", REInt), RecordField("Bool", REBool)),
-  [Shape1(RecordValue("a"), RecordValue(1), RecordValue(True))],
-  \Shape1(f1, f2, f3) -> [REString(f1), REInt(f2), REBool(f3)]
+  PS(RecordField("String", REString), PS(RecordField("Int", REInt), PS(RecordField("Bool", REBool), NilShape))),
+  [PS(RecordValue("a"), PS(RecordValue(1), PS(RecordValue(True), NilShape)))],
+  PS(RecordGetter(\PS(x,_) -> x), PS(RecordGetter(\PS(_, PS(x, _)) -> x), PS(RecordGetter(\PS(_, PS(_, PS(x, _))) -> x), NilShape)))
 )
 
-rs0 = rs.restructure(\Shape1(a,b,c) -> Shape2(a,c,b), \Shape2(f1,f2,f3) -> [REString(f1), REBool(f2), REInt(f3)])
-rs1 = rs0.add_int_field("Second Int", \Shape2(_,_,RecordValue(x)) -> x.add(4))
-rs2 = rs1.restructure(\PairShape(Shape2(a,b,c), IntShape(i)) -> Shape3(a,b,c,i), \Shape3(f1,f2,f3,f4) -> [REString(f1), REBool(f2), REInt(f3), REInt(f4)])
+rs0 = rs.restructure(\PS(a, PS(b, PS(c, _))) -> s(b))
 
 ##################################################
 
@@ -72,9 +65,6 @@ def equal_List(is_equal, l1, l2):
       []: False
       [h2, *r2]: is_equal(h1, h2) && equal_List(is_equal, r1, r2)
 
-def compare_shape3((compare1, compare2, compare3), Shape3(RecordValue(x1), RecordValue(x2), RecordValue(x3), RecordValue(x4)), Shape3(RecordValue(y1), RecordValue(y2), RecordValue(y3), RecordValue(y4))):
-  compare1.equals(x1, y1) && compare2.equals(x2, y2) && compare3.equals(x3, y3) && compare3.equals(x4, y4)
-
 def equal_RowEntry(re1, re2):
   match (re1, re2):
     (REBool(RecordValue(x1)), REBool(RecordValue(x2))): cmp_Bool.equals(x1, x2)
@@ -85,9 +75,14 @@ def equal_RowEntry(re1, re2):
 def equal_rows(row1, row2):
   equal_RowEntry.equal_List(row1, row2)
 
-RecordSet(_, rows, to_row) = rs2
+RecordSet(_, rows, _) = rs0
+
+def to_row(PS(RecordValue(x), _)):
+  [REInt(RecordValue(1))]
+
 tests = Test("reordering",
   [
-    Assertion(equal_rows.equal_List(rows.map_List(to_row), [[REString(RecordValue("a")), REBool(RecordValue(True)), REInt(RecordValue(1)), REInt(RecordValue(5))]]), "swap")
+    Assertion(equal_rows.equal_List(rows.map_List(to_row), [[REInt(RecordValue(1))]]), "swap")
   ]
 )
+

--- a/test_workspace/recordset.bosatsu
+++ b/test_workspace/recordset.bosatsu
@@ -55,16 +55,13 @@ struct PS[t,rest,w](left: w[t], right: rest[w])
 
 new_record_set = RecordSet(NilShape, [], NilShape, \NilShape,fn -> NilShape, \NilShape -> [])
 
-def s(RecordGetter(f1, v1)):
-  def traverse(PS(x, _), g):
-    PS(g(x), NilShape)
-  RestructureOutput(
-    \x -> PS(f1(x),NilShape),
-    \x -> PS(v1(x),NilShape),
-    PS(RecordGetter(\PS(x, _) -> x, \PS(x, _) -> x), NilShape),
-    traverse,
-    \PS(RecordRowEntry(row_entry), _) -> [row_entry]
-  )
+(ps_end: forall t. RestructureOutput[t, NilShape]) = RestructureOutput(
+  \ns -> NilShape,
+  \ns -> NilShape,
+  NilShape,
+  \ns,fn -> NilShape,
+  \ns -> []
+)
 
 def ps(
   RecordGetter(fF, fV): RecordGetter[shape1, t],
@@ -121,11 +118,11 @@ def equal_rows(row1, row2):
 
 ##################################################
 
-rs_empty = new_record_set.restructure(\ns -> ps("String field".string_field(\_ -> ""), ps("Int field".int_field(\_ -> 0), s("Bool field".bool_field(\_ -> True)))))
+rs_empty = new_record_set.restructure(\ns -> ps("String field".string_field(\_ -> ""), ps("Int field".int_field(\_ -> 0), ps("Bool field".bool_field(\_ -> True), ps_end))))
 
 rs = rs_empty.concat_records([PS(RecordValue("a"), PS(RecordValue(1), PS(RecordValue(False), NilShape)))])
 
-rs0 = rs.restructure(\PS(a, PS(b, PS(c, _))) -> ps(c, ps(b, ps(a, s("Plus 2".int_field( \r -> r.get(b).add(2) ))))))
+rs0 = rs.restructure(\PS(a, PS(b, PS(c, _))) -> ps(c, ps(b, ps(a, ps("Plus 2".int_field( \r -> r.get(b).add(2) ), ps_end)))))
 
 tests = Test("reordering",
   [

--- a/test_workspace/recordset.bosatsu
+++ b/test_workspace/recordset.bosatsu
@@ -7,45 +7,67 @@ enum RowEntry[w]:
 
 struct RecordField[t](name: String, to_entry: forall w. w[t] -> RowEntry[w])
 struct RecordValue[t](value: t)
-struct RecordGetter[shape, t](f: forall w. shape[w] -> w[t])
+struct RecordGetter[shape, t](
+  field: shape[RecordField] -> RecordField[t],
+  value: shape[RecordValue] -> RecordValue[t]
+)
 
-struct RecordSet[shape](fields: shape[RecordField], rows: List[shape[RecordValue]], getters: shape[RecordGetter[shape]])
+struct RecordSet[shape](
+  fields: shape[RecordField],
+  rows: List[shape[RecordValue]],
+  getters: shape[RecordGetter[shape]]
+)
 
-def restructure(RecordSet(fields, rows, getters): RecordSet[shape1], f: shape1[RecordGetter[shape1]] -> ((forall w. shape1[w] -> shape2[w]), shape2[RecordGetter[shape2]], (forall w1,w2. shape2[w1] -> (forall ss. w1[ss] -> w2[ss]) -> shape2[w2]))) -> RecordSet[shape2]:
-  (reshaper1, new_getters, _) = f(getters)
-  (reshaper2, _, _) = f(getters)
-  RecordSet(reshaper1(fields), rows.map_List(reshaper2), new_getters)
+def get(sh: shape[RecordValue], RecordGetter(_, getter): RecordGetter[shape, t]) -> t:
+  RecordValue(result) = sh.getter
+  result
+
+def createField(rf: RecordField[t], fn: shape[RecordValue] -> t):
+  RecordGetter(\sh -> rf, \sh -> RecordValue(fn(sh)))
+
+struct RestructureOutput[shape1, shape2](
+  reshaperFields: shape1[RecordField] -> shape2[RecordField],
+  reshaperValues: shape1[RecordValue] -> shape2[RecordValue],
+  getters: shape2[RecordGetter[shape2]],
+  traverse: (forall w1,w2. shape2[w1] -> (forall ss. w1[ss] -> w2[ss]) -> shape2[w2])
+)
+def restructure(RecordSet(fields, rows, getters): RecordSet[shape1], f: shape1[RecordGetter[shape1]] -> RestructureOutput[shape1, shape2]) -> RecordSet[shape2]:
+  RestructureOutput(reshaperF, reshaperV, new_getters, _) = f(getters)
+  RecordSet(reshaperF(fields), rows.map_List(reshaperV), new_getters)
 
 struct NilShape[w]
-struct IntShape[w](int: w[Int])
-struct PS[t,shape2,w](left: w[t], right: shape2[w])
+struct PS[t,rest,w](left: w[t], right: rest[w])
 
-def s(rg):
-  RecordGetter(f) = rg
+def s(RecordGetter(f1, v1)):
   def traverse(PS(x, _), g):
     PS(g(x), NilShape)
-  (
-    \x -> PS(f(x),NilShape),
-    PS(RecordGetter(\PS(x, _) -> x), NilShape),
+  RestructureOutput(
+    \x -> PS(f1(x),NilShape),
+    \x -> PS(v1(x),NilShape),
+    PS(RecordGetter(\PS(x, _) -> x, \PS(x, _) -> x), NilShape),
     traverse
   )
 
-# def ps(RecordGetter(f): RecordGetter[shapae1, t], (g, sh2, traverse): (forall w. shape1[w] -> shape2[w], shape2[RecordGetter[shape2]], forall w1,w2. shape2[w1] -> (forall s. w1[s] -> w2[s]) -> shape2[w2] )):
-#  (
-#    \sh1 -> PS(f(sh1), g(sh1)),
-#    PS(RecordGetter(\PS(x,_) -> x), sh2.traverse(\RecordGetter(f1) -> RecordGetter(\PS(_, sh2) -> f1(sh2)))),
-#    \PS(x, sh2), g -> PS(g(x), sh2.traverse(g))
-#  )
+def ps(
+  RecordGetter(fF, fV): RecordGetter[shape1, t],
+  RestructureOutput(reshaper1F, reshaper1V, getters1, traverse1): RestructureOutput[shape1, shape2]):
+  getters2 = getters1.traverse1(\RecordGetter(f1, v1) -> RecordGetter(\PS(_, sh2) -> f1(sh2), \PS(_, sh2) -> v1(sh2)))
+  RestructureOutput(
+    \sh1 -> PS(fF(sh1), reshaper1F(sh1)),
+    \sh1 -> PS(fV(sh1), reshaper1V(sh1)),
+    PS(RecordGetter(\PS(x,_) -> x, \PS(x,_) -> x), getters2),
+    \PS(x, sh2), g -> PS(g(x), sh2.traverse1(g))
+  )
 
 ##################################################
 
 rs = RecordSet(
   PS(RecordField("String", REString), PS(RecordField("Int", REInt), PS(RecordField("Bool", REBool), NilShape))),
   [PS(RecordValue("a"), PS(RecordValue(1), PS(RecordValue(True), NilShape)))],
-  PS(RecordGetter(\PS(x,_) -> x), PS(RecordGetter(\PS(_, PS(x, _)) -> x), PS(RecordGetter(\PS(_, PS(_, PS(x, _))) -> x), NilShape)))
+  PS(RecordGetter(\PS(x,_) -> x, \PS(x,_) -> x), PS(RecordGetter(\PS(_, PS(x, _)) -> x, \PS(_, PS(x, _)) -> x), PS(RecordGetter(\PS(_, PS(_, PS(x, _))) -> x, \PS(_, PS(_, PS(x, _))) -> x), NilShape)))
 )
 
-rs0 = rs.restructure(\PS(a, PS(b, PS(c, _))) -> s(b))
+rs0 = rs.restructure(\PS(a, PS(b, PS(c, _))) -> ps(c,ps(a,s(b))))
 
 ##################################################
 

--- a/test_workspace/recordset.bosatsu
+++ b/test_workspace/recordset.bosatsu
@@ -1,4 +1,4 @@
-package RecordSet
+package RecordSet/Library
 
 enum RowEntry[w]:
   REBool(value: w[Bool])
@@ -81,12 +81,6 @@ def ps(
 def string_field(name, fn: shape[RecordValue] -> String): RecordField(name, REString).create_field(fn)
 def int_field(name, fn: shape[RecordValue] -> Int): RecordField(name, REInt).create_field(fn)
 def bool_field(name, fn: shape[RecordValue] -> Bool): RecordField(name, REBool).create_field(fn)
-##################################################
-
-rs_empty = new_record_set.restructure(\ns -> ps("String field".string_field(\_ -> ""), ps("Int field".int_field(\_ -> 0), s("Bool field".bool_field(\_ -> True)))))
-rs = rs_empty.concat_records([PS(RecordValue("a"), PS(RecordValue(1), PS(RecordValue(False), NilShape)))])
-
-rs0 = rs.restructure(\PS(a, PS(b, PS(c, _))) -> ps(c, ps(b, ps(a, s("Plus 2".int_field( \r -> r.get(b).add(2) ))))))
 
 ##################################################
 
@@ -125,11 +119,16 @@ def equal_RowEntry(re1, re2):
 def equal_rows(row1, row2):
   equal_RowEntry.equal_List(row1, row2)
 
-rows = rs0.list_of_rows
+##################################################
+
+rs_empty = new_record_set.restructure(\ns -> ps("String field".string_field(\_ -> ""), ps("Int field".int_field(\_ -> 0), s("Bool field".bool_field(\_ -> True)))))
+
+rs = rs_empty.concat_records([PS(RecordValue("a"), PS(RecordValue(1), PS(RecordValue(False), NilShape)))])
+
+rs0 = rs.restructure(\PS(a, PS(b, PS(c, _))) -> ps(c, ps(b, ps(a, s("Plus 2".int_field( \r -> r.get(b).add(2) ))))))
 
 tests = Test("reordering",
   [
-    Assertion(equal_rows.equal_List(rows, [[REBool(RecordValue(False)), REInt(RecordValue(1)), REString(RecordValue("a")), REInt(RecordValue(3))]]), "swap")
+    Assertion(equal_rows.equal_List(rs0.list_of_rows, [[REBool(RecordValue(False)), REInt(RecordValue(1)), REString(RecordValue("a")), REInt(RecordValue(3))]]), "swap")
   ]
 )
-


### PR DESCRIPTION
I figure I'll keep PRing this example into this repo because it seems useful to see how the language can be used. But I should make a separate repo with its own dependent bazel build.

One thing that popped up is there might be a bug where you can export constructors but not import them? I get a parse error on the parentheses.

Something else that comes up is `ps(c, ps(b, ps(a, s("Plus 2".int_field( \r -> r.get(b).add(2) ))))))` is pretty meh for syntax. Note this pattern is the same for constructing tuples, but I'm doing more than just creating a structure so I can't just use tuples, even if there were a way to make the types work.

My dream would be if I could do something like `record[c, b, a, "Plus 2".int_field( \r -> r.get(b).add(2) )]` and somehow define `record[...,...]` as "apply `s` to the last term and nest applications of `ps` on through the rest of the terms in reverse order". You could then define `[]` for `List` and `()` for `TupleCons` this way too. But that might be a bit much for a fairly narrow use case.

Alternatively, if I could fold through a tuple I think that might unlock something. But it's a weird meaning of `fold` because the accumulator keeps changing type.