### PR TITLE
Fix bugs uncovered with a stricter checks

### DIFF
--- a/core/src/main/scala/org/bykn/bosatsu/Normalization.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/Normalization.scala
@@ -506,6 +506,7 @@ case class NormalizePackageMap(pm: PackageMap.Inferred) {
     NormState[TypedExpr[(Declaration, NormalExpressionTag)]] = {
       val lambdaVars = al.arg :: env._2
       val nextEnv: Env = (env._1 ++ lambdaVars.zipWithIndex
+        .reverse
         .toMap
         .mapValues(idx => NormalExpressionTag(NormalExpression.LambdaVar(idx), Set[NormalExpression]())),
         lambdaVars)
@@ -533,6 +534,7 @@ case class NormalizePackageMap(pm: PackageMap.Inferred) {
         case RecursionKind.Recursive =>
           val lambdaVars = l.arg :: env._2
           val nextEnv = (env._1 ++ lambdaVars.zipWithIndex
+            .reverse
             .toMap
             .mapValues(idx => NormalExpressionTag(NormalExpression.LambdaVar(idx), Set[NormalExpression]())),
             lambdaVars)
@@ -598,6 +600,7 @@ case class NormalizePackageMap(pm: PackageMap.Inferred) {
     val names = pattern.names.collect { case b: Identifier.Bindable => b }
     val lambdaVars = names ++ env._2
     val nextEnv = (env._1 ++ lambdaVars.zipWithIndex
+      .reverse
       .toMap
       .mapValues(idx => NormalExpressionTag(NormalExpression.LambdaVar(idx), Set[NormalExpression]())),
       lambdaVars)

--- a/core/src/main/scala/org/bykn/bosatsu/TypedExpr.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/TypedExpr.scala
@@ -341,7 +341,17 @@ object TypedExpr {
       case App(fnT, arg, tpe, tag) =>
         App(recur(fnT), recur(arg), tpe, tag)
       case Let(b, e, in, r, t) =>
-        if (b == name) te // shadow
+        if (b == name) {
+          if (r.isRecursive) {
+            // in this case, b is in scope for e
+            // so it shadows a the previous definition
+            te // shadow
+          } else {
+            // then b is not in scope for e
+            // but b does shadow inside `in`
+            Let(b, recur(e), in, r, t)
+          }
+        }
         else Let(b, recur(e), recur(in), r, t)
       case lit@Literal(_, _, _) => lit
       case Match(arg, branches, tag) =>

--- a/core/src/main/scala/org/bykn/bosatsu/TypedExpr.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/TypedExpr.scala
@@ -238,30 +238,40 @@ object TypedExpr {
   }
 
   type Coerce = FunctionK[TypedExpr, TypedExpr]
+
   def coerceRho(tpe: Type.Rho): Coerce =
-    new FunctionK[TypedExpr, TypedExpr] { self =>
-      def apply[A](expr: TypedExpr[A]) =
-        expr match {
-          case Annotation(t, _, _) => self(t)
-          case Generic(params, expr, tag) =>
-            // This definitely feels wrong,
-            // but without this, I don't see what else we can do
-            Generic(params, self(expr), tag)
-          case Var(p, name, _, t) => Var(p, name, tpe, t)
-          case AnnotatedLambda(arg, argT, res, tag) =>
-            // only some coercions would make sense here
-            // how to handle?
-            // one way out could be to return a type to Annotation
-            // and just wrap it in this case, could it be that simple?
-            Annotation(expr, tpe, expr.tag)
-          case App(fn, arg, _, tag) =>
-            // do we need to coerce fn into the right shape?
-            App(fn, arg, tpe, tag)
-          case Let(arg, argE, in, rec, tag) =>
-            Let(arg, argE, self(in), rec, tag)
-          case Literal(l, _, tag) => Literal(l, tpe, tag)
-          case Match(arg, branches, tag) =>
-            Match(arg, branches.map { case (p, expr) => (p, self(expr)) }, tag)
+    tpe match {
+      case Type.Fun(a: Type.Rho, b: Type.Rho) =>
+        coerceFn(a, b, coerceRho(a), coerceRho(b))
+      case _ =>
+        new FunctionK[TypedExpr, TypedExpr] { self =>
+          def apply[A](expr: TypedExpr[A]) =
+            expr match {
+              case Annotation(t, _, _) => self(t)
+              case Generic(_, expr, _) =>
+                // a Generic type is not a rho type,
+                // so we discard the outer forAll and continue on
+                self(expr)
+              case Var(p, name, _, t) => Var(p, name, tpe, t)
+              case AnnotatedLambda(arg, argT, res, tag) =>
+                // only some coercions would make sense here
+                // how to handle?
+                // one way out could be to return a type to Annotation
+                // and just wrap it in this case, could it be that simple?
+                Annotation(expr, tpe, expr.tag)
+              case App(fn, arg, _, tag) =>
+                // TODO, what should we do here?
+                // we have learned that the type is tpe
+                // but that implies something for fn and arg
+                // but we are ignoring that, which
+                // leaves them with potentially skolems or metavars
+                App(fn, arg, tpe, tag)
+              case Let(arg, argE, in, rec, tag) =>
+                Let(arg, argE, self(in), rec, tag)
+              case Literal(l, _, tag) => Literal(l, tpe, tag)
+              case Match(arg, branches, tag) =>
+                Match(arg, branches.map { case (p, expr) => (p, self(expr)) }, tag)
+            }
         }
     }
 
@@ -310,6 +320,35 @@ object TypedExpr {
       .distinct
   }
 
+  private def replaceVarType[A](te: TypedExpr[A], name: Identifier, tpe: Type): TypedExpr[A] = {
+    def recur(t: TypedExpr[A]) = replaceVarType(t, name, tpe)
+
+    te match {
+      case Generic(tv, in, tag) => Generic(tv, recur(in), tag)
+      case Annotation(term, tpe, tag) => Annotation(recur(term), tpe, tag)
+      case AnnotatedLambda(b, tpe, expr, tag) =>
+        // this is a kind of let:
+        if (b == name) {
+          // we are shadowing, so we are done:
+          te
+        }
+        else {
+          // no shadow
+          AnnotatedLambda(b, tpe, recur(expr), tag)
+        }
+      case Var(None, nm, _, tag) if nm == name => Var(None, name, tpe, tag)
+      case v@Var(_, _, _, _) => v
+      case App(fnT, arg, tpe, tag) =>
+        App(recur(fnT), recur(arg), tpe, tag)
+      case Let(b, e, in, r, t) =>
+        if (b == name) te // shadow
+        else Let(b, recur(e), recur(in), r, t)
+      case lit@Literal(_, _, _) => lit
+      case Match(arg, branches, tag) =>
+        Match(recur(arg), branches.map { case (p, t) => (p, recur(t)) }, tag)
+    }
+  }
+
   /**
    * TODO this seems pretty expensive to blindly apply: we are deoptimizing
    * the nodes pretty heavily
@@ -317,15 +356,28 @@ object TypedExpr {
   def coerceFn(arg: Type, result: Type.Rho, coarg: Coerce, cores: Coerce): Coerce =
     new FunctionK[TypedExpr, TypedExpr] { self =>
       def apply[A](expr: TypedExpr[A]) = {
-        /*
-         * We have to be careful not to collide with the free vars in expr
-         */
-        val free = SortedSet(freeVars(expr :: Nil): _*)
-        val name = Type.allBinders.iterator.map { v => Identifier.Name(v.name) }.filterNot(free).next
-        AnnotatedLambda(name, arg, cores(App(expr, coarg(Var(None, name, arg, expr.tag)), result, expr.tag)), expr.tag)
+        expr match {
+          case Annotation(t, _, _) => self(t)
+          case AnnotatedLambda(name, _, res, tag) =>
+            // note, Var(None, name, originalType, tag)
+            // is hanging out in res, or it is unused
+            AnnotatedLambda(name, arg, cores(replaceVarType(res, name, arg)), tag)
+          case Generic(_, in, _) => self(in)
+          case Var(p, n, _, tag) =>
+            Var(p, n, Type.Fun(arg, result), tag)
+          case _ =>
+            /*
+             * We have to be careful not to collide with the free vars in expr
+             */
+            val free = SortedSet(freeVars(expr :: Nil): _*)
+            val name = Type.allBinders.iterator.map { v => Identifier.Name(v.name) }.filterNot(free).next
+            // \name -> (expr((name: arg)): result)
+            // TODO: why do we need coarg when we already know the type (arg)?
+            val result1 = cores(App(expr, coarg(Var(None, name, arg, expr.tag)), result, expr.tag))
+            AnnotatedLambda(name, arg, result1, expr.tag)
+        }
       }
     }
-
 
   def forAll[A](params: NonEmptyList[Type.Var.Bound], expr: TypedExpr[A]): TypedExpr[A] =
     Generic(params, expr, expr.tag)

--- a/core/src/main/scala/org/bykn/bosatsu/rankn/Infer.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/rankn/Infer.scala
@@ -1,5 +1,7 @@
 package org.bykn.bosatsu.rankn
+
 import cats.Monad
+import cats.arrow.FunctionK
 import cats.data.{NonEmptyList, Writer}
 import cats.implicits._
 
@@ -290,7 +292,7 @@ object Infer {
           // this case is not really discussed in the paper
           zonkTypedExpr(rho)
         case Some(metas) =>
-          val used: Set[Type.Var.Bound] = Type.tyVarBinders(List(rho.getType))
+          val used: Set[Type.Var.Bound] = Type.tyVarBinders(rho.getType :: Nil)
           val aligned = Type.alignBinders(metas, used)
           val bound = aligned.traverse_ { case (m, n) => writeMeta(m, Type.TyVar(n)) }
           (bound *> zonkTypedExpr(rho)).map(TypedExpr.forAll(aligned.map(_._2), _))
@@ -683,14 +685,17 @@ object Infer {
         // note: we need rho2 in weak prenex form, but skolemize does this
         coerce <- subsCheckRho(inferred, rho2, left, right)
         // if there are no skolem variables, we can shortcut here, because empty.filter(fn) == empty
-        _ <- if (skolTvs.isEmpty) unit
-             else getFreeTyVars(inferred :: declared :: Nil).flatMap { escTvs =>
+        res <- NonEmptyList.fromList(skolTvs) match {
+          case None => pure(coerce)
+          case Some(nel) =>
+             getFreeTyVars(inferred :: declared :: Nil).flatMap { escTvs =>
                NonEmptyList.fromList(skolTvs.filter(escTvs)) match {
-                 case None => unit
+                 case None => pure(coerce.andThen(unskolemize(nel)))
                  case Some(badTvs) => fail(Error.SubsumptionCheckFailure(inferred, declared, left, right, badTvs))
                }
              }
-      } yield coerce
+          }
+      } yield res
 
     /**
      * Invariant: if the second argument is (Check rho) then rho is in weak prenex form
@@ -716,7 +721,9 @@ object Infer {
              (argT, resT) = argRes
              typedArg <- checkSigma(arg, argT)
              coerce <- instSigma(resT, expect, region(term))
-           } yield coerce(TypedExpr.App(typedFn, typedArg, resT, tag))
+             precoerce = TypedExpr.App(typedFn, typedArg, resT, tag)
+             res = coerce(precoerce)
+           } yield res
         case Lambda(name, result, tag) =>
           expect match {
             case Expected.Check((expTy, rr)) =>
@@ -806,11 +813,12 @@ object Infer {
               typedBody <- extendEnv(name, varT)(typeCheckRho(body, expect))
             } yield TypedExpr.Let(name, typedRhs, typedBody, isRecursive, tag)
           }
-        case Annotation(term, tpe, tag) =>
+        case ann@Annotation(term, tpe, tag) =>
           for {
             typedTerm <- checkSigma(term, tpe)
             coerce <- instSigma(tpe, expect, region(term))
-            res = coerce(TypedExpr.Annotation(typedTerm, tpe, tag))
+            pre = TypedExpr.Annotation(typedTerm, tpe, tag)
+            res = coerce(pre)
           } yield res
         case Match(term, branches, tag) =>
           // all of the branches must return the same type:
@@ -1080,15 +1088,20 @@ object Infer {
         (skols, rho) = skolRho
         // we need rho in weak-prenex form, but skolemize does this
         te <- checkRho(t, rho)
-        // if skols.isEmpty, skols.filter(fn).isEmpty, so we can skip the rest
-        _ <- if (skols.isEmpty) unit
-             else for {
-               envTys <- getEnv
-               escTvs <- getFreeTyVars(tpe :: envTys.values.toList)
-               badTvs = skols.filter(escTvs)
-               _ <- require(badTvs.isEmpty, Error.NotPolymorphicEnough(tpe, t, NonEmptyList.fromListUnsafe(badTvs), region(t)))
-             } yield ()
-      } yield te // should be fine since the everything after te is just checking
+        te1 <- NonEmptyList.fromList(skols) match {
+          case None =>
+            // if skols.isEmpty, skols.filter(fn).isEmpty, so we can skip the rest
+            zonkTypedExpr(te)
+          case Some(neskols) =>
+            for {
+              envTys <- getEnv
+              escTvs <- getFreeTyVars(tpe :: envTys.values.toList)
+              badTvs = skols.filter(escTvs)
+              _ <- require(badTvs.isEmpty, Error.NotPolymorphicEnough(tpe, t, NonEmptyList.fromListUnsafe(badTvs), region(t)))
+              zte <- zonkTypedExpr(te)
+            } yield unskolemize(neskols)(zte)
+        }
+      } yield te1 // should be fine since the everything after te is just checking
 
     /**
      * invariant: rho needs to be in weak-prenex form
@@ -1117,6 +1130,17 @@ object Infer {
   def typeCheck[A: HasRegion](t: Expr[A]): Infer[TypedExpr[A]] =
     typeCheckMeta(t, None)
 
+  private def unskolemize(skols: NonEmptyList[Type.Var.Skolem]): TypedExpr.Coerce =
+    new FunctionK[TypedExpr, TypedExpr] {
+      def apply[A](te: TypedExpr[A]) = {
+        // now replace the skols with generics
+        val used = Type.tyVarBinders(te.getType :: Nil)
+        val aligned = Type.alignBinders(skols, used)
+        val newVars = aligned.map(_._2)
+        val te2 = substTyExpr(skols, newVars.map(Type.TyVar(_)), te)
+        TypedExpr.forAll(newVars, te2)
+      }
+    }
 
   private def typeCheckMeta[A: HasRegion](t: Expr[A], optMeta: Option[(Identifier, Type.TyMeta, Region)]): Infer[TypedExpr[A]] = {
     def run(t: Expr[A]) = inferSigmaMeta(t, optMeta).flatMap(zonkTypedExpr _)
@@ -1142,17 +1166,20 @@ object Infer {
           mt <- replace
           (skols, t1) = mt
           te <- run(t1)
-          // now replace the skols with generics
-          used = Type.tyVarBinders(te.getType :: Nil)
-          aligned = Type.alignBinders(skols, used)
-          newVars = aligned.map(_._2)
-          te2 = substTyExpr(skols, newVars.map(Type.TyVar(_)), te)
-          forall = TypedExpr.forAll(newVars, te2)
-        } yield forall
+        } yield unskolemize(skols)(te)
     }
 
-      // todo this should be a law...
+      // todo this should be a law... but since
+      // we don't have confidence yet I'm leaving it here
+      // so we see the errors
     res.map { te =>
+      te.traverseType[cats.Id] {
+        case t@Type.TyVar(Type.Var.Skolem(_, _)) =>
+          sys.error(s"illegal skolem ($t) escape in ${te.repr}")
+        case t@Type.TyMeta(_) =>
+          sys.error(s"illegal meta ($t) escape in ${te.repr}")
+        case good => good
+      }
       val tp = te.getType
       lazy val teStr = TypeRef.fromTypes(None, tp :: Nil)(tp).toDoc.render(80)
       scala.Predef.require(Type.freeTyVars(tp :: Nil).isEmpty, s"illegal inferred type: $teStr")
@@ -1162,7 +1189,6 @@ object Infer {
       te
     }
   }
-
 
   def extendEnv[A](varName: Bindable, tpe: Type)(of: Infer[A]): Infer[A] =
     extendEnvList(List((varName, tpe)))(of)
@@ -1191,5 +1217,5 @@ object Infer {
    * a for for b
    */
   def substitutionCheck(a: Type, b: Type, ra: Region, rb: Region): Infer[Unit] =
-    subsCheck(a, b, ra, rb).map(_ => ())
+    subsCheck(a, b, ra, rb).void
 }

--- a/core/src/main/scala/org/bykn/bosatsu/rankn/Type.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/rankn/Type.scala
@@ -123,12 +123,7 @@ object Type {
       case ForAll(ns, rho) =>
         val boundSet: Set[Var] = ns.toList.toSet
         val env1 = env.filterKeys { v => !boundSet(v) }
-        substituteVar(rho, env1) match {
-          case ForAll(ns1, r1) =>
-            ForAll(ns ::: ns1, r1)
-          case notForAll: Rho =>
-            ForAll(ns, notForAll)
-        }
+        forAll(ns.toList, substituteVar(rho, env1))
       case m@TyMeta(_) => m
       case c@TyConst(_) => c
     }

--- a/core/src/test/scala/org/bykn/bosatsu/EvaluationTest.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/EvaluationTest.scala
@@ -1251,4 +1251,25 @@ main = match Bar(a):
     }
   }
 
+  test("pattern example from pair to triple") {
+    runBosatsuTest(
+      List("""
+package A
+
+struct Pair(f, s)
+struct Trip(f, s, t)
+
+Trip(a, b, c) = match Pair(1, "two"):
+  Pair(f, s): Trip(3, s, f)
+
+bgood = match b:
+  "two": True
+  _: False
+
+tests = Test("test triple",
+  [ Assertion(a.eq_Int(3), "a == 3"),
+    Assertion(bgood, b),
+    Assertion(c.eq_Int(1), "c == 1") ])
+"""), "A", 3)
+  }
 }

--- a/core/src/test/scala/org/bykn/bosatsu/NormalizationTest.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/NormalizationTest.scala
@@ -161,8 +161,8 @@ def result(x, c):
 out=result
 """
       ), "Match/Vars",
-        Lambda(Lambda(Match(LambdaVar(1),NonEmptyList.of((PositionalStruct(None,List(Var(0), PositionalStruct(None,List(Var(1), PositionalStruct(None,List()))))),Lambda(Lambda(Struct(0,
-  List(LambdaVar(1), LambdaVar(0)))))))))))
+        Lambda(Lambda(Match(LambdaVar(1),NonEmptyList.of((PositionalStruct(None,List(Var(0), PositionalStruct(None,List(Var(1), PositionalStruct(None,List()))))),Lambda(Lambda(Struct(0,List(LambdaVar(1), Struct(0,List(LambdaVar(2), Struct(0,List(LambdaVar(0), Struct(0,List()))))))))))))))
+      )
 
     normalExpressionTest(
       List("""
@@ -176,7 +176,7 @@ out=match Pair(1, "two"):
 
 """
       ), "Match/Structs",
-      Struct(0,List(Literal(Lit(3)), Literal(Lit(1)), Literal(Lit(1))))
+      Struct(0,List(Literal(Lit(3)), Literal(Lit.Str("two")), Literal(Lit(1))))
     )
     normalExpressionTest(
       List("""

--- a/core/src/test/scala/org/bykn/bosatsu/NormalizationTest.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/NormalizationTest.scala
@@ -38,11 +38,12 @@ main = ["aa"]
 """
         ), "NormTest/List", NormalExpressionTag(
           Struct(1,List(Literal(Str("aa")), Struct(0,List()))),
-          Set(
-            Lambda(Lambda(Struct(1,List(LambdaVar(1), LambdaVar(0))))),
-            Literal(Str("aa")),
-            Lambda(Struct(1,List(Literal(Str("aa")), LambdaVar(0)))),
-            Struct(0,List())
+          Set(LambdaVar(0),
+              Lambda(Lambda(Struct(1,List(LambdaVar(1), LambdaVar(0))))),
+              Struct(0,List()),
+              Literal(Str("aa")),
+              Lambda(Struct(1,List(Literal(Str("aa")), LambdaVar(0)))),
+              Struct(1,List(Literal(Str("aa")), LambdaVar(0)))
           )
         ),
         Some("Struct(1,Literal('aa'),Struct(0,))")
@@ -159,13 +160,10 @@ def result(x, c):
 
 out=result
 """
-      ), "Match/Vars", 
-    Lambda(Lambda(Match(LambdaVar(1),NonEmptyList.fromList(List(
-      (
-        PositionalStruct(None,List(Var(0), PositionalStruct(None,List(Var(1), PositionalStruct(None,List()))))),
-        Lambda(Lambda(Struct(0,List(LambdaVar(1), Struct(0,List(LambdaVar(2), Struct(0,List(LambdaVar(0), Struct(0,List())))))))))
-      )
-    )).get))))
+      ), "Match/Vars",
+        Lambda(Lambda(Match(LambdaVar(1),NonEmptyList.of((PositionalStruct(None,List(Var(0), PositionalStruct(None,List(Var(1), PositionalStruct(None,List()))))),Lambda(Lambda(Struct(0,
+  List(LambdaVar(1), LambdaVar(0)))))))))))
+
     normalExpressionTest(
       List("""
 package Match/Structs
@@ -178,7 +176,7 @@ out=match Pair(1, "two"):
 
 """
       ), "Match/Structs",
-      Struct(0,List(Literal(Integer(BigInteger.valueOf(3))), Literal(Str("two")), Literal(Integer(BigInteger.valueOf(1)))))
+      Struct(0,List(Literal(Lit(3)), Literal(Lit(1)), Literal(Lit(1))))
     )
     normalExpressionTest(
       List("""
@@ -225,7 +223,7 @@ out = match ["a","b","c","d","e"]:
       ), "Match/List",
       Struct(1,List(
         Struct(0,List(
-          Literal(Str("a")), 
+          Literal(Str("a")),
           Struct(0,List(
             Struct(1,List(Literal(Str("b")), Struct(1,List(Literal(Str("c")), Struct(1,List(Literal(Str("d")), Struct(1,List(Literal(Str("e")), Struct(0,List()))))))))),
             Struct(0,List())

--- a/core/src/test/scala/org/bykn/bosatsu/TestUtils.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/TestUtils.scala
@@ -99,7 +99,7 @@ object TestUtils {
               ev.evalTest(mainPack) match {
                 case None => fail(s"$mainPack had no tests evaluted")
                 case Some(t) =>
-                  assert(t.assertions == cnt)
+                  assert(t.assertions == cnt, s"${t.assertions} == $cnt")
                   val (suc, failcount, message) = Test.report(t)
                   assert(t.failures.map(_.assertions).getOrElse(0) == failcount)
                   if (failcount > 0) fail(message.render(80))
@@ -156,7 +156,7 @@ object TestUtils {
       val normPackMap = NormalizePackageMap(infPackMap).hashKey(ne => (ne, ne.serialize))
       (for {
         pack <- normPackMap.toMap.get(mainPack)
-        exprs = pack.program.lets.map { case (_, rec, e) => e }        
+        exprs = pack.program.lets.map { case (_, rec, e) => e }
         fleft = exprs.map(_.size.toInt)
         fright = exprs.map(_.foldRight(Eval.now(0)) { case (_, m) => m.map(_ + 1) }.value)
         expr <- exprs.lastOption

--- a/test_workspace/euler1.bosatsu
+++ b/test_workspace/euler1.bosatsu
@@ -19,4 +19,4 @@ def sum(as): as.foldLeft(0, add)
 # 233168
 computed = [i for i in range(1000) if keep(i)].sum
 
-test = trace(out, Assertion(computed == 233168, "expected 233168"))
+test = Assertion(computed == 233168, "expected 233168")

--- a/test_workspace/euler1.bosatsu
+++ b/test_workspace/euler1.bosatsu
@@ -19,4 +19,4 @@ def sum(as): as.foldLeft(0, add)
 # 233168
 computed = [i for i in range(1000) if keep(i)].sum
 
-test = Assertion(computed == 233168, "expected 233168")
+test = trace(out, Assertion(computed == 233168, "expected 233168"))


### PR DESCRIPTION
when starting to use the proto output I discovered new lurking bugs. The proto cannot serialize metavars or skolems, which should never appear in fully compiled code. Unfortunately that wasn't the case.

The top-level types for lets in the `TypedExpr` were correct, but inside there could still be meta-vars or skolems that shouldn't have been there. The full typing is something the paper is a bit short on and I made some mistakes implementing it.

I still have some questions, but it seems at least the bugs that were present are gone.

After this is merged, I should be able to send the PR which enables incremental compilation using the protobuf outputs.