### PR TITLE
Normalization bugs

### DIFF
--- a/core/src/main/scala/org/bykn/bosatsu/Normalization.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/Normalization.scala
@@ -153,8 +153,8 @@ object Normalization {
                     }
                     case Matches(acc1) => fnt(structTail, acc1)
                   }
-                  case NormalExpression.Struct(_, _) => NoMatch
-                  case _ => NotProvable
+                case NormalExpression.Struct(_, _) => NoMatch
+                case _ => NotProvable
               }
             }
           case Left(splice) :: Nil =>
@@ -328,7 +328,7 @@ object Normalization {
         applyLambdaSubstituion(innerExpr, None, 0)
       // eta reduction
       case Lambda(App(innerExpr, LambdaVar(0))) =>
-        innerExpr
+        applyLambdaSubstituion(innerExpr, Some(LambdaVar(0)), 0)
       case _ => expr
     }
 
@@ -376,7 +376,7 @@ object Normalization {
         })
       case LambdaVar(varIndex) if varIndex >= lambdaDepth => LambdaVar(varIndex + 1)
       case lv @ LambdaVar(_)                      => lv
-      case Lambda(fn)                             => incrementLambdaVars(fn, lambdaDepth + 1)
+      case Lambda(fn)                             => Lambda(incrementLambdaVars(fn, lambdaDepth + 1))
       case Struct(enum, args) =>
         Struct(enum, args.map(incrementLambdaVars(_, lambdaDepth)))
       case l @ Literal(_) => l

--- a/core/src/main/scala/org/bykn/bosatsu/Normalization.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/Normalization.scala
@@ -327,7 +327,7 @@ object Normalization {
       case Recursion(Lambda(innerExpr)) if(innerExpr.maxLambdaVar.map(_ < 0).getOrElse(true)) =>
         applyLambdaSubstituion(innerExpr, None, 0)
       // eta reduction
-      case Lambda(App(innerExpr, LambdaVar(0))) =>
+      case Lambda(App(innerExpr, LambdaVar(0))) if innerExpr.maxLambdaVar.map(_ < 0).getOrElse(true) =>
         applyLambdaSubstituion(innerExpr, Some(LambdaVar(0)), 0)
       case _ => expr
     }

--- a/core/src/test/scala/org/bykn/bosatsu/NormalizationTest.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/NormalizationTest.scala
@@ -448,9 +448,9 @@ main = (rec_fn(lst1), rec_fn(lst1))
       ), "Substitution/Lambda",
       Struct(0,
         List(
-          App(Recursion(Lambda(Lambda(Match(LambdaVar(0),NonEmptyList.of((ListPat(List()),Struct(1,List())), (ListPat(List(Right(Var(1)), Left(Some(0)))),Lambda(LambdaVar(2)))))))),Struct(1,List(Literal(Str("zooom")),Struct(0,List())))),
+          App(Recursion(Lambda(Lambda(Match(LambdaVar(0),NonEmptyList.of((ListPat(List()),Struct(1,List())), (ListPat(List(Right(Var(1)), Left(Some(0)))),Lambda(Lambda(App(LambdaVar(3), LambdaVar(0)))))))))),Struct(1,List(Literal(Str("zooom")),Struct(0,List())))),
           Struct(0,List(
-            App(Recursion(Lambda(Lambda(Match(LambdaVar(0),NonEmptyList.of((ListPat(List()),Struct(1,List())),(ListPat(List(Right(Var(1)), Left(Some(0)))),Lambda(LambdaVar(2)))))))),Struct(1,List(Literal(Str("zooom")), Struct(0,List())))),
+            App(Recursion(Lambda(Lambda(Match(LambdaVar(0),NonEmptyList.of((ListPat(List()),Struct(1,List())),(ListPat(List(Right(Var(1)), Left(Some(0)))),Lambda(Lambda(App(LambdaVar(3), LambdaVar(0)))))))))),Struct(1,List(Literal(Str("zooom")), Struct(0,List())))),
             Struct(0,List())
           ))
         )
@@ -462,7 +462,15 @@ package Substitution/Eta
 
 out = \x,y -> x(y)
 """
-      ), "Substitution/Eta", Lambda(LambdaVar(0))
+      ), "Substitution/Eta", Lambda(Lambda(App(LambdaVar(1), LambdaVar(0))))
+    )
+    normalExpressionTest(
+      List("""
+package Substitution/Eta2
+
+out = \x,y -> x(y, y)
+"""
+      ), "Substitution/Eta2", Lambda(Lambda(App(App(LambdaVar(1), LambdaVar(0)), LambdaVar(0))))
     )
   }
 }

--- a/core/src/test/scala/org/bykn/bosatsu/NormalizationTest.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/NormalizationTest.scala
@@ -432,4 +432,37 @@ out = match foo("c"):
       )
     )
   }
+  test("Lambda Substitution") {
+    normalExpressionTest(
+      List("""
+package Substitution/Lambda
+
+def rec_fn(lst1):
+  recur lst1:
+    []: True
+    [h1, *t1]: rec_fn(t1)
+
+lst1 = ["zooom"]
+main = (rec_fn(lst1), rec_fn(lst1))
+"""
+      ), "Substitution/Lambda",
+      Struct(0,
+        List(
+          App(Recursion(Lambda(Lambda(Match(LambdaVar(0),NonEmptyList.of((ListPat(List()),Struct(1,List())), (ListPat(List(Right(Var(1)), Left(Some(0)))),Lambda(LambdaVar(2)))))))),Struct(1,List(Literal(Str("zooom")),Struct(0,List())))),
+          Struct(0,List(
+            App(Recursion(Lambda(Lambda(Match(LambdaVar(0),NonEmptyList.of((ListPat(List()),Struct(1,List())),(ListPat(List(Right(Var(1)), Left(Some(0)))),Lambda(LambdaVar(2)))))))),Struct(1,List(Literal(Str("zooom")), Struct(0,List())))),
+            Struct(0,List())
+          ))
+        )
+      )  
+    )
+    normalExpressionTest(
+      List("""
+package Substitution/Eta
+
+out = \x,y -> x(y)
+"""
+      ), "Substitution/Eta", Lambda(LambdaVar(0))
+    )
+  }
 }


### PR DESCRIPTION
I came across two bugs in normalization when I tried to use it for caching. In one case it would crash when trying to normalize some code (see `Substitution/Lambda`). In the other case `\x,y -> x(y)` would become `Lambda(LambdaVar(1))` (which would suggest being bound to an outer lambda which doesn't exist)
