### PR TITLE
Add Bosatsu/Nothing, showing how to make a Nothing or Void type

### DIFF
--- a/test_workspace/BUILD
+++ b/test_workspace/BUILD
@@ -103,3 +103,8 @@ bosatsu_test(
     srcs = ["recordset.bosatsu"],
     packages = ["RecordSet/Library"],
     )
+
+bosatsu_library(
+    name = "nothing",
+    srcs = ["Nothing.bosatsu"],
+    )

--- a/test_workspace/Nothing.bosatsu
+++ b/test_workspace/Nothing.bosatsu
@@ -1,16 +1,14 @@
 package Bosatsu/Nothing
 
-export [ Nothing(), impossible ]
+export [ Nothing, impossible ]
 
 # In a total language, it is not possible
 # to create a value with the type of magic
-struct Nothing(magic: forall a. (a -> a) -> a)
+struct Nothing(magic: forall a. a)
 
 # since, we cannot create an instance of Nothing
 # assuming we have one is a contradiction, so
 # anything is possible
 def impossible(n: Nothing) -> a:
   Nothing(magic) = n
-  # forall a. a -> a is the same as unit, there
-  # there is only one instance: identity.
-  magic(\x -> x)
+  magic

--- a/test_workspace/Nothing.bosatsu
+++ b/test_workspace/Nothing.bosatsu
@@ -1,0 +1,14 @@
+package Bosatsu/Nothing
+
+# In a total language, it is not possible
+# to create a value with the type of magic
+struct Nothing(magic: forall a. (a -> a) -> a)
+
+# since, we cannot create an instance of Nothing
+# assuming we have one is a contradiction, so
+# anything is possible
+def impossible(n: Nothing) -> a:
+  Nothing(magic) = n
+  # forall a. a -> a is the same as unit, there
+  # there is only one instance: identity.
+  magic(\x -> x)

--- a/test_workspace/Nothing.bosatsu
+++ b/test_workspace/Nothing.bosatsu
@@ -1,5 +1,7 @@
 package Bosatsu/Nothing
 
+export [ Nothing(), impossible ]
+
 # In a total language, it is not possible
 # to create a value with the type of magic
 struct Nothing(magic: forall a. (a -> a) -> a)


### PR DESCRIPTION
In a non-total language, we would need the ability to make enums with no variants.

In a total language, `forall a. (a -> a) -> a` is uninhabited, so we can use a struct containing one as a synonym for Nothing. If we ever had one, we could produce any value.