### PR TITLE
Copy scalajs options from paiges

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -60,6 +60,16 @@ lazy val commonSettings = Seq(
   testOptions in Test += Tests.Argument("-oDF")
 )
 
+lazy val commonJsSettings = Seq(
+  scalaJSStage in Global := FastOptStage,
+  parallelExecution := false,
+  jsEnv := new org.scalajs.jsenv.nodejs.NodeJSEnv(),
+  // batch mode decreases the amount of memory needed to compile scala.js code
+  scalaJSOptimizerOptions := scalaJSOptimizerOptions.value.withBatchMode(scala.sys.env.get("TRAVIS").isDefined),
+  coverageEnabled := false,
+  scalaJSUseMainModuleInitializer := true
+)
+
 lazy val root = (crossProject(JSPlatform, JVMPlatform).crossType(CrossType.Pure) in file("."))
   .aggregate(core)
   .settings(
@@ -116,10 +126,9 @@ lazy val core = (crossProject(JSPlatform, JVMPlatform).crossType(CrossType.Pure)
         scalaCheck.value % Test,
         scalaTest.value % Test
       )
-  ).dependsOn(base).
-  jsSettings(
-    scalaJSUseMainModuleInitializer := true
   )
+  .dependsOn(base)
+  .jsSettings(commonJsSettings)
 
 lazy val coreJVM = core.jvm
 lazy val coreJS = core.js


### PR DESCRIPTION
This is an attempt to make the CI run better in scalajs. I'd like to reduce the number of trials we run in scalajs, but naively following the approach I thought would work in #299 didn't work.

I don't really know where sbt decides to magically look for files, and adding the platform files to `core/js/...` didn't seem to get picked up, but maybe I made a mistake.