### PR TITLE
Add struct/enum record syntax

### DIFF
--- a/core/src/main/scala/org/bykn/bosatsu/Declaration.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/Declaration.scala
@@ -118,8 +118,8 @@ sealed abstract class Declaration {
 
       case RecordConstructor(name, args) =>
         val argDoc = Doc.char('{') +
-          Doc.intercalate(Doc.char(',') + Doc.line,
-          args.toList.map(_.toDoc)).grouped.nested(2) + Doc.char('}')
+          Doc.intercalate(Doc.char(',') + Doc.space,
+          args.toList.map(_.toDoc)) + Doc.char('}')
 
         Declaration.identDoc.document(name) + Doc.space + argDoc
     }

--- a/core/src/main/scala/org/bykn/bosatsu/Declaration.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/Declaration.scala
@@ -189,6 +189,12 @@ sealed abstract class Declaration {
           val bound1 = bound ++ b.names
           val acc2 = loop(ex.key, bound1, acc1)
           loop(ex.value, bound1, acc2)
+        case RecordConstructor(_, args) =>
+          // A constructor doesn't introduce new bindings
+          args.foldLeft(acc) {
+            case (acc, RecordArg.Pair(_, v)) => loop(v, bound, acc)
+            case (acc, RecordArg.Simple(n)) => acc
+          }
       }
 
     loop(this, Set.empty, SortedSet.empty)

--- a/core/src/main/scala/org/bykn/bosatsu/DefRecursionCheck.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/DefRecursionCheck.scala
@@ -345,6 +345,9 @@ object DefRecursionCheck {
                 checkDecl(i) *>
                 (f.traverse_(checkDecl))
           }
+
+        case RecordConstructor(name, args) =>
+          sys.error("TODO: record constructor not supported yet")
       }
     }
 

--- a/core/src/main/scala/org/bykn/bosatsu/SourceConverter.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/SourceConverter.scala
@@ -252,6 +252,8 @@ final class SourceConverter(
               l)
             Expr.buildApp(opExpr, apply(in) :: empty :: foldFn :: Nil, l)
           }
+        case RecordConstructor(name, args) =>
+          sys.error("TODO: we need to have the ParsedTypeEnv for this and imports to translate to an Expr")
     }
 
   final def toType(t: TypeRef): Type = {

--- a/core/src/test/scala/org/bykn/bosatsu/Gen.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/Gen.scala
@@ -572,7 +572,9 @@ object Generators {
                   tailArgs #:: tailStream(tailArgs) #::: tailStream(NonEmptyList(of.head, tailArgs.tail))
               }
 
-            Var(n)(emptyRegion) #:: head #::: tailStream(args).map(RecordConstructor(n, _)(emptyRegion))
+            Var(n)(emptyRegion) #::
+              head #:::
+              tailStream(args).map(RecordConstructor(n, _)(emptyRegion): Declaration) // type annotation for scala 2.11
         }
     })
 

--- a/core/src/test/scala/org/bykn/bosatsu/ParserTest.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/ParserTest.scala
@@ -105,7 +105,7 @@ class ParserTest extends ParserTestBase {
   implicit val generatorDrivenConfig =
     //PropertyCheckConfiguration(minSuccessful = 5000)
     PropertyCheckConfiguration(minSuccessful = 300)
-    //PropertyCheckConfiguration(minSuccessful = 5)
+    //PropertyCheckConfiguration(minSuccessful = 1)
 
   test("we can parse integers") {
     forAll { b: BigInt =>
@@ -265,6 +265,40 @@ class ParserTest extends ParserTestBase {
     forAll(genWild) { wd =>
       parseTestAll(strDict, wd.stringRep, wd.original)
     }
+  }
+
+  test("we can parse RecordConstructors") {
+    def check(str: String) =
+      roundTrip[Declaration](Declaration.recordConstructorP(""), str)
+
+    check("Foo { bar }")
+    check("Foo{bar}")
+    check("Foo {   bar   }")
+    check("Foo {\nbar\n}")
+
+    check("Foo { bar: baz }")
+    check("Foo{bar:baz}")
+    check("Foo {   bar : baz   }")
+    check("Foo {\nbar:\n\tbaz}")
+    check("Foo {\nbar:\n\n\tbaz}")
+
+    check("Foo { bar, baz }")
+    check("Foo{bar,baz}")
+    check("Foo {   bar , baz  }")
+    check("Foo {\nbar,\n baz}")
+    check("Foo {\nbar\n, baz}")
+
+    check("Foo { bar, baz: 42 }")
+    check("Foo{bar,baz:42}")
+    check("Foo {   bar , baz : 42  }")
+    check("Foo {\nbar,\n baz:\n 42}")
+    check("Foo {\nbar\n, baz\n:\t42}")
+
+    check("Foo { bar: baz, quux: 42 }")
+    check("Foo{bar:baz,quux:42}")
+    check("Foo {   bar : baz , quux : 42  }")
+    check("Foo {\nbar:\n\tbaz, quux:\n\t42\n\t}")
+    check("Foo {\nbar:\n\n\tbaz,\nquux\n:\n42\n}")
   }
 
   test("we can parse tuples") {


### PR DESCRIPTION
This PR adds the parsing of creating structs and enums using record syntax.

The variant in #289 I went with was the dict-like syntax:
```
struct Foo(bar: Int)

f = Foo { bar: 3 }

# like rust we can also do:
struct Person(name: String, age: Int)

name = "Alice"
age = 37
p = Person { name, age }
```
I didn't implement pattern matching yet, but that would work like:

```
Person { name: nm, ... } = p
# or use name as the binding value:
Person { name, ... } = p
```

The analogy was suggested by @avibryant : you can make values with tuple-like or dict-like syntax (but not a hybrid of the two).

Lastly, I've decided to make one minor change: pattern matches on structs/enums must cover all the fields or explicitly add `...` to say you don't care about the rest of the fields. To preserve the duality between matching and creation, I may remove automatic currying of tuple like constructors:
```
struct Foo(bar, baz)

# currently this works, but is suprising
# x is the same as x = \z -> Foo(12, z)
x = Foo(12)
```
When I'm done with this record project, the above will become a compilation error and require explicit `\baz -> Foo(12, baz)` to get this result.

This does open the question: is automatic currying too strange in the rest of the code? Syntactically it it is hard to avoid it now since there is only one function type: `a -> b`. So once we put a function in a binding, we can't check arity, so to be consistent, we allow currying of any function. But constructors have capital names which cannot be bound except in type definitions, so we can syntactically check arity for constructors.

cc @non who also recommended this syntax.