### PR TITLE
Add better types in Pattern

### DIFF
--- a/core/src/main/scala/org/bykn/bosatsu/Normalization.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/Normalization.scala
@@ -452,7 +452,7 @@ case class NormalizePackageMap(pm: PackageMap.Inferred) {
           }
           (letsName, recursive, newExpr)
         }
-        val newProgram = pack.program.copy(lets = newLets) 
+        val newProgram = pack.program.copy(lets = newLets)
         val newPack = pack.copy(program = newProgram)
         (packName, newPack)
       }
@@ -580,9 +580,9 @@ case class NormalizePackageMap(pm: PackageMap.Inferred) {
         case Pattern.Named(n, p) => NormalPattern.Named(names.indexOf(n), loop(p))
         case Pattern.ListPat(items) =>
           NormalPattern.ListPat(items.map {
-            case Left(Some(n)) =>Left(Some(names.indexOf(n)))
-            case Left(None) => Left(None)
-            case Right(p) => Right(loop(p))
+            case Pattern.ListPart.NamedList(n) =>Left(Some(names.indexOf(n)))
+            case Pattern.ListPart.WildList => Left(None)
+            case Pattern.ListPart.Item(p) => Right(loop(p))
           })
         case Pattern.Annotation(p, tpe) => loop(p)
         case Pattern.PositionalStruct(pc@(_, ctor), params) =>

--- a/core/src/main/scala/org/bykn/bosatsu/SourceConverter.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/SourceConverter.scala
@@ -405,7 +405,7 @@ final class SourceConverter(
    */
   def unTuplePattern(pat: Pattern.Parsed): Pattern[(PackageName, Constructor), rankn.Type] =
     pat.mapStruct[(PackageName, Constructor)] {
-      case (None, args) =>
+      case (Pattern.StructKind.Tuple, args) =>
         // this is a tuple pattern
         def loop(args: List[Pattern[(PackageName, Constructor), TypeRef]]): Pattern[(PackageName, Constructor), TypeRef] =
           args match {
@@ -422,7 +422,7 @@ final class SourceConverter(
           }
 
         loop(args)
-      case (Some(nm), args) =>
+      case (Pattern.StructKind.Named(nm), args) =>
         // this is a struct pattern
         Pattern.PositionalStruct(nameToCons(nm), args)
     }

--- a/core/src/main/scala/org/bykn/bosatsu/Statement.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/Statement.scala
@@ -147,7 +147,7 @@ object Statement {
 
      val bindingP: P[Statement => Statement] = {
        val bop = BindingStatement
-         .bindingParser[Pattern[Option[Identifier.Constructor], TypeRef], Statement => Padding[Statement]](
+         .bindingParser[Pattern.Parsed, Statement => Padding[Statement]](
            Declaration.parser, Indy.lift(maybeSpace ~ padding))("")
 
        (Pattern.bindParser ~ bop).map { case (p, parseBs) =>

--- a/core/src/test/scala/org/bykn/bosatsu/ParserTest.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/ParserTest.scala
@@ -552,7 +552,7 @@ x""")
           assert(pat == parsePat)
       }
     }
-    forAll(Generators.patternDecl(5))(law1(_))
+    forAll(Generators.patternDecl(4))(law1(_))
 
     {
       import Declaration._

--- a/core/src/test/scala/org/bykn/bosatsu/TotalityTest.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/TotalityTest.scala
@@ -44,9 +44,9 @@ class TotalityTest extends FunSuite {
   def showPat(pat: Pattern[(PackageName, Constructor), Type]): String = {
     val allTypes = pat.traverseType { t => Writer(Chain.one(t), ()) }.run._1.toList
     val toStr = TypeRef.fromTypes(None, allTypes)
-    val pat0 = pat.mapName { case (_, n) => Some(n) }
+    val pat0 = pat.mapName { case (_, n) => Pattern.StructKind.Named(n) }
       .mapType { t => toStr(t) }
-    Document[Pattern[Option[Identifier.Constructor], TypeRef]].document(pat0).render(80)
+    Document[Pattern.Parsed].document(pat0).render(80)
   }
   def showPatU(pat: Pattern[(PackageName, Constructor), Type]): String =
     showPat(pat.unbind)


### PR DESCRIPTION
Previously, we have been using types like `Option[Bindable]` to mean, either a tuple or named struct, or `Either[Option[Bindable, Pattern[N, T]]` to mean an element of a list pattern that can either be an unnamed splice `*_`, a named splice `*foo` or a regular pattern.

This is clearly an insane style. Just make new types so you can see what is going on.

As I want to add more to pattern matching for #289 and #301 now is a good time to improve this code.