### PR TITLE
Add ellipsis to ADT parsing

### DIFF
--- a/core/src/main/scala/org/bykn/bosatsu/SourceConverter.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/SourceConverter.scala
@@ -425,7 +425,12 @@ final class SourceConverter(
 
         loop(args)
       case (Pattern.StructKind.Named(nm), args) =>
-        // this is a struct pattern
+        // TODO: we need to change this to check
+        // that the arity matches here
+        Pattern.PositionalStruct(nameToCons(nm), args)
+      case (Pattern.StructKind.NamedPartial(nm), args) =>
+        // Here we don't care if the arity is <= the
+        // real arity, but should fail if there are too many items
         Pattern.PositionalStruct(nameToCons(nm), args)
     }
     .mapType(toType)

--- a/core/src/test/scala/org/bykn/bosatsu/Gen.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/Gen.scala
@@ -324,7 +324,8 @@ object Generators {
   val genStructKind: Gen[Pattern.StructKind] =
     Gen.oneOf(
       Gen.const(Pattern.StructKind.Tuple),
-      consIdentGen.map(Pattern.StructKind.Named(_)))
+      consIdentGen.map(Pattern.StructKind.Named(_)),
+      consIdentGen.map(Pattern.StructKind.NamedPartial(_)))
 
   def genPattern(depth: Int, useUnion: Boolean = true): Gen[Pattern.Parsed] =
     genPatternGen(

--- a/core/src/test/scala/org/bykn/bosatsu/ParserTest.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/ParserTest.scala
@@ -558,6 +558,8 @@ x""")
   test("we can parse patterns") {
     roundTrip(Pattern.matchParser, "Foo([])")
     roundTrip(Pattern.matchParser, "Foo([], bar)")
+    roundTrip(Pattern.matchParser, "Foo(...)")
+    roundTrip(Pattern.matchParser, "Foo(a, ...)")
     roundTrip(Pattern.matchParser, "x")
     roundTrip(Pattern.matchParser, "_")
     roundTrip(Pattern.matchParser, "(a, b)")


### PR DESCRIPTION
close #306 

We don't do anything different yet, but when we update the code to handle record syntax, we should add the checking then (see #308).