### PR TITLE
Rewrite records into tuple-like syntax

### DIFF
--- a/core/src/main/scala/org/bykn/bosatsu/Evaluation.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/Evaluation.scala
@@ -6,6 +6,7 @@ import com.stripe.dagon.Memoize
 import java.math.BigInteger
 import org.bykn.bosatsu.rankn.{DefinedType, Type}
 import scala.collection.immutable.SortedMap
+import org.typelevel.paiges.Doc
 
 import cats.implicits._
 
@@ -196,7 +197,7 @@ object Evaluation {
     def letNameIn(name: Bindable, in: Scoped): Scoped =
       Scoped.Let(name, this, in)
 
-    def flatMap(fn: (Env, Value) => Eval[Value]): Scoped =
+    def branch(fn: (Env, Value) => Eval[Value]): Scoped =
       fromFn { env =>
         inEnv(env).flatMap { v =>
           fn(env, v)
@@ -291,6 +292,19 @@ case class Evaluation[T](pm: PackageMap.Typed[T], externals: Externals) {
       (scope0, tpe) = eval((pack, Right(expr)))
       scope = if (rec.isRecursive) Scoped.recursive(name, scope0) else scope0
     } yield (scope.inEnv(Map.empty), tpe)
+
+  def repr: String = {
+    val packs = pm.toMap.map { case (_, pack) =>
+      Doc.text(s"(package ${pack.name.asString}") +
+        (Doc.lineOrSpace + Doc.intercalate(Doc.lineOrSpace,
+          pack.program.lets.map { case (b, _, te) =>
+            Doc.text(s"(let ${b.asString}") +
+              (Doc.lineOrSpace + Doc.text(te.repr) + Doc.text(")")).nested(2)
+          })).nested(2) + Doc.char(')')
+    }
+
+    Doc.intercalate(Doc.lineOrSpace, packs).render(80)
+  }
 
   def evalTest(ps: PackageName): Option[Test] =
     evaluateLast(ps).flatMap { case (ea, tpe) =>
@@ -512,7 +526,8 @@ case class Evaluation[T](pm: PackageMap.Typed[T], externals: Externals) {
                   case other =>
                     // $COVERAGE-OFF$this should be unreachable
                     val ts = TypeRef.fromTypes(Some(p.name), tpe :: Nil)(tpe).toDoc.render(80)
-                    sys.error(s"ill typed in match (${ctor.asString}${items.mkString}): $ts\n\n$other")
+                    val itemStr = items.mkString("(", ", ", ")")
+                    sys.error(s"ill typed in match (${ctor.asString}$itemStr: $ts\n\n$other\n\nenv: $acc")
                     // $COVERAGE-ON$
                 }
               }
@@ -546,19 +561,12 @@ case class Evaluation[T](pm: PackageMap.Typed[T], externals: Externals) {
             // $COVERAGE-ON$
           case (p, e) :: tail =>
             val pfn = maybeBind(p)
-
-            val fnh = { (arg: Value, env: Env) =>
-              pfn(arg, env) match {
-                case None => None
-                case Some(env) => Some((env, e))
-              }
-            }
             val fntail = bindEnv(tail)
 
-            { (arg, acc) =>
-              fnh(arg, acc) match {
-                case None => fntail(arg, acc)
-                case Some(r) => r
+            { (arg, env) =>
+              pfn(arg, env) match {
+                case None => fntail(arg, env)
+                case Some(env) => (env, e)
               }
             }
         }
@@ -601,7 +609,7 @@ case class Evaluation[T](pm: PackageMap.Typed[T], externals: Externals) {
          }
        case Var(Some(p), ident, _, _) =>
          val pack = pm.toMap.get(p).getOrElse(sys.error(s"cannot find $p, shouldn't happen due to typechecking"))
-         val (scoped, _) = eval((pack, Left(ident)))
+         val (scoped, _) = recurse((pack, Left(ident)))
          scoped
        case App(AnnotatedLambda(name, _, fn, _), arg, _, _) =>
          val argE = recurse((p, Right(arg)))._1
@@ -613,7 +621,7 @@ case class Evaluation[T](pm: PackageMap.Typed[T], externals: Externals) {
          val earg = recurse((p, Right(arg)))._1
 
          efn.applyArg(earg)
-       case a@AnnotatedLambda(name, _, expr, _) =>
+       case AnnotatedLambda(name, _, expr, _) =>
          val inner = recurse((p, Right(expr)))._1
          inner.asLambda(name)
        case Let(arg, e, in, rec, _) =>
@@ -631,7 +639,7 @@ case class Evaluation[T](pm: PackageMap.Typed[T], externals: Externals) {
          val argR = recurse((p, Right(arg)))._1
          val branchR = evalBranch(arg.getType, branches, p, recurse)
 
-         argR.flatMap { (env, a) =>
+         argR.branch { (env, a) =>
            branchR(a, env)
          }
     }

--- a/core/src/main/scala/org/bykn/bosatsu/Evaluation.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/Evaluation.scala
@@ -6,7 +6,6 @@ import com.stripe.dagon.Memoize
 import java.math.BigInteger
 import org.bykn.bosatsu.rankn.{DefinedType, Type}
 import scala.collection.immutable.SortedMap
-import org.typelevel.paiges.Doc
 
 import cats.implicits._
 
@@ -293,6 +292,9 @@ case class Evaluation[T](pm: PackageMap.Typed[T], externals: Externals) {
       scope = if (rec.isRecursive) Scoped.recursive(name, scope0) else scope0
     } yield (scope.inEnv(Map.empty), tpe)
 
+  /* TODO: this is useful for debugging, but we should probably test it and write a parser for the
+   * list syntax
+
   def repr: String = {
     val packs = pm.toMap.map { case (_, pack) =>
       Doc.text(s"(package ${pack.name.asString}") +
@@ -305,6 +307,8 @@ case class Evaluation[T](pm: PackageMap.Typed[T], externals: Externals) {
 
     Doc.intercalate(Doc.lineOrSpace, packs).render(80)
   }
+
+  */
 
   def evalTest(ps: PackageName): Option[Test] =
     evaluateLast(ps).flatMap { case (ea, tpe) =>

--- a/core/src/main/scala/org/bykn/bosatsu/Package.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/Package.scala
@@ -144,14 +144,12 @@ object Package {
       ValidatedNel[PackageError,
       Program[TypeEnv[Variance], TypedExpr[Declaration], Statement]] = {
 
-    val Program(parsedTypeEnv, lets, extDefs, _) = {
+    val Program((importedTypeEnv, parsedTypeEnv), lets, extDefs, _) = {
       // here we make a pass to get all the local names
       val localDefs = Statement.definitionsOf(stmt)
       val srcConv = SourceConverter(p, imps, localDefs)
       srcConv.toProgram(stmt)
     }
-
-    val importedTypeEnv = Referant.importedTypeEnv(imps)(_.name)
 
     val inferVarianceParsed: Either[PackageError, ParsedTypeEnv[Variance]] =
       VarianceFormula.solve(importedTypeEnv, parsedTypeEnv.allDefinedTypes)

--- a/core/src/main/scala/org/bykn/bosatsu/Package.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/Package.scala
@@ -1,7 +1,7 @@
 package org.bykn.bosatsu
 
-import cats.Functor
-import cats.data.{ValidatedNel, Validated, NonEmptyList}
+import cats.{Functor, Semigroup}
+import cats.data.{Ior, ValidatedNel, Validated, NonEmptyList}
 import cats.implicits._
 import fastparse.all._
 import org.typelevel.paiges.{Doc, Document}
@@ -144,76 +144,82 @@ object Package {
       ValidatedNel[PackageError,
       Program[TypeEnv[Variance], TypedExpr[Declaration], Statement]] = {
 
-    val Program((importedTypeEnv, parsedTypeEnv), lets, extDefs, _) = {
-      // here we make a pass to get all the local names
-      val localDefs = Statement.definitionsOf(stmt)
-      val srcConv = SourceConverter(p, imps, localDefs)
-      try {
-        srcConv.toProgram(stmt)
-      }
-      catch {
-        case err: SourceConverter.Error =>
-          // TODO, make toProgram return an Ior
-          return Validated.invalidNel(PackageError.SourceConverterErrorIn(err, p))
-      }
-    }
+    // here we make a pass to get all the local names
+    val localDefs = Statement.definitionsOf(stmt)
+    val optProg = SourceConverter(p, imps, localDefs)
+      .toProgram(stmt)
+      .leftMap(_.map(PackageError.SourceConverterErrorIn(_, p): PackageError).toNonEmptyList)
 
-    val inferVarianceParsed: Either[PackageError, ParsedTypeEnv[Variance]] =
-      VarianceFormula.solve(importedTypeEnv, parsedTypeEnv.allDefinedTypes)
-        .map { infDTs => ParsedTypeEnv(infDTs, parsedTypeEnv.externalDefs) }
-        .leftMap(PackageError.VarianceInferenceFailure(p, _))
-
-    inferVarianceParsed.toValidatedNel.andThen { parsedTypeEnv =>
-      /*
-       * Check that the types defined here are not circular.
-       */
-      val circularCheck: ValidatedNel[PackageError, Unit] =
-        TypeRecursionCheck.checkLegitRecursion(importedTypeEnv, parsedTypeEnv.allDefinedTypes)
-          .leftMap { badPaths =>
-            badPaths.map(PackageError.CircularType(p, _))
+    def andThen[A: Semigroup, B, C](ior: Ior[A, B])(fn: B => Validated[A, C]): Validated[A, C] =
+      ior match {
+        case Ior.Right(b) => fn(b)
+        case Ior.Left(a) => Validated.Invalid(a)
+        case Ior.Both(a, b) =>
+          fn(b) match {
+            case Validated.Valid(_) => Validated.Invalid(a)
+            case Validated.Invalid(a1) => Validated.Invalid(Semigroup[A].combine(a, a1))
           }
-      /*
-       * Check that all recursion is allowable
-       */
-      val defRecursionCheck: ValidatedNel[PackageError, Unit] =
-        DefRecursionCheck.checkStatement(stmt)
-          .leftMap { badRecursions =>
-            badRecursions.map(PackageError.RecursionError(p, _))
-          }
+      }
 
-      val typeEnv = TypeEnv.fromParsed(parsedTypeEnv)
-      /*
-      * These are values, including all constructor functions
-      * that have been imported, this includes local external
-      * defs
-      */
-      val importedValues: Map[Identifier, Type] =
-        Referant.importedValues(imps) ++ typeEnv.localValuesOf(p)
+    andThen(optProg) {
+      case Program((importedTypeEnv, parsedTypeEnv), lets, extDefs, _) =>
+        val inferVarianceParsed: Either[PackageError, ParsedTypeEnv[Variance]] =
+          VarianceFormula.solve(importedTypeEnv, parsedTypeEnv.allDefinedTypes)
+            .map { infDTs => ParsedTypeEnv(infDTs, parsedTypeEnv.externalDefs) }
+            .leftMap(PackageError.VarianceInferenceFailure(p, _))
 
-      val withFQN: Map[(Option[PackageName], Identifier), Type] =
-        (Referant.fullyQualifiedImportedValues(imps)(_.name)
-          .iterator
-          .map { case ((p, n), t) => ((Some(p), n), t) } ++
-            importedValues.iterator.map { case (n, t) => ((None, n), t) }
-          ).toMap
+        inferVarianceParsed.toValidatedNel.andThen { parsedTypeEnv =>
+          /*
+           * Check that the types defined here are not circular.
+           */
+          val circularCheck: ValidatedNel[PackageError, Unit] =
+            TypeRecursionCheck.checkLegitRecursion(importedTypeEnv, parsedTypeEnv.allDefinedTypes)
+              .leftMap { badPaths =>
+                badPaths.map(PackageError.CircularType(p, _))
+              }
+          /*
+           * Check that all recursion is allowable
+           */
+          val defRecursionCheck: ValidatedNel[PackageError, Unit] =
+            DefRecursionCheck.checkStatement(stmt)
+              .leftMap { badRecursions =>
+                badRecursions.map(PackageError.RecursionError(p, _))
+              }
 
-      val fullTypeEnv = importedTypeEnv ++ typeEnv
-      val totalityCheck =
-        lets
-          .traverse { case (_, _, expr) => TotalityCheck(fullTypeEnv).checkExpr(expr) }
-          .leftMap { errs => errs.map(PackageError.TotalityCheckError(p, _)) }
+          val typeEnv = TypeEnv.fromParsed(parsedTypeEnv)
+          /*
+          * These are values, including all constructor functions
+          * that have been imported, this includes local external
+          * defs
+          */
+          val importedValues: Map[Identifier, Type] =
+            Referant.importedValues(imps) ++ typeEnv.localValuesOf(p)
 
-      val inferenceEither = Infer.typeCheckLets(lets)
-        .runFully(withFQN,
-          Referant.typeConstructors(imps) ++ typeEnv.typeConstructors
-        )
-        .map { lets => Program(typeEnv, lets, extDefs, stmt) }
-        .left
-        .map(PackageError.TypeErrorIn(_, p))
+          val withFQN: Map[(Option[PackageName], Identifier), Type] =
+            (Referant.fullyQualifiedImportedValues(imps)(_.name)
+              .iterator
+              .map { case ((p, n), t) => ((Some(p), n), t) } ++
+                importedValues.iterator.map { case (n, t) => ((None, n), t) }
+              ).toMap
 
-      val inference = Validated.fromEither(inferenceEither).leftMap(NonEmptyList.of(_))
+          val fullTypeEnv = importedTypeEnv ++ typeEnv
+          val totalityCheck =
+            lets
+              .traverse { case (_, _, expr) => TotalityCheck(fullTypeEnv).checkExpr(expr) }
+              .leftMap { errs => errs.map(PackageError.TotalityCheckError(p, _)) }
 
-      defRecursionCheck *> circularCheck *> totalityCheck *> inference
+          val inferenceEither = Infer.typeCheckLets(lets)
+            .runFully(withFQN,
+              Referant.typeConstructors(imps) ++ typeEnv.typeConstructors
+            )
+            .map { lets => Program(typeEnv, lets, extDefs, stmt) }
+            .left
+            .map(PackageError.TypeErrorIn(_, p))
+
+          val inference = Validated.fromEither(inferenceEither).leftMap(NonEmptyList.of(_))
+
+          defRecursionCheck *> circularCheck *> totalityCheck *> inference
+        }
     }
   }
 }

--- a/core/src/main/scala/org/bykn/bosatsu/Package.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/Package.scala
@@ -148,7 +148,7 @@ object Package {
       // here we make a pass to get all the local names
       val localDefs = Statement.definitionsOf(stmt)
       val srcConv = SourceConverter(p, imps, localDefs)
-      srcConv.toProgram(p, stmt)
+      srcConv.toProgram(stmt)
     }
 
     val importedTypeEnv = Referant.importedTypeEnv(imps)(_.name)

--- a/core/src/main/scala/org/bykn/bosatsu/Package.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/Package.scala
@@ -148,7 +148,14 @@ object Package {
       // here we make a pass to get all the local names
       val localDefs = Statement.definitionsOf(stmt)
       val srcConv = SourceConverter(p, imps, localDefs)
-      srcConv.toProgram(stmt)
+      try {
+        srcConv.toProgram(stmt)
+      }
+      catch {
+        case err: SourceConverter.Error =>
+          // TODO, make toProgram return an Ior
+          return Validated.invalidNel(PackageError.SourceConverterErrorIn(err, p))
+      }
     }
 
     val inferVarianceParsed: Either[PackageError, ParsedTypeEnv[Variance]] =

--- a/core/src/main/scala/org/bykn/bosatsu/PackageMap.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/PackageMap.scala
@@ -501,6 +501,23 @@ object PackageError {
     }
   }
 
+  case class SourceConverterErrorIn(err: SourceConverter.Error, pack: PackageName) extends PackageError {
+    def message(sourceMap: Map[PackageName, (LocationMap, String)]) = {
+      val (lm, sourceName) = sourceMap.get(pack) match {
+        case None => (LocationMap(""), "<unknown source>")
+        case Some(found) => found
+      }
+
+      val msg = {
+        val context =
+          lm.showRegion(err.region).getOrElse(err.region.toString) // we should highlight the whole region
+
+        err.message + "\n" + context
+      }
+      s"in file: $sourceName, package ${pack.asString}, $msg"
+    }
+  }
+
   case class TotalityCheckError(pack: PackageName, err: TotalityCheck.ExprError[Declaration]) extends PackageError {
     def message(sourceMap: Map[PackageName, (LocationMap, String)]) = {
       val (lm, sourceName) = sourceMap.get(pack) match {

--- a/core/src/main/scala/org/bykn/bosatsu/Pattern.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/Pattern.scala
@@ -157,8 +157,6 @@ object Pattern {
       }
       final case object TupleLike extends Style
       // represents the fields like: Foo { bar: x, age }
-      // the None means we expect the corresponding argument to
-      // be a Var(_: Bindable)
       final case class RecordLike(fields: NonEmptyList[FieldKind]) extends Style
     }
     sealed abstract class NamedKind extends StructKind {

--- a/core/src/main/scala/org/bykn/bosatsu/Pattern.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/Pattern.scala
@@ -17,18 +17,7 @@ sealed abstract class Pattern[+N, +T] {
     }
 
   def mapType[U](fn: T => U): Pattern[N, U] =
-    this match {
-      case Pattern.WildCard => Pattern.WildCard
-      case Pattern.Literal(lit) => Pattern.Literal(lit)
-      case Pattern.Var(v) => Pattern.Var(v)
-      case Pattern.Named(n, p) => Pattern.Named(n, p.mapType(fn))
-      case Pattern.ListPat(items) =>
-        Pattern.ListPat(items.map(_.map(_.mapType(fn))))
-      case Pattern.Annotation(p, tpe) => Pattern.Annotation(p.mapType(fn), fn(tpe))
-      case Pattern.PositionalStruct(name, params) =>
-        Pattern.PositionalStruct(name, params.map(_.mapType(fn)))
-      case Pattern.Union(h, t) => Pattern.Union(h.mapType(fn), t.map(_.mapType(fn)))
-    }
+    (new Pattern.InvariantPattern(this)).traverseType[cats.Id, U](fn)
 
   /**
    * List all the names that are bound in Vars inside this pattern

--- a/core/src/main/scala/org/bykn/bosatsu/SourceConverter.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/SourceConverter.scala
@@ -364,7 +364,10 @@ final class SourceConverter(
         val typeParams0 = typeVars.reverseMap { tv =>
           tv.toVar match {
             case b@Type.Var.Bound(_) => b
-            case unexpected => sys.error(s"unexpectedly parsed a non bound var: $unexpected")
+            // $COVERAGE-OFF$ this should be unreachable
+            case unexpected =>
+              sys.error(s"unexpectedly parsed a non bound var: $unexpected")
+            // $COVERAGE-ON$
           }
         }
 
@@ -399,7 +402,9 @@ final class SourceConverter(
         val typeParams0 = typeVars.reverseMap { tv =>
           tv.toVar match {
             case b@Type.Var.Bound(_) => b
+            // $COVERAGE-OFF$ this should be unreachable
             case unexpected => sys.error(s"unexpectedly parsed a non bound var: $unexpected")
+            // $COVERAGE-ON$
           }
         }
         val typeParams = updateInferedWithDecl(typeArgs, typeParams0)

--- a/core/src/main/scala/org/bykn/bosatsu/TypeRefConverter.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/TypeRefConverter.scala
@@ -1,0 +1,44 @@
+package org.bykn.bosatsu
+
+import cats.Applicative
+import cats.data.NonEmptyList
+import cats.implicits._
+import org.bykn.bosatsu.rankn.Type
+import org.bykn.bosatsu.Identifier.Constructor
+
+object TypeRefConverter {
+  /**
+   * given the ability to convert a name to a fully resolved
+   * type constant, convert TypeRef to Type
+   */
+  def apply[F[_]: Applicative](t: TypeRef)(nameToType: Constructor => F[Type.Const]): F[Type] = {
+    def toType(t: TypeRef): F[Type] = apply(t)(nameToType)
+
+    import Type._
+    import TypeRef._
+
+    t match {
+      case TypeVar(v) => Applicative[F].pure(TyVar(Type.Var.Bound(v)))
+      case TypeName(n) => nameToType(n.ident).map(TyConst(_))
+      case TypeArrow(a, b) => (toType(a), toType(b)).mapN(Fun(_, _))
+      case TypeApply(a, bs) =>
+        @annotation.tailrec
+        def toType1(fn: Type, args: NonEmptyList[Type]): Type =
+          args match {
+            case NonEmptyList(a0, Nil) => TyApply(fn,a0)
+            case NonEmptyList(a0, a1 :: as) =>
+              toType1(TyApply(fn, a0), NonEmptyList(a1, as))
+          }
+        (toType(a), bs.traverse(toType)).mapN(toType1(_, _))
+      case TypeLambda(pars0, TypeLambda(pars1, e)) =>
+        // we normalize to lifting all the foralls to the outside
+        toType(TypeLambda(pars0 ::: pars1, e))
+      case TypeLambda(pars, e) =>
+        toType(e).map { te =>
+          Type.forAll(pars.map { case TypeVar(v) => Type.Var.Bound(v) }.toList, te)
+        }
+      case TypeTuple(ts) =>
+        ts.traverse(toType).map(Type.Tuple(_))
+    }
+  }
+}

--- a/core/src/main/scala/org/bykn/bosatsu/TypedExpr.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/TypedExpr.scala
@@ -45,6 +45,8 @@ sealed abstract class TypedExpr[+T] { self: Product =>
         branches.head._2.getType
     }
 
+  // TODO: we need to make sure this parsable and maybe have a mode that has the compiler
+  // emit these
   def repr: String = {
     def rept(t: Type): String =
       TypeRef.fromTypes(None, t :: Nil)(t).toDoc.renderWideStream.mkString

--- a/core/src/main/scala/org/bykn/bosatsu/TypedExpr.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/TypedExpr.scala
@@ -56,9 +56,9 @@ sealed abstract class TypedExpr[+T] { self: Product =>
       case Annotation(expr, tpe, _) =>
         s"(ann ${rept(tpe)} ${expr.repr})"
       case a@AnnotatedLambda(arg, tpe, res, _) =>
-        s"(lambda $arg ${rept(tpe)} ${res.repr})"
+        s"(lambda ${arg.asString} ${rept(tpe)} ${res.repr})"
       case Var(p, v, tpe, _) =>
-        s"(var $p $v ${rept(tpe)})"
+        s"(var $p ${v.asString} ${rept(tpe)})"
       case App(fn, arg, tpe, _) =>
         s"(ap ${fn.repr} ${arg.repr} ${rept(tpe)})"
       case Let(n, b, in, rec, _) =>

--- a/core/src/test/scala/org/bykn/bosatsu/EvaluationTest.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/EvaluationTest.scala
@@ -1500,7 +1500,7 @@ struct Pair(first, second)
 get = \Pair { first } -> first
 
 res = get(Pair(1, "two"))
-"""), "B") { case PackageError.SourceConverterErrorIn(_, _) => () }
+"""), "B") { case s@PackageError.SourceConverterErrorIn(_, _) => s.message(Map.empty); () }
 
     evalFail(
       List("""
@@ -1512,6 +1512,54 @@ struct Pair(first, second)
 get = \Pair(first) -> first
 
 res = get(Pair(1, "two"))
-"""), "B") { case PackageError.SourceConverterErrorIn(_, _) => () }
+"""), "B") { case s@PackageError.SourceConverterErrorIn(_, _) => s.message(Map.empty); () }
+
+    evalFail(
+      List("""
+package A
+
+struct Pair(first, second)
+
+# Pair does not have a field called sec
+get = \Pair { first, sec: _ } -> first
+
+res = get(Pair(1, "two"))
+"""), "B") { case s@PackageError.SourceConverterErrorIn(_, _) => s.message(Map.empty); () }
+
+    evalFail(
+      List("""
+package A
+
+struct Pair(first, second)
+
+# Pair does not have a field called sec
+get = \Pair { first, sec: _, ... } -> first
+
+res = get(Pair(1, "two"))
+"""), "B") { case s@PackageError.SourceConverterErrorIn(_, _) => s.message(Map.empty); () }
+
+    evalFail(
+      List("""
+package A
+
+struct Pair(first, second)
+
+# Pair has two fields, not three
+get = \Pair(first, _, _) -> first
+
+res = get(Pair(1, "two"))
+"""), "B") { case s@PackageError.SourceConverterErrorIn(_, _) => s.message(Map.empty); () }
+
+    evalFail(
+      List("""
+package A
+
+struct Pair(first, second)
+
+# Pair has two fields, not three
+get = \Pair(first, _, _, ...) -> first
+
+res = get(Pair(1, "two"))
+"""), "B") { case s@PackageError.SourceConverterErrorIn(_, _) => s.message(Map.empty); () }
   }
 }

--- a/core/src/test/scala/org/bykn/bosatsu/Gen.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/Gen.scala
@@ -428,10 +428,10 @@ object Generators {
     }
   }
 
-  def genCompiledPattern(depth: Int): Gen[Pattern[(PackageName, Identifier.Constructor), rankn.Type]] =
+  def genCompiledPattern(depth: Int, useUnion: Boolean = true, useAnnotation: Boolean = true): Gen[Pattern[(PackageName, Identifier.Constructor), rankn.Type]] =
     genPatternGen(
       { args: List[Pattern[(PackageName, Identifier.Constructor), rankn.Type]] => Gen.zip(packageNameGen, consIdentGen) },
-      NTypeGen.genDepth03, depth, useUnion = true, useAnnotation = true)
+      NTypeGen.genDepth03, depth, useUnion = useUnion, useAnnotation = useAnnotation)
 
   def matchGen(bodyGen: Gen[Declaration]): Gen[Declaration.Match] = {
     import Declaration._

--- a/core/src/test/scala/org/bykn/bosatsu/Gen.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/Gen.scala
@@ -326,16 +326,17 @@ object Generators {
       case None =>
         Gen.const(Pattern.StructKind.Style.TupleLike)
       case Some(NonEmptyList(h, tail)) =>
-        def toArg(p: Pattern.Parsed): Gen[Option[Identifier.Bindable]] =
+        def toArg(p: Pattern.Parsed): Gen[Pattern.StructKind.Style.FieldKind] =
           p match {
             case Pattern.Var(b: Identifier.Bindable) =>
-              Gen.oneOf(Gen.const(None),
-                Gen.oneOf(bindIdentGen, Gen.const(b)).map(Some(_))
+              Gen.oneOf(Gen.const(Pattern.StructKind.Style.FieldKind.Implicit(b)),
+                Gen.oneOf(bindIdentGen, Gen.const(b))
+                  .map(Pattern.StructKind.Style.FieldKind.Explicit(_))
                 )
             case Pattern.Annotation(p, _) => toArg(p)
             case _ =>
               // if we don't have a var, we can't omit the key
-              bindIdentGen.map(Some(_))
+              bindIdentGen.map(Pattern.StructKind.Style.FieldKind.Explicit(_))
           }
 
         lazy val args = tail.foldLeft(toArg(h)

--- a/core/src/test/scala/org/bykn/bosatsu/TestUtils.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/TestUtils.scala
@@ -70,6 +70,7 @@ object TestUtils {
   def evalTestMode[A](packages: List[String], mainPackS: String, expected: EvaluationMode[A], extern: Externals = Externals.empty) = {
     def inferredHandler(packMap: PackageMap.Inferred, mainPack: PackageName): Assertion = {
       val ev = Evaluation(packMap, Predef.jvmExternals ++ extern)
+      //if (mainPackS == "A") println(ev.repr)
       ev.evaluateLast(mainPack) match {
         case None => fail("found no main expression")
         case Some((eval, schm)) =>

--- a/core/src/test/scala/org/bykn/bosatsu/TestUtils.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/TestUtils.scala
@@ -22,19 +22,12 @@ object TestUtils {
       { cons => (pack, cons) }
 
     val stmt = statementOf(pack, str)
-    val srcConv = SourceConverter.from(tpeFn, consFn)
-    val prog = srcConv.toProgram(Predef.packageName, stmt)
+    val srcConv = SourceConverter(pack, Nil, Statement.definitionsOf(stmt))
+    val prog = srcConv.toProgram(stmt)
     TypeEnv.fromParsed(prog.types)
   }
 
-  def statementOf(pack: PackageName, str: String): Statement = {
-
-    val tpeFn: Identifier.Constructor => Type.Const =
-      { tpe => Type.Const.Defined(pack, TypeName(tpe)) }
-
-    val consFn: Identifier.Constructor => (PackageName, Identifier.Constructor) =
-      { cons => (pack, cons) }
-
+  def statementOf(pack: PackageName, str: String): Statement =
     Statement.parser.parse(str) match {
       case Parsed.Success(stmt, idx) =>
         assert(idx == str.length)
@@ -42,7 +35,6 @@ object TestUtils {
       case Parsed.Failure(exp, idx, extra) =>
         sys.error(s"failed to parse: $str: $exp at $idx in region ${region(str, idx)} with trace: ${extra.traced.trace}")
     }
-  }
 
   def checkLast(statement: String)(fn: TypedExpr[Declaration] => Assertion): Assertion =
     Statement.parser.parse(statement) match {

--- a/core/src/test/scala/org/bykn/bosatsu/TestUtils.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/TestUtils.scala
@@ -23,7 +23,7 @@ object TestUtils {
 
     val stmt = statementOf(pack, str)
     val srcConv = SourceConverter(pack, Nil, Statement.definitionsOf(stmt))
-    val prog = srcConv.toProgram(stmt)
+    val cats.data.Ior.Right(prog) = srcConv.toProgram(stmt)
     TypeEnv.fromParsed(prog.types._2)
   }
 

--- a/core/src/test/scala/org/bykn/bosatsu/TestUtils.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/TestUtils.scala
@@ -22,7 +22,7 @@ object TestUtils {
       { cons => (pack, cons) }
 
     val stmt = statementOf(pack, str)
-    val srcConv = new SourceConverter(tpeFn, consFn)
+    val srcConv = SourceConverter.from(tpeFn, consFn)
     val prog = srcConv.toProgram(Predef.packageName, stmt)
     TypeEnv.fromParsed(prog.types)
   }

--- a/core/src/test/scala/org/bykn/bosatsu/TestUtils.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/TestUtils.scala
@@ -24,7 +24,7 @@ object TestUtils {
     val stmt = statementOf(pack, str)
     val srcConv = SourceConverter(pack, Nil, Statement.definitionsOf(stmt))
     val prog = srcConv.toProgram(stmt)
-    TypeEnv.fromParsed(prog.types)
+    TypeEnv.fromParsed(prog.types._2)
   }
 
   def statementOf(pack: PackageName, str: String): Statement =

--- a/core/src/test/scala/org/bykn/bosatsu/TotalityTest.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/TotalityTest.scala
@@ -23,23 +23,11 @@ class TotalityTest extends FunSuite {
     //PropertyCheckConfiguration(minSuccessful = 500000)
     PropertyCheckConfiguration(minSuccessful = 5000)
 
-  val tpeFn: Constructor => Type.Const =
-    { tpe => Type.Const.Defined(Predef.packageName, TypeName(tpe)) }
-
-  val consFn: Constructor => (PackageName, Constructor) =
-    { cons => (Predef.packageName, cons) }
-
-  val srcConv = SourceConverter.from(tpeFn, consFn)
-  def parsedToExpr(pat: Pattern.Parsed): Pattern[(PackageName, Constructor), Type] =
-    srcConv.unTuplePattern(pat)
-
   val genPattern: Gen[Pattern[(PackageName, Constructor), Type]] =
-    Generators.genPattern(5)
-      .map(parsedToExpr _)
+    Generators.genCompiledPattern(5, useAnnotation = false)
 
   val genPatternNoUnion: Gen[Pattern[(PackageName, Constructor), Type]] =
-    Generators.genPattern(5, useUnion = false)
-      .map(parsedToExpr _)
+    Generators.genCompiledPattern(5, useUnion = false, useAnnotation = false)
 
   def showPat(pat: Pattern[(PackageName, Constructor), Type]): String = {
     val allTypes = pat.traverseType { t => Writer(Chain.one(t), ()) }.run._1.toList
@@ -62,7 +50,44 @@ struct Unit
 struct TupleCons(fst, snd)
 """)
 
-  def patterns(str: String): List[Pattern[(PackageName, Constructor), Type]] =
+  def patterns(str: String): List[Pattern[(PackageName, Constructor), Type]] = {
+    val nameToCons: Constructor => (PackageName, Constructor) =
+      { cons => (Predef.packageName, cons) }
+
+    /**
+     * This is sufficient for these tests, but is not
+     * a full features pattern compiler.
+     */
+    def parsedToExpr(pat: Pattern.Parsed): Pattern[(PackageName, Constructor), rankn.Type] =
+      pat.mapStruct[(PackageName, Constructor)] {
+        case (Pattern.StructKind.Tuple, args) =>
+          // this is a tuple pattern
+          def loop(args: List[Pattern[(PackageName, Constructor), TypeRef]]): Pattern[(PackageName, Constructor), TypeRef] =
+            args match {
+              case Nil =>
+                // ()
+                Pattern.PositionalStruct(
+                  (Predef.packageName, Constructor("Unit")),
+                  Nil)
+              case h :: tail =>
+                val tailP = loop(tail)
+                Pattern.PositionalStruct(
+                  (Predef.packageName, Constructor("TupleCons")),
+                  h :: tailP :: Nil)
+            }
+
+          loop(args)
+        case (Pattern.StructKind.Named(nm, _), args) =>
+          Pattern.PositionalStruct(nameToCons(nm), args)
+        case (Pattern.StructKind.NamedPartial(nm, _), args) =>
+          Pattern.PositionalStruct(nameToCons(nm), args)
+      }
+      .mapType { tref =>
+        TypeRefConverter[cats.Id](tref) { tpe =>
+          Type.Const.Defined(Predef.packageName, TypeName(tpe))
+        }
+      }
+
     Pattern.matchParser.listSyntax.parse(str) match {
       case Parsed.Success(pats, idx) =>
         pats.map(parsedToExpr _)
@@ -70,6 +95,7 @@ struct TupleCons(fst, snd)
         fail(s"failed to parse: $str: $exp at $idx in region ${region(str, idx)} with trace: ${extra.traced.trace}")
         sys.error("could not produce TypeEnv")
     }
+  }
 
   def notTotal(te: TypeEnv[Any], pats: List[Pattern[(PackageName, Constructor), Type]], testMissing: Boolean = true): Unit = {
     TotalityCheck(te).isTotal(pats) match {

--- a/core/src/test/scala/org/bykn/bosatsu/TotalityTest.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/TotalityTest.scala
@@ -29,7 +29,7 @@ class TotalityTest extends FunSuite {
   val consFn: Constructor => (PackageName, Constructor) =
     { cons => (Predef.packageName, cons) }
 
-  val srcConv = new SourceConverter(tpeFn, consFn)
+  val srcConv = SourceConverter.from(tpeFn, consFn)
   def parsedToExpr(pat: Pattern.Parsed): Pattern[(PackageName, Constructor), Type] =
     srcConv.unTuplePattern(pat)
 

--- a/core/src/test/scala/org/bykn/bosatsu/TypeRefTest.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/TypeRefTest.scala
@@ -19,7 +19,7 @@ class TypeRefTest extends FunSuite {
 
   test("TypeRef -> Type -> TypeRef") {
     val pn = PackageName.parts("Test")
-    val srcConv = new SourceConverter(
+    val srcConv = SourceConverter.from(
       { c => Type.Const.Defined(pn, TypeName(c)) },
       { c => (pn, c) })
     forAll(typeRefGen) { tr =>

--- a/core/src/test/scala/org/bykn/bosatsu/TypeRefTest.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/TypeRefTest.scala
@@ -19,11 +19,9 @@ class TypeRefTest extends FunSuite {
 
   test("TypeRef -> Type -> TypeRef") {
     val pn = PackageName.parts("Test")
-    val srcConv = SourceConverter.from(
-      { c => Type.Const.Defined(pn, TypeName(c)) },
-      { c => (pn, c) })
+
     forAll(typeRefGen) { tr =>
-      val tpe = srcConv.toType(tr)
+      val tpe = TypeRefConverter[cats.Id](tr) { c => Type.Const.Defined(pn, TypeName(c)) }
       val tr1 = TypeRef.fromTypes(Some(pn), tpe :: Nil)(tpe)
       assert(tr1 == tr.normalizeForAll)
     }

--- a/core/src/test/scala/org/bykn/bosatsu/rankn/RankNInferTest.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/rankn/RankNInferTest.scala
@@ -27,14 +27,10 @@ class RankNInferTest extends FunSuite {
         Type.Const.Defined(PackageName.parts("Test"), TypeName(str))
     }
 
-  private val srcConv = SourceConverter.from(
-    strToConst _,
-    { c => (PackageName.parts("Test"), c) })
-
   def typeFrom(str: String): Type =
     TypeRef.parser.parse(str) match {
       case Parsed.Success(typeRef, _) =>
-        srcConv.toType(typeRef)
+        TypeRefConverter[cats.Id](typeRef)(strToConst(_))
       case Parsed.Failure(exp, idx, extra) =>
         sys.error(s"failed to parse: $str: $exp at $idx with trace: ${extra.traced.trace}")
     }

--- a/core/src/test/scala/org/bykn/bosatsu/rankn/RankNInferTest.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/rankn/RankNInferTest.scala
@@ -120,6 +120,8 @@ class RankNInferTest extends FunSuite {
         case good =>
           good
       }
+      // make sure we can render repr:
+      val rendered = te.repr
       val tp = te.getType
       lazy val teStr = TypeRef.fromTypes(None, tp :: Nil)(tp).toDoc.render(80)
       assert(Type.freeTyVars(tp :: Nil).isEmpty, s"illegal inferred type: $teStr")

--- a/core/src/test/scala/org/bykn/bosatsu/rankn/RankNInferTest.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/rankn/RankNInferTest.scala
@@ -27,7 +27,7 @@ class RankNInferTest extends FunSuite {
         Type.Const.Defined(PackageName.parts("Test"), TypeName(str))
     }
 
-  private val srcConv = new SourceConverter(
+  private val srcConv = SourceConverter.from(
     strToConst _,
     { c => (PackageName.parts("Test"), c) })
 


### PR DESCRIPTION
close #308 

Translate record syntax, so we don't need to change anything about typechecking or evaluation.

I did hit a new bug here filed at #311

- [x] remove cruft from code