### PR TITLE
Use covariant recursion in the built in Test type

### DIFF
--- a/core/src/main/resources/bosatsu/predef.bosatsu
+++ b/core/src/main/resources/bosatsu/predef.bosatsu
@@ -1,7 +1,6 @@
 package Bosatsu/Predef
 
 export [
-  Assertion(),
   Bool(),
   Comparison(),
   Int,
@@ -9,7 +8,6 @@ export [
   List(),
   String,
   Test(),
-  TestSuite(),
   TupleCons(),
   Order,
   Unit(),
@@ -131,8 +129,8 @@ external struct String
 external def string_Order_fn(str0: String, str1: String) -> Comparison
 string_Order = Order(string_Order_fn)
 
-struct Assertion(value: Bool, message: String)
-struct Test(name: String, assertions: List[Assertion])
-struct TestSuite(name: String, tests: List[Test])
+enum Test:
+  Assertion(value: Bool, message: String)
+  TestSuite(name: String, tests: List[Test])
 
 external def trace(prefix: String, item: a) -> a

--- a/core/src/test/scala/org/bykn/bosatsu/EvaluationTest.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/EvaluationTest.scala
@@ -51,7 +51,7 @@ test = Assertion(eq_String("hello", foo), "checking equality")
       List("""
 package Foo
 
-test = Test("three trivial tests", [ Assertion(True, "t0"),
+test = TestSuite("three trivial tests", [ Assertion(True, "t0"),
     Assertion(True, "t1"),
     Assertion(True, "t2"),
     ])
@@ -1158,7 +1158,7 @@ inc4 = \Pair(F(x) | B(x), Foo(y)) -> x.add(y)
 test5 = Assertion(inc4(Pair(F(1), Foo(1))).eq_Int(2), "inc4(Pair(F(1), Foo(1))) == 2")
 test6 = Assertion(inc4(Pair(B(1), Foo(1))).eq_Int(2), "inc4(Pair(B(1), Foo(1))) == 2")
 
-suite = Test("match tests", [test0, test1, test2, test3, test4, test5, test6])
+suite = TestSuite("match tests", [test0, test1, test2, test3, test4, test5, test6])
 """), "A", 7)
 
     runBosatsuTest(List("""
@@ -1187,7 +1187,7 @@ def inc4(Pair(F(x) | B(x), Foo(y))): x.add(y)
 test5 = Assertion(inc4(Pair(F(1), Foo(1))).eq_Int(2), "inc4(Pair(F(1), Foo(1))) == 2")
 test6 = Assertion(inc4(Pair(B(1), Foo(1))).eq_Int(2), "inc4(Pair(B(1), Foo(1))) == 2")
 
-suite = Test("match tests", [test0, test1, test2, test3, test4, test5, test6])
+suite = TestSuite("match tests", [test0, test1, test2, test3, test4, test5, test6])
 """), "A", 7)
   }
 
@@ -1266,7 +1266,7 @@ bgood = match b:
   "two": True
   _: False
 
-tests = Test("test triple",
+tests = TestSuite("test triple",
   [ Assertion(a.eq_Int(3), "a == 3"),
     Assertion(bgood, b),
     Assertion(c.eq_Int(1), "c == 1") ])
@@ -1403,7 +1403,7 @@ rs = rs_empty.concat_records([PS(RecordValue("a"), PS(RecordValue(1), PS(RecordV
 
 rs0 = rs.restructure(\PS(a, PS(b, PS(c, _))) -> ps(c, ps(b, ps(a, ps("Plus 2".int_field( \r -> r.get(b).add(2) ), ps_end)))))
 
-tests = Test("reordering",
+tests = TestSuite("reordering",
   [
     Assertion(equal_rows.equal_List(rs0.list_of_rows, [[REBool(RecordValue(False)), REInt(RecordValue(1)), REString(RecordValue("a")), REInt(RecordValue(3))]]), "swap")
   ]
@@ -1421,7 +1421,7 @@ struct Pair(first, second)
 f2 = match Pair(1, "1"):
   Pair { first, ... }: first
 
-tests = Test("test record",
+tests = TestSuite("test record",
   [
     Assertion(f2.eq_Int(1), "f2 == 1"),
   ])
@@ -1437,7 +1437,7 @@ def res:
   Pair { first, ... } = Pair(1, 2)
   first
 
-tests = Test("test record",
+tests = TestSuite("test record",
   [
     Assertion(res.eq_Int(1), "res == 1"),
   ])
@@ -1453,7 +1453,7 @@ get = \Pair { first, ...} -> first
 
 res = get(Pair(1, "two"))
 
-tests = Test("test record",
+tests = TestSuite("test record",
   [
     Assertion(res.eq_Int(1), "res == 1"),
   ])
@@ -1469,7 +1469,7 @@ get = \Pair { first: f, ...} -> f
 
 res = get(Pair(1, "two"))
 
-tests = Test("test record",
+tests = TestSuite("test record",
   [
     Assertion(res.eq_Int(1), "res == 1"),
   ])
@@ -1485,7 +1485,7 @@ get = \Pair(first, ...) -> first
 
 res = get(Pair(1, "two"))
 
-tests = Test("test record",
+tests = TestSuite("test record",
   [
     Assertion(res.eq_Int(1), "res == 1"),
   ])
@@ -1501,7 +1501,7 @@ get = \Pair(first, ...) -> first
 
 res = get(Pair { first: 1, second: "two" })
 
-tests = Test("test record",
+tests = TestSuite("test record",
   [
     Assertion(res.eq_Int(1), "res == 1"),
   ])
@@ -1519,7 +1519,7 @@ first = 1
 
 res = get(Pair { first, second: "two" })
 
-tests = Test("test record",
+tests = TestSuite("test record",
   [
     Assertion(res.eq_Int(1), "res == 1"),
   ])
@@ -1632,7 +1632,7 @@ struct Foo(x, y)
 
 Foo { x, ... } = Foo(42, "42")
 
-tests = Test("test record",
+tests = TestSuite("test record",
   [
     Assertion(x.eq_Int(42), "x == 42"),
   ])
@@ -1646,7 +1646,7 @@ a = Foo(42, "42")
 x = match a:
    Foo(y, _): y
 
-tests = Test("test record",
+tests = TestSuite("test record",
   [
     Assertion(x.eq_Int(42), "x == 42"),
   ])
@@ -1669,7 +1669,7 @@ def add_x(a):
 # should be 43
 y = add_x(1)
 
-tests = Test("test record",
+tests = TestSuite("test record",
   [
     Assertion(y.eq_Int(43), "y == 43"),
   ])

--- a/core/src/test/scala/org/bykn/bosatsu/OperatorTest.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/OperatorTest.scala
@@ -69,7 +69,7 @@ operator * = times
 operator == = eq_Int
 def operator %(a, b): mod_Int(a, b)
 
-test = Test("precedence",
+test = TestSuite("precedence",
   [
     Assertion(1 + 2 * 3 == 1 + (2 * 3), "p1"),
     Assertion(1 * 2 * 3 == (1 * 2) * 3, "p1"),
@@ -90,7 +90,7 @@ operator == = \x, y ->
   (((a, b), c), ((d, e), f)) = (x, y)
   (a =*= d) & (b =*= e) & (c =*= f)
 
-test = Test("precedence",
+test = TestSuite("precedence",
   [
     Assertion(1 *> 2 *> 3 == (1 *> 2) *> 3, "p1"),
   ])
@@ -113,7 +113,7 @@ import T1 [ operator + as operator ++, `*`, `==` ]
 `.+` = `++`
 `+.` = `++`
 
-test = Test("import export",
+test = TestSuite("import export",
   [ Assertion(1 +. (2 * 3) == 1 .+ (2 * 3), "p1"),
     Assertion(1 .+ 2 * 3 == (1 .+ 2) * 3, "p1") ])
 """), "T2", 2)
@@ -134,7 +134,7 @@ left2 = 1 if True else 2 + 3
 # above should be 1 not (1 + 3)
 right2 = 1
 
-test = Test("precedence",
+test = TestSuite("precedence",
   [
     Assertion(left1 == right1, "p1"),
     Assertion(left2 == right2, "p2"),

--- a/test_workspace/ApplicativeTraverse.bosatsu
+++ b/test_workspace/ApplicativeTraverse.bosatsu
@@ -50,7 +50,7 @@ eq_opt_list_int = eq_Option(eq_List(eq_Int))
 
 operator == = eq_opt_list_int
 
-test = Test("applicative/traverse tests",
+test = TestSuite("applicative/traverse tests",
   [
     Assertion(trav_list_opt(\x -> Some(2.times(x)), [1, 2, 3]) == Some([2, 4, 6]), "double"),
     Assertion(trav_list_opt(\x -> None, [1, 2, 3]) == None, "all to None"),

--- a/test_workspace/List.bosatsu
+++ b/test_workspace/List.bosatsu
@@ -19,7 +19,7 @@ eq_li = eq_List(eq_Int)
 
 def not(x): False if x else True
 
-tests = Test("List tests", [
+tests = TestSuite("List tests", [
   Assertion([1, 2, 3].eq_li([1, 2, 3]), "list [1, 2, 3]"),
   Assertion(not([1, 2, 3].eq_li([1, 2])), "list [1, 2, 3] != [1, 2]"),
   ])

--- a/test_workspace/Queue.bosatsu
+++ b/test_workspace/Queue.bosatsu
@@ -63,7 +63,7 @@ def to_List(Queue(f, b): Queue[a]) -> List[a]:
   f.concat(b.reverse)
 
 ########
-## Tests below
+## TestSuites below
 ########
 
 def eq_Opt(fn, a, b):
@@ -78,7 +78,7 @@ eq_li = eq_List(eq_Int)
 
 q12 = empty.push(1).push(2)
 
-tests = Test("queue tests", [
+tests = TestSuite("queue tests", [
   Assertion(eq_oi(q12.pop_value, Some(1)), "1"),
   Assertion(q12.fold_Queue(0,add).eq_Int(3), "fold_Queue add"),
   Assertion(q12.fold_Queue(0,\_, x -> x).eq_Int(2), "take the second"),

--- a/test_workspace/TreeList.bosatsu
+++ b/test_workspace/TreeList.bosatsu
@@ -123,7 +123,7 @@ tl12 = 2 +/ (1 +/ empty)
 list14 = from_List([1, 2, 3, 4])
 cons14 = 1 +/ ( 2 +/ ( 3 +/ ( 4 +/ empty ) ) )
 
-tests = Test("TreeList tests", [
+tests = TestSuite("TreeList tests", [
   Assertion(tl12.get(0).eq_oi(Some(2)), "get 0 == 2"),
   Assertion(tl12.get(1).eq_oi(Some(1)), "get 1 == 1"),
   Assertion(tl12.get(2).eq_oi(None), "get 2 == None"),

--- a/test_workspace/euler6.bosatsu
+++ b/test_workspace/euler6.bosatsu
@@ -42,4 +42,4 @@ diff = sum(\x ->
 
 test0 = Assertion(diff(10) == 2640, "matched problem")
 test1 = Assertion(diff(100) == 25164150, "matched problem")
-tests = Test("two examples", [test0, test1])
+tests = TestSuite("two examples", [test0, test1])

--- a/test_workspace/euler7.bosatsu
+++ b/test_workspace/euler7.bosatsu
@@ -53,7 +53,7 @@ def ith_prime(total):
     [h, *_]: h
     []: -1
 
-test = Test("euler 7", [
+test = TestSuite("euler 7", [
   Assertion(is_prime(13), "6th prime is 13"),
   Assertion(ith_prime(6) == 13, "6th prime is 13"),
   Assertion(ith_prime(11) == 31, "11th prime is 31")])

--- a/test_workspace/recordset.bosatsu
+++ b/test_workspace/recordset.bosatsu
@@ -123,7 +123,7 @@ rs = rs_empty.concat_records([PS(RecordValue("a"), PS(RecordValue(1), PS(RecordV
 
 rs0 = rs.restructure(\PS(a, PS(b, PS(c, _))) -> ps(c, ps(b, ps(a, ps("Plus 2".int_field( \r -> r.get(b).add(2) ), ps_end)))))
 
-tests = Test("reordering",
+tests = TestSuite("reordering",
   [
     Assertion(equal_rows.equal_List(rs0.list_of_rows, [[REBool(RecordValue(False)), REInt(RecordValue(1)), REString(RecordValue("a")), REInt(RecordValue(3))]]), "swap")
   ]

--- a/test_workspace/test_example.bosatsu
+++ b/test_workspace/test_example.bosatsu
@@ -1,3 +1,0 @@
-package Example/Test
-
-tests = TestList(NonEmptyList(TestLabel("example", TestAssert(True)), NonEmptyList(TestLabel("example2", TestAssert(True)), EmptyList)))


### PR DESCRIPTION
Originally, this is how Test worked, but when we temporarily removed when recursive types (#102) were removed before we added checks for covariant recursion (#158).

I should have done this when I added list back in #159.