### PR TITLE
Add cuts for more precise parser errors

### DIFF
--- a/core/src/main/scala/org/bykn/bosatsu/BindingStatement.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/BindingStatement.scala
@@ -21,7 +21,7 @@ object BindingStatement {
   def bindingParser[B, T](parser: Indy[Declaration], rest: Indy[T]): Indy[B => BindingStatement[B, T]] = {
     val eqP = P("=" ~ !"=")
 
-    (Indy.lift(P(maybeSpace ~ eqP ~ maybeSpace)) *> parser)
+    (Indy.lift(P(maybeSpace ~ eqP ~/ maybeSpace)) *> parser)
       .product(rest)
       .map { case (value, rest) =>
 

--- a/core/src/main/scala/org/bykn/bosatsu/BindingStatement.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/BindingStatement.scala
@@ -7,6 +7,8 @@ import Parser.{ Indy, maybeSpace }
 import cats.implicits._
 import org.bykn.fastparse_cats.StringInstances._
 
+import Indy.IndyMethods
+
 case class BindingStatement[B, T](name: B, value: Declaration, in: T)
 
 object BindingStatement {
@@ -19,10 +21,10 @@ object BindingStatement {
     }
 
   def bindingParser[B, T](parser: Indy[Declaration], rest: Indy[T]): Indy[B => BindingStatement[B, T]] = {
-    val eqP = P("=" ~ !"=")
+    val eqP = P("=" ~ !Operators.multiToksP)
 
     (Indy.lift(P(maybeSpace ~ eqP ~/ maybeSpace)) *> parser)
-      .product(rest)
+      .cutThen(rest)
       .map { case (value, rest) =>
 
         { (bname: B) => BindingStatement(bname, value, rest) }

--- a/core/src/main/scala/org/bykn/bosatsu/Expr.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/Expr.scala
@@ -100,7 +100,11 @@ object Expr {
         (argB, branchB).mapN(Match(_, _, tag))
     }
 
-  implicit val exprTraverse: Traverse[Expr] =
+  /*
+   * We have seen some intermitten CI failures if this isn't lazy
+   * presumably due to initialiazation order
+   */
+  implicit lazy val exprTraverse: Traverse[Expr] =
     new Traverse[Expr] {
 
       // Traverse on NonEmptyList[(Pattern[_], Expr[?])]

--- a/core/src/main/scala/org/bykn/bosatsu/ListLang.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/ListLang.scala
@@ -71,7 +71,7 @@ object ListLang {
     // shouldn't but currently it looks like they are
     val comp = P(
       "for" ~ spacesAndLines ~/ pbind ~ maybeSpacesAndLines ~
-      "in" ~ spacesAndLines ~ pa ~ (maybeSpacesAndLines ~ filterExpr).?)
+      "in" ~ spacesAndLines ~/ pa ~ (maybeSpacesAndLines ~ filterExpr).?)
         .map { case (b, i, f) =>
           { e: F[A] => Comprehension(e, b, i, f) }
         }
@@ -80,7 +80,7 @@ object ListLang {
     val commaCons = ("," ~ maybeSpacesAndLines ~ consTail)
     val inner = commaCons | (spacesAndLines ~ (commaCons | comp))
 
-    P(left ~ maybeSpacesAndLines ~ (sia ~ inner.?).? ~ maybeSpacesAndLines ~ right)
+    P(left ~/ maybeSpacesAndLines ~ (sia ~ inner.?).? ~ maybeSpacesAndLines ~ right)
       .map {
         case None => Cons(Nil)
         case Some((a, None)) => Cons(a :: Nil)

--- a/core/src/main/scala/org/bykn/bosatsu/Operators.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/Operators.scala
@@ -42,12 +42,18 @@ object Operators {
       "&", "^", "|",
       "?", "~").map(_.intern)
 
+  private def from(strs: Iterable[String]): P[Unit] =
+    strs.map(P(_)).reduce(_ | _)
+
   /**
    * strings for operators allowed in single character
    * operators includes singleToks and . and =
    */
   val multiToks: List[String] =
     ".".intern :: singleToks ::: List("=".intern)
+
+  val multiToksP: P[Unit] =
+    from(multiToks)
 
   private val priorityMap: Map[String, Int] =
     multiToks
@@ -59,12 +65,9 @@ object Operators {
    * Here are a list of operators we allow
    */
   val operatorToken: P[String] = {
-    def from(strs: Iterable[String]): P[Unit] =
-      strs.map(P(_)).reduce(_ | _)
-
     val singles = from(singleToks)
     // = can appear with at least one other character
-    val twoOrMore: P[Unit] = from(multiToks).rep(min = 2)
+    val twoOrMore: P[Unit] = multiToksP.rep(min = 2)
     // we can also repeat core operators one or more times
     val singleP = singles.rep(min = 1)
     (twoOrMore | singleP).!.map(_.intern)

--- a/core/src/main/scala/org/bykn/bosatsu/Parser.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/Parser.scala
@@ -77,6 +77,11 @@ object Parser {
             case Nil => sys.error("rep 1 matched 0")
           }
         }
+
+      def cutThen[B](that: Indy[B]): Indy[(A, B)] =
+        Indy { indent =>
+          toKleisli(indent) ~/ that(indent)
+        }
     }
   }
 

--- a/core/src/main/scala/org/bykn/bosatsu/Parser.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/Parser.scala
@@ -53,7 +53,7 @@ object Parser {
       blockLike(first, next, P(maybeSpace ~ ":"))
 
     def blockLike[A, B](first: Indy[A], next: Indy[B], sep: P[Unit]): Indy[(A, OptIndent[B])] =
-      (first <* lift(sep ~ maybeSpace))
+      (first <* lift(sep ~/ maybeSpace))
         .product(OptIndent.indy(next))
 
     implicit class IndyMethods[A](val toKleisli: Indy[A]) extends AnyVal {

--- a/core/src/test/scala/org/bykn/bosatsu/ParserTest.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/ParserTest.scala
@@ -1011,6 +1011,21 @@ z = 3
 z = 4
 y = {'x': 'x' : 'y'}
 """, 18)
+
+    expectFail(Statement.parser,
+      """x = 1
+def z:
+  x = 1
+  x x
+""", 25)
+
+    expectFail(Statement.parser,
+      """x = 1
+def z:
+  x = 1
+  y = [1, 2, 3]
+  x x
+""", 41)
   }
 
 }


### PR DESCRIPTION
Ideally, the parser can point to as close as possible to where a parse fails. Unfortunately, we are using a fair amount of backtracking currently in the parser, which makes it both slower and also prone to print unhelpful error messages.

By reducing backtracking, which can be done in fastparse with more cuts, we can print better locations for parser errors.

In some cases, we need to restructure the parsers to avoid using backtracking. For instance, we have two mechanisms to parse binds, rather than parsing a prefix, and then upon seeing `=` always move to parsing a bind. Similarly, trailing `if` is an operator if it has an `else` but it is also a filtering operation in a for comprehension. Ideally we should have a parser that knows that trailing is isn't allowed unless nested in a parens, and call that in the for comprehension, so we can avoid the backtracking which happens on each filter currently.