### PR TITLE
Add an example of bazel-like use case

### DIFF
--- a/test_workspace/BUILD
+++ b/test_workspace/BUILD
@@ -136,3 +136,8 @@ bosatsu_test(
     deps = [":binnat"],
     packages = ["Bosatsu/BinNat"]
     )
+
+bosatsu_library(
+    name = "BuildLibrary",
+    srcs = ["BuildLibrary.bosatsu", "BuildExample.bosatsu"],
+)

--- a/test_workspace/BuildExample.bosatsu
+++ b/test_workspace/BuildExample.bosatsu
@@ -1,0 +1,14 @@
+package BuildExample
+
+import BuildLibrary [ build, files, library, empty, LibArgs, build_all ]
+
+lib1 = library(
+  files(["file1.bosatsu", "file2.bosatsu"]),
+  empty,
+)
+
+# a different style using named arguments and a Struct
+lib2 = build(LibArgs {
+  srcs: files([]),
+  deps: build_all([lib1]),
+})

--- a/test_workspace/BuildLibrary.bosatsu
+++ b/test_workspace/BuildLibrary.bosatsu
@@ -1,0 +1,53 @@
+package BuildLibrary
+
+export [File(), Library(), LibArgs(), build, Build, file, files, build_all, library, empty]
+
+struct Leibniz[a, b](cast: forall f. f[a] -> f[b])
+(refl: forall a. Leibniz[a, a]) = Leibniz(\x -> x)
+
+# In Bosatsu, like System F, the type exists a. P can be encoded as forall b. (forall a. P -> b) -> b
+# We encode Mapped in this way, we want: Mapped(to_tuple: exists b. (Build[b], b -> a))
+# we write: Mapped(to_tuple: forall c. (forall b. (Build[b], b -> a) -> c) -> c)
+
+enum Build[a]:
+  LoadFile(name: String, is_file: Leibniz[a, File])
+  Pure(value: a)
+  Mapped(consume: forall b. (forall c. (Build[c], c -> a) -> b) -> b)
+  Map2(consume: forall b. (forall c, d. (Build[c], Build[d], c -> d -> a) -> b) -> b)
+  BuildLib(files: Build[List[File]], deps: Build[List[Library]], is_lib: Leibniz[a, Library])
+
+def map_Build(b: Build[a], fn: a -> b) -> Build[b]:
+  Mapped(\cb -> cb((b, fn)))
+
+def map2_Build(ba: Build[a], bb: Build[b], fn: a -> b -> c) -> Build[c]:
+  Map2(\cb -> cb((ba, bb, fn)))
+
+struct File(path: String)
+struct Library
+
+def file(s: String) -> Build[File]:
+    LoadFile(s, refl)
+
+(empty: forall a. Build[List[a]]) = Pure([])
+
+def build_all(items: List[Build[a]]) -> Build[List[a]]:
+    recur items:
+      []: empty
+      [h, *t]:
+          (rest: Build[List[a]]) = build_all(t)
+          map2_Build(h, rest, \h, t -> [h, *t])
+
+def files(fs: List[String]) -> Build[List[File]]:
+    build_all([file(f) for f in fs])
+
+def library(
+    sources: Build[List[File]],
+    deps: Build[List[Library]]) -> Build[Library]:
+    BuildLib(sources, deps, refl)
+
+struct LibArgs(srcs: Build[List[File]], deps: Build[List[Library]])
+
+def build(args: LibArgs) -> Build[Library]:
+  LibArgs { srcs, deps } = args
+  library(srcs, deps)
+


### PR DESCRIPTION
This adds a compile-only example of using Bosatsu in a bazel-like use case. First we implement a toy API that is real enough (has a Build type constructor and it composes in an applicative fashion), then we use the API to write two build targets.

It is clearly advanced functional programming to encode the Build library, but using it seems like it could be done without a huge depth of knowledge. I don't think this is a real problem, since writing libraries is generally harder writing application code since libraries are generally encoding some abstraction, but the encoding of the library is probably not a great sales pitch so far.

On the other hand, it is quite interesting we can encode all of this in a total functional language without any problem now.

cc @snoble 