### PR TITLE
Remove the built-in List structure of Statement

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,25 +20,25 @@ matrix:
     - scala: 2.11.12
       language: scala
       jdk: openjdk8
-      env: PLATFORM="jvm"
+      env: PLATFORM=jvm
       script: sbt "++ ${TRAVIS_SCALA_VERSION}" coreJVM/test cli/test doc
 
     - scala: 2.12.8
       language: scala
       jdk: openjdk8
-      env: PLATFORM="jvm"
+      env: PLATFORM=jvm
       script: sbt "++ ${TRAVIS_SCALA_VERSION}" coverage coreJVM/test cli/test coverageReport doc && codecov
 
     - scala: 2.11.12
       language: scala
       jdk: openjdk8
-      env: PLATFORM="js"
+      env: PLATFORM=js
       script: sbt "++ ${TRAVIS_SCALA_VERSION}" coreJS/test
 
     - scala: 2.12.8
       language: scala
       jdk: openjdk8
-      env: PLATFORM="js"
+      env: PLATFORM=js
       script: sbt "++ ${TRAVIS_SCALA_VERSION}" coreJS/test
 
     - language: generic

--- a/core/src/main/scala/org/bykn/bosatsu/PackageMap.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/PackageMap.scala
@@ -53,8 +53,8 @@ object PackageMap {
 
   type MapF3[A, B, C] = PackageMap[FixPackage[A, B, C], A, B, C]
   type MapF2[A, B] = MapF3[A, A, B]
-  type ParsedImp = PackageMap[PackageName, Unit, Unit, (Statement, ImportMap[PackageName, Unit])]
-  type Resolved = MapF2[Unit, (Statement, ImportMap[PackageName, Unit])]
+  type ParsedImp = PackageMap[PackageName, Unit, Unit, (List[Statement], ImportMap[PackageName, Unit])]
+  type Resolved = MapF2[Unit, (List[Statement], ImportMap[PackageName, Unit])]
   type Typed[+T] = PackageMap[
     Package.Interface,
     NonEmptyList[Referant[Variance]],
@@ -157,7 +157,7 @@ object PackageMap {
 
     def toProg(p: Package.Parsed):
       (Option[PackageError],
-        Package[PackageName, Unit, Unit, (Statement, ImportMap[PackageName, Unit])]) = {
+        Package[PackageName, Unit, Unit, (List[Statement], ImportMap[PackageName, Unit])]) = {
 
       val (errs0, imap) = ImportMap.fromImports(p.imports)
       val errs =
@@ -170,7 +170,7 @@ object PackageMap {
     // we know all the package names are unique here
     def foldMap(m: Map[PackageName, (A, Package.Parsed)]): (List[PackageError], PackageMap.ParsedImp) = {
       val initPm = PackageMap
-        .empty[PackageName, Unit, Unit, (Statement, ImportMap[PackageName, Unit])]
+        .empty[PackageName, Unit, Unit, (List[Statement], ImportMap[PackageName, Unit])]
 
       m.iterator.foldLeft((List.empty[PackageError], initPm)) {
         case ((errs, pm), (_, (_, pack))) =>
@@ -200,10 +200,10 @@ object PackageMap {
 
     // This is unfixed resolved
     type ResolvedU = Package[
-      FixPackage[Unit, Unit, (Statement, ImportMap[PackageName, Unit])],
+      FixPackage[Unit, Unit, (List[Statement], ImportMap[PackageName, Unit])],
       Unit,
       Unit,
-      (Statement, ImportMap[PackageName, Unit])]
+      (List[Statement], ImportMap[PackageName, Unit])]
     /*
      * We memoize this function to avoid recomputing diamond dependencies
      */

--- a/core/src/main/scala/org/bykn/bosatsu/Padding.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/Padding.scala
@@ -13,16 +13,33 @@ object Padding {
       Doc.line.repeat(padding.lines) + Document[T].document(padding.padded)
     }
 
-  def parseFn[A]: P[A => Padding[A]] =
+  private def parser[A](p: P[A], min: Int): P[Padding[A]] =
     // if we have a P[Unit] then rep() is also P[Unit] due to weird shit
-    P((maybeSpace ~ "\n").map(_ => 0).rep()).map { vec =>
-      { a => Padding(vec.size, a) }
-    }
+    // If p consumes nothing, toEOL is dangerous because
+    // it can match End, and End.rep() will OOM when it hits
+    // the end of the file
+    (P(maybeSpace ~ "\n").map(_ => 0).rep(min) ~ p)
+      .map { case (vec, t) => Padding(vec.size, t) }
 
+  /**
+   * This allows an empty padding
+   * this is a bit dangerous with a p that consumes nothing
+   * as parsers that succeed without consuming input
+   * are dangerous to use with rep
+   */
   def parser[T](p: P[T]): P[Padding[T]] =
-    (parseFn[T] ~ p).map { case (fn, t) => fn(t) }
+    parser(p, 0)
 
+  /**
+   * Parses a padding of length 1 or more, then p
+   */
   def parser1[T](p: P[T]): P[Padding[T]] =
-    P((maybeSpace ~ "\n").!.rep(1) ~ p).map { case (vec, t) => Padding(vec.size, t) }
+    parser(p, 1)
+
+  /**
+   * This is parser1 by itself, with the padded value being ()
+   */
+  val nonEmptyParser: P[Padding[Unit]] =
+    parser1(PassWith(()))
 }
 

--- a/core/src/main/scala/org/bykn/bosatsu/Parser.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/Parser.scala
@@ -285,7 +285,12 @@ object Parser {
     }
   }
 
-  val toEOL: P[Unit] = P(maybeSpace ~ "\n")
+  /**
+   * Parse until the end of a line or to end of file.
+   * WARNING: never use this with .rep because
+   * repeatedly parsing End will OOM
+   */
+  val toEOL: P[Unit] = P(maybeSpace ~ ("\n" | End))
 
   /**
    * If we have a list like structure where

--- a/core/src/main/scala/org/bykn/bosatsu/Parser.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/Parser.scala
@@ -291,22 +291,4 @@ object Parser {
    * repeatedly parsing End will OOM
    */
   val toEOL: P[Unit] = P(maybeSpace ~ ("\n" | End))
-
-  /**
-   * If we have a list like structure where
-   * we parse the function to add something
-   * to the head, we can use this
-   */
-  def chained[A](p: P[A => A], end: P[A]): P[A] = {
-    (p.rep() ~ end).map { case (fns, a) =>
-      @annotation.tailrec
-      def loop(revFn: List[A => A], a: A): A =
-        revFn match {
-          case Nil => a
-          case h :: t => loop(t, h(a))
-        }
-
-      loop(fns.toList.reverse, a)
-    }
-  }
 }

--- a/core/src/main/scala/org/bykn/bosatsu/Statement.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/Statement.scala
@@ -1,6 +1,6 @@
 package org.bykn.bosatsu
 
-import Parser.{ Combinators, Indy, lowerIdent, maybeSpace, spaces }
+import Parser.{ Combinators, Indy, lowerIdent, maybeSpace, spaces, toEOL }
 import cats.data.NonEmptyList
 import cats.implicits._
 import fastparse.all._
@@ -19,31 +19,6 @@ sealed abstract class Statement {
    * of statements
    */
   def region: Region
-
-  def next: Option[Statement] = {
-    import Statement._
-    this match {
-      case Bind(BindingStatement(_, _, Padding(_, rest))) =>
-        Some(rest)
-      case Comment(CommentStatement(_, Padding(_, rest))) =>
-        Some(rest)
-      case Def(DefStatement(_, _, _, (_, Padding(_, rest)))) =>
-        Some(rest)
-      case Struct(_, _, _, Padding(_, rest)) =>
-        Some(rest)
-      case Enum(_, _, _, Padding(_, rest)) =>
-        Some(rest)
-      case ExternalDef(_, _, _, Padding(_, rest)) =>
-        Some(rest)
-      case ExternalStruct(_, _, Padding(_, rest)) =>
-        Some(rest)
-      case EndOfFile() =>
-        None
-    }
-  }
-
-  def toStream: Stream[Statement] =
-    Stream.iterate(this)(_.next.orNull).takeWhile(_ != null)
 }
 
 sealed abstract class TypeDefinitionStatement extends Statement {
@@ -59,14 +34,20 @@ sealed abstract class TypeDefinitionStatement extends Statement {
    */
   def constructors: List[Constructor] =
     this match {
-      case Struct(nm, _, _, _) => nm :: Nil
-      case Enum(_, _, items, _) =>
+      case Struct(nm, _, _) => nm :: Nil
+      case Enum(_, _, items) =>
         items.get.toList.map { case (nm, _) => nm }
-      case ExternalStruct(_, _, _) => Nil
+      case ExternalStruct(_, _) => Nil
     }
 }
 
 object Statement {
+
+  def definitionsOf(stmts: Iterable[Statement]): Stream[TypeDefinitionStatement] =
+    stmts.iterator.collect { case tds: TypeDefinitionStatement => tds }.toStream
+
+  def valuesOf(stmts: Iterable[Statement]): Stream[ValueStatement] =
+    stmts.iterator.collect { case vs: ValueStatement => vs }.toStream
 
   /**
    * These introduce new values into scope
@@ -79,7 +60,7 @@ object Statement {
       this match {
         case Bind(BindingStatement(bound, _, _)) => bound.names // TODO Keep identifiers
         case Def(defstatement) => defstatement.name :: Nil
-        case ExternalDef(name, _, _, _) => name :: Nil
+        case ExternalDef(name, _, _) => name :: Nil
       }
 
     /**
@@ -90,10 +71,10 @@ object Statement {
       this match {
         case Bind(BindingStatement(_, decl, _)) => decl.freeVars
         case Def(defstatement) =>
-          val innerFrees = defstatement.result._1.get.freeVars
+          val innerFrees = defstatement.result.get.freeVars
           // but the def name and, args shadow
           (innerFrees - defstatement.name) -- defstatement.args.flatMap(_.names)
-        case ExternalDef(name, _, _, _) => SortedSet.empty
+        case ExternalDef(name, _, _) => SortedSet.empty
       }
 
     /**
@@ -103,84 +84,67 @@ object Statement {
       this match {
         case Bind(BindingStatement(pat, decl, _)) => decl.allNames ++ pat.names
         case Def(defstatement) =>
-          (defstatement.result._1.get.allNames + defstatement.name) ++
+          (defstatement.result.get.allNames + defstatement.name) ++
             defstatement.args.flatMap(_.names)
-        case ExternalDef(name, _, _, _) => SortedSet(name)
+        case ExternalDef(name, _, _) => SortedSet(name)
       }
     }
   }
 
-  def definitionsOf(s: Statement): Stream[TypeDefinitionStatement] =
-    s.toStream.collect {
-      case tds: TypeDefinitionStatement => tds
-    }
-
-  def valuesOf(s: Statement): Stream[ValueStatement] =
-    s.toStream.collect {
-      case vs: ValueStatement => vs
-    }
-
   //////
   // All the ValueStatements, which set up new bindings in the order they appear in the file
   /////.
-  case class Bind(bind: BindingStatement[Pattern.Parsed, Padding[Statement]])(val region: Region) extends ValueStatement
-  case class Def(defstatement: DefStatement[Pattern.Parsed, (OptIndent[Declaration], Padding[Statement])])(val region: Region) extends ValueStatement
-  case class ExternalDef(name: Bindable, params: List[(Bindable, TypeRef)], result: TypeRef, rest: Padding[Statement])(val region: Region) extends ValueStatement
+  case class Bind(bind: BindingStatement[Pattern.Parsed, Unit])(val region: Region) extends ValueStatement
+  case class Def(defstatement: DefStatement[Pattern.Parsed, OptIndent[Declaration]])(val region: Region) extends ValueStatement
+  case class ExternalDef(name: Bindable, params: List[(Bindable, TypeRef)], result: TypeRef)(val region: Region) extends ValueStatement
 
   //////
   // TypeDefinitionStatement types:
   //////
   case class Enum(name: Constructor,
     typeArgs: Option[NonEmptyList[TypeRef.TypeVar]],
-    items: OptIndent[NonEmptyList[(Constructor, List[(Bindable, Option[TypeRef])])]],
-    rest: Padding[Statement])(val region: Region) extends TypeDefinitionStatement
-  case class ExternalStruct(name: Constructor, typeArgs: List[TypeRef.TypeVar], rest: Padding[Statement])(val region: Region) extends TypeDefinitionStatement
+    items: OptIndent[NonEmptyList[(Constructor, List[(Bindable, Option[TypeRef])])]]
+    )(val region: Region) extends TypeDefinitionStatement
+  case class ExternalStruct(name: Constructor, typeArgs: List[TypeRef.TypeVar])(val region: Region) extends TypeDefinitionStatement
   case class Struct(name: Constructor,
     typeArgs: Option[NonEmptyList[TypeRef.TypeVar]],
-    args: List[(Bindable, Option[TypeRef])],
-    rest: Padding[Statement])(val region: Region) extends TypeDefinitionStatement
+    args: List[(Bindable, Option[TypeRef])])(val region: Region) extends TypeDefinitionStatement
 
   ////
   // These have no effect on the semantics of the Statement linked list
   ////
-  case class Comment(comment: CommentStatement[Padding[Statement]])(val region: Region) extends Statement
-  case class EndOfFile()(val region: Region) extends Statement
+  case class PaddingStatement(padding: Padding[Unit])(val region: Region) extends Statement
+  case class Comment(comment: CommentStatement[Unit])(val region: Region) extends Statement
 
   // Parse a single item
-  private val item: P[Statement => Statement] = {
-     val padding = Padding.parseFn[Statement]
+  final val parser1: P[Statement] = {
+     val punit: P[Unit] = PassWith(())
 
-     val bindingP: P[Statement => Statement] = {
+     val bindingP: P[Statement] = {
        val bop = BindingStatement
-         .bindingParser[Pattern.Parsed, Statement => Padding[Statement]](
-           Declaration.parser, Indy.lift(maybeSpace ~ padding))("")
+         .bindingParser[Pattern.Parsed, Unit](Declaration.parser, Indy.lift(toEOL))("")
 
        (Pattern.bindParser ~ bop).region.map { case (region, (p, parseBs)) =>
-         val BindingStatement(n, v, fn) = parseBs(p)
-
-         { next: Statement =>
-           val bs = BindingStatement(n, v, fn(next))
-           Bind(bs)(region)
-         }
+         val bs = parseBs(p)
+          Bind(bs)(region)
        }
      }
 
-     val commentP: P[Statement => Statement] =
-       CommentStatement.parser(Indy.lift(padding)).region
-         .map { case (region, CommentStatement(text, on)) =>
+     val paddingSP: P[Statement] =
+       Padding
+         .nonEmptyParser
+         .region
+         .map { case (region, p) => PaddingStatement(p)(region) }
 
-           { next: Statement =>
-             Comment(CommentStatement(text, on(next)))(region)
-           }
-         }.run("")
+     val commentP: P[Statement] =
+       CommentStatement.parser(Indy.lift(punit)).region
+         .map { case (region, cs) => Comment(cs)(region) }.run("")
 
      val defBody = maybeSpace ~ OptIndent.indy(Declaration.parser).run("")
-     val defP: P[Statement => Def] =
-      DefStatement.parser(Pattern.bindParser, P(defBody ~ maybeSpace ~ padding)).region
-        .map { case (region, DefStatement(nm, args, ret, (body, resFn))) =>
-          { next: Statement =>
-            Def(DefStatement(nm, args, ret, (body, resFn(next))))(region)
-          }
+     val defP: P[Statement] =
+      DefStatement.parser(Pattern.bindParser, defBody ~ toEOL).region
+        .map { case (region, DefStatement(nm, args, ret, body)) =>
+          Def(DefStatement(nm, args, ret, body))(region)
         }
 
      val argParser: P[(Bindable, Option[TypeRef])] =
@@ -191,25 +155,25 @@ object Statement {
 
      val external = {
        val typeParamsList = Parser.nonEmptyListToList(typeParams)
+
        val externalStruct =
-         (P("struct" ~/ spaces ~ Identifier.consParser ~ typeParamsList).region ~ maybeSpace ~ padding).map {
-           case (region, (name, tva), rest) =>
-             { next: Statement => ExternalStruct(name, tva, rest(next))(region) }
+         (P("struct" ~ spaces ~/ Identifier.consParser ~ typeParamsList).region ~ toEOL).map {
+           case (region, (name, tva)) => ExternalStruct(name, tva)(region)
          }
 
        val externalDef = {
          val argParser: P[(Bindable, TypeRef)] = P(Identifier.bindableParser ~ ":" ~/ maybeSpace ~ TypeRef.parser)
          val args = P("(" ~ maybeSpace ~ argParser.nonEmptyList ~ maybeSpace ~ ")")
-         val result = P(maybeSpace ~ "->" ~/ maybeSpace ~ TypeRef.parser ~ maybeSpace)
-         ((P("def" ~ spaces ~/ Identifier.bindableParser ~ args.? ~ result).region) ~ maybeSpace ~ padding)
+         val result = P(maybeSpace ~ "->" ~/ maybeSpace ~ TypeRef.parser)
+         ((P("def" ~ spaces ~/ Identifier.bindableParser ~ args.? ~ result).region) ~ toEOL)
            .map {
-             case (region, (name, optArgs, resType), rest) =>
+             case (region, (name, optArgs, resType)) =>
                val alist = optArgs match {
                  case None => Nil
                  case Some(ne) => ne.toList
                }
 
-               { next: Statement => ExternalDef(name, alist, resType, rest(next))(region) }
+               ExternalDef(name, alist, resType)(region)
            }
        }
 
@@ -217,14 +181,14 @@ object Statement {
      }
 
      val struct =
-       (P("struct" ~ spaces ~/ Identifier.consParser ~ typeParams.? ~ argParser.parensLines1.?).region ~ padding)
-         .map { case (region, (name, typeArgs, argsOpt), rest) =>
+       (P("struct" ~ spaces ~/ Identifier.consParser ~ typeParams.? ~ argParser.parensLines1.?).region ~ toEOL)
+         .map { case (region, (name, typeArgs, argsOpt)) =>
            val argList = argsOpt match {
              case None => Nil
              case Some(ne) => ne.toList
            }
 
-           { next: Statement => Struct(name, typeArgs, argList, rest(next))(region) }
+           Struct(name, typeArgs, argList)(region)
          }
 
      val enum = {
@@ -245,20 +209,21 @@ object Statement {
          .run("")
          .region
 
-       (nameVars ~ padding)
-         .map { case (region, ((ename, typeArgs), vars), rest) =>
-           { next: Statement => Enum(ename, typeArgs, vars, rest(next))(region) }
+       (nameVars ~ toEOL)
+         .map { case (region, ((ename, typeArgs), vars)) =>
+           Enum(ename, typeArgs, vars)(region)
          }
      }
 
-     // bP should come last so there is no ambiguity about identifiers
-     commentP | defP | struct | enum | external | bindingP
+     // bindingP should come last so there is no ambiguity about identifiers
+     commentP | paddingSP | defP | struct | enum | external | bindingP
   }
 
-  val parser: P[Statement] = {
-    val end = P(End).region.map { case (r, _) => EndOfFile()(r) }
-    Parser.chained(item, end)
-  }
+  /**
+   * This parses the *rest* of the string (it must end with End)
+   */
+  val parser: P[List[Statement]] =
+    parser1.rep().map(_.toList) ~ End
 
   private def constructor(name: Constructor, taDoc: Doc, args: List[(Bindable, Option[TypeRef])]): Doc =
     Document[Identifier].document(name) + taDoc +
@@ -273,28 +238,32 @@ object Statement {
         Doc.char('[') + Doc.intercalate(Doc.text(", "), params) + Doc.char(']')
     }
 
+  private implicit val dunit: Document[Unit] = Document.instance[Unit](_ => Doc.empty)
+
   implicit lazy val document: Document[Statement] =
     Document.instance[Statement] {
       case Bind(bs) =>
-        Document[BindingStatement[Pattern.Parsed, Padding[Statement]]].document(bs)
+        Document[BindingStatement[Pattern.Parsed, Unit]].document(bs) + Doc.line
       case Comment(cm) =>
-        Document[CommentStatement[Padding[Statement]]].document(cm)
+        // Comments already end with newline
+        Document[CommentStatement[Unit]].document(cm)
       case Def(d) =>
-        implicit val pair = Document.instance[(OptIndent[Declaration], Padding[Statement])] {
-          case (body, next) =>
+        implicit val pair = Document.instance[OptIndent[Declaration]] {
+          body =>
             body.sepDoc +
-            Document[OptIndent[Declaration]].document(body) +
-              Document[Padding[Statement]].document(next)
-        };
-        DefStatement.document[Pattern.Parsed, (OptIndent[Declaration], Padding[Statement])].document(d)
-      case Struct(nm, typeArgs, args, rest) =>
+            Document[OptIndent[Declaration]].document(body)
+        }
+        DefStatement.document[Pattern.Parsed, OptIndent[Declaration]].document(d) + Doc.line
+      case PaddingStatement(p) =>
+        // this will just be some number of lines
+        Padding.document[Unit].document(p)
+      case Struct(nm, typeArgs, args) =>
         val taDoc = typeArgs match {
           case None => Doc.empty
           case Some(ta) => docTypeArgs(ta.toList)
         }
-        Doc.text("struct ") + constructor(nm, taDoc, args) +
-          Document[Padding[Statement]].document(rest)
-      case Enum(nm, typeArgs, parts, rest) =>
+        Doc.text("struct ") + constructor(nm, taDoc, args) + Doc.line
+      case Enum(nm, typeArgs, parts) =>
         implicit val consDoc = Document.instance[(Constructor, List[(Bindable, Option[TypeRef])])] {
           case (nm, parts) => constructor(nm, Doc.empty, parts)
         }
@@ -318,10 +287,8 @@ object Statement {
 
         Doc.text("enum ") + Document[Constructor].document(nm) + taDoc + Doc.char(':') +
           colonSep +
-          indentedCons +
-          Document[Padding[Statement]].document(rest)
-      case EndOfFile() => Doc.empty
-      case ExternalDef(name, args, res, rest) =>
+          indentedCons + Doc.line
+      case ExternalDef(name, args, res) =>
         val argDoc = args match {
           case Nil => Doc.empty
           case nonEmpty =>
@@ -330,12 +297,15 @@ object Statement {
             })
             Doc.char('(') + da + Doc.char(')')
         }
-        Doc.text("external def ") + Document[Bindable].document(name) + argDoc + Doc.text(" -> ") + res.toDoc +
-          Document[Padding[Statement]].document(rest)
-      case ExternalStruct(nm, targs, rest) =>
+        Doc.text("external def ") + Document[Bindable].document(name) + argDoc + Doc.text(" -> ") + res.toDoc + Doc.line
+      case ExternalStruct(nm, targs) =>
         val argsDoc = docTypeArgs(targs)
-        Doc.text("external struct ") + Document[Constructor].document(nm) + argsDoc +
-          Document[Padding[Statement]].document(rest)
+        Doc.text("external struct ") + Document[Constructor].document(nm) + argsDoc + Doc.line
+    }
+
+  implicit lazy val documentList: Document[List[Statement]] =
+    Document.instance[List[Statement]] { stmts =>
+      Doc.intercalate(Doc.empty, stmts.toList.map(document.document(_)))
     }
 }
 

--- a/core/src/test/scala/org/bykn/bosatsu/DefRecursionCheckTest.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/DefRecursionCheckTest.scala
@@ -3,11 +3,13 @@ package org.bykn.bosatsu
 import cats.data.Validated
 import org.scalatest.FunSuite
 
+import cats.implicits._
+
 class DefRecursionCheckTest extends FunSuite {
 
   def allowed(teStr: String) = {
-    val stmt = TestUtils.statementOf(Predef.packageName, teStr)
-    DefRecursionCheck.checkStatement(stmt) match {
+    val stmt = TestUtils.statementsOf(Predef.packageName, teStr)
+    stmt.traverse_(DefRecursionCheck.checkStatement(_)) match {
       case Validated.Valid(_) => succeed
       case Validated.Invalid(errs) =>
         fail(s"$errs")
@@ -15,8 +17,8 @@ class DefRecursionCheckTest extends FunSuite {
   }
 
   def disallowed(teStr: String) = {
-    val stmt = TestUtils.statementOf(Predef.packageName, teStr)
-    DefRecursionCheck.checkStatement(stmt) match {
+    val stmt = TestUtils.statementsOf(Predef.packageName, teStr)
+    stmt.traverse_(DefRecursionCheck.checkStatement(_)) match {
       case Validated.Valid(_) => fail("expected failure")
       case Validated.Invalid(_) => succeed
     }

--- a/core/src/test/scala/org/bykn/bosatsu/EvaluationTest.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/EvaluationTest.scala
@@ -1877,7 +1877,7 @@ external def foo(x: String) -> List[String]
 def foo(x): x
 
 """), "A") { case s@PackageError.SourceConverterErrorIn(_, _) =>
-      assert(s.message(Map.empty) == "in file: <unknown source>, package A, bind names foo shadow external def\nRegion(57,72)")
+      assert(s.message(Map.empty) == "in file: <unknown source>, package A, bind names foo shadow external def\nRegion(57,71)")
       ()
     }
 
@@ -1890,7 +1890,7 @@ external def foo(x: String) -> List[String]
 foo = 1
 
 """), "A") { case s@PackageError.SourceConverterErrorIn(_, _) =>
-      assert(s.message(Map.empty) == "in file: <unknown source>, package A, bind names foo shadow external def\nRegion(57,66)")
+      assert(s.message(Map.empty) == "in file: <unknown source>, package A, bind names foo shadow external def\nRegion(57,65)")
       ()
     }
 

--- a/core/src/test/scala/org/bykn/bosatsu/FreeVarTest.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/FreeVarTest.scala
@@ -3,7 +3,7 @@ package org.bykn.bosatsu
 import org.scalatest.FunSuite
 import org.scalatest.prop.PropertyChecks.{ forAll, PropertyCheckConfiguration }
 
-import fastparse.all.Parsed
+import fastparse.all._
 
 class FreeVarTest extends FunSuite {
   implicit val generatorDrivenConfig =
@@ -34,7 +34,7 @@ class FreeVarTest extends FunSuite {
 
   test("freeVars is a subset of allNames") {
     forAll(Generators.genStatement(3)) { stmt =>
-      Statement.valuesOf(stmt)
+      Statement.valuesOf(stmt :: Nil)
         .foreach { v =>
           assert(v.freeVars.subsetOf(v.allNames))
         }

--- a/core/src/test/scala/org/bykn/bosatsu/Gen.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/Gen.scala
@@ -619,20 +619,17 @@ object Generators {
       import Statement._
 
       def apply(s: Statement): Stream[Statement] = s match {
-        case EndOfFile() => Stream.empty
         case Bind(bs@BindingStatement(_, d, _)) =>
-          shrinkDecl.shrink(d).flatMap { sd =>
-            Bind(bs.copy(value = sd))(emptyRegion).toStream
+          shrinkDecl.shrink(d).map { sd =>
+            Bind(bs.copy(value = sd))(emptyRegion)
           }
         case Def(ds) =>
-          ds.result match {
-            case (body, Padding(l, in)) =>
-              body.traverse(shrinkDecl.shrink(_))
-                .flatMap { bod =>
-                  apply(in).map { rest => Def(ds.copy(result = (bod, Padding(1, rest))))(emptyRegion) }
-                }
-          }
-        case rest => rest.toStream.tail
+          val body = ds.result
+          body.traverse(shrinkDecl.shrink(_))
+            .map { bod =>
+              Def(ds.copy(result = bod))(emptyRegion)
+            }
+        case rest => Stream.empty
       }
     })
 
@@ -644,58 +641,75 @@ object Generators {
     } yield (name, args)
 
 
-  def genStruct(tail: Gen[Statement]): Gen[Statement] =
-    Gen.zip(constructorGen, Gen.listOf(typeRefVarGen), padding(tail, 1))
-      .map { case ((name, args), ta, rest) =>
-        Statement.Struct(name, NonEmptyList.fromList(ta.distinct), args, rest)(emptyRegion)
+  val genStruct: Gen[Statement] =
+    Gen.zip(constructorGen, Gen.listOf(typeRefVarGen))
+      .map { case ((name, args), ta) =>
+        Statement.Struct(name, NonEmptyList.fromList(ta.distinct), args)(emptyRegion)
       }
 
-  def genExternalStruct(tail: Gen[Statement]): Gen[Statement] =
+  val genExternalStruct: Gen[Statement] =
     for {
       name <- consIdentGen
       argc <- Gen.choose(0, 5)
       args <- Gen.listOfN(argc, typeRefVarGen)
-      rest <- padding(tail, 1)
-    } yield Statement.ExternalStruct(name, args, rest)(emptyRegion)
+    } yield Statement.ExternalStruct(name, args)(emptyRegion)
 
-  def genExternalDef(tail: Gen[Statement]): Gen[Statement] =
+  val genExternalDef: Gen[Statement] =
     for {
       name <- bindIdentGen
       argc <- Gen.choose(0, 5)
       argG = Gen.zip(bindIdentGen, typeRefGen)
       args <- Gen.listOfN(argc, argG)
       res <- typeRefGen
-      rest <- padding(tail, 1)
-    } yield Statement.ExternalDef(name, args, res, rest)(emptyRegion)
+    } yield Statement.ExternalDef(name, args, res)(emptyRegion)
 
-  def genEnum(tail: Gen[Statement]): Gen[Statement] =
+  val genEnum: Gen[Statement] =
     for {
       name <- consIdentGen
       ta <- Gen.listOf(typeRefVarGen)
       consc <- Gen.choose(1, 5)
       i <- Gen.choose(1, 16)
       cons <- optIndent(nonEmptyN(constructorGen, consc))
-      rest <- padding(tail, 1)
-    } yield Statement.Enum(name, NonEmptyList.fromList(ta.distinct), cons, rest)(emptyRegion)
+    } yield Statement.Enum(name, NonEmptyList.fromList(ta.distinct), cons)(emptyRegion)
 
   def genStatement(depth: Int): Gen[Statement] = {
-    val recur = Gen.lzy(genStatement(depth-1))
     val decl = genDeclaration(depth)
     // TODO make more powerful
     val pat: Gen[Pattern.Parsed] = genPattern(1)
     Gen.frequency(
-      (1, bindGen(pat, decl, padding(recur, 1)).map(Statement.Bind(_)(emptyRegion))),
-      (1, commentGen(padding(recur, 1)
-        .map {
-          case Padding(0, c@Statement.Comment(_)) => Padding[Statement](1, c) // make sure not two back to back comments
-          case other => other
-        }).map(Statement.Comment(_)(emptyRegion))),
-      (1, defGen(Gen.zip(optIndent(decl), padding(recur, 1))).map(Statement.Def(_)(emptyRegion))),
-      (1, genStruct(recur)),
-      (1, genExternalStruct(recur)),
-      (1, genExternalDef(recur)),
-      (1, genEnum(recur)),
-      (3, Gen.const(Statement.EndOfFile()(emptyRegion))))
+      (1, bindGen(pat, decl, Gen.const(())).map(Statement.Bind(_)(emptyRegion))),
+      (1, commentGen(Gen.const(())).map(Statement.Comment(_)(emptyRegion))),
+      (1, defGen(optIndent(decl)).map(Statement.Def(_)(emptyRegion))),
+      (1, genStruct),
+      (1, genExternalStruct),
+      (1, genExternalDef),
+      (1, genEnum),
+      (1, padding(Gen.const(()), 1).map(Statement.PaddingStatement(_)(emptyRegion))))
+  }
+
+  def genStatements(depth: Int, maxLength: Int): Gen[List[Statement]] = {
+    import Statement._
+
+    /*
+     * repeated paddings or comments will be combined by parsing
+     * and will never be seen
+     */
+    def combineDuplicates(stmts: List[Statement]): List[Statement] =
+      stmts match {
+        case Nil => Nil
+        case h :: Nil => h :: Nil
+        case PaddingStatement(Padding(a, _)) :: PaddingStatement(Padding(b, _)) :: rest =>
+          combineDuplicates(PaddingStatement(Padding(a + b, ()))(emptyRegion) :: rest)
+        case Comment(CommentStatement(lines1, _)) :: Comment(CommentStatement(lines2, _)) :: rest =>
+          combineDuplicates(Comment(CommentStatement(lines1 ::: lines2, ()))(emptyRegion) :: rest)
+        case h1 :: rest =>
+          h1 :: combineDuplicates(rest)
+      }
+
+    for {
+      cnt <- Gen.choose(0, maxLength)
+      lst <- Gen.listOfN(cnt, Generators.genStatement(depth))
+    } yield combineDuplicates(lst)
   }
 
   val packageNameGen: Gen[PackageName] =
@@ -738,7 +752,7 @@ object Generators {
       ec <- Gen.choose(0, 10)
       imports <- smallList(importGen)
       exports <- Gen.listOfN(ec, exportedNameGen)
-      body <- genStatement(depth)
+      body <- genStatements(depth, 30)
     } yield Package(p, imports, exports, body)
 
 

--- a/core/src/test/scala/org/bykn/bosatsu/Gen.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/Gen.scala
@@ -752,7 +752,7 @@ object Generators {
       ec <- Gen.choose(0, 10)
       imports <- smallList(importGen)
       exports <- Gen.listOfN(ec, exportedNameGen)
-      body <- genStatements(depth, 30)
+      body <- genStatements(depth, 10)
     } yield Package(p, imports, exports, body)
 
 

--- a/core/src/test/scala/org/bykn/bosatsu/rankn/RankNInferTest.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/rankn/RankNInferTest.scala
@@ -1,7 +1,6 @@
 package org.bykn.bosatsu.rankn
 
 import cats.data.{NonEmptyList, Validated}
-import fastparse.all.Parsed
 import org.scalatest.FunSuite
 import org.bykn.bosatsu._
 
@@ -12,6 +11,8 @@ import Type.ForAll
 import TestUtils.checkLast
 
 import Identifier.Constructor
+
+import fastparse.all._
 
 class RankNInferTest extends FunSuite {
 
@@ -140,8 +141,8 @@ class RankNInferTest extends FunSuite {
    */
   def parseProgramIllTyped(statement: String) =
     Statement.parser.parse(statement) match {
-      case Parsed.Success(stmt, _) =>
-        Package.inferBody(PackageName.parts("Test"), Nil, stmt) match {
+      case Parsed.Success(stmts, _) =>
+        Package.inferBody(PackageName.parts("Test"), Nil, stmts) match {
           case Validated.Invalid(_) => assert(true)
           case Validated.Valid(program) =>
             fail("expected an invalid program, but got: " + program.lets.toString)


### PR DESCRIPTION
This refactors a design I've not been happy with: Statement is an ADT with a built in linked list. This creates parsing complications, and also weird ambiguities in that we can never deal with a single statement (but we kind of pretend to by dealing with the head).

This fixes this.