### PR TITLE
Improve Declaration parsing code

### DIFF
--- a/core/src/test/scala/org/bykn/bosatsu/ParserTest.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/ParserTest.scala
@@ -967,7 +967,7 @@ def foo(
   }
 
   test("Any declaration may append any whitespace and optionally a comma and parse") {
-    forAll(Generators.genDeclaration(5), Gen.listOf(Gen.oneOf(' ', '\t')).map(_.mkString), Gen.oneOf(true, false)) {
+    forAll(Generators.genDeclaration(4), Gen.listOf(Gen.oneOf(' ', '\t')).map(_.mkString), Gen.oneOf(true, false)) {
       case (s, ws, comma) =>
         val str = Document[Declaration].document(s).render(80) + ws + (if (comma) "," else "")
         roundTrip(Declaration.parser(""), str, lax = true)


### PR DESCRIPTION
This does not, I believe, improve performance (much?). It just improves the way the code is factored.

There is an ambiguity in the syntax which requires some backtracking it seems around bindings.

```
pattern = decl
```
so, we don't know until we see `=` if the left should parse as a pattern. So, if we parse it as a declaration, we would need to convert it to a pattern, or if we parse it as a pattern, we would need to convert it to a declaration if the `=` is not present.

Relates to #344 