### PR TITLE
Improve Record Declaration Parsing

### DIFF
--- a/core/src/main/scala/org/bykn/bosatsu/BindingStatement.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/BindingStatement.scala
@@ -9,7 +9,7 @@ import org.bykn.fastparse_cats.StringInstances._
 
 import Indy.IndyMethods
 
-case class BindingStatement[B, T](name: B, value: Declaration, in: T)
+case class BindingStatement[B, T](name: B, value: Declaration.NonBinding, in: T)
 
 object BindingStatement {
   private[this] val eqDoc = Doc.text(" = ")
@@ -20,7 +20,7 @@ object BindingStatement {
       Document[A].document(name) + eqDoc + value.toDoc + Document[T].document(in)
     }
 
-  def bindingParser[B, T](parser: Indy[Declaration], rest: Indy[T]): Indy[B => BindingStatement[B, T]] = {
+  def bindingParser[B, T](parser: Indy[Declaration.NonBinding], rest: Indy[T]): Indy[B => BindingStatement[B, T]] = {
     val eqP = P("=" ~ !Operators.multiToksP)
 
     (Indy.lift(P(maybeSpace ~ eqP ~/ maybeSpace)) *> parser)

--- a/core/src/main/scala/org/bykn/bosatsu/Operators.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/Operators.scala
@@ -117,7 +117,7 @@ object Operators {
      */
     def infixOps1[A](p: P[A]): P[A => Formula[A]] = {
       val chain: P[List[(String, A)]] =
-        P(Parser.maybeSpace ~ operatorToken ~ Parser.maybeSpacesAndLines ~ p)
+        P(Parser.maybeSpace ~ operatorToken ~/ Parser.maybeSpacesAndLines ~ p)
           .rep(min = 1)
           .map(_.toList)
 

--- a/core/src/main/scala/org/bykn/bosatsu/Parser.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/Parser.scala
@@ -226,6 +226,13 @@ object Parser {
     def nonEmptyListOfWs(ws: P[Unit], min: Int): P[NonEmptyList[T]] =
       nonEmptyListOfWsSep(ws, P(","), allowTrailing = true, min)
 
+    def maybeAp(fn: P[T => T]): P[T] =
+      (item ~ fn.?)
+        .map {
+          case (a, None) => a
+          case (a, Some(f)) => f(a)
+        }
+
     def nonEmptyListOfWsSep(ws: P[Unit], sep: P[Unit], allowTrailing: Boolean, min: Int): P[NonEmptyList[T]] = {
       require(min >= 1, s"min is too small: $min")
       val wsSep = ws ~ sep ~ ws

--- a/core/src/main/scala/org/bykn/bosatsu/Parser.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/Parser.scala
@@ -134,6 +134,11 @@ object Parser {
   val nonSpaces: P[String] = P(CharsWhile { c => !isSpace(c) }.!)
   val maybeSpace: P[Unit] = spaces.?
 
+  /** prefer to parse Right, then Left
+   */
+  def either[A, B](pb: P[B], pa: P[A]): P[Either[B, A]] =
+    pa.map(Right(_)) | pb.map(Left(_))
+
   def maybeIndentedOrSpace(indent: String): P[Unit] =
     (Parser.spaces | P("\n" ~ indent)).rep().map(_ => ())
 
@@ -261,6 +266,11 @@ object Parser {
     def parensLines1: P[NonEmptyList[T]] = {
       val nel = item.nonEmptyListOfWs(maybeSpacesAndLines, 1)
       P("(" ~ maybeSpacesAndLines ~ nel ~ maybeSpacesAndLines ~ ")")
+    }
+
+    def parensLines1Cut: P[NonEmptyList[T]] = {
+      val nel = item.nonEmptyListOfWs(maybeSpacesAndLines, 1)
+      P("(" ~/ maybeSpacesAndLines ~ nel ~ maybeSpacesAndLines ~ ")")
     }
 
     /**

--- a/core/src/main/scala/org/bykn/bosatsu/SourceConverter.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/SourceConverter.scala
@@ -238,12 +238,13 @@ final class SourceConverter(
                     Expr.Var(pn, Identifier.Constructor("EmptyList"), cond)
                   val ressing = res match {
                     case SpliceOrItem.Item(r) =>
+                      val rdec: Declaration = r
                       // here we lift the result into a a singleton list
                       apply(r).map { ritem =>
                         Expr.App(
-                          Expr.App(Expr.Var(pn, Identifier.Constructor("NonEmptyList"), r), ritem, r),
+                          Expr.App(Expr.Var(pn, Identifier.Constructor("NonEmptyList"), rdec), ritem, rdec),
                           empty,
-                          r)
+                          rdec)
                       }
                     case SpliceOrItem.Splice(r) => apply(r)
                   }

--- a/core/src/main/scala/org/bykn/bosatsu/Statement.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/Statement.scala
@@ -122,7 +122,7 @@ object Statement {
 
      val bindingP: P[Statement] = {
        val bop = BindingStatement
-         .bindingParser[Pattern.Parsed, Unit](Declaration.parser, Indy.lift(toEOL))("")
+         .bindingParser[Pattern.Parsed, Unit](Declaration.nonBindingParser, Indy.lift(toEOL))("")
 
        (Pattern.bindParser ~ bop).region.map { case (region, (p, parseBs)) =>
          val bs = parseBs(p)

--- a/core/src/test/scala/org/bykn/bosatsu/EvaluationTest.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/EvaluationTest.scala
@@ -138,6 +138,23 @@ def run(z):
 main = run(x)
 """), "Foo", Str("good"))
 
+    /*
+     * TODO this should parse correctly
+    evalTest(
+      List("""
+package Foo
+
+enum Res[a, b]: Err(a: a), Good(a:a, b: b)
+
+x = Err("good")
+
+def run(z):
+  Err(y) | Good(y, _) = z
+  y
+
+main = run(x)
+"""), "Foo", Str("good"))
+     */
     evalFail(
       List("""
 package Err

--- a/core/src/test/scala/org/bykn/bosatsu/EvaluationTest.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/EvaluationTest.scala
@@ -138,8 +138,6 @@ def run(z):
 main = run(x)
 """), "Foo", Str("good"))
 
-    /*
-     * TODO this should parse correctly
     evalTest(
       List("""
 package Foo
@@ -154,7 +152,7 @@ def run(z):
 
 main = run(x)
 """), "Foo", Str("good"))
-     */
+
     evalFail(
       List("""
 package Err

--- a/core/src/test/scala/org/bykn/bosatsu/Gen.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/Gen.scala
@@ -224,8 +224,14 @@ object Generators {
     Gen.oneOf(cons, comp).map(Declaration.DictDecl(_)(emptyRegion))
   }
 
+  def varOrParens(decl: Gen[Declaration]): Gen[NonBinding] =
+    decl.map {
+      case v@Declaration.Var(_) => v
+      case notVar => Declaration.Parens(notVar)(emptyRegion)
+    }
+
   def applyGen(decl: Gen[NonBinding]): Gen[NonBinding] =
-    applyGen(decl, decl, Gen.oneOf(true, false))
+    applyGen(varOrParens(decl), decl, Gen.oneOf(true, false))
 
   def isVar(d: Declaration): Boolean =
     d match {

--- a/core/src/test/scala/org/bykn/bosatsu/ParserTest.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/ParserTest.scala
@@ -273,10 +273,12 @@ class ParserTest extends ParserTestBase {
 
   test("we can parse RecordConstructors") {
     def check(str: String) =
-      roundTrip[Declaration](Declaration.recordConstructorP(""), str)
+      roundTrip[Declaration](Declaration.recordConstructorP("", Declaration.parser("")), str)
 
     check("Foo { bar }")
     check("Foo{bar}")
+    check("Foo(bar)")
+    check("Foo(bar\n)")
     check("Foo {   bar   }")
     check("Foo {\nbar\n}")
 
@@ -288,6 +290,7 @@ class ParserTest extends ParserTestBase {
 
     check("Foo { bar, baz }")
     check("Foo{bar,baz}")
+    check("Foo(bar,baz)")
     check("Foo {   bar , baz  }")
     check("Foo {\nbar,\n baz}")
     check("Foo {\nbar\n, baz}")

--- a/core/src/test/scala/org/bykn/bosatsu/ParserTest.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/ParserTest.scala
@@ -664,7 +664,9 @@ x""",
   test("we can parse if") {
     import Declaration._
 
-    val parser0 = ifElseP(varP, Parser.Indy.lift(varP))("")
+    val liftVar = Parser.Indy.lift(varP: P[Declaration])
+    val liftVar0 = Parser.Indy.lift(varP: P[NonBinding])
+    val parser0 = ifElseP(liftVar0, liftVar)("")
 
     roundTrip[Declaration](parser0,
       """if w:
@@ -700,7 +702,9 @@ else: y""")
   }
 
   test("we can parse a match") {
-    roundTrip[Declaration](Declaration.matchP(Declaration.varP, Parser.Indy.lift(Declaration.varP))(""),
+    val liftVar = Parser.Indy.lift(Declaration.varP: P[Declaration])
+    val liftVar0 = Parser.Indy.lift(Declaration.varP: P[Declaration.NonBinding])
+    roundTrip[Declaration](Declaration.matchP(liftVar0, liftVar)(""),
 """match x:
   y:
     z


### PR DESCRIPTION
close #357

This introduces `Declaration.NonBinding` which prevents us from writing code like:
```
x = y = z
f(y)
f(x)
```
which would have confusingly been the same as:
```
f(f(z))
```
