### PR TITLE
Refactor skolemize freevar

### DIFF
--- a/core/src/main/scala/org/bykn/bosatsu/Expr.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/Expr.scala
@@ -6,9 +6,10 @@ package org.bykn.bosatsu
  */
 
 import cats.implicits._
-import cats.data.NonEmptyList
+import cats.data.{Writer, NonEmptyList}
 import cats.{Applicative, Eval, Traverse}
 import scala.collection.immutable.SortedSet
+import org.bykn.bosatsu.rankn.Type
 
 import Identifier.{Bindable, Constructor}
 
@@ -17,14 +18,14 @@ sealed abstract class Expr[T] {
 }
 
 object Expr {
-  case class Annotation[T](expr: Expr[T], tpe: rankn.Type, tag: T) extends Expr[T]
-  case class AnnotatedLambda[T](arg: Bindable, tpe: rankn.Type, expr: Expr[T], tag: T) extends Expr[T]
+  case class Annotation[T](expr: Expr[T], tpe: Type, tag: T) extends Expr[T]
+  case class AnnotatedLambda[T](arg: Bindable, tpe: Type, expr: Expr[T], tag: T) extends Expr[T]
   case class Var[T](pack: Option[PackageName], name: Identifier, tag: T) extends Expr[T]
   case class App[T](fn: Expr[T], arg: Expr[T], tag: T) extends Expr[T]
   case class Lambda[T](arg: Bindable, expr: Expr[T], tag: T) extends Expr[T]
   case class Let[T](arg: Bindable, expr: Expr[T], in: Expr[T], recursive: RecursionKind, tag: T) extends Expr[T]
   case class Literal[T](lit: Lit, tag: T) extends Expr[T]
-  case class Match[T](arg: Expr[T], branches: NonEmptyList[(Pattern[(PackageName, Constructor), rankn.Type], Expr[T])], tag: T) extends Expr[T]
+  case class Match[T](arg: Expr[T], branches: NonEmptyList[(Pattern[(PackageName, Constructor), Type], Expr[T])], tag: T) extends Expr[T]
 
 
   /**
@@ -52,9 +53,9 @@ object Expr {
   /*
    * Allocate these once
    */
-  private[this] val TruePat: Pattern[(PackageName, Constructor), rankn.Type] =
+  private[this] val TruePat: Pattern[(PackageName, Constructor), Type] =
     Pattern.PositionalStruct((Predef.packageName, Constructor("True")), Nil)
-  private[this] val FalsePat: Pattern[(PackageName, Constructor), rankn.Type] =
+  private[this] val FalsePat: Pattern[(PackageName, Constructor), Type] =
     Pattern.PositionalStruct((Predef.packageName, Constructor("False")), Nil)
   /**
    * build a Match expression that is equivalent to if/else using Predef::True and Predef::False
@@ -73,7 +74,7 @@ object Expr {
         buildApp(App(fn, h, appTag), tail, appTag)
     }
 
-  def traverseType[T, F[_]](expr: Expr[T], fn: rankn.Type => F[rankn.Type])(implicit F: Applicative[F]): F[Expr[T]] =
+  def traverseType[T, F[_]](expr: Expr[T], fn: Type => F[Type])(implicit F: Applicative[F]): F[Expr[T]] =
     expr match {
       case Annotation(e, tpe, a) =>
         (traverseType(e, fn), fn(tpe)).mapN(Annotation(_, _, a))
@@ -89,7 +90,7 @@ object Expr {
       case l@Literal(_, _) => F.pure(l)
       case Match(arg, branches, tag) =>
         val argB = traverseType(arg, fn)
-        type B = (Pattern[(PackageName, Constructor), rankn.Type], Expr[T])
+        type B = (Pattern[(PackageName, Constructor), Type], Expr[T])
         def branchFn(b: B): F[B] =
           b match {
             case (pat, expr) =>
@@ -100,6 +101,44 @@ object Expr {
         (argB, branchB).mapN(Match(_, _, tag))
     }
 
+  def substExpr[A](keys: NonEmptyList[Type.Var], vals: NonEmptyList[Type.Rho], expr: Expr[A]): Expr[A] = {
+    val fn = Type.substTy(keys, vals)
+    Expr.traverseType[A, cats.Id](expr, fn)
+  }
+
+  /**
+   * Here we substitute any free bound variables with skolem variables
+   *
+   * This is a deviation from the paper.
+   * We are allowing a syntax like:
+   *
+   * def identity(x: a) -> a:
+   *   x
+   *
+   * or:
+   *
+   * def foo(x: a): x
+   *
+   * We handle this by converting a to a skolem variable,
+   * running inference, then quantifying over that skolem
+   * variable.
+   */
+  def skolemizeFreeVars[F[_]: Applicative, A](expr: Expr[A])(newSkolemTyVar: Type.Var => F[Type.Var.Skolem]): Option[F[(NonEmptyList[Type.Var.Skolem], Expr[A])]] = {
+    val w = Expr.traverseType[A, Writer[List[Type.Var.Bound], ?]](expr, { t =>
+      val frees = Type.freeBoundTyVars(t :: Nil)
+      Writer(frees, t)
+    })
+    val frees = w.written.distinct
+    NonEmptyList.fromList(frees)
+      .map { tvs =>
+        for {
+          skVs <- tvs.traverse(newSkolemTyVar)
+          sksT = skVs.map(Type.TyVar(_))
+          expr1 = substExpr(tvs, sksT, expr)
+        } yield (skVs, expr1)
+      }
+  }
+
   /*
    * We have seen some intermitten CI failures if this isn't lazy
    * presumably due to initialiazation order
@@ -109,8 +148,8 @@ object Expr {
 
       // Traverse on NonEmptyList[(Pattern[_], Expr[?])]
       private lazy val tne = {
-        type Tup[T] = (Pattern[(PackageName, Constructor), rankn.Type], T)
-        type TupExpr[T] = (Pattern[(PackageName, Constructor), rankn.Type], Expr[T])
+        type Tup[T] = (Pattern[(PackageName, Constructor), Type], T)
+        type TupExpr[T] = (Pattern[(PackageName, Constructor), Type], Expr[T])
         val tup: Traverse[TupExpr] = Traverse[Tup].compose(exprTraverse)
         Traverse[NonEmptyList].compose(tup)
       }
@@ -203,7 +242,7 @@ object Expr {
     }
 
   def buildPatternLambda[A](
-    args: NonEmptyList[Pattern[(PackageName, Constructor), rankn.Type]],
+    args: NonEmptyList[Pattern[(PackageName, Constructor), Type]],
     body: Expr[A],
     outer: A): Expr[A] = {
 
@@ -211,7 +250,7 @@ object Expr {
      * compute this once if needed, which is why it is lazy.
      * we don't want to traverse body if it is never needed
      */
-    lazy val anons = rankn.Type
+    lazy val anons = Type
       .allBinders
       .iterator
       .map(_.name)
@@ -219,10 +258,10 @@ object Expr {
       .filterNot(allNames(body) ++ args.toList.flatMap(_.names))
 
     def loop(
-      args: NonEmptyList[Pattern[(PackageName, Constructor), rankn.Type]],
+      args: NonEmptyList[Pattern[(PackageName, Constructor), Type]],
       body: Expr[A]): Expr[A] = {
 
-      def makeBindBody(matchPat: Pattern[(PackageName, Constructor), rankn.Type]): (Bindable, Expr[A]) =
+      def makeBindBody(matchPat: Pattern[(PackageName, Constructor), Type]): (Bindable, Expr[A]) =
         // We don't need to worry about shadowing here
         // because we immediately match the pattern but still this is ugly
         matchPat match {

--- a/core/src/main/scala/org/bykn/bosatsu/rankn/Type.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/rankn/Type.scala
@@ -118,6 +118,15 @@ object Type {
     loop(t, Nil)
   }
 
+  /**
+   * This form is often useful in Infer
+   */
+  def substTy(keys: NonEmptyList[Var], vals: NonEmptyList[Rho]): Type => Type = {
+    val env = keys.toList.iterator.zip(vals.toList.iterator).toMap
+
+    { t => substituteVar(t, env) }
+  }
+
   def substituteVar(t: Type, env: Map[Type.Var, Type]): Type =
     t match {
       case TyApply(on, arg) => TyApply(substituteVar(on, env), substituteVar(arg, env))

--- a/core/src/test/scala/org/bykn/bosatsu/rankn/RankNInferTest.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/rankn/RankNInferTest.scala
@@ -1042,4 +1042,18 @@ struct Foo
 x: Foo = Foo
 """, "Foo")
   }
+
+  test("test inner quantification") {
+    parseProgram("""#
+struct Foo
+
+# this should just be: type Foo
+def foo:
+  # the universal should only apply on the body here
+  #def ident(x: a) -> a: x
+  def ident(x): x
+  ident(Foo)
+
+""", "Foo")
+  }
 }

--- a/core/src/test/scala/org/bykn/bosatsu/rankn/RankNInferTest.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/rankn/RankNInferTest.scala
@@ -1049,7 +1049,8 @@ struct Foo
 
 # this should just be: type Foo
 def foo:
-  # the universal should only apply on the body here
+  # TODO, we would like this test to pass with
+  # the annotations below
   #def ident(x: a) -> a: x
   def ident(x): x
   ident(Foo)


### PR DESCRIPTION
this was an attempt to fix #321 but I couldn't yet get there.

My idea was to not fully skolemize all free variables, but instead look for the lambda patterns and only skolemize the lambdas. This makes it much more complex to see when variables escape. I wonder if this is a misfeature...

Alternatives:

1. only do this for top level declarations.
2. require type annotations like `def foo[a](x: a)` and only quantify over the declared variables.

It seems like we should be able to infer which are free, but more inference is also a double edged sword: it makes more programs type-check that the user might not intend. I'm not sure where the balance is in this case.

skolemizing all free variables for each top-level let is certainly simpler.