### PR TITLE
Add MainModule to generalize the CLI api

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,12 +29,6 @@ matrix:
       env: PLATFORM=jvm
       script: sbt "++ ${TRAVIS_SCALA_VERSION}" coverage coreJVM/test cli/test coverageReport doc && codecov
 
-    - scala: 2.11.12
-      language: scala
-      jdk: openjdk8
-      env: PLATFORM=js
-      script: sbt "++ ${TRAVIS_SCALA_VERSION}" coreJS/test
-
     - scala: 2.12.9
       language: scala
       jdk: openjdk8

--- a/cli/src/main/scala/org/bykn/bosatsu/Main.scala
+++ b/cli/src/main/scala/org/bykn/bosatsu/Main.scala
@@ -1,334 +1,104 @@
 package org.bykn.bosatsu
 
-import cats.data.{Validated, ValidatedNel, NonEmptyList}
 import cats.effect.IO
-import cats.Traverse
-import com.monovore.decline.{Argument, Command, Opts}
-import fastparse.all.P
-import java.nio.file.{Files, Path}
+import com.monovore.decline.Argument
 import org.typelevel.paiges.Doc
 import scala.util.{ Failure, Success, Try }
 
 import cats.implicits._
 
-sealed abstract class MainCommand {
-  def run: IO[Unit]
-}
+object PathModule extends MainModule[IO] {
+  type Path = java.nio.file.Path
 
-object MainCommand {
-  def parseInputs[F[_]: Traverse](paths: F[Path]): IO[ValidatedNel[ParseError, F[((Path, LocationMap), Package.Parsed)]]] =
-    IO(paths.traverse { path =>
-      parseFile(Package.parser, path).map { case (lm, parsed) =>
-        ((path, lm), parsed)
-      }
-    })
+  override def pathArg: Argument[Path] =
+    Argument.readPath
 
-  sealed trait ParseError {
-    def showContext: Option[String] =
-      this match {
-        case ParseError.PartialParse(err, _) =>
-          err.showContext
-        case ParseError.ParseFailure(err, _) =>
-          err.showContext
-        case ParseError.FileError(_, _) =>
-          None
-      }
-  }
+  def readPath(path: Path): IO[String] =
+    IO(new String(java.nio.file.Files.readAllBytes(path), "utf-8"))
 
-  object ParseError {
-     case class PartialParse[A](error: Parser.Error.PartialParse[A], path: Path) extends ParseError
-     case class ParseFailure(error: Parser.Error.ParseFailure, path: Path) extends ParseError
-     case class FileError(readPath: Path, error: Throwable) extends ParseError
-  }
+  def readPackages(paths: List[Path]): IO[List[Package.Typed[Unit]]] =
+    ProtoConverter.readPackages(paths)
 
-  // This is side effecting, so should only be called inside an IO
-  private def parseFile[A](p: P[A], path: Path): ValidatedNel[ParseError, (LocationMap, A)] =
-    Try(new String(Files.readAllBytes(path), "utf-8")) match {
-      case Success(str) => Parser.parse(p, str).leftMap { nel =>
-        nel.map {
-          case pp@Parser.Error.PartialParse(_, _, _) => ParseError.PartialParse(pp, path)
-          case pf@Parser.Error.ParseFailure(_, _) => ParseError.ParseFailure(pf, path)
-        }
-      }
-      case Failure(err) => Validated.invalidNel(ParseError.FileError(path, err))
-    }
+  def readInterfaces(paths: List[Path]): IO[List[Package.Interface]] =
+    ProtoConverter.readInterfaces(paths)
 
-  /**
-   * like typecheck, but a no-op for empty lists
-   */
-  def typeCheck0(inputs: List[Path], ifs: List[Package.Interface]): IO[(PackageMap.Inferred, List[(Path, PackageName)])] =
-    NonEmptyList.fromList(inputs) match {
-      case None =>
-        // we should still return the predef
-        // if it is not in ifs
-        val useInternalPredef =
-          !ifs.contains { p: Package.Interface => p.name == PackageName.PredefName }
+  def writeInterfaces(interfaces: List[Package.Interface], path: Path): IO[Unit] =
+    ProtoConverter.writeInterfaces(interfaces, path)
 
-        if (useInternalPredef) {
-          IO.pure((PackageMap.fromIterable(Predef.predefCompiled :: Nil), Nil))
-        }
+  def writePackages[A](packages: List[Package.Typed[A]], path: Path): IO[Unit] =
+    ProtoConverter.writePackages(packages, path)
+
+  def print(str: => String): IO[Unit] =
+    IO(println(str))
+
+  def reportOutput(out: Output): IO[Unit] =
+    out match {
+      case Output.TestOutput(resMap) =>
+        val noTests = resMap.collect { case (p, None) => p }.toList
+        val results = resMap.collect { case (p, Some(t)) => (p, Test.report(t)) }.toList.sortBy(_._1)
+
+        val failures = results.iterator.map { case (_, (_, f, _)) => f }.sum
+        val success = noTests.isEmpty && (failures == 0)
+        val docRes: Doc =
+          Doc.intercalate(Doc.line,
+            results.map { case (p, (_, _, d)) =>
+              Doc.text(p.asString) + Doc.char(':') + (Doc.lineOrSpace + d).nested(2)
+            })
+
+        if (success) print(docRes.render(80))
         else {
-          IO.pure((PackageMap.empty, Nil))
-        }
-      case Some(nel) => typeCheck(nel, ifs)
-    }
-
-  def typeCheck(inputs: NonEmptyList[Path], ifs: List[Package.Interface]): IO[(PackageMap.Inferred, List[(Path, PackageName)])] =
-    parseInputs(inputs)
-      .flatMap { ins =>
-        // if we have passed in a use supplied predef, don't use the internal one
-        val useInternalPredef = !ifs.contains { p: Package.Interface => p.name == PackageName.PredefName }
-        IO.fromTry {
-          // Now we have completed all IO, here we do all the checks we need for correctness
-          for {
-            packs <- toTry(ins)
-            parsed =
-              if (useInternalPredef) Predef.withPredefA(("predef", LocationMap("")), packs.toList)
-              else Predef.withPredefImportsA(packs.toList)
-            (dups, resPacks) = PackageMap.resolveThenInfer(parsed, ifs)
-            _ <- checkDuplicatePackages(dups)(_._1.toString)
-            map = PackageMap.buildSourceMap(packs)
-            p <- fromPackageError(map, resPacks)
-            pathToName: List[(Path, PackageName)] = packs.map { case ((path, _), p) => (path, p.name) }.toList
-          } yield (p, pathToName)
-        }
-      }
-
-  def buildPackMap(srcs: List[Path], deps: List[Path]): IO[PackageMap.Typed[Any]] =
-    ProtoConverter
-      .readPackages(deps)
-      .flatMap { packs =>
-        val ifaces = packs.map(Package.interfaceOf(_))
-        typeCheck0(srcs, ifaces)
-          .map { case (thesePacks, _) =>
-            packs.foldLeft(PackageMap.toAnyTyped(thesePacks))(_ + _)
-          }
-      }
-
-  case class Evaluate(inputs: List[Path], mainPackage: PackageName, deps: List[Path]) extends MainCommand {
-    def run =
-      buildPackMap(inputs.toList, deps)
-        .flatMap { packs =>
-          val ev = Evaluation(packs, Predef.jvmExternals)
-          ev.evaluateLast(mainPackage) match {
-            case None => IO.raiseError(new Exception("found no main expression"))
-            case Some((eval, scheme)) =>
-              IO {
-                val res = eval.value
-                println(s"$res: $scheme")
-              }
-          }
-        }
-  }
-  case class ToJson(inputs: List[Path], deps: List[Path], mainPackage: PackageName, output: Path) extends MainCommand {
-    def checkEmpty =
-      if (inputs.isEmpty && deps.isEmpty) IO.raiseError(new Exception("no test sources or test dependencies"))
-      else IO.unit
-
-    def run = checkEmpty *> buildPackMap(inputs.toList, deps)
-      .flatMap { packs =>
-        val ev = Evaluation(packs, Predef.jvmExternals)
-        ev.evaluateLast(mainPackage) match {
-          case None =>
-            IO.raiseError(new Exception("found no main expression"))
-          case Some((eval, scheme)) =>
-            val res = eval.value
-            ev.toJson(res, scheme) match {
-              case None =>
-                IO.raiseError(new Exception(
-                  s"cannot convert type to Json: $scheme"))
-              case Some(j) =>
-                CodeGenWrite.writeDoc(output, j.toDoc)
+          val missingDoc =
+            if (noTests.isEmpty) Nil
+            else {
+              val prefix = Doc.text("packages with missing tests: ")
+              val missingDoc = Doc.intercalate(Doc.lineOrSpace, noTests.sorted.map { p => Doc.text(p.asString) })
+              (prefix + missingDoc.nested(2)) :: Nil
             }
+
+          val fullOut = Doc.intercalate(Doc.line + Doc.text("#######") + Doc.line, docRes :: missingDoc)
+
+          val failureStr =
+            if (failures == 1) "1 test failure"
+            else s"$failures test failures"
+
+          val missingCount = noTests.size
+          val excepMessage =
+            if (missingCount > 0) {
+              val packString = if (missingCount == 1) "package" else "packages"
+              s"$failureStr and $missingCount $packString with no tests found"
+            }
+            else failureStr
+
+          print(fullOut.render(80)) *> IO.raiseError(new Exception(excepMessage))
         }
-      }
-  }
-  case class TypeCheck(inputs: NonEmptyList[Path], ifaces: List[Path], output: Path, ifout: Option[Path]) extends MainCommand {
-    def run =
-      ProtoConverter
-        .readInterfaces(ifaces)
-        .flatMap(typeCheck(inputs, _))
-        .flatMap { case (packs, _) =>
-          val packList =
-            packs.toMap
-              .iterator
-              .map { case (_, p) => p }
-              // TODO currently we recompile predef in every run, so every interface includes
-              // predef, we filter that out
-              .filter(_.name != PackageName.PredefName)
-              .toList
-              .sortBy(_.name)
-
-          val ifres = ifout match {
-            case None =>
-              IO.unit
-            case Some(ifacePath) =>
-              val ifs = packList.map(Package.interfaceOf(_))
-              ProtoConverter.writeInterfaces(ifs, ifacePath)
-          }
-          val out = ProtoConverter.writePackages(packList, output)
-
-          ifres *> out
-      }
-  }
-
-  case class RunTests(tests: List[Path], testPacks: List[PackageName], dependencies: List[Path]) extends MainCommand {
-    def run = {
-      if (tests.isEmpty && dependencies.isEmpty) {
-        IO.raiseError(new Exception("no test sources or test dependencies"))
-      }
-      else {
-        val typeChecked =
-          for {
-            deps <- ProtoConverter.readPackages(dependencies)
-            ifaces = deps.map(Package.interfaceOf(_))
-            pn <- typeCheck0(tests, ifaces)
-            (packs0, nameMap) = pn
-            // add the dependencies into the package map
-            packs = deps.foldLeft(PackageMap.toAnyTyped(packs0))(_ + _)
-          } yield (packs, nameMap)
-
-        typeChecked.flatMap { case (packs, nameMap) =>
-          val testSet = tests.toSet
-          val testPackages: List[PackageName] =
-            (nameMap.iterator.collect { case (p, name) if testSet(p) => name } ++
-              testPacks.iterator).toList.sorted.distinct
-          val ev = Evaluation(packs, Predef.jvmExternals)
-          val resMap = testPackages.map { p => (p, ev.evalTest(p)) }
-          val noTests = resMap.collect { case (p, None) => p }.toList
-          val results = resMap.collect { case (p, Some(t)) => (p, Test.report(t)) }.toList.sortBy(_._1)
-
-          val failures = results.iterator.map { case (_, (_, f, _)) => f }.sum
-          val success = noTests.isEmpty && (failures == 0)
-          val docRes: Doc =
-            Doc.intercalate(Doc.line,
-              results.map { case (p, (_, _, d)) =>
-                Doc.text(p.asString) + Doc.char(':') + (Doc.lineOrSpace + d).nested(2)
-              })
-
-          if (success) IO(println(docRes.render(80)))
-          else {
-            val missingDoc =
-              if (noTests.isEmpty) Nil
-              else {
-                val prefix = Doc.text("packages with missing tests: ")
-                val missingDoc = Doc.intercalate(Doc.lineOrSpace, noTests.sorted.map { p => Doc.text(p.asString) })
-                (prefix + missingDoc.nested(2)) :: Nil
-              }
-
-            val fullOut = Doc.intercalate(Doc.line + Doc.text("#######") + Doc.line, docRes :: missingDoc)
-
-            val failureStr =
-              if (failures == 1) "1 test failure"
-              else s"$failures test failures"
-
-            val missingCount = noTests.size
-            val excepMessage =
-              if (missingCount > 0) {
-                val packString = if (missingCount == 1) "package" else "packages"
-                s"$failureStr and $missingCount $packString with no tests found"
-              }
-              else failureStr
-
-            IO(println(fullOut.render(80))) *> IO.raiseError(new Exception(excepMessage))
-          }
+      case Output.EvaluationResult(res, tpe) =>
+        IO.suspend {
+          val r = res.value
+          print(s"$res: $tpe")
         }
-      }
-    }
-  }
+      case Output.JsonOutput(json, path) =>
+        CodeGenWrite.writeDoc(path, json.toDoc)
 
-  def errors(msgs: List[String]): Try[Nothing] =
-    Failure(new Exception(msgs.mkString("\n######\n")))
-
-  def toTry[A](v: ValidatedNel[ParseError, A]): Try[A] =
-    v match {
-      case Validated.Valid(a) => Success(a)
-      case Validated.Invalid(errs) =>
-        val msgs = errs.toList.flatMap {
-          case ParseError.PartialParse(pp, path) =>
-            // we should never be partial here
-            val (r, c) = pp.locations.toLineCol(pp.position).get
-            val ctx = pp.locations.showContext(pp.position).get
-            List(s"failed to parse completely $path at line ${r + 1}, column ${c + 1}",
-                ctx.toString)
-          case ParseError.ParseFailure(pf, path) =>
-            // we should never be partial here
-            val (r, c) = pf.locations.toLineCol(pf.position).get
-            val ctx = pf.locations.showContext(pf.position).get
-            List(s"failed to parse $path at line ${r + 1}, column ${c + 1}",
-                ctx.toString)
-          case ParseError.FileError(path, err) =>
-            List(s"failed to parse $path",
-                err.getMessage,
-                err.getClass.toString)
+      case Output.CompileOut(packList, ifout, output) =>
+        val ifres = ifout match {
+          case None =>
+            IO.unit
+          case Some(ifacePath) =>
+            val ifs = packList.map(Package.interfaceOf(_))
+            writeInterfaces(ifs, ifacePath)
         }
-      errors(msgs)
+        val out = writePackages(packList, output)
+
+        (ifres *> out)
     }
-
-  def fromPackageError[A](sourceMap: Map[PackageName, (LocationMap, String)], v: ValidatedNel[PackageError, A]): Try[A] =
-    v match {
-      case Validated.Invalid(errs) => errors(errs.map(_.message(sourceMap)).toList)
-      case Validated.Valid(a) => Success(a)
-    }
-
-  def checkDuplicatePackages[A](dups: Map[PackageName, ((A, Package.Parsed), NonEmptyList[(A, Package.Parsed)])])(fn: A => String): Try[Unit] =
-    if (dups.isEmpty) Success(())
-    else
-      errors(
-        dups.iterator.map { case (pname, ((src, _), nelist)) =>
-          val dupsrcs = (fn(src) :: nelist.map { case (s, _) => fn(s) }.toList).sorted.mkString(", ")
-          s"package ${pname.asString} duplicated in $dupsrcs"
-        }.toList
-      )
-
-  val opts: Opts[MainCommand] = {
-    implicit val argPack: Argument[PackageName] =
-      new Argument[PackageName] {
-        def defaultMetavar: String = "packageName"
-        def read(string: String): ValidatedNel[String, PackageName] =
-          PackageName.parse(string) match {
-            case Some(pn) => Validated.valid(pn)
-            case None => Validated.invalidNel(s"could not parse $string as a package name. Must be capitalized strings separated by /")
-          }
-      }
-
-    def toList[A](neo: Opts[NonEmptyList[A]]): Opts[List[A]] = {
-      neo.orNone.map {
-        case None => Nil
-        case Some(ne) => ne.toList
-      }
-    }
-
-    val ins = Opts.options[Path]("input", help = "input files")
-    val ifaces = toList(Opts.options[Path]("interface", help = "interface files"))
-    val includes = toList(Opts.options[Path]("include", help = "compiled packages to include files"))
-
-    val mainP = Opts.option[PackageName]("main", help = "main package to evaluate")
-    val testP = toList(Opts.options[PackageName]("test_package", help = "package for which to run tests"))
-    val outputPath = Opts.option[Path]("output", help = "output path")
-    val interfaceOutputPath = Opts.option[Path]("interface_out", help = "interface output path")
-    val compileRoot = Opts.option[Path]("compile_root", help = "root directory to write java output")
-
-    val evalOpt = (toList(ins), mainP, includes).mapN(Evaluate(_, _, _))
-    val toJsonOpt = (toList(ins), includes, mainP, outputPath).mapN(ToJson(_, _, _, _))
-    val typeCheckOpt = (ins, ifaces, outputPath, interfaceOutputPath.orNone).mapN(TypeCheck(_, _, _, _))
-    val testOpt = (toList(ins), testP, includes).mapN(RunTests(_, _, _))
-
-    Opts.subcommand("eval", "evaluate an expression and print the output")(evalOpt)
-      .orElse(Opts.subcommand("write-json", "evaluate a data expression into json")(toJsonOpt))
-      .orElse(Opts.subcommand("type-check", "type check a set of packages")(typeCheckOpt))
-      .orElse(Opts.subcommand("test", "test a set of bosatsu modules")(testOpt))
-  }
 }
 
 object Main {
-  def command: Command[MainCommand] =
-    Command("bosatsu", "a total and functional programming language")(MainCommand.opts)
-
   def main(args: Array[String]): Unit =
-    command.parse(args.toList) match {
-      case Right(cmd) =>
-        Try(cmd.run.unsafeRunSync) match {
+    PathModule.run(args.toList) match {
+      case Right(out) =>
+        val run = out.flatMap(PathModule.reportOutput(_))
+        Try(run.unsafeRunSync) match {
           case Failure(err) =>
             // TODO use some verbosity flag to modulate this
             //err.printStackTrace

--- a/core/src/main/scala/org/bykn/bosatsu/MainModule.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/MainModule.scala
@@ -1,0 +1,313 @@
+package org.bykn.bosatsu
+
+import cats.arrow.FunctionK
+import cats.data.{Validated, ValidatedNel, NonEmptyList}
+import cats.{Eval, Traverse, MonadError}
+import com.monovore.decline.{Argument, Command, Help, Opts}
+import fastparse.all.P
+import scala.util.{ Failure, Success, Try }
+
+import cats.implicits._
+
+/**
+ * This is an implementation of the CLI tool where Path is abstracted.
+ * The idea is to allow it to be testable and usable in scalajs where
+ * we don't have file-IO
+ */
+abstract class MainModule[IO[_]](implicit val moduleIOMonad: MonadError[IO, Throwable]) {
+  type Path
+
+  implicit def pathArg: Argument[Path]
+
+  def readPath(p: Path): IO[String]
+
+  def readPackages(paths: List[Path]): IO[List[Package.Typed[Unit]]]
+
+  def readInterfaces(paths: List[Path]): IO[List[Package.Interface]]
+
+  //////////////////////////////
+  // Below here are concrete and should not use override
+  //////////////////////////////
+
+  final def run(args: List[String]): Either[Help, IO[Output]] =
+    MainCommand.command
+      .parse(args.toList)
+      .map(_.run)
+
+  sealed abstract class Output
+  object Output {
+    case class TestOutput(tests: List[(PackageName, Option[Test])]) extends Output
+    case class EvaluationResult(value: Eval[Value], tpe: rankn.Type) extends Output
+    case class JsonOutput(json: Json, output: Path) extends Output
+    case class CompileOut(packList: List[Package.Typed[Any]], ifout: Option[Path], output: Path) extends Output
+  }
+
+  sealed abstract class MainCommand {
+    def run: IO[Output]
+  }
+
+  object MainCommand {
+    def parseInputs[F[_]: Traverse](paths: F[Path]): IO[ValidatedNel[ParseError, F[((Path, LocationMap), Package.Parsed)]]] =
+      // we use IO(traverse) so we can accumulate all the errors in parallel easily
+      // if do this with parseFile returning an IO, we need to do IO.Par[Validated[...]]
+      // and use the composed applicative... too much work for the same result
+      paths.traverse { path =>
+        parseFile(Package.parser, path).map(_.map { case (lm, parsed) =>
+          ((path, lm), parsed)
+        })
+      }
+      .map(_.sequence)
+
+    sealed trait ParseError {
+      def showContext: Option[String] =
+        this match {
+          case ParseError.PartialParse(err, _) =>
+            err.showContext
+          case ParseError.ParseFailure(err, _) =>
+            err.showContext
+          case ParseError.FileError(_, _) =>
+            None
+        }
+    }
+
+    object ParseError {
+       case class PartialParse[A](error: Parser.Error.PartialParse[A], path: Path) extends ParseError
+       case class ParseFailure(error: Parser.Error.ParseFailure, path: Path) extends ParseError
+       case class FileError(readPath: Path, error: Throwable) extends ParseError
+    }
+
+    def parseFile[A](p: P[A], path: Path): IO[ValidatedNel[ParseError, (LocationMap, A)]] =
+      readPath(path)
+        .attempt
+        .map {
+          case Right(str) => Parser.parse(p, str).leftMap { nel =>
+            nel.map {
+              case pp@Parser.Error.PartialParse(_, _, _) => ParseError.PartialParse(pp, path)
+              case pf@Parser.Error.ParseFailure(_, _) => ParseError.ParseFailure(pf, path)
+            }
+          }
+          case Left(err) => Validated.invalidNel(ParseError.FileError(path, err))
+        }
+
+    /**
+     * like typecheck, but a no-op for empty lists
+     */
+    def typeCheck0(inputs: List[Path], ifs: List[Package.Interface]): IO[(PackageMap.Inferred, List[(Path, PackageName)])] =
+      NonEmptyList.fromList(inputs) match {
+        case None =>
+          // we should still return the predef
+          // if it is not in ifs
+          val useInternalPredef =
+            !ifs.contains { p: Package.Interface => p.name == PackageName.PredefName }
+
+          if (useInternalPredef) {
+            moduleIOMonad.pure((PackageMap.fromIterable(Predef.predefCompiled :: Nil), Nil))
+          }
+          else {
+            moduleIOMonad.pure((PackageMap.empty, Nil))
+          }
+        case Some(nel) => typeCheck(nel, ifs)
+      }
+
+    def typeCheck(inputs: NonEmptyList[Path], ifs: List[Package.Interface]): IO[(PackageMap.Inferred, List[(Path, PackageName)])] =
+      parseInputs(inputs)
+        .flatMap { ins =>
+          moduleIOMonad.fromTry {
+            // Now we have completed all IO, here we do all the checks we need for correctness
+            toTry(ins)
+              .flatMap { packs =>
+                val map = PackageMap.buildSourceMap(packs)
+                val liftError = Lambda[FunctionK[ValidatedNel[PackageError, ?], Try]](fromPackageError(map, _))
+                // TODO, we could use applicative, to report both duplicate packages and the other
+                // errors
+                PackageMap.typeCheckParsed(packs, ifs, "predef", liftError)(checkDuplicatePackages(_)(_._1.toString))
+                  .map { p =>
+                    val pathToName: List[(Path, PackageName)] =
+                      packs.map { case ((path, _), p) => (path, p.name) }.toList
+                    (p, pathToName)
+                  }
+              }
+          }
+        }
+
+    def buildPackMap(srcs: List[Path], deps: List[Path]): IO[PackageMap.Typed[Any]] =
+      readPackages(deps)
+        .flatMap { packs =>
+          val ifaces = packs.map(Package.interfaceOf(_))
+          typeCheck0(srcs, ifaces)
+            .map { case (thesePacks, _) =>
+              packs.foldLeft(PackageMap.toAnyTyped(thesePacks))(_ + _)
+            }
+        }
+
+    case class Evaluate(inputs: List[Path], mainPackage: PackageName, deps: List[Path]) extends MainCommand {
+      def run =
+        buildPackMap(inputs.toList, deps)
+          .flatMap { packs =>
+            val ev = Evaluation(packs, Predef.jvmExternals)
+            ev.evaluateLast(mainPackage) match {
+              case None => moduleIOMonad.raiseError(new Exception("found no main expression"))
+              case Some((eval, tpe)) =>
+                moduleIOMonad.pure(Output.EvaluationResult(eval, tpe))
+            }
+          }
+    }
+
+    case class ToJson(inputs: List[Path], deps: List[Path], mainPackage: PackageName, output: Path) extends MainCommand {
+      def checkEmpty =
+        if (inputs.isEmpty && deps.isEmpty) moduleIOMonad.raiseError(new Exception("no test sources or test dependencies"))
+        else moduleIOMonad.unit
+
+      def run = checkEmpty *> buildPackMap(inputs.toList, deps)
+        .flatMap { packs =>
+          val ev = Evaluation(packs, Predef.jvmExternals)
+          ev.evaluateLast(mainPackage) match {
+            case None =>
+              moduleIOMonad.raiseError(new Exception("found no main expression"))
+            case Some((eval, scheme)) =>
+              val res = eval.value
+              ev.toJson(res, scheme) match {
+                case None =>
+                  moduleIOMonad.raiseError(new Exception(
+                    s"cannot convert type to Json: $scheme"))
+                case Some(j) =>
+                  moduleIOMonad.pure(Output.JsonOutput(j, output))
+              }
+          }
+        }
+    }
+    case class TypeCheck(inputs: NonEmptyList[Path], ifaces: List[Path], output: Path, ifout: Option[Path]) extends MainCommand {
+      def run =
+        readInterfaces(ifaces)
+          .flatMap(typeCheck(inputs, _))
+          .map { case (packs, _) =>
+            val packList =
+              packs.toMap
+                .iterator
+                .map { case (_, p) => p }
+                // TODO currently we recompile predef in every run, so every interface includes
+                // predef, we filter that out
+                .filter(_.name != PackageName.PredefName)
+                .toList
+                .sortBy(_.name)
+
+            Output.CompileOut(packList, ifout, output)
+          }
+    }
+
+    case class RunTests(tests: List[Path], testPacks: List[PackageName], dependencies: List[Path]) extends MainCommand {
+      def run = {
+        if (tests.isEmpty && dependencies.isEmpty) {
+          moduleIOMonad.raiseError(new Exception("no test sources or test dependencies"))
+        }
+        else {
+          val typeChecked =
+            for {
+              deps <- readPackages(dependencies)
+              ifaces = deps.map(Package.interfaceOf(_))
+              pn <- typeCheck0(tests, ifaces)
+              (packs0, nameMap) = pn
+              // add the dependencies into the package map
+              packs = deps.foldLeft(PackageMap.toAnyTyped(packs0))(_ + _)
+            } yield (packs, nameMap)
+
+          typeChecked.map { case (packs, nameMap) =>
+            val testSet = tests.toSet
+            val testPackages: List[PackageName] =
+              (nameMap.iterator.collect { case (p, name) if testSet(p) => name } ++
+                testPacks.iterator).toList.sorted.distinct
+            val ev = Evaluation(packs, Predef.jvmExternals)
+            Output.TestOutput(testPackages.map { p => (p, ev.evalTest(p)) })
+          }
+        }
+      }
+    }
+
+    def errors(msgs: List[String]): Try[Nothing] =
+      Failure(new Exception(msgs.mkString("\n######\n")))
+
+    def toTry[A](v: ValidatedNel[ParseError, A]): Try[A] =
+      v match {
+        case Validated.Valid(a) => Success(a)
+        case Validated.Invalid(errs) =>
+          val msgs = errs.toList.flatMap {
+            case ParseError.PartialParse(pp, path) =>
+              // we should never be partial here
+              val (r, c) = pp.locations.toLineCol(pp.position).get
+              val ctx = pp.locations.showContext(pp.position).get
+              List(s"failed to parse completely $path at line ${r + 1}, column ${c + 1}",
+                  ctx.toString)
+            case ParseError.ParseFailure(pf, path) =>
+              // we should never be partial here
+              val (r, c) = pf.locations.toLineCol(pf.position).get
+              val ctx = pf.locations.showContext(pf.position).get
+              List(s"failed to parse $path at line ${r + 1}, column ${c + 1}",
+                  ctx.toString)
+            case ParseError.FileError(path, err) =>
+              List(s"failed to parse $path",
+                  err.getMessage,
+                  err.getClass.toString)
+          }
+        errors(msgs)
+      }
+
+    def fromPackageError[A](sourceMap: Map[PackageName, (LocationMap, String)], v: ValidatedNel[PackageError, A]): Try[A] =
+      v match {
+        case Validated.Invalid(errs) => errors(errs.map(_.message(sourceMap)).toList)
+        case Validated.Valid(a) => Success(a)
+      }
+
+    def checkDuplicatePackages[A](dups: Map[PackageName, ((A, Package.Parsed), NonEmptyList[(A, Package.Parsed)])])(fn: A => String): Try[Unit] =
+      if (dups.isEmpty) Success(())
+      else
+        errors(
+          dups.iterator.map { case (pname, ((src, _), nelist)) =>
+            val dupsrcs = (fn(src) :: nelist.map { case (s, _) => fn(s) }.toList).sorted.mkString(", ")
+            s"package ${pname.asString} duplicated in $dupsrcs"
+          }.toList
+        )
+
+    val opts: Opts[MainCommand] = {
+      implicit val argPack: Argument[PackageName] =
+        new Argument[PackageName] {
+          def defaultMetavar: String = "packageName"
+          def read(string: String): ValidatedNel[String, PackageName] =
+            PackageName.parse(string) match {
+              case Some(pn) => Validated.valid(pn)
+              case None => Validated.invalidNel(s"could not parse $string as a package name. Must be capitalized strings separated by /")
+            }
+        }
+
+      def toList[A](neo: Opts[NonEmptyList[A]]): Opts[List[A]] = {
+        neo.orNone.map {
+          case None => Nil
+          case Some(ne) => ne.toList
+        }
+      }
+
+      val ins = Opts.options[Path]("input", help = "input files")
+      val ifaces = toList(Opts.options[Path]("interface", help = "interface files"))
+      val includes = toList(Opts.options[Path]("include", help = "compiled packages to include files"))
+
+      val mainP = Opts.option[PackageName]("main", help = "main package to evaluate")
+      val testP = toList(Opts.options[PackageName]("test_package", help = "package for which to run tests"))
+      val outputPath = Opts.option[Path]("output", help = "output path")
+      val interfaceOutputPath = Opts.option[Path]("interface_out", help = "interface output path")
+      val compileRoot = Opts.option[Path]("compile_root", help = "root directory to write java output")
+
+      val evalOpt = (toList(ins), mainP, includes).mapN(Evaluate(_, _, _))
+      val toJsonOpt = (toList(ins), includes, mainP, outputPath).mapN(ToJson(_, _, _, _))
+      val typeCheckOpt = (ins, ifaces, outputPath, interfaceOutputPath.orNone).mapN(TypeCheck(_, _, _, _))
+      val testOpt = (toList(ins), testP, includes).mapN(RunTests(_, _, _))
+
+      Opts.subcommand("eval", "evaluate an expression and print the output")(evalOpt)
+        .orElse(Opts.subcommand("write-json", "evaluate a data expression into json")(toJsonOpt))
+        .orElse(Opts.subcommand("type-check", "type check a set of packages")(typeCheckOpt))
+        .orElse(Opts.subcommand("test", "test a set of bosatsu modules")(testOpt))
+    }
+
+    def command: Command[MainCommand] =
+      Command("bosatsu", "a total and functional programming language")(opts)
+  }
+
+}

--- a/core/src/test/scala/org/bykn/bosatsu/TestUtils.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/TestUtils.scala
@@ -1,7 +1,7 @@
 package org.bykn.bosatsu
 
+import cats.data.{Kleisli, Validated}
 import org.bykn.bosatsu.rankn._
-import cats.data.Validated
 import org.scalatest.{Assertion, Assertions}
 
 import fastparse.all.Parsed
@@ -80,60 +80,95 @@ object TestUtils {
         fail(s"failed to parse: $statement: $exp at $idx with trace: ${extra.traced.trace}")
     }
 
-  sealed abstract class EvaluationMode[A] {
-    def expected: A
-  }
-  object EvaluationMode {
-    case class JsonMode(expected: Json) extends EvaluationMode[Json]
-    case class EvalMode(expected: Value) extends EvaluationMode[Value]
-    case class TestMode(expected: Int) extends EvaluationMode[Int]
-  }
+  /**
+   * This is mock MainModule that uses Int as Paths and reads them out of the vector input
+   */
+  class TestModule(inputs: Vector[String]) extends MainModule[Kleisli[Either[Throwable, ?], Vector[String], ?]] {
+    type Path = Int
 
-  def evalTest(packages: List[String], mainPackS: String, expected: Value, extern: Externals = Externals.empty) =
-    evalTestMode(packages, mainPackS, EvaluationMode.EvalMode(expected), extern)
+    val get: Int => Option[String] = inputs.lift
 
-  def evalTestJson(packages: List[String], mainPackS: String, expected: Json, extern: Externals = Externals.empty) =
-    evalTestMode(packages, mainPackS, EvaluationMode.JsonMode(expected), extern)
+    type IO[A] = Kleisli[Either[Throwable, ?], Vector[String], A]
 
-  def runBosatsuTest(packages: List[String], mainPackS: String, assertionCount: Int, extern: Externals = Externals.empty) =
-    evalTestMode(packages, mainPackS, EvaluationMode.TestMode(assertionCount), extern)
+    val pathArg = com.monovore.decline.Argument.readInt
 
-  def evalTestMode[A](packages: List[String], mainPackS: String, expected: EvaluationMode[A], extern: Externals = Externals.empty) = {
-    def inferredHandler(packMap: PackageMap.Inferred, mainPack: PackageName): Assertion = {
-      val ev = Evaluation(packMap, Predef.jvmExternals ++ extern)
-      // Make sure all the typed expressions are valid (no Metas/Skolems)
-      packMap.toMap.values.foreach { pack =>
-        pack.program.lets.foreach { case (_, _, te) => assertValid(te) }
+    def readPath(p: Path): IO[String] =
+      get(p) match {
+        case None => moduleIOMonad.raiseError(new Exception(s"invalid index: $p, length: ${inputs.size}"))
+        case Some(str) => moduleIOMonad.pure(str)
       }
-      //if (mainPackS == "A") println(ev.repr)
-      ev.evaluateLast(mainPack) match {
-        case None => fail("found no main expression")
-        case Some((eval, schm)) =>
-          val typeStr = TypeRef.fromTypes(Some(mainPack), schm :: Nil)(schm).toDoc.render(80)
-          expected match {
-            case EvaluationMode.EvalMode(exp) =>
-              val left = eval.value
-              assert(left == exp,
-                s"failed: for type: $typeStr, ${left} != $exp")
-              succeed
-            case EvaluationMode.JsonMode(json) =>
-              val leftJson = ev.toJson(eval.value, schm)
-              assert(leftJson == Some(json), s"type: $typeStr, $leftJson != $json")
-              succeed
-            case EvaluationMode.TestMode(cnt) =>
-              ev.evalTest(mainPack) match {
-                case None => fail(s"$mainPack had no tests evaluted")
-                case Some(t) =>
-                  assert(t.assertions == cnt, s"${t.assertions} == $cnt")
-                  val (suc, failcount, message) = Test.report(t)
-                  assert(t.failures.map(_.assertions).getOrElse(0) == failcount)
-                  if (failcount > 0) fail(message.render(80))
-                  else succeed
-              }
-          }
+
+    def readPackages(paths: List[Path]): IO[List[Package.Typed[Unit]]] =
+      paths match {
+        case Nil => moduleIOMonad.pure(Nil)
+        case _ =>
+          moduleIOMonad.raiseError(new Exception(s"no packages available: ${paths}"))
       }
+
+    def readInterfaces(paths: List[Path]): IO[List[Package.Interface]] =
+      paths match {
+        case Nil => moduleIOMonad.pure(Nil)
+        case _ =>
+          moduleIOMonad.raiseError(new Exception(s"no interfaces available: ${paths}"))
+      }
+
+
+    def apply(cmd: List[String]): Either[Throwable, Output] =
+      run(cmd) match {
+        case Left(_) => Left(new Exception(s"got the help message for: $cmd"))
+        case Right(io) => io.run(inputs)
+      }
+  }
+
+  def evalTest(packages: List[String], mainPackS: String, expected: Value) = {
+    val module = new TestModule(packages.toVector)
+
+    val args = packages.zipWithIndex.flatMap { case (_, idx) => List("--input", idx.toString) }
+    module("eval" :: "--main" :: mainPackS :: args) match {
+      case Right(module.Output.EvaluationResult(got, _)) =>
+        assert(got.value == expected, s"${got.value} != $expected")
+      case Right(other) =>
+        fail(s"got an unexpected success: $other")
+      case Left(err) =>
+        fail(s"got an exception: $err")
     }
-    testInferred(packages, mainPackS, inferredHandler(_, _))
+  }
+
+  def evalTestJson(packages: List[String], mainPackS: String, expected: Json) = {
+    val module = new TestModule(packages.toVector)
+
+    val args = packages.zipWithIndex.flatMap { case (_, idx) => List("--input", idx.toString) }
+    module("write-json" :: "--main" :: mainPackS :: "--output" :: "-1" :: args) match {
+      case Right(module.Output.JsonOutput(got, _)) =>
+        assert(got == expected, s"$got != $expected")
+      case Right(other) =>
+        fail(s"got an unexpected success: $other")
+      case Left(err) =>
+        fail(s"got an exception: $err")
+    }
+  }
+
+  def runBosatsuTest(packages: List[String], mainPackS: String, assertionCount: Int) = {
+    val module = new TestModule(packages.toVector)
+
+    val args = packages.zipWithIndex.flatMap { case (_, idx) => List("--input", idx.toString) }
+    module("test" :: "--test_package" :: mainPackS :: args) match {
+      case Right(module.Output.TestOutput(results)) =>
+        results match {
+          case (_, Some(t)) :: Nil =>
+            assert(t.assertions == assertionCount, s"${t.assertions} != $assertionCount")
+            val (suc, failcount, message) = Test.report(t)
+            assert(t.failures.map(_.assertions).getOrElse(0) == failcount)
+            if (failcount > 0) fail(message.render(80))
+            else succeed
+          case other =>
+            fail(s"expected exactly one test result, got: $other")
+        }
+      case Right(other) =>
+        fail(s"got an unexpected success: $other")
+      case Left(err) =>
+        fail(s"got an exception: $err")
+    }
   }
 
   def testInferred(packages: List[String], mainPackS: String, inferredHandler: (PackageMap.Inferred, PackageName) => Assertion ) = {


### PR DESCRIPTION
I am working towards having a javascript API. The approach is to expose functions that match the CLI.

This PR takes all the IO work in the main method and abstracts it. Then we can share parsing a `List[String]` into a command to run.

This also helps us improve test coverage (once we use this) since we can exercise the same paths.

I will change the TestUtils to call MainModule to run tests, evaluate, and run bosatsu tests.