### PR TITLE
Try again on the deploy front

### DIFF
--- a/elmui/build.sh
+++ b/elmui/build.sh
@@ -1,9 +1,11 @@
 #!/bin/bash
+set -e
 
 if [ ! -z "$TRAVIS" ]
 then
   # install elm on travis
   npm install -g elm
+  echo "About to set up deploy key"
   echo $DEPLOY_TRAVIS | base64 -d > bosatsu_deploy_key
 fi
 


### PR DESCRIPTION
the setup for the deploy key was broken, but ssh rather than reporting a bad key, just waits for a passphrase. IMO, using `ssh -i` on an identity it can't parse should be fatal.
