### PR TITLE
Move interop code from js to elm

### DIFF
--- a/bench/src/main/scala/org/bykn/bosatsu/TestBench.scala
+++ b/bench/src/main/scala/org/bykn/bosatsu/TestBench.scala
@@ -21,7 +21,7 @@ class TestBench {
       case Validated.Valid(vs) => vs
       case Validated.Invalid(errs) =>
         errs.toList.foreach { p =>
-          p.showContext.foreach(System.err.println)
+          p.showContext(LocationMap.Colorize.none).foreach(System.err.println)
         }
         sys.error("failed to parse") //errs.toString)
     }

--- a/core/src/main/scala/org/bykn/bosatsu/Package.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/Package.scala
@@ -11,6 +11,7 @@ import rankn._
 import Parser.{spaces, maybeSpace, Combinators}
 
 import FixType.Fix
+import LocationMap.Colorize
 /**
  * Represents a package over its life-cycle: from parsed to resolved to inferred
  */
@@ -246,8 +247,9 @@ object Package {
   }
 }
 
+
 sealed abstract class PackageError {
-  def message(sourceMap: Map[PackageName, (LocationMap, String)]): String
+  def message(sourceMap: Map[PackageName, (LocationMap, String)], errColor: Colorize): String
 
   protected def getMapSrc(sourceMap: Map[PackageName, (LocationMap, String)], pack: PackageName): (LocationMap, String) =
     sourceMap.get(pack) match {
@@ -279,7 +281,7 @@ object PackageError {
   case class UnknownExport[A](ex: ExportedName[A],
     in: PackageName,
     lets: List[(Identifier.Bindable, RecursionKind, TypedExpr[Declaration])]) extends PackageError {
-    def message(sourceMap: Map[PackageName, (LocationMap, String)]) = {
+    def message(sourceMap: Map[PackageName, (LocationMap, String)], errColor: Colorize) = {
       val (lm, sourceName) = getMapSrc(sourceMap, in)
       val header =
         s"in $sourceName unknown export ${ex.name}"
@@ -300,14 +302,14 @@ object PackageError {
   }
 
   case class UnknownImportPackage[A, B, C](pack: PackageName, from: Package[PackageName, A, B, C]) extends PackageError {
-    def message(sourceMap: Map[PackageName, (LocationMap, String)]) = {
+    def message(sourceMap: Map[PackageName, (LocationMap, String)], errColor: Colorize) = {
       val (_, sourceName) = getMapSrc(sourceMap, from.name)
       s"in $sourceName package ${from.name.asString} imports unknown package ${pack.asString}"
     }
   }
 
   case class DuplicatedImport(duplicates: NonEmptyList[(PackageName, ImportedName[Unit])]) extends PackageError {
-    def message(sourceMap: Map[PackageName, (LocationMap, String)]) =
+    def message(sourceMap: Map[PackageName, (LocationMap, String)], errColor: Colorize) =
       duplicates.sortBy(_._2.localName)
         .toList
         .iterator
@@ -324,7 +326,7 @@ object PackageError {
     importing: Package.Inferred,
     iname: ImportedName[A],
     exports: List[ExportedName[B]]) extends PackageError {
-      def message(sourceMap: Map[PackageName, (LocationMap, String)]) = {
+      def message(sourceMap: Map[PackageName, (LocationMap, String)], errColor: Colorize) = {
         val ls = importing
           .program
           .lets
@@ -349,7 +351,7 @@ object PackageError {
     importing: Package.Interface,
     iname: ImportedName[A],
     exports: List[ExportedName[B]]) extends PackageError {
-      def message(sourceMap: Map[PackageName, (LocationMap, String)]) = {
+      def message(sourceMap: Map[PackageName, (LocationMap, String)], errColor: Colorize) = {
 
         val (_, sourceName) = getMapSrc(sourceMap, in)
         val exportMap = importing.exports.map { e => (e.name, ()) }.toMap
@@ -361,7 +363,7 @@ object PackageError {
     }
 
   case class CircularDependency[A, B, C](from: Package[PackageName, A, B, C], path: NonEmptyList[PackageName]) extends PackageError {
-    def message(sourceMap: Map[PackageName, (LocationMap, String)]) = {
+    def message(sourceMap: Map[PackageName, (LocationMap, String)], errColor: Colorize) = {
       val packs = from.name :: (path.toList)
       val msg = packs.map { p =>
         val (_, src) = getMapSrc(sourceMap, p)
@@ -373,35 +375,39 @@ object PackageError {
   }
 
   case class CircularType[A](from: PackageName, path: NonEmptyList[rankn.DefinedType[A]]) extends PackageError {
-    def message(sourceMap: Map[PackageName, (LocationMap, String)]) = {
+    def message(sourceMap: Map[PackageName, (LocationMap, String)], errColor: Colorize) = {
       s"circular types in ${from.asString} " + path.toList.reverse.map(_.name.ident.asString).mkString(" -> ")
     }
   }
 
   case class VarianceInferenceFailure(from: PackageName, failed: NonEmptyList[rankn.DefinedType[Unit]]) extends PackageError {
-    def message(sourceMap: Map[PackageName, (LocationMap, String)]) = {
+    def message(sourceMap: Map[PackageName, (LocationMap, String)], errColor: Colorize) = {
       s"failed to infer variance in ${from.asString} of " + failed.toList.map(_.name.ident.asString).sorted.mkString(", ")
     }
   }
 
   case class TypeErrorIn(tpeErr: Infer.Error, pack: PackageName) extends PackageError {
-    def message(sourceMap: Map[PackageName, (LocationMap, String)]) = {
+    def message(sourceMap: Map[PackageName, (LocationMap, String)], errColor: Colorize) = {
       val (lm, sourceName) = getMapSrc(sourceMap, pack)
       val teMessage = tpeErr match {
         case Infer.Error.NotUnifiable(t0, t1, r0, r1) =>
           val context0 =
-            if (r0 == r1) " " // sometimes the region of the error is the same on right and left
+            if (r0 == r1) Doc.space // sometimes the region of the error is the same on right and left
             else {
-              val m = lm.showRegion(r0).getOrElse(r0.toString) // we should highlight the whole region
-              s"\n$m\n"
+              val m = lm.showRegion(r0, 2, errColor).getOrElse(Doc.str(r0)) // we should highlight the whole region
+              Doc.hardLine + m + Doc.hardLine
             }
           val context1 =
-            lm.showRegion(r1).getOrElse(r1.toString) // we should highlight the whole region
+            lm.showRegion(r1, 2, errColor).getOrElse(Doc.str(r1)) // we should highlight the whole region
 
           val tmap = showTypes(pack, List(t0, t1))
-          s"type error: expected type ${tmap(t0)}${context0}to be the same as type ${tmap(t1)}\n$context1"
+          val doc = Doc.text("type error: expected type ") + Doc.text(tmap(t0)) +
+            context0 + Doc.text("to be the same as type ") + Doc.text(tmap(t1)) +
+            Doc.hardLine + context1
+
+          doc.render(80)
         case Infer.Error.VarNotInScope((pack, name), scope, region) =>
-          val ctx = lm.showRegion(region).getOrElse(region.toString)
+          val ctx = lm.showRegion(region, 2, errColor).getOrElse(Doc.str(region))
           val candidates: List[String] =
             nearest(name, scope.map { case ((_, n), _) => (n, ()) }, 3)
               .map { case (n, _) => n.asString }
@@ -410,19 +416,24 @@ object PackageError {
             if (candidates.nonEmpty) candidates.mkString("\nClosest: ", ", ", ".\n")
             else ""
           val qname = "\"" + name.sourceCodeRepr + "\""
-          s"name $qname unknown.$cmessage\n$ctx"
+          (Doc.text("name ") + Doc.text(qname) + Doc.text(" unknown.") + Doc.text(cmessage) + Doc.hardLine +
+            ctx).render(80)
         case Infer.Error.SubsumptionCheckFailure(t0, t1, r0, r1, tvs) =>
           val context0 =
-            if (r0 == r1) " " // sometimes the region of the error is the same on right and left
+            if (r0 == r1) Doc.space // sometimes the region of the error is the same on right and left
             else {
-              val m = lm.showRegion(r0).getOrElse(r0.toString) // we should highlight the whole region
-              s"\n$m\n"
+              val m = lm.showRegion(r0, 2, errColor).getOrElse(Doc.str(r0)) // we should highlight the whole region
+              Doc.hardLine + m + Doc.hardLine
             }
           val context1 =
-            lm.showRegion(r1).getOrElse(r1.toString) // we should highlight the whole region
+            lm.showRegion(r1, 2, errColor).getOrElse(Doc.str(r1)) // we should highlight the whole region
 
           val tmap = showTypes(pack, List(t0, t1))
-          s"type ${tmap(t0)}${context0}does not subsume type ${tmap(t1)}\n$context1"
+          val doc = Doc.text("type ") + Doc.text(tmap(t0)) + context0 +
+            Doc.text("does not subsume type ") + Doc.text(tmap(t1)) + Doc.hardLine +
+            context1
+
+          doc.render(80)
         case uc@Infer.Error.UnknownConstructor((p, n), region, _) =>
           val near = nearest(n, uc.knownConstructors.map { case (_, n) => (n, ()) }.toMap, 3)
             .map { case (n, _) => n.asString }
@@ -432,9 +443,11 @@ object PackageError {
             else near.mkString(", nearest: ", ", ", "")
 
           val context =
-            lm.showRegion(region).getOrElse(region.toString) // we should highlight the whole region
+            lm.showRegion(region, 2, errColor).getOrElse(Doc.str(region)) // we should highlight the whole region
 
-          s"unknown constructor ${n.asString}$nearStr" + "\n" + context
+          val doc = Doc.text("unknown constructor ") + Doc.text(n.asString) +
+            Doc.text(nearStr) + Doc.hardLine + context
+          doc.render(80)
         case err => err.message
       }
       // TODO use the sourceMap/regiouns in Infer.Error
@@ -443,27 +456,30 @@ object PackageError {
   }
 
   case class SourceConverterErrorIn(err: SourceConverter.Error, pack: PackageName) extends PackageError {
-    def message(sourceMap: Map[PackageName, (LocationMap, String)]) = {
+    def message(sourceMap: Map[PackageName, (LocationMap, String)], errColor: Colorize) = {
       val (lm, sourceName) = getMapSrc(sourceMap, pack)
       val msg = {
         val context =
-          lm.showRegion(err.region).getOrElse(err.region.toString) // we should highlight the whole region
+          lm.showRegion(err.region, 2, errColor)
+            .getOrElse(Doc.str(err.region)) // we should highlight the whole region
 
-        err.message + "\n" + context
+        Doc.text(err.message) + Doc.hardLine + context
       }
-      s"in file: $sourceName, package ${pack.asString}, $msg"
+      val doc = Doc.text("in file: ") + Doc.text(sourceName) + Doc.text(", package ") + Doc.text(pack.asString) +
+        Doc.text(", ") + msg
+
+      doc.render(80)
     }
   }
 
   case class TotalityCheckError(pack: PackageName, err: TotalityCheck.ExprError[Declaration]) extends PackageError {
-    def message(sourceMap: Map[PackageName, (LocationMap, String)]) = {
+    def message(sourceMap: Map[PackageName, (LocationMap, String)], errColor: Colorize) = {
       val (lm, sourceName) = getMapSrc(sourceMap, pack)
       val region = err.matchExpr.tag.region
       val context1 =
-        lm.showRegion(region).getOrElse(region.toString) // we should highlight the whole region
+        lm.showRegion(region, 2, errColor).getOrElse(Doc.str(region)) // we should highlight the whole region
       val teMessage = err match {
         case TotalityCheck.NonTotalMatch(_, missing) =>
-          import Identifier.Constructor
           val allTypes = missing.traverse(_.traverseType { t => Writer(Chain.one(t), ()) })
             .run._1.toList.distinct
           val showT = showTypes(pack, allTypes)
@@ -471,35 +487,40 @@ object PackageError {
           val doc = Pattern.compiledDocument(Document.instance[Type] { t =>
             Doc.text(showT(t))
           })
-          def showPat(p: Pattern[(PackageName, Constructor), Type]): String =
-            doc.document(p).render(80)
 
-          "non-total match, missing: " +
+          Doc.text("non-total match, missing: ") +
             (Doc.intercalate(Doc.char(',') + Doc.lineOrSpace,
-              missing.toList.map(doc.document(_)))).render(80)
+              missing.toList.map(doc.document(_))))
         case TotalityCheck.InvalidPattern(_, err) =>
           import TotalityCheck._
           err match {
             case ArityMismatch((_, n), _, _, exp, found) =>
-              s"arity mismatch: ${n.asString} expected $exp parameters, found $found"
+              Doc.text(s"arity mismatch: ${n.asString} expected $exp parameters, found $found")
             case UnknownConstructor((_, n), _, _) =>
-              s"unknown constructor: ${n.asString}"
+              Doc.text(s"unknown constructor: ${n.asString}")
             case MultipleSplicesInPattern(_, _) =>
-              "multiple splices in pattern, only one per match allowed"
+              Doc.text("multiple splices in pattern, only one per match allowed")
           }
       }
       // TODO use the sourceMap/regions in Infer.Error
-      s"in file: $sourceName, package ${pack.asString}\n$context1\n$teMessage"
+      val doc = Doc.text(s"in file: $sourceName, package ${pack.asString}") + Doc.hardLine +
+        context1 + Doc.hardLine + teMessage
+
+      doc.render(80)
     }
   }
 
   case class RecursionError(pack: PackageName, err: DefRecursionCheck.RecursionError) extends PackageError {
-    def message(sourceMap: Map[PackageName, (LocationMap, String)]) = {
+    def message(sourceMap: Map[PackageName, (LocationMap, String)], errColor: Colorize) = {
       val (lm, sourceName) = getMapSrc(sourceMap, pack)
-      val ctx = lm.showRegion(err.region).getOrElse(err.region.toString) // we should highlight the whole region
+      val ctx = lm.showRegion(err.region, 2, errColor)
+        .getOrElse(Doc.str(err.region)) // we should highlight the whole region
       val errMessage = err.message
       // TODO use the sourceMap/regions in RecursionError
-      s"in file: $sourceName, package ${pack.asString}, $errMessage\n$ctx\n"
+      val doc = Doc.text(s"in file: $sourceName, package ${pack.asString}, $errMessage") +
+        Doc.hardLine + ctx + Doc.hardLine
+
+      doc.render(80)
     }
   }
 }

--- a/core/src/main/scala/org/bykn/bosatsu/Parser.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/Parser.scala
@@ -2,6 +2,7 @@ package org.bykn.bosatsu
 
 import cats.data.{Kleisli, Validated, ValidatedNel, NonEmptyList}
 import fastparse.all._
+import org.typelevel.paiges.Doc
 
 import org.bykn.fastparse_cats.StringInstances._
 import cats.implicits._
@@ -74,12 +75,12 @@ object Parser {
   }
 
   sealed trait Error {
-    def showContext: Option[String] =
+    def showContext(errColor: LocationMap.Colorize): Option[Doc] =
       this match {
         case Error.PartialParse(_, pos, locations) =>
-          locations.showContext(pos)
+          locations.showContext(pos, 2, errColor)
         case Error.ParseFailure(pos, locations) =>
-          locations.showContext(pos)
+          locations.showContext(pos, 2, errColor)
       }
   }
 

--- a/core/src/main/scala/org/bykn/bosatsu/Predef.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/Predef.scala
@@ -28,7 +28,7 @@ object Predef {
       case Parsed.Success(pack, _) => pack
       case Parsed.Failure(exp, idx, extra) =>
         val lm = LocationMap(predefString)
-        sys.error(s"couldn't parse predef: ${lm.showContext(idx)} with trace: ${extra.traced.trace}")
+        sys.error(s"couldn't parse predef: ${lm.showContext(idx, 2, LocationMap.Colorize.none)} with trace: ${extra.traced.trace}")
     }
 
   /**

--- a/core/src/test/scala/org/bykn/bosatsu/EvaluationTest.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/EvaluationTest.scala
@@ -4,6 +4,8 @@ import org.scalatest.FunSuite
 
 import Value._
 
+import LocationMap.Colorize
+
 class EvaluationTest extends FunSuite {
 
   import TestUtils._
@@ -181,7 +183,7 @@ main = go(IntCase(42))
 """
     val packs = Map((PackageName.parts("Err"), (LocationMap(errPack), "Err.bosatsu")))
     evalFail(List(errPack), "Err") { case te@PackageError.TypeErrorIn(_, _) =>
-      val msg = te.message(packs)
+      val msg = te.message(packs, Colorize.none)
       assert(msg.contains("type error: expected type Bosatsu/Predef::Int to be the same as type Bosatsu/Predef::String"))
       ()
     }
@@ -1232,7 +1234,7 @@ main = a"""), "B") { case PackageError.UnknownImportPackage(_, _) => () }
 package B
 
 main = a"""), "B") { case te@PackageError.TypeErrorIn(_, _) =>
-    val msg = te.message(Map.empty)
+    val msg = te.message(Map.empty, Colorize.none)
     assert(!msg.contains("Name("))
     assert(msg.contains("package B, name \"a\" unknown"))
     ()
@@ -1247,7 +1249,7 @@ x = 1
 main = match x:
   Foo: 2
 """), "B") { case te@PackageError.SourceConverterErrorIn(_, _) =>
-    val msg = te.message(Map.empty)
+    val msg = te.message(Map.empty, Colorize.none)
     assert(!msg.contains("Name("))
     assert(msg.contains("package B, unknown constructor Foo"))
     ()
@@ -1262,7 +1264,7 @@ struct X
 main = match 1:
   X1: 0
 """), "B") { case te@PackageError.SourceConverterErrorIn(_, _) =>
-      val b = assert(te.message(Map.empty) == "in file: <unknown source>, package B, unknown constructor X1\nRegion(44,45)")
+      val b = assert(te.message(Map.empty, Colorize.none) == "in file: <unknown source>, package B, unknown constructor X1\nRegion(44,45)")
       ()
     }
 
@@ -1274,7 +1276,7 @@ main = match [1, 2, 3]:
   []: 0
   [*a, _, *b]: 2
 """), "A") { case te@PackageError.TotalityCheckError(_, _) =>
-      val b = assert(te.message(Map.empty) == "in file: <unknown source>, package A\nRegion(19,60)\nmultiple splices in pattern, only one per match allowed")
+      val b = assert(te.message(Map.empty, Colorize.none) == "in file: <unknown source>, package A\nRegion(19,60)\nmultiple splices in pattern, only one per match allowed")
       ()
     }
 
@@ -1287,7 +1289,7 @@ enum Foo: Bar(a), Baz(b)
 main = match Bar(a):
   Baz(b): b
 """), "A") { case te@PackageError.TotalityCheckError(_, _) =>
-      val b = assert(te.message(Map.empty) == "in file: <unknown source>, package A\nRegion(45,70)\nnon-total match, missing: Bar(_)")
+      val b = assert(te.message(Map.empty, Colorize.none) == "in file: <unknown source>, package A\nRegion(45,70)\nnon-total match, missing: Bar(_)")
       ()
     }
 
@@ -1301,7 +1303,7 @@ def fn(x):
 
 main = fn
 """), "A") { case te@PackageError.RecursionError(_, _) =>
-      val b = assert(te.message(Map.empty) == "in file: <unknown source>, package A, recur but no recursive call to fn\nRegion(25,42)\n")
+      val b = assert(te.message(Map.empty, Colorize.none) == "in file: <unknown source>, package A, recur but no recursive call to fn\nRegion(25,42)\n")
       ()
     }
 
@@ -1315,7 +1317,7 @@ def fn(x):
 
 main = fn
 """), "A") { case te@PackageError.RecursionError(_, _) =>
-      val b = assert(te.message(Map.empty) == "in file: <unknown source>, package A, recur not on an argument to the def of fn, args: x\nRegion(25,43)\n")
+      val b = assert(te.message(Map.empty, Colorize.none) == "in file: <unknown source>, package A, recur not on an argument to the def of fn, args: x\nRegion(25,43)\n")
       ()
     }
 
@@ -1329,7 +1331,7 @@ def fn(x):
 
 main = fn
 """), "A") { case te@PackageError.RecursionError(_, _) =>
-      val b = assert(te.message(Map.empty) == "in file: <unknown source>, package A, recur not on an argument to the def of fn, args: x\nRegion(25,42)\n")
+      val b = assert(te.message(Map.empty, Colorize.none) == "in file: <unknown source>, package A, recur not on an argument to the def of fn, args: x\nRegion(25,42)\n")
       ()
     }
 
@@ -1345,7 +1347,7 @@ def fn(x):
 
 main = fn
 """), "A") { case te@PackageError.RecursionError(_, _) =>
-      val b = assert(te.message(Map.empty) == "in file: <unknown source>, package A, unexpected recur: may only appear unnested inside a def\nRegion(47,70)\n")
+      val b = assert(te.message(Map.empty, Colorize.none) == "in file: <unknown source>, package A, unexpected recur: may only appear unnested inside a def\nRegion(47,70)\n")
       ()
     }
 
@@ -1362,7 +1364,7 @@ def fn(x):
 
 main = fn
 """), "A") { case te@PackageError.RecursionError(_, _) =>
-      val b = assert(te.message(Map.empty) == "in file: <unknown source>, package A, illegal shadowing on: fn. Recursive shadowing of def names disallowed\nRegion(25,81)\n")
+      val b = assert(te.message(Map.empty, Colorize.none) == "in file: <unknown source>, package A, illegal shadowing on: fn. Recursive shadowing of def names disallowed\nRegion(25,81)\n")
       ()
     }
 
@@ -1377,7 +1379,7 @@ def fn(x, y):
 
 main = fn
 """), "A") { case te@PackageError.RecursionError(_, _) =>
-      val b = assert(te.message(Map.empty) == "in file: <unknown source>, package A, invalid recursion on fn\nRegion(53,69)\n")
+      val b = assert(te.message(Map.empty, Colorize.none) == "in file: <unknown source>, package A, invalid recursion on fn\nRegion(53,69)\n")
       ()
     }
 
@@ -1394,7 +1396,7 @@ import A [ fooz ]
 
 baz = fooz
 """), "B") { case te@PackageError.UnknownImportName(_, _, _, _) =>
-      val b = assert(te.message(Map.empty) == "in <unknown source> package: A does not have name fooz. Nearest: foo")
+      val b = assert(te.message(Map.empty, Colorize.none) == "in <unknown source> package: A does not have name fooz. Nearest: foo")
       ()
     }
 
@@ -1412,7 +1414,7 @@ import A [ bar ]
 
 baz = bar
 """), "B") { case te@PackageError.UnknownImportName(_, _, _, _) =>
-      val b = assert(te.message(Map.empty) == "in <unknown source> package: A has bar but it is not exported. Add to exports")
+      val b = assert(te.message(Map.empty, Colorize.none) == "in <unknown source> package: A has bar but it is not exported. Add to exports")
       ()
     }
   }
@@ -1702,7 +1704,7 @@ get = \Pair(first, ...) -> first
 # missing second
 first = 1
 res = get(Pair { first })
-"""), "A") { case s@PackageError.SourceConverterErrorIn(_, _) => s.message(Map.empty); () }
+"""), "A") { case s@PackageError.SourceConverterErrorIn(_, _) => s.message(Map.empty, Colorize.none); () }
 
     evalFail(
       List("""
@@ -1716,7 +1718,7 @@ get = \Pair(first, ...) -> first
 first = 1
 second = 3
 res = get(Pair { first, second, third })
-"""), "A") { case s@PackageError.SourceConverterErrorIn(_, _) => s.message(Map.empty); () }
+"""), "A") { case s@PackageError.SourceConverterErrorIn(_, _) => s.message(Map.empty, Colorize.none); () }
 
     evalFail(
       List("""
@@ -1727,7 +1729,7 @@ struct Pair(first, second)
 get = \Pair { first } -> first
 
 res = get(Pair(1, "two"))
-"""), "A") { case s@PackageError.SourceConverterErrorIn(_, _) => s.message(Map.empty); () }
+"""), "A") { case s@PackageError.SourceConverterErrorIn(_, _) => s.message(Map.empty, Colorize.none); () }
 
     evalFail(
       List("""
@@ -1739,7 +1741,7 @@ struct Pair(first, second)
 get = \Pair(first) -> first
 
 res = get(Pair(1, "two"))
-"""), "A") { case s@PackageError.SourceConverterErrorIn(_, _) => s.message(Map.empty); () }
+"""), "A") { case s@PackageError.SourceConverterErrorIn(_, _) => s.message(Map.empty, Colorize.none); () }
 
     evalFail(
       List("""
@@ -1751,7 +1753,7 @@ struct Pair(first, second)
 get = \Pair { first, sec: _ } -> first
 
 res = get(Pair(1, "two"))
-"""), "A") { case s@PackageError.SourceConverterErrorIn(_, _) => s.message(Map.empty); () }
+"""), "A") { case s@PackageError.SourceConverterErrorIn(_, _) => s.message(Map.empty, Colorize.none); () }
 
     evalFail(
       List("""
@@ -1763,7 +1765,7 @@ struct Pair(first, second)
 get = \Pair { first, sec: _, ... } -> first
 
 res = get(Pair(1, "two"))
-"""), "A") { case s@PackageError.SourceConverterErrorIn(_, _) => s.message(Map.empty); () }
+"""), "A") { case s@PackageError.SourceConverterErrorIn(_, _) => s.message(Map.empty, Colorize.none); () }
 
     evalFail(
       List("""
@@ -1775,7 +1777,7 @@ struct Pair(first, second)
 get = \Pair(first, _, _) -> first
 
 res = get(Pair(1, "two"))
-"""), "A") { case s@PackageError.SourceConverterErrorIn(_, _) => s.message(Map.empty); () }
+"""), "A") { case s@PackageError.SourceConverterErrorIn(_, _) => s.message(Map.empty, Colorize.none); () }
 
     evalFail(
       List("""
@@ -1787,7 +1789,7 @@ struct Pair(first, second)
 get = \Pair(first, _, _, ...) -> first
 
 res = get(Pair(1, "two"))
-"""), "A") { case s@PackageError.SourceConverterErrorIn(_, _) => s.message(Map.empty); () }
+"""), "A") { case s@PackageError.SourceConverterErrorIn(_, _) => s.message(Map.empty, Colorize.none); () }
   }
 
   test("test scoping bug (issue #311)") {
@@ -1892,7 +1894,7 @@ external def foo(x: String) -> List[String]
 def foo(x): x
 
 """), "A") { case s@PackageError.SourceConverterErrorIn(_, _) =>
-      assert(s.message(Map.empty) == "in file: <unknown source>, package A, bind names foo shadow external def\nRegion(57,71)")
+      assert(s.message(Map.empty, Colorize.none) == "in file: <unknown source>, package A, bind names foo shadow external def\nRegion(57,71)")
       ()
     }
 
@@ -1905,7 +1907,7 @@ external def foo(x: String) -> List[String]
 foo = 1
 
 """), "A") { case s@PackageError.SourceConverterErrorIn(_, _) =>
-      assert(s.message(Map.empty) == "in file: <unknown source>, package A, bind names foo shadow external def\nRegion(57,65)")
+      assert(s.message(Map.empty, Colorize.none) == "in file: <unknown source>, package A, bind names foo shadow external def\nRegion(57,65)")
       ()
     }
 
@@ -1917,7 +1919,7 @@ external def foo(x: String) -> List[String]
 
 external def foo(x: String) -> List[String]
 """), "A") { case s@PackageError.SourceConverterErrorIn(_, _) =>
-      assert(s.message(Map.empty) == "in file: <unknown source>, package A, foo defined multiple times\nRegion(21,55)")
+      assert(s.message(Map.empty, Colorize.none) == "in file: <unknown source>, package A, foo defined multiple times\nRegion(21,55)")
       ()
     }
   }
@@ -1947,7 +1949,7 @@ struct Foo[a](a)
 
 main = Foo(1, "2")
 """), "Err") { case sce@PackageError.SourceConverterErrorIn(_, _) =>
-      assert(sce.message(Map.empty) == "in file: <unknown source>, package Err, Foo found declared: [a], not a superset of [anon0]\nRegion(14,30)")
+      assert(sce.message(Map.empty, Colorize.none) == "in file: <unknown source>, package Err, Foo found declared: [a], not a superset of [anon0]\nRegion(14,30)")
       ()
     }
 
@@ -1959,7 +1961,7 @@ struct Foo[a](a: a, b: b)
 
 main = Foo(1, "2")
 """), "Err") { case sce@PackageError.SourceConverterErrorIn(_, _) =>
-      assert(sce.message(Map.empty) == "in file: <unknown source>, package Err, Foo found declared: [a], not a superset of [a, b]\nRegion(14,39)")
+      assert(sce.message(Map.empty, Colorize.none) == "in file: <unknown source>, package Err, Foo found declared: [a], not a superset of [a, b]\nRegion(14,39)")
       ()
     }
 
@@ -1971,7 +1973,7 @@ enum Enum[a]: Foo(a)
 
 main = Foo(1, "2")
 """), "Err") { case sce@PackageError.SourceConverterErrorIn(_, _) =>
-      assert(sce.message(Map.empty) == "in file: <unknown source>, package Err, Enum found declared: [a], not a superset of [anon0]\nRegion(14,34)")
+      assert(sce.message(Map.empty, Colorize.none) == "in file: <unknown source>, package Err, Enum found declared: [a], not a superset of [anon0]\nRegion(14,34)")
       ()
     }
 
@@ -1983,7 +1985,7 @@ enum Enum[a]: Foo(a: a), Bar(a: b)
 
 main = Foo(1, "2")
 """), "Err") { case sce@PackageError.SourceConverterErrorIn(_, _) =>
-      assert(sce.message(Map.empty) == "in file: <unknown source>, package Err, Enum found declared: [a], not a superset of [a, b]\nRegion(14,48)")
+      assert(sce.message(Map.empty, Colorize.none) == "in file: <unknown source>, package Err, Enum found declared: [a], not a superset of [a, b]\nRegion(14,48)")
       ()
     }
   }

--- a/core/src/test/scala/org/bykn/bosatsu/TestUtils.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/TestUtils.scala
@@ -70,7 +70,7 @@ object TestUtils {
       case Parsed.Success(stmts, _) =>
         Package.inferBody(PackageName.parts("Test"), Nil, stmts) match {
           case Validated.Invalid(errs) =>
-            fail("inference failure: " + errs.toList.map(_.message(Map.empty)).mkString("\n"))
+            fail("inference failure: " + errs.toList.map(_.message(Map.empty, LocationMap.Colorize.none)).mkString("\n"))
           case Validated.Valid(program) =>
             // make sure all the TypedExpr are valid
             program.lets.foreach { case (_, _, te) => assertValid(te) }
@@ -147,7 +147,7 @@ object TestUtils {
       case Validated.Valid(vs) => vs
       case Validated.Invalid(errs) =>
         errs.toList.foreach { p =>
-          p.showContext.foreach(System.err.println)
+          p.showContext(LocationMap.Colorize.none).foreach(System.err.println)
         }
         sys.error("failed to parse") //errs.toString)
     }
@@ -244,7 +244,7 @@ object TestUtils {
       case (sm, Validated.Invalid(errs)) if errs.collect(errFn).nonEmpty =>
         // make sure we can print the messages:
         val sm = PackageMap.buildSourceMap(withPre)
-        errs.toList.foreach(_.message(sm))
+        errs.toList.foreach(_.message(sm, LocationMap.Colorize.none))
         assert(true)
       case (_, Validated.Invalid(errs)) =>
           fail(s"failed, but no type errors: $errs")

--- a/elmui/Makefile
+++ b/elmui/Makefile
@@ -5,3 +5,6 @@ main.js: src/Main.elm
 
 bosatsu.js: ../jsapi/.js/target/scala-2.12/bosatsu-jsapi-fastopt.js
 	cp ../jsapi/.js/target/scala-2.12/bosatsu-jsapi-fastopt.js out/bosatsu.js
+
+format: src/*
+	elm-format --yes src/

--- a/elmui/elm.json
+++ b/elmui/elm.json
@@ -8,10 +8,10 @@
         "direct": {
             "elm/browser": "1.0.1",
             "elm/core": "1.0.2",
-            "elm/html": "1.0.0"
+            "elm/html": "1.0.0",
+            "elm/json": "1.1.3"
         },
         "indirect": {
-            "elm/json": "1.1.3",
             "elm/time": "1.0.0",
             "elm/url": "1.0.0",
             "elm/virtual-dom": "1.0.2"

--- a/elmui/elm.json
+++ b/elmui/elm.json
@@ -9,12 +9,15 @@
             "elm/browser": "1.0.1",
             "elm/core": "1.0.2",
             "elm/html": "1.0.0",
-            "elm/json": "1.1.3"
+            "elm/json": "1.1.3",
+            "hecrj/html-parser": "2.3.4"
         },
         "indirect": {
+            "elm/parser": "1.1.0",
             "elm/time": "1.0.0",
             "elm/url": "1.0.0",
-            "elm/virtual-dom": "1.0.2"
+            "elm/virtual-dom": "1.0.2",
+            "rtfeldman/elm-hex": "1.0.0"
         }
     },
     "test-dependencies": {

--- a/elmui/index.html
+++ b/elmui/index.html
@@ -11,18 +11,7 @@
       });
       app.ports.toJS.subscribe(function (msg) {
         let res = Bosatsu.evaluateJson(null, "file", {"file": msg })
-        let err = res["error_message"]
-        if (err) {
-          app.ports.toElm.send("error: " + err)
-        }
-        let success = res["result"]
-        if (success) {
-          app.ports.toElm.send(JSON.stringify(success))
-        }
-        else {
-          app.ports.toElm.send("unknown result: " + JSON.stringify(res))
-        }
-
+        app.ports.toElm.send(res)
       });
     </script>
   </body>

--- a/jsapi/src/main/scala/org/bykn/bosatsu/jsapi/JsApi.scala
+++ b/jsapi/src/main/scala/org/bykn/bosatsu/jsapi/JsApi.scala
@@ -26,9 +26,10 @@ object JsApi {
    */
   @JSExport
   def evaluate(mainPackage: String, mainFile: String, files: js.Dictionary[String]): EvalSuccess | Error = {
+    val withColor = "--color" :: "html" :: Nil
     val main =
-      if (mainPackage != null) "--main" :: mainPackage :: Nil
-      else "--main_file" :: mainFile :: Nil
+      if (mainPackage != null) "--main" :: mainPackage :: withColor
+      else "--main_file" :: mainFile :: withColor
     module.runWith(files)("eval" :: main ::: makeInputArgs(files.keys)) match {
       case Left(err) =>
         new Error(s"error: $err")
@@ -67,9 +68,10 @@ object JsApi {
    */
   @JSExport
   def evaluateJson(mainPackage: String, mainFile: String, files: js.Dictionary[String]): EvalSuccess | Error = {
+    val withColor = "--color" :: "html" :: Nil
     val main =
-      if (mainPackage != null) "--main" :: mainPackage :: Nil
-      else "--main_file" :: mainFile :: Nil
+      if (mainPackage != null) "--main" :: mainPackage :: withColor
+      else "--main_file" :: mainFile :: withColor
     module.runWith(files)("write-json" :: "--output" :: "" :: main ::: makeInputArgs(files.keys)) match {
       case Left(err) =>
         new Error(s"error: $err")


### PR DESCRIPTION
This moves parsing the result from the bosatsu js api into elm. This paves the way for a more structured response from bosatsu.