### PR TITLE
Support implicit package names

### DIFF
--- a/bench/src/main/scala/org/bykn/bosatsu/TestBench.scala
+++ b/bench/src/main/scala/org/bykn/bosatsu/TestBench.scala
@@ -12,7 +12,7 @@ class TestBench {
     val mainPack = PackageName.parse(mainPackS).get
 
     val parsed = packages.zipWithIndex.traverse { case (pack, i) =>
-      Parser.parse(Package.parser, pack).map { case (lm, parsed) =>
+      Parser.parse(Package.parser(None), pack).map { case (lm, parsed) =>
         ((i.toString, lm), parsed)
       }
     }

--- a/cli/src/main/scala/org/bykn/bosatsu/Main.scala
+++ b/cli/src/main/scala/org/bykn/bosatsu/Main.scala
@@ -91,6 +91,34 @@ object PathModule extends MainModule[IO] {
 
         (ifres *> out)
     }
+
+  def pathPackage(roots: List[Path], packFile: Path): Option[PackageName] = {
+    import scala.collection.JavaConverters._
+
+    def getP(p: Path): Option[PackageName] = {
+      val subPath = p.relativize(packFile)
+        .asScala
+        .map { part =>
+          part.toString.toLowerCase.capitalize
+        }
+        .mkString("/")
+
+      PackageName.parse(subPath)
+    }
+
+    @annotation.tailrec
+    def loop(roots: List[Path]): Option[PackageName] =
+      roots match {
+        case Nil => None
+        case h :: t =>
+          getP(h) match {
+            case None => loop(t)
+            case some => some
+          }
+      }
+
+    loop(roots)
+  }
 }
 
 object Main {

--- a/cli/src/main/scala/org/bykn/bosatsu/Main.scala
+++ b/cli/src/main/scala/org/bykn/bosatsu/Main.scala
@@ -103,18 +103,20 @@ object PathModule extends MainModule[IO] {
         }
         .mkString("/")
 
-      PackageName.parse(subPath)
+      val dropExtension = """(.*)\.[^.]*$""".r
+      val toParse = subPath match {
+        case dropExtension(prefix) => prefix
+        case _ => subPath
+      }
+      PackageName.parse(toParse)
     }
 
     @annotation.tailrec
     def loop(roots: List[Path]): Option[PackageName] =
       roots match {
         case Nil => None
-        case h :: t =>
-          getP(h) match {
-            case None => loop(t)
-            case some => some
-          }
+        case h :: t if packFile.startsWith(h) => getP(h)
+        case _ :: t => loop(t)
       }
 
     if (packFile.toString.isEmpty) None

--- a/cli/src/main/scala/org/bykn/bosatsu/Main.scala
+++ b/cli/src/main/scala/org/bykn/bosatsu/Main.scala
@@ -96,14 +96,18 @@ object PathModule extends MainModule[IO] {
     import scala.collection.JavaConverters._
 
     def getP(p: Path): Option[PackageName] = {
-      val subPath = p.relativize(packFile)
-        .asScala
-        .map { part =>
-          part.toString.toLowerCase.capitalize
-        }
-        .mkString("/")
+      val rel = p.relativize(packFile)
+      if (packFile != rel) {
+        val subPath = rel
+          .asScala
+          .map { part =>
+            part.toString.toLowerCase.capitalize
+          }
+          .mkString("/")
 
-      PackageName.parse(subPath)
+        PackageName.parse(subPath)
+      }
+      else None
     }
 
     @annotation.tailrec

--- a/cli/src/main/scala/org/bykn/bosatsu/Main.scala
+++ b/cli/src/main/scala/org/bykn/bosatsu/Main.scala
@@ -96,18 +96,14 @@ object PathModule extends MainModule[IO] {
     import scala.collection.JavaConverters._
 
     def getP(p: Path): Option[PackageName] = {
-      val rel = p.relativize(packFile)
-      if (packFile != rel) {
-        val subPath = rel
-          .asScala
-          .map { part =>
-            part.toString.toLowerCase.capitalize
-          }
-          .mkString("/")
+      val subPath = p.relativize(packFile)
+        .asScala
+        .map { part =>
+          part.toString.toLowerCase.capitalize
+        }
+        .mkString("/")
 
-        PackageName.parse(subPath)
-      }
-      else None
+      PackageName.parse(subPath)
     }
 
     @annotation.tailrec
@@ -121,7 +117,8 @@ object PathModule extends MainModule[IO] {
           }
       }
 
-    loop(roots)
+    if (packFile.toString.isEmpty) None
+    else loop(roots)
   }
 }
 

--- a/cli/src/test/scala/org/bykn/bosatsu/PathModuleTest.scala
+++ b/cli/src/test/scala/org/bykn/bosatsu/PathModuleTest.scala
@@ -1,0 +1,52 @@
+package org.bykn.bosatsu
+
+import org.scalacheck.{Arbitrary, Gen}
+import org.scalatest.prop.PropertyChecks.forAll
+import org.scalatest.FunSuite
+import java.nio.file.{Path, Paths}
+
+import scala.collection.JavaConverters._
+
+class PathModuleTest extends FunSuite {
+
+  implicit val arbPath: Arbitrary[Path] =
+    Arbitrary {
+      val str = Gen.identifier
+
+      Gen.listOf(str).map { parts => Paths.get(parts.mkString("/")) }
+    }
+
+  test("no roots means no Package") {
+    forAll { p: Path =>
+      assert(PathModule.pathPackage(Nil, p) == None)
+    }
+  }
+
+  test("empty path is not okay for a package") {
+    forAll { roots: List[Path] =>
+      assert(PathModule.pathPackage(roots, Paths.get("")) == None)
+    }
+  }
+
+  test("if we add to a path that becomes Package") {
+    forAll { (root: Path, otherRoots: List[Path], rest: Path) =>
+      if (rest.toString != "") {
+        val path = root.resolve(rest)
+        val pack =
+          PackageName.parse(rest.asScala.map(_.toString.toLowerCase.capitalize).mkString("/"))
+        assert(PathModule.pathPackage(root :: otherRoots, path) == pack)
+      }
+    }
+  }
+
+  test("if none of the roots are prefixes we have none") {
+    forAll { (r0: Path, roots0: List[Path], file: Path) =>
+      val roots = (r0 :: roots0).filterNot(_.toString == "")
+      val pack = PathModule.pathPackage(roots, file)
+
+      val noPrefix = !roots.exists { r => file.asScala.toList.startsWith(r.asScala.toList) }
+
+      if (noPrefix) assert(pack == None)
+    }
+  }
+}

--- a/cli/src/test/scala/org/bykn/bosatsu/PathModuleTest.scala
+++ b/cli/src/test/scala/org/bykn/bosatsu/PathModuleTest.scala
@@ -1,9 +1,10 @@
 package org.bykn.bosatsu
 
+import cats.data.NonEmptyList
+import java.nio.file.{Path, Paths}
 import org.scalacheck.{Arbitrary, Gen}
 import org.scalatest.prop.PropertyChecks.forAll
 import org.scalatest.FunSuite
-import java.nio.file.{Path, Paths}
 
 import scala.collection.JavaConverters._
 
@@ -15,6 +16,17 @@ class PathModuleTest extends FunSuite {
 
       Gen.listOf(str).map { parts => Paths.get(parts.mkString("/")) }
     }
+
+  test("test some hand written examples") {
+    def pn(roots: List[String], file: String): Option[PackageName] =
+      PathModule.pathPackage(roots.map(Paths.get(_)), Paths.get(file))
+
+    assert(pn(List("/root0", "/root1"), "/root0/Bar.bosatsu") == Some(PackageName(NonEmptyList.of("Bar"))))
+    assert(pn(List("/root0", "/root1"), "/root1/Bar/Baz.bosatsu") == Some(PackageName(NonEmptyList.of("Bar", "Baz"))))
+    assert(pn(List("/root0", "/root0/Bar"), "/root0/Bar/Baz.bosatsu") == Some(PackageName(NonEmptyList.of("Bar", "Baz"))))
+    assert(pn(List("/root0/", "/root0/Bar"), "/root0/Bar/Baz.bosatsu") == Some(PackageName(NonEmptyList.of("Bar", "Baz"))))
+    assert(pn(List("/root0/ext", "/root0/Bar"), "/root0/ext/Bar/Baz.bosatsu") == Some(PackageName(NonEmptyList.of("Bar", "Baz"))))
+  }
 
   test("no roots means no Package") {
     forAll { p: Path =>

--- a/core/src/main/scala/org/bykn/bosatsu/PackageName.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/PackageName.scala
@@ -26,7 +26,7 @@ object PackageName {
 
   def parse(s: String): Option[PackageName] =
     parser.parse(s) match {
-      case Parsed.Success(pn, _) => Some(pn)
+      case Parsed.Success(pn, idx) if idx == s.length => Some(pn)
       case _ => None
     }
 

--- a/core/src/main/scala/org/bykn/bosatsu/Predef.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/Predef.scala
@@ -24,7 +24,7 @@ object Predef {
    * The parsed representation of the predef.
    */
   lazy val predefPackage: Package.Parsed =
-    Package.parser.parse(predefString) match {
+    Package.parser(None).parse(predefString) match {
       case Parsed.Success(pack, _) => pack
       case Parsed.Failure(exp, idx, extra) =>
         val lm = LocationMap(predefString)

--- a/core/src/test/scala/org/bykn/bosatsu/EvaluationTest.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/EvaluationTest.scala
@@ -18,13 +18,13 @@ package Foo
 x = 1
 """), "Foo", VInt(1))
 
+    evalTest(List("x = 1"), "Package0", VInt(1))
+
     evalTest(
       List("""
-package Foo
-
 # test shadowing
 x = match 1: x: x
-"""), "Foo", VInt(1))
+"""), "Package0", VInt(1))
 
     evalTest(
       List("""

--- a/core/src/test/scala/org/bykn/bosatsu/PackageTest.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/PackageTest.scala
@@ -10,7 +10,7 @@ class PackageTest extends FunSuite {
     PackageMap.resolveThenInfer(ps.toList.map { p => ((), p) }, Nil)._2
 
   def parse(s: String): Package.Parsed =
-    Package.parser.parse(s) match {
+    Package.parser(None).parse(s) match {
       case Parsed.Success(p, idx) =>
         assert(idx == s.length)
         p

--- a/core/src/test/scala/org/bykn/bosatsu/ParserTest.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/ParserTest.scala
@@ -1019,7 +1019,7 @@ external def foo2(i: Integer, b: a) -> String
   }
 
   test("we can parse any package") {
-    roundTrip(Package.parser,
+    roundTrip(Package.parser(None),
 """
 package Foo/Bar
 import Baz [Bippy]
@@ -1028,7 +1028,7 @@ export [foo]
 foo = 1
 """)
 
-    forAll(Generators.packageGen(4))(law(Package.parser))
+    forAll(Generators.packageGen(4))(law(Package.parser(None)))
   }
 
   test("parse errors point near where they occur") {

--- a/elmui/index.html
+++ b/elmui/index.html
@@ -10,7 +10,7 @@
         node: document.getElementById('elm')
       });
       app.ports.toJS.subscribe(function (msg) {
-        let res = Bosatsu.evaluateJson(null, "file", {"file": msg })
+        let res = Bosatsu.evaluateJson(null, "/file", {"/file": msg })
         app.ports.toElm.send(res)
       });
     </script>

--- a/jsapi/src/main/scala/org/bykn/bosatsu/jsapi/JsApi.scala
+++ b/jsapi/src/main/scala/org/bykn/bosatsu/jsapi/JsApi.scala
@@ -11,7 +11,10 @@ import cats.implicits._
 @JSExportTopLevel("Bosatsu")
 object JsApi {
 
-  private val module = new MemoryMain[Either[Throwable, ?], String]
+  private def splitPath(p: String): List[String] =
+    p.split("/", -1).toList.map(_.toLowerCase.capitalize)
+
+  private val module = new MemoryMain[Either[Throwable, ?], String](splitPath)
 
   private def makeInputArgs(keys: Iterable[String]): List[String] =
     keys.iterator.flatMap { key => "--input" :: key :: Nil }.toList
@@ -26,10 +29,10 @@ object JsApi {
    */
   @JSExport
   def evaluate(mainPackage: String, mainFile: String, files: js.Dictionary[String]): EvalSuccess | Error = {
-    val withColor = "--color" :: "html" :: Nil
+    val baseArgs = "--package_root" :: "" :: "--color" :: "html" :: Nil
     val main =
-      if (mainPackage != null) "--main" :: mainPackage :: withColor
-      else "--main_file" :: mainFile :: withColor
+      if (mainPackage != null) "--main" :: mainPackage :: baseArgs
+      else "--main_file" :: mainFile :: baseArgs
     module.runWith(files)("eval" :: main ::: makeInputArgs(files.keys)) match {
       case Left(err) =>
         new Error(s"error: $err")
@@ -68,10 +71,10 @@ object JsApi {
    */
   @JSExport
   def evaluateJson(mainPackage: String, mainFile: String, files: js.Dictionary[String]): EvalSuccess | Error = {
-    val withColor = "--color" :: "html" :: Nil
+    val baseArgs = "--package_root" :: "" :: "--color" :: "html" :: Nil
     val main =
-      if (mainPackage != null) "--main" :: mainPackage :: withColor
-      else "--main_file" :: mainFile :: withColor
+      if (mainPackage != null) "--main" :: mainPackage :: baseArgs
+      else "--main_file" :: mainFile :: baseArgs
     module.runWith(files)("write-json" :: "--output" :: "" :: main ::: makeInputArgs(files.keys)) match {
       case Left(err) =>
         new Error(s"error: $err")


### PR DESCRIPTION
closes #10 

This allows the option of passing a list of package_roots, which if there is no explicit `package` in a file, we check if the given path is in the root in the order they are given.

This allows us to have implicit package names in the web UI, but could also be very useful in applications like bazel where you don't want to have to declare a redundant package name.

In Path based examples, we pass the relative path to `toLowerCase.capitalize` in an attempt to make it a valid package name.