### PR TITLE
Improve error message on javascript tool

### DIFF
--- a/core/src/main/scala/org/bykn/bosatsu/MainModule.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/MainModule.scala
@@ -228,12 +228,13 @@ abstract class MainModule[IO[_]](implicit val moduleIOMonad: MonadError[IO, Thro
               ev.evaluateLast(mainPackage) match {
                 case None =>
                   moduleIOMonad.raiseError(new Exception("found no main expression"))
-                case Some((eval, scheme)) =>
+                case Some((eval, tpe)) =>
                   val res = eval.value
-                  ev.toJson(res, scheme) match {
+                  ev.toJson(res, tpe) match {
                     case None =>
+                      val tpeStr = TypeRef.fromTypes(None, tpe :: Nil)(tpe).toDoc.render(80)
                       moduleIOMonad.raiseError(new Exception(
-                        s"cannot convert type to Json: $scheme"))
+                        s"cannot convert type to Json: $tpeStr"))
                     case Some(j) =>
                       moduleIOMonad.pure(Output.JsonOutput(j, output))
                   }

--- a/jsapi/src/main/scala/org/bykn/bosatsu/jsapi/JsApi.scala
+++ b/jsapi/src/main/scala/org/bykn/bosatsu/jsapi/JsApi.scala
@@ -35,7 +35,7 @@ object JsApi {
       else "--main_file" :: mainFile :: baseArgs
     module.runWith(files)("eval" :: main ::: makeInputArgs(files.keys)) match {
       case Left(err) =>
-        new Error(s"error: $err")
+        new Error(s"error: ${err.getMessage}")
       case Right(module.Output.EvaluationResult(res, tpe)) =>
         new EvalSuccess(res.value.toString)
       case Right(other) =>
@@ -77,7 +77,7 @@ object JsApi {
       else "--main_file" :: mainFile :: baseArgs
     module.runWith(files)("write-json" :: "--output" :: "" :: main ::: makeInputArgs(files.keys)) match {
       case Left(err) =>
-        new Error(s"error: $err")
+        new Error(s"error: ${err.getMessage}")
       case Right(module.Output.JsonOutput(json, _)) =>
         new EvalSuccess(jsonToAny(json))
       case Right(other) =>


### PR DESCRIPTION
Does two things:

1. report the type of the item we can't convert to JS in terms of bosatsu syntax, not a giant internal AST.
2. use `err.getMessage` not `err.toString` which also prints the type of the error.