### PR TITLE
Improve Evaluation

### DIFF
--- a/core/src/main/scala/org/bykn/bosatsu/Evaluation.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/Evaluation.scala
@@ -71,9 +71,11 @@ object Evaluation {
 
     def recursive(name: Bindable, item: Scoped): Scoped =
       fromFn { env =>
+        lazy val res: Eval[Value] =
+          Eval.defer(item.inEnv(env1)).memoize
         lazy val env1: Map[Identifier, Eval[Value]] =
-          env.updated(name, Eval.defer(item.inEnv(env1)).memoize)
-        item.inEnv(env1)
+          env.updated(name, res)
+        res
       }
 
     private case class Let(name: Bindable, arg: Scoped, in: Scoped) extends Scoped {

--- a/core/src/main/scala/org/bykn/bosatsu/Evaluation.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/Evaluation.scala
@@ -239,8 +239,14 @@ case class Evaluation[T](pm: PackageMap.Typed[T], externals: Externals) {
         }
       def toTest(a: Value): Test =
         a match {
-          case SumValue(0, assertion) => toAssert(assertion)
-          case SumValue(1, suite) => toSuite(suite)
+          case s: SumValue =>
+            if (s.variant == 0) toAssert(s.value)
+            else if (s.variant == 1) toSuite(s.value)
+            else {
+              // $COVERAGE-OFF$
+              sys.error(s"unexpected variant in: $s")
+              // $COVERAGE-ON$
+            }
           case unexpected =>
             // $COVERAGE-OFF$
             sys.error(s"unreachable if compilation has worked: $unexpected")
@@ -749,7 +755,7 @@ case class Evaluation[T](pm: PackageMap.Typed[T], externals: Externals) {
       case _ =>
         val vp =
           a match {
-            case SumValue(variant, p) => Some((variant, p))
+            case s: SumValue => Some((s.variant, s.value))
             case p: ProductValue => Some((0, p))
             case _ => None
           }

--- a/core/src/main/scala/org/bykn/bosatsu/Pattern.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/Pattern.scala
@@ -187,6 +187,12 @@ object Pattern {
     }
   }
 
+  /**
+   * This will match any list without any binding
+   */
+  val AnyList: Pattern[Nothing, Nothing] =
+    Pattern.ListPat(ListPart.WildList :: Nil)
+
   type Parsed = Pattern[StructKind, TypeRef]
 
   /**

--- a/core/src/main/scala/org/bykn/bosatsu/Pattern.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/Pattern.scala
@@ -190,15 +190,19 @@ object Pattern {
   type Parsed = Pattern[StructKind, TypeRef]
 
   /**
+   * Flatten a pattern out such that there are no top-level
+   * unions
+   */
+  def flatten[N, T](p: Pattern[N, T]): NonEmptyList[Pattern[N, T]] =
+    p match {
+      case Union(h, t) => NonEmptyList(h, t.toList).flatMap(flatten(_))
+      case nonU => NonEmptyList(nonU, Nil)
+    }
+
+  /**
    * Create a normalized pattern, which doesn't have nested top level unions
    */
   def union[N, T](head: Pattern[N, T], tail: List[Pattern[N, T]]): Pattern[N, T] = {
-    def flatten(p: Pattern[N, T]): NonEmptyList[Pattern[N, T]] =
-      p match {
-        case Union(h, t) => NonEmptyList(h, t.toList).flatMap(flatten(_))
-        case nonU => NonEmptyList(nonU, Nil)
-      }
-
     NonEmptyList(head, tail).flatMap(flatten(_)) match {
       case NonEmptyList(h, Nil) => h
       case NonEmptyList(h0, h1 :: tail) => Union(h0, NonEmptyList(h1, tail))

--- a/core/src/main/scala/org/bykn/bosatsu/Predef.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/Predef.scala
@@ -203,8 +203,9 @@ object PredefImpl {
         val fnV = ord.asFn
         def compare(a: Value, b: Value): Int =
           fnV(a).flatMap(_.asFn(b)).value match {
-            case SumValue(v, _) =>
-              v - 1
+            case s: SumValue =>
+              // this should be Comparison ADT
+              s.variant - 1
             case other => sys.error(s"type error: $other")
           }
       }

--- a/core/src/main/scala/org/bykn/bosatsu/Predef.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/Predef.scala
@@ -197,22 +197,19 @@ object PredefImpl {
   }
 
 
-  def empty_Dict(ord: Value): Value =
-    ord match {
-      case ConsValue(fn, _) =>
-        implicit val ordValue: Ordering[Value] =
-          new Ordering[Value] {
-            val fnV = fn.asFn
-            def compare(a: Value, b: Value): Int =
-              fnV(a).flatMap(_.asFn(b)).value match {
-                case SumValue(v, _) =>
-                  v - 1
-                case other => sys.error(s"type error: $other")
-              }
+  def empty_Dict(ord: Value): Value = {
+    implicit val ordValue: Ordering[Value] =
+      new Ordering[Value] {
+        val fnV = ord.asFn
+        def compare(a: Value, b: Value): Int =
+          fnV(a).flatMap(_.asFn(b)).value match {
+            case SumValue(v, _) =>
+              v - 1
+            case other => sys.error(s"type error: $other")
           }
-        ExternalValue(SortedMap.empty[Value, Value])
-      case other => sys.error(s"type error: $other")
-    }
+      }
+    ExternalValue(SortedMap.empty[Value, Value])
+  }
 
   def toDict(v: Value): SortedMap[Value, Value] =
     v match {

--- a/core/src/main/scala/org/bykn/bosatsu/Predef.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/Predef.scala
@@ -201,13 +201,11 @@ object PredefImpl {
     implicit val ordValue: Ordering[Value] =
       new Ordering[Value] {
         val fnV = ord.asFn
-        def compare(a: Value, b: Value): Int =
-          fnV(a).flatMap(_.asFn(b)).value match {
-            case s: SumValue =>
-              // this should be Comparison ADT
-              s.variant - 1
-            case other => sys.error(s"type error: $other")
-          }
+        def compare(a: Value, b: Value): Int = {
+          val v = fnV(a).flatMap(_.asFn(b)).value
+          // this should be Comparison ADT
+          v.asInstanceOf[SumValue].variant - 1
+        }
       }
     ExternalValue(SortedMap.empty[Value, Value])
   }

--- a/core/src/main/scala/org/bykn/bosatsu/Value.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/Value.scala
@@ -56,7 +56,20 @@ object Value {
     override val hashCode = (head, tail).hashCode
   }
   case class SumValue(variant: Int, value: ProductValue) extends Value
+  object SumValue {
+    private[this] val sizeMask = 0xffffff00
+    private[this] val constCount = 256
+    private[this] val constants: Array[SumValue] =
+      (0 until constCount).map(new SumValue(_, UnitValue)).toArray
+
+    def apply(variant: Int, value: ProductValue): SumValue =
+      if ((value == UnitValue) && ((variant & sizeMask) == 0)) constants(variant)
+      else new SumValue(variant, value)
+  }
   case class FnValue(toFn: Eval[Value] => Eval[Value]) extends Value
+  object FnValue {
+    val identity: FnValue = FnValue(v => v)
+  }
   case class ExternalValue(toAny: Any) extends Value
 
   val False: Value = SumValue(0, UnitValue)

--- a/core/src/main/scala/org/bykn/bosatsu/rankn/DefinedType.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/rankn/DefinedType.scala
@@ -8,7 +8,7 @@ import cats.implicits._
 
 import org.bykn.bosatsu.Identifier.{Bindable, Constructor}
 
-case class DefinedType[+A](
+final case class DefinedType[+A](
   packageName: PackageName,
   name: TypeName,
   annotatedTypeParams: List[(Type.Var.Bound, A)],
@@ -23,6 +23,17 @@ case class DefinedType[+A](
    * A type with exactly one constructor is a struct
    */
   def isStruct: Boolean = constructors.lengthCompare(1) == 0
+
+  /**
+   * A newtype is just a wrapper for another type.
+   * It could be removed statically from the program
+   */
+  def isNewType: Boolean =
+    constructors match {
+      case (_, _ :: Nil, _) :: Nil => true
+      case _ => false
+    }
+
   /**
    * This is not the full type, since the full type
    * has a ForAll(typeParams, ... in front if the

--- a/core/src/main/scala/org/bykn/bosatsu/rankn/DefinedType.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/rankn/DefinedType.scala
@@ -39,10 +39,10 @@ final case class DefinedType[+A](
    * has a ForAll(typeParams, ... in front if the
    * typeParams is nonEmpty
    */
-  def toTypeConst: Type.Const.Defined =
+  val toTypeConst: Type.Const.Defined =
     DefinedType.toTypeConst(packageName, name)
 
-  def toTypeTyConst: Type.TyConst =
+  val toTypeTyConst: Type.TyConst =
     Type.TyConst(toTypeConst)
 }
 

--- a/core/src/test/scala/org/bykn/bosatsu/EvaluationTest.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/EvaluationTest.scala
@@ -838,6 +838,41 @@ def fib(n):
 # fib(5) = 1, 1, 2, 3, 5, 8
 main = fib(S(S(S(S(S(Z))))))
 """), "A", VInt(8))
+
+  /*
+   * TODO: make this test pass
+  evalTest(
+    List("""
+package A
+
+enum Nat[a]: Z, S(p: Nat[a])
+
+def fib(n):
+  recur n:
+    Z: 1
+    S(Z): 1
+    S(n1@S(n2)): fib(n1).add(fib(n2))
+
+# fib(5) = 1, 1, 2, 3, 5, 8
+main = fib(S(S(S(S(S(Z))))))
+"""), "A", VInt(8))
+  */
+
+  evalTest(
+    List("""
+package A
+
+enum Nat: S(p: Nat), Z
+
+def fib(n):
+  recur n:
+    Z: 1
+    S(Z): 1
+    S(n1@S(n2)): fib(n1).add(fib(n2))
+
+# fib(5) = 1, 1, 2, 3, 5, 8
+main = fib(S(S(S(S(S(Z))))))
+"""), "A", VInt(8))
   }
 
   test("test matching the front of a list") {
@@ -1094,6 +1129,22 @@ main = [Foo(1), Bar("1")]
         List("foo" -> Json.JNumberStr("1"))),
       Json.JObject(
         List("bar" -> Json.JString("1"))))))
+  }
+
+  test("json handling of Nat special case") {
+    evalTestJson(
+      List("""
+package Foo
+
+enum Nat: Z, S(n: Nat)
+
+main = [Z, S(Z), S(S(Z))]
+"""), "Foo",
+  Json.JArray(
+    Vector(
+      Json.JNumberStr("0"),
+      Json.JNumberStr("1"),
+      Json.JNumberStr("2"))))
   }
 
   test("json with backticks") {

--- a/core/src/test/scala/org/bykn/bosatsu/EvaluationTest.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/EvaluationTest.scala
@@ -456,7 +456,7 @@ struct Bar(a: Int)
 
 main = Bar(1)
 """), "Foo",
-  ConsValue(VInt(1), UnitValue))
+  VInt(1))
 
     evalTest(
       List("""

--- a/core/src/test/scala/org/bykn/bosatsu/ValueTest.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/ValueTest.scala
@@ -1,0 +1,105 @@
+package org.bykn.bosatsu
+
+import org.scalacheck.{Arbitrary, Cogen, Gen}
+import org.scalatest.prop.PropertyChecks.{ forAll, PropertyCheckConfiguration }
+import org.scalatest.FunSuite
+import Value._
+
+object GenValue {
+
+  val cogenValue: Cogen[Value] =
+    Cogen[Int].contramap { v: Value => v.hashCode }
+
+  lazy val genProd: Gen[ProductValue] =
+    Gen.lzy(Gen.oneOf(Gen.const(UnitValue),
+      genValue.flatMap { v => genProd.map(ConsValue(v, _)) }))
+
+  lazy val genValue: Gen[Value] = {
+    val recur = Gen.lzy(genValue)
+    val genEnumLike = Gen.choose(0, 1024).map(SumValue(_, UnitValue))
+
+    val genSum =
+      for {
+        i <- Gen.choose(0, 1024)
+        v <- genProd
+      } yield SumValue(i, v)
+
+    val genExt: Gen[Value] =
+      Gen.oneOf(
+        Gen.choose(Int.MinValue, Int.MaxValue).map(VInt(_)),
+        Arbitrary.arbitrary[String].map(Str(_)))
+
+    val genFn: Gen[FnValue] = {
+      val fn: Gen[Value => Value] = Gen.function1(recur)(cogenValue)
+
+      fn.map { valueFn =>
+
+        FnValue { eval => eval.map(valueFn(_)) }
+      }
+    }
+
+    Gen.oneOf(genEnumLike, genProd, genSum, genExt, genFn)
+  }
+}
+
+class ValueTest extends FunSuite {
+  import GenValue.genValue
+
+  implicit val generatorDrivenConfig =
+    PropertyCheckConfiguration(minSuccessful = 500)
+
+  test("SumValue.toString is what we expect") {
+    forAll(Gen.choose(0, 1024), GenValue.genProd) { (i, p) =>
+      assert(SumValue(i, p).toString == s"SumValue($i, $p)")
+    }
+  }
+
+  test("Value.equals is false if the class isn't right") {
+    forAll(genValue, genValue) { (v1, v2) =>
+      if (v1.getClass != v2.getClass) assert(v1 != v2)
+      else if (v1 == v2) assert(v1.getClass == v2.getClass)
+    }
+  }
+
+  test("VOption works") {
+    forAll(genValue) { v =>
+      VOption.some(v) match {
+        case VOption(Some(v1)) => assert(v1 == v)
+        case other => fail(s"expected Some($v) got $other")
+      }
+    }
+
+    forAll(genValue) { v =>
+      VOption.unapply(v) match {
+        case None => ()
+        case Some(None) =>
+          assert(v == VOption.none)
+        case Some(Some(v1)) =>
+          assert(v == VOption.some(v1))
+      }
+    }
+
+    assert(VOption.unapply(VOption.none) == Some(None))
+  }
+
+  test("VList works") {
+    forAll(Gen.listOf(genValue)) { vs =>
+      VList(vs) match {
+        case VList(vs1) => assert(vs1 == vs)
+        case other => fail(s"expected VList($vs) got $other")
+      }
+    }
+
+    forAll(genValue) { v =>
+      VList.unapply(v) match {
+        case None => ()
+        case Some(Nil) =>
+          assert(v == VList.VNil)
+        case Some(v1) =>
+          assert(v == VList(v1))
+      }
+    }
+
+    assert(VList.unapply(VList.VNil) == Some(Nil))
+  }
+}


### PR DESCRIPTION
close #331 

This optimizes evaluation for a few cases:
1. unit like types can do less work
2. enums that are like ints are memoized for fewer allocations
3. when we have a struct match that doesn't do any binding (`Foo(_, _)`) we simpilfy things
4. we optimize the representation of Nat-like types so they are stored by a BigInteger, not a linear-sized linked list
5. new-types don't add a layer of wrapping.

cc @snoble 