### PR TITLE
Improve the usability of the CLI

### DIFF
--- a/bench/src/main/scala/org/bykn/bosatsu/TestBench.scala
+++ b/bench/src/main/scala/org/bykn/bosatsu/TestBench.scala
@@ -21,7 +21,7 @@ class TestBench {
       case Validated.Valid(vs) => vs
       case Validated.Invalid(errs) =>
         errs.toList.foreach { p =>
-          p.showContext(LocationMap.Colorize.none).foreach(System.err.println)
+          p.showContext(LocationMap.Colorize.None).foreach(System.err.println)
         }
         sys.error("failed to parse") //errs.toString)
     }

--- a/bosatsuj
+++ b/bosatsuj
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+# make sure to run sbt cli/assembly first
+java -jar cli/target/scala-2.12/bosatsu-cli-assembly-0.1.0-SNAPSHOT.jar $@

--- a/build_native.sh
+++ b/build_native.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+#sbt cli/assembly
+native-image --static \
+  --no-fallback \
+  --initialize-at-build-time \
+  -jar cli/target/scala-2.12/bosatsu-cli-assembly-0.1.0-SNAPSHOT.jar \
+  bosatsu

--- a/cli/src/main/scala/org/bykn/bosatsu/Main.scala
+++ b/cli/src/main/scala/org/bykn/bosatsu/Main.scala
@@ -31,20 +31,6 @@ object PathModule extends MainModule[IO] {
       }
     )
 
-  def expandDirectories(path: Path): IO[List[Path]] =
-    IO {
-      val file = path.toFile
-      if (file.isDirectory) {
-        file
-          .listFiles()
-          .iterator
-          .map(_.toPath)
-          .filter(_.toString.endsWith(".bosatsu"))
-          .toList
-      }
-      else path :: Nil
-    }
-
   def readPackages(paths: List[Path]): IO[List[Package.Typed[Unit]]] =
     ProtoConverter.readPackages(paths)
 

--- a/cli/src/test/scala/org/bykn/bosatsu/PathModuleTest.scala
+++ b/cli/src/test/scala/org/bykn/bosatsu/PathModuleTest.scala
@@ -103,4 +103,15 @@ class PathModuleTest extends FunSuite {
       case other => fail(s"expected test output")
     }
   }
+
+  test("test search with write-json") {
+
+    val out = run("write-json --package_root test_workspace --search --main_file test_workspace/Bar.bosatsu".split("\\s+"): _*)
+    out match {
+      case PathModule.Output.JsonOutput(j@Json.JObject(_), _) =>
+        assert(j.toMap == Map("value" -> Json.JBool(true), "message" -> Json.JString("got the right string")))
+        assert(j.items.length == 2)
+      case other => fail(s"expected json object output")
+    }
+  }
 }

--- a/cli/src/test/scala/org/bykn/bosatsu/PathModuleTest.scala
+++ b/cli/src/test/scala/org/bykn/bosatsu/PathModuleTest.scala
@@ -74,7 +74,12 @@ class PathModuleTest extends FunSuite {
   def run(args: String*): PathModule.Output =
     PathModule.run(args.toList) match {
       case Left(_) => fail(s"got help on command: ${args.toList}")
-      case Right(io) => io.unsafeRunSync()
+      case Right(io) =>
+        val output = io.unsafeRunSync()
+        // This is a cheat, but at least we call the code so
+        // we see it doesn't crash or infinite loop or something
+        PathModule.reportOutput(output)
+        output
     }
 
   test("test direct run of a file") {

--- a/cli/src/test/scala/org/bykn/bosatsu/PathModuleTest.scala
+++ b/cli/src/test/scala/org/bykn/bosatsu/PathModuleTest.scala
@@ -70,4 +70,32 @@ class PathModuleTest extends FunSuite {
       if (noPrefix) assert(pack == None)
     }
   }
+
+  def run(args: String*): PathModule.Output =
+    PathModule.run(args.toList) match {
+      case Left(_) => fail(s"got help on command: ${args.toList}")
+      case Right(io) => io.unsafeRunSync()
+    }
+
+  test("test direct run of a file") {
+    val out = run("test --input test_workspace/List.bosatsu --input test_workspace/Bool.bosatsu --test_file test_workspace/Queue.bosatsu".split("\\s+"): _*)
+    out match {
+      case PathModule.Output.TestOutput(results, _) =>
+        val res = results.collect { case (pn, Some(t)) if pn.asString == "Queue" => t }
+        assert(res.length == 1)
+      case other => fail(s"expected test output")
+    }
+  }
+
+  test("test search run of a file") {
+    val out = run("test --package_root test_workspace --search --test_file test_workspace/Bar.bosatsu".split("\\s+"): _*)
+    out match {
+      case PathModule.Output.TestOutput(results, _) =>
+        val res = results.collect { case (pn, Some(t)) if pn.asString == "Bar" => t }
+        assert(res.length == 1)
+        assert(res.head.assertions == 1)
+        assert(res.head.failureCount == 0)
+      case other => fail(s"expected test output")
+    }
+  }
 }

--- a/core/src/main/scala/org/bykn/bosatsu/LocationMap.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/LocationMap.scala
@@ -126,30 +126,30 @@ case class LocationMap(fromString: String) { self =>
 
 object LocationMap {
   sealed trait Colorize {
-    def apply(d: Doc): Doc
+    def red(d: Doc): Doc
+    def green(d: Doc): Doc
   }
 
   object Colorize {
-    val none: Colorize =
-      new Colorize {
-        def apply(d: Doc) = d
-      }
-
-    object Console {
-      val red: Colorize =
-        new Colorize {
-          def apply(d: Doc) =
-            Doc.zeroWidth(scala.Console.RED) + d.unzero + Doc.zeroWidth(scala.Console.RESET)
-        }
+    object None extends Colorize {
+      def red(d: Doc) = d
+      def green(d: Doc) = d
     }
 
-    object HmtlFont {
-      val red: Colorize =
-        new Colorize {
-          def apply(d: Doc) =
-            Doc.zeroWidth("<font color=\"red\">") + d.unzero +
-              Doc.zeroWidth("</font>")
-        }
+    object Console extends Colorize {
+      def red(d: Doc) =
+        Doc.zeroWidth(scala.Console.RED) + d.unzero + Doc.zeroWidth(scala.Console.RESET)
+
+      def green(d: Doc) =
+        Doc.zeroWidth(scala.Console.GREEN) + d.unzero + Doc.zeroWidth(scala.Console.RESET)
+    }
+
+    object HmtlFont extends Colorize {
+      def red(d: Doc) =
+        Doc.zeroWidth("<font color=\"red\">") + d.unzero + Doc.zeroWidth("</font>")
+
+      def green(d: Doc) =
+        Doc.zeroWidth("<font color=\"green\">") + d.unzero + Doc.zeroWidth("</font>")
     }
   }
 
@@ -161,7 +161,7 @@ object LocationMap {
   def pointerTo(column: Int, color: Colorize): Doc = {
     val col = Doc.spaces(column)
     val pointer = Doc.char('^')
-    col + color(pointer)
+    col + color.red(pointer)
   }
 
   def pointerRange(start: Int, exEnd: Int, color: Colorize): Doc = {
@@ -170,7 +170,7 @@ object LocationMap {
     else {
       val col = Doc.spaces(start)
       val pointer = Doc.char('^') * width
-      col + color(pointer)
+      col + color.red(pointer)
     }
   }
 

--- a/core/src/main/scala/org/bykn/bosatsu/MainModule.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/MainModule.scala
@@ -28,8 +28,6 @@ abstract class MainModule[IO[_]](implicit val moduleIOMonad: MonadError[IO, Thro
 
   def readInterfaces(paths: List[Path]): IO[List[Package.Interface]]
 
-  def expandDirectories(path: Path): IO[List[Path]]
-
   /**
    * given an ordered list of prefered roots, if a packFile starts
    * with one of these roots, return a PackageName based on the rest
@@ -84,8 +82,8 @@ abstract class MainModule[IO[_]](implicit val moduleIOMonad: MonadError[IO, Thro
      * This parses all the given paths and returns them first, and if the PackageResolver supports
      * it, we look for any missing dependencies that are not already included
      */
-    def parseAllInputs(paths: List[Path], included: Set[PackageName], packRes: PackageResolver): IO[ValidatedNel[ParseError, List[((Path, LocationMap), Package.Parsed)]]] = {
-      def run(paths: List[Path]) = parseInputs(paths, packRes)
+    def parseAllInputs(paths: List[Path], included: Set[PackageName], packRes: PackageResolver): IO[ValidatedNel[ParseError, List[((Path, LocationMap), Package.Parsed)]]] =
+      parseInputs(paths, packRes)
         .flatMap {
           flatTrav(_) { parsed =>
             val done = included ++ parsed.toList.map(_._2.name)
@@ -96,14 +94,6 @@ abstract class MainModule[IO[_]](implicit val moduleIOMonad: MonadError[IO, Thro
           }
         }
 
-      paths
-        .traverse { p =>
-          expandDirectories(p)
-        }
-        .flatMap { ps =>
-          run(ps.flatten)
-        }
-    }
 
     type ParseTransResult = ValidatedNel[ParseError, (Chain[((Path, LocationMap), Package.Parsed)], Set[PackageName])]
 

--- a/core/src/main/scala/org/bykn/bosatsu/MainModule.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/MainModule.scala
@@ -494,7 +494,8 @@ abstract class MainModule[IO[_]](implicit val moduleIOMonad: MonadError[IO, Thro
                   ctx.render(80))
             case ParseError.FileError(path, err) =>
               err match {
-                case _: java.nio.file.NoSuchFileException =>
+                case e if e.getClass.getName == "java.nio.file.NoSuchFileException" =>
+                  // This class isn't present in scalajs, use the String
                   List(s"file not found: $path")
                 case _ =>
                   List(s"failed to parse $path",

--- a/core/src/main/scala/org/bykn/bosatsu/MainModule.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/MainModule.scala
@@ -1,8 +1,8 @@
 package org.bykn.bosatsu
 
 import cats.arrow.FunctionK
-import cats.data.{Validated, ValidatedNel, NonEmptyList}
-import cats.{Eval, Traverse, MonadError}
+import cats.data.{Chain, Validated, ValidatedNel, NonEmptyList}
+import cats.{Eval, MonadError}
 import com.monovore.decline.{Argument, Command, Help, Opts}
 import fastparse.all.P
 import org.typelevel.paiges.Doc
@@ -34,6 +34,12 @@ abstract class MainModule[IO[_]](implicit val moduleIOMonad: MonadError[IO, Thro
    */
   def pathPackage(roots: List[Path], packFile: Path): Option[PackageName]
 
+  /**
+   * Modules optionally have the capability to combine paths into
+   * a tree
+   */
+  def resolvePath: Option[(Path, PackageName) => IO[Option[Path]]]
+
   //////////////////////////////
   // Below here are concrete and should not use override
   //////////////////////////////
@@ -45,9 +51,9 @@ abstract class MainModule[IO[_]](implicit val moduleIOMonad: MonadError[IO, Thro
 
   sealed abstract class Output
   object Output {
-    case class TestOutput(tests: List[(PackageName, Option[Test])]) extends Output
+    case class TestOutput(tests: List[(PackageName, Option[Test])], colorize: Colorize) extends Output
     case class EvaluationResult(value: Eval[Value], tpe: rankn.Type) extends Output
-    case class JsonOutput(json: Json, output: Path) extends Output
+    case class JsonOutput(json: Json, output: Option[Path]) extends Output
     case class CompileOut(packList: List[Package.Typed[Any]], ifout: Option[Path], output: Path) extends Output
   }
 
@@ -56,17 +62,105 @@ abstract class MainModule[IO[_]](implicit val moduleIOMonad: MonadError[IO, Thro
   }
 
   object MainCommand {
-    def parseInputs[F[_]: Traverse](paths: F[Path], pathToPack: Path => Option[PackageName]): IO[ValidatedNel[ParseError, F[((Path, LocationMap), Package.Parsed)]]] =
+    def parseInputs(paths: NonEmptyList[Path], packRes: PackageResolver): IO[ValidatedNel[ParseError, NonEmptyList[((Path, LocationMap), Package.Parsed)]]] =
       // we use IO(traverse) so we can accumulate all the errors in parallel easily
       // if do this with parseFile returning an IO, we need to do IO.Par[Validated[...]]
       // and use the composed applicative... too much work for the same result
       paths.traverse { path =>
-        val defaultPack = pathToPack(path)
-        parseFile(Package.parser(defaultPack), path).map(_.map { case (lm, parsed) =>
-          ((path, lm), parsed)
-        })
+        val defaultPack = packRes.packageNameFor(path)
+        parseFile(Package.parser(defaultPack), path)
+          .map(_.map { case (lm, parsed) =>
+            ((path, lm), parsed)
+          })
       }
       .map(_.sequence)
+
+    private def flatTrav[A, B, C](va: Validated[A, B])(fn: B => IO[Validated[A, C]]): IO[Validated[A, C]] =
+      va.traverse(fn).map(_.andThen(identity _))
+
+    /**
+     * This parses all the given paths and returns them first, and if the PackageResolver supports
+     * it, we look for any missing dependencies that are not already included
+     */
+    def parseAllInputs(paths: NonEmptyList[Path], included: Set[PackageName], packRes: PackageResolver): IO[ValidatedNel[ParseError, NonEmptyList[((Path, LocationMap), Package.Parsed)]]] = {
+      parseInputs(paths, packRes)
+        .flatMap {
+          flatTrav(_) { parsed =>
+            val done = included ++ parsed.toList.map(_._2.name)
+            val allImports = parsed.toList.flatMap(_._2.imports.map(_.pack))
+            val missing: List[PackageName] = allImports.filterNot(done)
+            parseTransitivePacks(missing, packRes, done)
+              .map(_.map { case (searched, _) => parsed.concat(searched.toList) })
+          }
+        }
+    }
+
+    type ParseTransResult = ValidatedNel[ParseError, (Chain[((Path, LocationMap), Package.Parsed)], Set[PackageName])]
+
+    private def parseTransitive(
+      search: PackageName,
+      packRes: PackageResolver,
+      done: Set[PackageName]): IO[ParseTransResult] = {
+
+      def maybeRead(p: Path): IO[Option[String]] =
+        readPath(p).map(Option(_)).recover { case _ => None }
+
+      val maybeReadPack: IO[Option[(Path, String)]] =
+        if (done(search)) {
+          moduleIOMonad.pure(Option.empty[(Path, String)])
+        }
+        else {
+          packRes
+            .pathFor(search)
+            .flatMap(_.traverse { path =>
+              readPath(path).map((path, _))
+            })
+        }
+
+      val optParsed: IO[ValidatedNel[ParseError, Option[((Path, LocationMap), Package.Parsed)]]] =
+        maybeReadPack.map { opt =>
+          opt.traverse { case (path, str) =>
+            val defaultPack = packRes.packageNameFor(path)
+            parseString(Package.parser(defaultPack), path, str)
+              .map { case (lm, parsed) =>
+                ((path, lm), parsed)
+              }
+          }
+        }
+
+      def imports(p: Package.Parsed): List[PackageName] =
+        p.imports.map(_.pack)
+
+      val newDone = done + search
+
+      optParsed.flatMap {
+        flatTrav(_) {
+          case None =>
+            moduleIOMonad.pure(
+              Validated.valid(
+                (Chain.empty[((Path, LocationMap), Package.Parsed)], newDone)
+              ): ParseTransResult
+            )
+          case Some(item@(plm, pack)) =>
+            val imps = imports(pack).filterNot(done)
+            parseTransitivePacks(imps, packRes, newDone)
+              .map(_.map { case (newPacks, newDone) => (item +: newPacks, newDone) })
+        }
+      }
+    }
+
+    private def parseTransitivePacks(
+      search: List[PackageName],
+      packRes: PackageResolver,
+      done: Set[PackageName]): IO[ParseTransResult] =
+        search.foldM(Validated.valid((Chain.empty, done)): ParseTransResult) { (prev, impPack) =>
+          flatTrav(prev) { case (acc, prevDone) =>
+            parseTransitive(impPack, packRes, prevDone)
+              .map(_.map {
+                case (newPacks, newDone) => (acc ++ newPacks, newDone)
+              })
+          }
+        }
 
     sealed trait ParseError {
       def showContext(errColor: Colorize): Option[Doc] =
@@ -86,18 +180,28 @@ abstract class MainModule[IO[_]](implicit val moduleIOMonad: MonadError[IO, Thro
        case class FileError(readPath: Path, error: Throwable) extends ParseError
     }
 
+    def parseString[A](p: P[A], path: Path, str: String): ValidatedNel[ParseError, (LocationMap, A)] =
+      Parser.parse(p, str).leftMap { nel =>
+        nel.map {
+          case pp@Parser.Error.PartialParse(_, _, _) => ParseError.PartialParse(pp, path)
+          case pf@Parser.Error.ParseFailure(_, _) => ParseError.ParseFailure(pf, path)
+        }
+      }
+
     def parseFile[A](p: P[A], path: Path): IO[ValidatedNel[ParseError, (LocationMap, A)]] =
-      readPath(path)
-        .attempt
+      parseFileOrError(p, path)
         .map {
-          case Right(str) => Parser.parse(p, str).leftMap { nel =>
-            nel.map {
-              case pp@Parser.Error.PartialParse(_, _, _) => ParseError.PartialParse(pp, path)
-              case pf@Parser.Error.ParseFailure(_, _) => ParseError.ParseFailure(pf, path)
-            }
-          }
+          case Right(v) => v
           case Left(err) => Validated.invalidNel(ParseError.FileError(path, err))
         }
+
+    /**
+     * If we cannot read the file, return the throwable, else parse
+     */
+    def parseFileOrError[A](p: P[A], path: Path): IO[Either[Throwable, ValidatedNel[ParseError, (LocationMap, A)]]] =
+      readPath(path)
+        .attempt
+        .map(_.map(parseString(p, path, _)))
 
     /**
      * like typecheck, but a no-op for empty lists
@@ -106,7 +210,7 @@ abstract class MainModule[IO[_]](implicit val moduleIOMonad: MonadError[IO, Thro
       inputs: List[Path],
       ifs: List[Package.Interface],
       errColor: Colorize,
-      pathToPack: Path => Option[PackageName]
+      packRes: PackageResolver
       ): IO[(PackageMap.Inferred, List[(Path, PackageName)])] =
       NonEmptyList.fromList(inputs) match {
         case None =>
@@ -121,16 +225,16 @@ abstract class MainModule[IO[_]](implicit val moduleIOMonad: MonadError[IO, Thro
           else {
             moduleIOMonad.pure((PackageMap.empty, Nil))
           }
-        case Some(nel) => typeCheck(nel, ifs, errColor, pathToPack)
+        case Some(nel) => typeCheck(nel, ifs, errColor, packRes)
       }
 
     def typeCheck(
       inputs: NonEmptyList[Path],
       ifs: List[Package.Interface],
       errColor: Colorize,
-      pathToPack: Path => Option[PackageName]
+      packRes: PackageResolver
       ): IO[(PackageMap.Inferred, List[(Path, PackageName)])] =
-      parseInputs(inputs, pathToPack)
+      parseAllInputs(inputs, ifs.map(_.name).toSet, packRes)
         .flatMap { ins =>
           moduleIOMonad.fromTry {
             // Now we have completed all IO, here we do all the checks we need for correctness
@@ -154,28 +258,35 @@ abstract class MainModule[IO[_]](implicit val moduleIOMonad: MonadError[IO, Thro
       srcs: List[Path],
       deps: List[Path],
       errColor: Colorize,
-      pathToPack: Path => Option[PackageName]): IO[(PackageMap.Typed[Any], List[(Path, PackageName)])] =
-      readPackages(deps)
-        .flatMap { packs =>
-          val ifaces = packs.map(Package.interfaceOf(_))
-          typeCheck0(srcs, ifaces, errColor, pathToPack)
-            .map { case (thesePacks, lst) =>
-              (packs.foldLeft(PackageMap.toAnyTyped(thesePacks))(_ + _), lst)
-            }
-        }
+      packRes: PackageResolver): IO[(PackageMap.Typed[Any], List[(Path, PackageName)])] =
+        for {
+          packs <- readPackages(deps)
+          ifaces = packs.map(Package.interfaceOf(_))
+          packsList <- typeCheck0(srcs, ifaces, errColor, packRes)
+          (thesePacks, lst) = packsList
+          packMap = packs.foldLeft(PackageMap.toAnyTyped(thesePacks))(_ + _)
+        } yield (packMap, lst)
 
     /**
      * This allows us to use either a path or packagename to select
      * the main file
      */
     sealed abstract class MainIdentifier {
+      def path: Option[Path]
+      def addIfAbsent(paths: List[Path]): List[Path] =
+        path match {
+          case Some(p) if !paths.contains(p) => p :: paths
+          case _ => paths
+        }
       def getMain(ps: List[(Path, PackageName)]): IO[PackageName]
     }
     object MainIdentifier {
       case class FromPackage(mainPackage: PackageName) extends MainIdentifier {
+        def path: Option[Path] = None
         def getMain(ps: List[(Path, PackageName)]): IO[PackageName] = moduleIOMonad.pure(mainPackage)
       }
       case class FromFile(mainFile: Path) extends MainIdentifier {
+        def path: Option[Path] = Some(mainFile)
         def getMain(ps: List[(Path, PackageName)]): IO[PackageName] =
           ps.collectFirst { case (path, pn) if path == mainFile => pn } match {
             case None => moduleIOMonad.raiseError(new Exception(s"could not find file $mainFile in parsed sources"))
@@ -185,6 +296,55 @@ abstract class MainModule[IO[_]](implicit val moduleIOMonad: MonadError[IO, Thro
 
       def opts(pnOpts: Opts[PackageName], fileOpts: Opts[Path]): Opts[MainIdentifier] =
         pnOpts.map(FromPackage(_)).orElse(fileOpts.map(FromFile(_)))
+
+      def list(packs: Opts[List[PackageName]], files: Opts[List[Path]]): Opts[List[MainIdentifier]] =
+        (packs, files).mapN { (ps, fs) =>
+          ps.map(FromPackage(_)) ::: fs.map(FromFile(_))
+        }
+
+      def addAnyAbsent(ms: List[MainIdentifier], paths: List[Path]): List[Path] = {
+        val present = paths.toSet
+        val toAdd = ms.iterator.flatMap(_.path).filterNot(present).toList
+        toAdd ::: paths
+      }
+    }
+
+    /**
+     * This is a class that names packages based on path
+     * and finds packages based on imports
+     */
+    sealed abstract class PackageResolver {
+      def pathFor(name: PackageName): IO[Option[Path]]
+      def packageNameFor(path: Path): Option[PackageName]
+    }
+    object PackageResolver {
+      case object ExplicitOnly extends PackageResolver {
+        def pathFor(name: PackageName): IO[Option[Path]] = moduleIOMonad.pure(Option.empty[Path])
+        def packageNameFor(path: Path): Option[PackageName] = None
+      }
+
+      case class LocalRoots(roots: NonEmptyList[Path], optResolvePath: Option[(Path, PackageName) => IO[Option[Path]]]) extends PackageResolver {
+        def pathFor(name: PackageName): IO[Option[Path]] =
+          optResolvePath match {
+            case None => moduleIOMonad.pure(Option.empty[Path])
+            case Some(resolvePath) =>
+              def step(p: List[Path]): IO[Either[List[Path], Option[Path]]] =
+                p match {
+                  case Nil =>
+                    moduleIOMonad.pure(Right[List[Path], Option[Path]](None))
+                  case phead :: ptail =>
+                    resolvePath(phead, name).map {
+                      case None => Left[List[Path], Option[Path]](ptail)
+                      case some@Some(_) => Right[List[Path], Option[Path]](some)
+                    }
+                }
+
+              moduleIOMonad.tailRecM(roots.toList)(step)
+          }
+
+        def packageNameFor(path: Path): Option[PackageName] =
+          pathPackage(roots.toList, path)
+      }
     }
 
     case class Evaluate(
@@ -192,18 +352,23 @@ abstract class MainModule[IO[_]](implicit val moduleIOMonad: MonadError[IO, Thro
       mainPackage: MainIdentifier,
       deps: List[Path],
       errColor: Colorize,
-      pathToPack: Path => Option[PackageName]) extends MainCommand {
+      packRes: PackageResolver) extends MainCommand {
       def run =
-        buildPackMap(inputs.toList, deps, errColor, pathToPack)
+        buildPackMap(mainPackage.addIfAbsent(inputs.toList), deps, errColor, packRes)
           .flatMap { case (packs, names) =>
             mainPackage
               .getMain(names)
               .flatMap { mainPackage =>
                 val ev = Evaluation(packs, Predef.jvmExternals)
-                ev.evaluateLast(mainPackage) match {
-                  case None => moduleIOMonad.raiseError(new Exception("found no main expression"))
-                  case Some((eval, tpe)) =>
-                    moduleIOMonad.pure(Output.EvaluationResult(eval, tpe))
+                if (packs.toMap.contains(mainPackage)) {
+                  ev.evaluateLast(mainPackage) match {
+                    case None => moduleIOMonad.raiseError(new Exception("found no main expression"))
+                    case Some((eval, tpe)) =>
+                      moduleIOMonad.pure(Output.EvaluationResult(eval, tpe))
+                  }
+                }
+                else {
+                  moduleIOMonad.raiseError(new Exception(s"package ${mainPackage.asString} not found"))
                 }
               }
           }
@@ -213,14 +378,17 @@ abstract class MainModule[IO[_]](implicit val moduleIOMonad: MonadError[IO, Thro
       inputs: List[Path],
       deps: List[Path],
       mainPackage: MainIdentifier,
-      output: Path,
+      outputOpt: Option[Path],
       errColor: Colorize,
-      pathToPack: Path => Option[PackageName]) extends MainCommand {
+      packRes: PackageResolver) extends MainCommand {
+
+      private[this] val inputs1: List[Path] = mainPackage.addIfAbsent(inputs)
+
       def checkEmpty =
-        if (inputs.isEmpty && deps.isEmpty) moduleIOMonad.raiseError(new Exception("no test sources or test dependencies"))
+        if (inputs1.isEmpty && deps.isEmpty) moduleIOMonad.raiseError(new Exception("no test sources or test dependencies"))
         else moduleIOMonad.unit
 
-      def run = checkEmpty *> buildPackMap(inputs.toList, deps, errColor, pathToPack)
+      def run = checkEmpty *> buildPackMap(inputs1, deps, errColor, packRes)
         .flatMap { case (packs, files) =>
           mainPackage.getMain(files)
             .flatMap { mainPackage =>
@@ -236,7 +404,7 @@ abstract class MainModule[IO[_]](implicit val moduleIOMonad: MonadError[IO, Thro
                       moduleIOMonad.raiseError(new Exception(
                         s"cannot convert type to Json: $tpeStr"))
                     case Some(j) =>
-                      moduleIOMonad.pure(Output.JsonOutput(j, output))
+                      moduleIOMonad.pure(Output.JsonOutput(j, outputOpt))
                   }
               }
             }
@@ -248,10 +416,10 @@ abstract class MainModule[IO[_]](implicit val moduleIOMonad: MonadError[IO, Thro
       output: Path,
       ifout: Option[Path],
       errColor: Colorize,
-      pathToPack: Path => Option[PackageName]) extends MainCommand {
+      packRes: PackageResolver) extends MainCommand {
       def run =
         readInterfaces(ifaces)
-          .flatMap(typeCheck(inputs, _, errColor, pathToPack))
+          .flatMap(typeCheck(inputs, _, errColor, packRes))
           .map { case (packs, _) =>
             val packList =
               packs.toMap
@@ -269,32 +437,36 @@ abstract class MainModule[IO[_]](implicit val moduleIOMonad: MonadError[IO, Thro
 
     case class RunTests(
       tests: List[Path],
-      testPacks: List[PackageName],
+      testPacks: List[MainIdentifier],
       dependencies: List[Path],
       errColor: Colorize,
-      pathToPack: Path => Option[PackageName]) extends MainCommand {
+      packRes: PackageResolver) extends MainCommand {
+
+      private[this] val tests1: List[Path] =
+        MainIdentifier.addAnyAbsent(testPacks, tests)
+
       def run = {
-        if (tests.isEmpty && dependencies.isEmpty) {
+        if (tests1.isEmpty && dependencies.isEmpty) {
           moduleIOMonad.raiseError(new Exception("no test sources or test dependencies"))
         }
         else {
-          val typeChecked =
-            for {
-              deps <- readPackages(dependencies)
-              ifaces = deps.map(Package.interfaceOf(_))
-              pn <- typeCheck0(tests, ifaces, errColor, pathToPack)
-              (packs0, nameMap) = pn
-              // add the dependencies into the package map
-              packs = deps.foldLeft(PackageMap.toAnyTyped(packs0))(_ + _)
-            } yield (packs, nameMap)
+          val typeChecked = buildPackMap(tests1, dependencies, errColor, packRes)
 
-          typeChecked.map { case (packs, nameMap) =>
-            val testSet = tests.toSet
+          val withTestPackNames = typeChecked
+            .flatMap { case (packs, nameMap) =>
+              testPacks.traverse(_.getMain(nameMap))
+                .map { testPackNames: List[PackageName] =>
+                  (packs, nameMap, testPackNames)
+                }
+            }
+
+          withTestPackNames.map { case (packs, nameMap, testPackNames) =>
+            val testSet = tests1.toSet
             val testPackages: List[PackageName] =
               (nameMap.iterator.collect { case (p, name) if testSet(p) => name } ++
-                testPacks.iterator).toList.sorted.distinct
+                testPackNames.iterator).toList.sorted.distinct
             val ev = Evaluation(packs, Predef.jvmExternals)
-            Output.TestOutput(testPackages.map { p => (p, ev.evalTest(p)) })
+            Output.TestOutput(testPackages.map { p => (p, ev.evalTest(p)) }, errColor)
           }
         }
       }
@@ -321,9 +493,14 @@ abstract class MainModule[IO[_]](implicit val moduleIOMonad: MonadError[IO, Thro
               List(s"failed to parse $path at line ${r + 1}, column ${c + 1}",
                   ctx.render(80))
             case ParseError.FileError(path, err) =>
-              List(s"failed to parse $path",
-                  err.getMessage,
-                  err.getClass.toString)
+              err match {
+                case _: java.nio.file.NoSuchFileException =>
+                  List(s"file not found: $path")
+                case _ =>
+                  List(s"failed to parse $path",
+                      err.getMessage,
+                      err.getClass.toString)
+              }
           }
         errors(msgs)
       }
@@ -370,9 +547,9 @@ abstract class MainModule[IO[_]](implicit val moduleIOMonad: MonadError[IO, Thro
           def defaultMetavar: String = "color"
           def read(str: String): ValidatedNel[String, Colorize] =
             str.toLowerCase match {
-              case "none" => Validated.valid(Colorize.none)
-              case "ansi" => Validated.valid(Colorize.Console.red)
-              case "html" => Validated.valid(Colorize.HmtlFont.red)
+              case "none" => Validated.valid(Colorize.None)
+              case "ansi" => Validated.valid(Colorize.Console)
+              case "html" => Validated.valid(Colorize.HmtlFont)
               case other => Validated.invalidNel(s"unknown colorize: $other, expected: none, ansi or html")
             }
         }
@@ -382,32 +559,53 @@ abstract class MainModule[IO[_]](implicit val moduleIOMonad: MonadError[IO, Thro
       val includes = toList(Opts.options[Path]("include", help = "compiled packages to include files"))
 
       val colorOpt = Opts.option[Colorize]("color", help = "colorize mode: none, ansi or html")
-        .orElse(Opts(Colorize.Console.red))
+        .orElse(Opts(Colorize.Console))
 
       val mainP =
           MainIdentifier.opts(
             Opts.option[PackageName]("main", help = "main package to evaluate"),
             Opts.option[Path]("main_file", help = "file containing the main package to evaluate"))
-      val testP = toList(Opts.options[PackageName]("test_package", help = "package for which to run tests"))
+
+      val testP =
+          MainIdentifier.list(
+            toList(Opts.options[PackageName]("test_package", help = "package for which to run tests")),
+            toList(Opts.options[Path]("test_file", help = "file containing the package for which to run tests")))
+
       val outputPath = Opts.option[Path]("output", help = "output path")
       val interfaceOutputPath = Opts.option[Path]("interface_out", help = "interface output path")
 
-      val pathToPack: Opts[Path => Option[PackageName]] =
-        toList(
-          Opts.options[Path](
-            "package_root",
-            help = "for implicit package names, consider these paths as roots"))
-          .map { paths =>
-            { p: Path => pathPackage(paths, p) }
+      val packRoot =
+        Opts.options[Path](
+          "package_root",
+          help = "for implicit package names, consider these paths as roots")
+
+      val packSearch =
+        resolvePath match {
+          case None => Opts(None)
+          case some@Some(_) =>
+            Opts.flag("search", help = "if set, we search the package_roots for imports not explicitly given")
+              .orFalse
+              .map {
+                case true => some
+                case false => None
+              }
+        }
+
+      val packRes: Opts[PackageResolver] =
+        (packRoot.product(packSearch))
+          .orNone
+          .map {
+            case None => PackageResolver.ExplicitOnly
+            case Some((paths, search)) => PackageResolver.LocalRoots(paths, search)
           }
 
-      val evalOpt = (toList(ins), mainP, includes, colorOpt, pathToPack)
+      val evalOpt = (toList(ins), mainP, includes, colorOpt, packRes)
         .mapN(Evaluate(_, _, _, _, _))
-      val toJsonOpt = (toList(ins), includes, mainP, outputPath, colorOpt, pathToPack)
+      val toJsonOpt = (toList(ins), includes, mainP, outputPath.orNone, colorOpt, packRes)
         .mapN(ToJson(_, _, _, _, _, _))
-      val typeCheckOpt = (ins, ifaces, outputPath, interfaceOutputPath.orNone, colorOpt, pathToPack)
+      val typeCheckOpt = (ins, ifaces, outputPath, interfaceOutputPath.orNone, colorOpt, packRes)
         .mapN(TypeCheck(_, _, _, _, _, _))
-      val testOpt = (toList(ins), testP, includes, colorOpt, pathToPack)
+      val testOpt = (toList(ins), testP, includes, colorOpt, packRes)
         .mapN(RunTests(_, _, _, _, _))
 
       Opts.subcommand("eval", "evaluate an expression and print the output")(evalOpt)

--- a/core/src/main/scala/org/bykn/bosatsu/MemoryMain.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/MemoryMain.scala
@@ -1,6 +1,6 @@
 package org.bykn.bosatsu
 
-import cats.MonadError
+import cats.{Monad, MonadError}
 import cats.data.Kleisli
 import com.monovore.decline.Argument
 import scala.collection.immutable.SortedMap
@@ -25,6 +25,9 @@ class MemoryMain[F[_], K: Ordering](split: K => List[String])(
       }
 
   def resolvePath: Option[(Path, PackageName) => IO[Option[Path]]] = None
+
+  def expandDirectories(path: Path): IO[List[Path]] =
+    Monad[IO].pure(path :: Nil)
 
   def readPackages(paths: List[Path]): IO[List[Package.Typed[Unit]]] =
     Kleisli.ask[F, MemoryMain.State[K]]

--- a/core/src/main/scala/org/bykn/bosatsu/MemoryMain.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/MemoryMain.scala
@@ -1,6 +1,6 @@
 package org.bykn.bosatsu
 
-import cats.{Monad, MonadError}
+import cats.MonadError
 import cats.data.Kleisli
 import com.monovore.decline.Argument
 import scala.collection.immutable.SortedMap
@@ -25,9 +25,6 @@ class MemoryMain[F[_], K: Ordering](split: K => List[String])(
       }
 
   def resolvePath: Option[(Path, PackageName) => IO[Option[Path]]] = None
-
-  def expandDirectories(path: Path): IO[List[Path]] =
-    Monad[IO].pure(path :: Nil)
 
   def readPackages(paths: List[Path]): IO[List[Package.Typed[Unit]]] =
     Kleisli.ask[F, MemoryMain.State[K]]

--- a/core/src/main/scala/org/bykn/bosatsu/MemoryMain.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/MemoryMain.scala
@@ -24,6 +24,8 @@ class MemoryMain[F[_], K: Ordering](split: K => List[String])(
         }
       }
 
+  def resolvePath: Option[(Path, PackageName) => IO[Option[Path]]] = None
+
   def readPackages(paths: List[Path]): IO[List[Package.Typed[Unit]]] =
     Kleisli.ask[F, MemoryMain.State[K]]
       .flatMap { files =>

--- a/core/src/main/scala/org/bykn/bosatsu/Predef.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/Predef.scala
@@ -28,7 +28,7 @@ object Predef {
       case Parsed.Success(pack, _) => pack
       case Parsed.Failure(exp, idx, extra) =>
         val lm = LocationMap(predefString)
-        sys.error(s"couldn't parse predef: ${lm.showContext(idx, 2, LocationMap.Colorize.none)} with trace: ${extra.traced.trace}")
+        sys.error(s"couldn't parse predef: ${lm.showContext(idx, 2, LocationMap.Colorize.None)} with trace: ${extra.traced.trace}")
     }
 
   /**

--- a/core/src/main/scala/org/bykn/bosatsu/Test.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/Test.scala
@@ -36,25 +36,26 @@ object Test {
     go(t :: Nil, 0)
   }
 
+  private[this] val colonSpace = Doc.text(": ")
+  private[this] val passed = Doc.text(" passed")
+  private[this] val failed = Doc.text(" failed")
+  private[this] val oneTest = Doc.text("1 test, ")
+
+  def summary(passes: Int, fails: Int, c: LocationMap.Colorize): Doc = {
+    @inline def failMsg = Doc.str(fails) + failed
+    val total = passes + fails
+    val tMsg = if (total == 1) oneTest else Doc.text(s"$total tests, ")
+    tMsg + c.green(Doc.str(passes) + passed) + Doc.space +
+      (if (fails > 0) c.red(failMsg) else failMsg)
+  }
+
   def report(t: Test, c: LocationMap.Colorize): (Int, Int, Doc) = {
 
-    val colonSpace = Doc.text(": ")
     val passDoc = c.green(Doc.text("pass"))
     val failDoc = c.red(Doc.text("fail"))
-    val passed = Doc.text(" passed")
-    val failed = Doc.text(" failed")
-    val oneTest = Doc.text("1 test, ")
 
     def init(t: List[Test]): (Int, Int, Doc) =
       loop(t, None, 0, 0, Doc.empty)
-
-    def summary(passes: Int, fails: Int): Doc = {
-      @inline def failMsg = Doc.str(fails) + failed
-      val total = passes + fails
-      val tMsg = if (total == 1) oneTest else Doc.text(s"$total tests, ")
-      tMsg + c.green(Doc.str(passes) + passed) + Doc.space +
-        (if (fails > 0) c.red(failMsg) else failMsg)
-    }
 
     @annotation.tailrec
     def loop(ts: List[Test], lastSuite: Option[(Int, Int)], passes: Int, fails: Int, front: Doc): (Int, Int, Doc) =
@@ -64,7 +65,7 @@ object Test {
             lastSuite match {
               case Some((p, f)) if (p == passes) && (f == fails) => Doc.empty
               case _ =>
-                Doc.line + summary(passes, fails)
+                Doc.line + summary(passes, fails, c)
             }
           (passes, fails, front + sumDoc)
         case Assertion(true, _) :: rest =>

--- a/core/src/main/scala/org/bykn/bosatsu/Test.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/Test.scala
@@ -16,6 +16,8 @@ sealed abstract class Test {
         else Some(Test.Suite(nm, innerFails))
       }
     }
+
+  def failureCount: Int = failures.fold(0)(_.assertions)
 }
 
 object Test {

--- a/core/src/main/scala/org/bykn/bosatsu/rankn/Type.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/rankn/Type.scala
@@ -194,15 +194,16 @@ object Type {
    * These are upper-case to leverage scala's pattern
    * matching on upper-cased vals
    */
-  val IntType: Type = TyConst(Const.predef("Int"))
   val BoolType: Type = TyConst(Const.predef("Bool"))
-  val StrType: Type = TyConst(Const.predef("String"))
-  val FnType: Type = TyConst(Const.predef("Fn"))
-  val ListType: Type = TyConst(Const.predef("List"))
   val DictType: Type = TyConst(Const.predef("Dict"))
+  val FnType: Type = TyConst(Const.predef("Fn"))
+  val IntType: Type = TyConst(Const.predef("Int"))
+  val ListType: Type = TyConst(Const.predef("List"))
   val OptionType: Type = TyConst(Const.predef("Option"))
-  val UnitType = TyConst(Type.Const.predef("Unit"))
+  val StrType: Type = TyConst(Const.predef("String"))
+  val TestType: Type = TyConst(Const.predef("Test"))
   val TupleConsType = TyConst(Type.Const.predef("TupleCons"))
+  val UnitType = TyConst(Type.Const.predef("Unit"))
 
   def const(pn: PackageName, name: TypeName): Type =
     TyConst(Type.Const.Defined(pn, name))

--- a/core/src/test/scala/org/bykn/bosatsu/EvaluationTest.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/EvaluationTest.scala
@@ -196,7 +196,7 @@ main = go(IntCase(42))
 """
     val packs = Map((PackageName.parts("Err"), (LocationMap(errPack), "Err.bosatsu")))
     evalFail(List(errPack), "Err") { case te@PackageError.TypeErrorIn(_, _) =>
-      val msg = te.message(packs, Colorize.none)
+      val msg = te.message(packs, Colorize.None)
       assert(msg.contains("type error: expected type Bosatsu/Predef::Int to be the same as type Bosatsu/Predef::String"))
       ()
     }
@@ -1316,7 +1316,7 @@ main = a"""), "B") { case PackageError.UnknownImportPackage(_, _) => () }
 package B
 
 main = a"""), "B") { case te@PackageError.TypeErrorIn(_, _) =>
-    val msg = te.message(Map.empty, Colorize.none)
+    val msg = te.message(Map.empty, Colorize.None)
     assert(!msg.contains("Name("))
     assert(msg.contains("package B, name \"a\" unknown"))
     ()
@@ -1331,7 +1331,7 @@ x = 1
 main = match x:
   Foo: 2
 """), "B") { case te@PackageError.SourceConverterErrorIn(_, _) =>
-    val msg = te.message(Map.empty, Colorize.none)
+    val msg = te.message(Map.empty, Colorize.None)
     assert(!msg.contains("Name("))
     assert(msg.contains("package B, unknown constructor Foo"))
     ()
@@ -1346,7 +1346,7 @@ struct X
 main = match 1:
   X1: 0
 """), "B") { case te@PackageError.SourceConverterErrorIn(_, _) =>
-      val b = assert(te.message(Map.empty, Colorize.none) == "in file: <unknown source>, package B, unknown constructor X1\nRegion(44,45)")
+      val b = assert(te.message(Map.empty, Colorize.None) == "in file: <unknown source>, package B, unknown constructor X1\nRegion(44,45)")
       ()
     }
 
@@ -1358,7 +1358,7 @@ main = match [1, 2, 3]:
   []: 0
   [*a, _, *b]: 2
 """), "A") { case te@PackageError.TotalityCheckError(_, _) =>
-      val b = assert(te.message(Map.empty, Colorize.none) == "in file: <unknown source>, package A\nRegion(19,60)\nmultiple splices in pattern, only one per match allowed")
+      val b = assert(te.message(Map.empty, Colorize.None) == "in file: <unknown source>, package A\nRegion(19,60)\nmultiple splices in pattern, only one per match allowed")
       ()
     }
 
@@ -1371,7 +1371,7 @@ enum Foo: Bar(a), Baz(b)
 main = match Bar(a):
   Baz(b): b
 """), "A") { case te@PackageError.TotalityCheckError(_, _) =>
-      val b = assert(te.message(Map.empty, Colorize.none) == "in file: <unknown source>, package A\nRegion(45,70)\nnon-total match, missing: Bar(_)")
+      val b = assert(te.message(Map.empty, Colorize.None) == "in file: <unknown source>, package A\nRegion(45,70)\nnon-total match, missing: Bar(_)")
       ()
     }
 
@@ -1385,7 +1385,7 @@ def fn(x):
 
 main = fn
 """), "A") { case te@PackageError.RecursionError(_, _) =>
-      val b = assert(te.message(Map.empty, Colorize.none) == "in file: <unknown source>, package A, recur but no recursive call to fn\nRegion(25,42)\n")
+      val b = assert(te.message(Map.empty, Colorize.None) == "in file: <unknown source>, package A, recur but no recursive call to fn\nRegion(25,42)\n")
       ()
     }
 
@@ -1399,7 +1399,7 @@ def fn(x):
 
 main = fn
 """), "A") { case te@PackageError.RecursionError(_, _) =>
-      val b = assert(te.message(Map.empty, Colorize.none) == "in file: <unknown source>, package A, recur not on an argument to the def of fn, args: x\nRegion(25,43)\n")
+      val b = assert(te.message(Map.empty, Colorize.None) == "in file: <unknown source>, package A, recur not on an argument to the def of fn, args: x\nRegion(25,43)\n")
       ()
     }
 
@@ -1413,7 +1413,7 @@ def fn(x):
 
 main = fn
 """), "A") { case te@PackageError.RecursionError(_, _) =>
-      val b = assert(te.message(Map.empty, Colorize.none) == "in file: <unknown source>, package A, recur not on an argument to the def of fn, args: x\nRegion(25,42)\n")
+      val b = assert(te.message(Map.empty, Colorize.None) == "in file: <unknown source>, package A, recur not on an argument to the def of fn, args: x\nRegion(25,42)\n")
       ()
     }
 
@@ -1429,7 +1429,7 @@ def fn(x):
 
 main = fn
 """), "A") { case te@PackageError.RecursionError(_, _) =>
-      val b = assert(te.message(Map.empty, Colorize.none) == "in file: <unknown source>, package A, unexpected recur: may only appear unnested inside a def\nRegion(47,70)\n")
+      val b = assert(te.message(Map.empty, Colorize.None) == "in file: <unknown source>, package A, unexpected recur: may only appear unnested inside a def\nRegion(47,70)\n")
       ()
     }
 
@@ -1446,7 +1446,7 @@ def fn(x):
 
 main = fn
 """), "A") { case te@PackageError.RecursionError(_, _) =>
-      val b = assert(te.message(Map.empty, Colorize.none) == "in file: <unknown source>, package A, illegal shadowing on: fn. Recursive shadowing of def names disallowed\nRegion(25,81)\n")
+      val b = assert(te.message(Map.empty, Colorize.None) == "in file: <unknown source>, package A, illegal shadowing on: fn. Recursive shadowing of def names disallowed\nRegion(25,81)\n")
       ()
     }
 
@@ -1461,7 +1461,7 @@ def fn(x, y):
 
 main = fn
 """), "A") { case te@PackageError.RecursionError(_, _) =>
-      val b = assert(te.message(Map.empty, Colorize.none) == "in file: <unknown source>, package A, invalid recursion on fn\nRegion(53,69)\n")
+      val b = assert(te.message(Map.empty, Colorize.None) == "in file: <unknown source>, package A, invalid recursion on fn\nRegion(53,69)\n")
       ()
     }
 
@@ -1478,7 +1478,7 @@ import A [ fooz ]
 
 baz = fooz
 """), "B") { case te@PackageError.UnknownImportName(_, _, _, _) =>
-      val b = assert(te.message(Map.empty, Colorize.none) == "in <unknown source> package: A does not have name fooz. Nearest: foo")
+      val b = assert(te.message(Map.empty, Colorize.None) == "in <unknown source> package: A does not have name fooz. Nearest: foo")
       ()
     }
 
@@ -1496,7 +1496,7 @@ import A [ bar ]
 
 baz = bar
 """), "B") { case te@PackageError.UnknownImportName(_, _, _, _) =>
-      val b = assert(te.message(Map.empty, Colorize.none) == "in <unknown source> package: A has bar but it is not exported. Add to exports")
+      val b = assert(te.message(Map.empty, Colorize.None) == "in <unknown source> package: A has bar but it is not exported. Add to exports")
       ()
     }
   }
@@ -1786,7 +1786,7 @@ get = \Pair(first, ...) -> first
 # missing second
 first = 1
 res = get(Pair { first })
-"""), "A") { case s@PackageError.SourceConverterErrorIn(_, _) => s.message(Map.empty, Colorize.none); () }
+"""), "A") { case s@PackageError.SourceConverterErrorIn(_, _) => s.message(Map.empty, Colorize.None); () }
 
     evalFail(
       List("""
@@ -1800,7 +1800,7 @@ get = \Pair(first, ...) -> first
 first = 1
 second = 3
 res = get(Pair { first, second, third })
-"""), "A") { case s@PackageError.SourceConverterErrorIn(_, _) => s.message(Map.empty, Colorize.none); () }
+"""), "A") { case s@PackageError.SourceConverterErrorIn(_, _) => s.message(Map.empty, Colorize.None); () }
 
     evalFail(
       List("""
@@ -1811,7 +1811,7 @@ struct Pair(first, second)
 get = \Pair { first } -> first
 
 res = get(Pair(1, "two"))
-"""), "A") { case s@PackageError.SourceConverterErrorIn(_, _) => s.message(Map.empty, Colorize.none); () }
+"""), "A") { case s@PackageError.SourceConverterErrorIn(_, _) => s.message(Map.empty, Colorize.None); () }
 
     evalFail(
       List("""
@@ -1823,7 +1823,7 @@ struct Pair(first, second)
 get = \Pair(first) -> first
 
 res = get(Pair(1, "two"))
-"""), "A") { case s@PackageError.SourceConverterErrorIn(_, _) => s.message(Map.empty, Colorize.none); () }
+"""), "A") { case s@PackageError.SourceConverterErrorIn(_, _) => s.message(Map.empty, Colorize.None); () }
 
     evalFail(
       List("""
@@ -1835,7 +1835,7 @@ struct Pair(first, second)
 get = \Pair { first, sec: _ } -> first
 
 res = get(Pair(1, "two"))
-"""), "A") { case s@PackageError.SourceConverterErrorIn(_, _) => s.message(Map.empty, Colorize.none); () }
+"""), "A") { case s@PackageError.SourceConverterErrorIn(_, _) => s.message(Map.empty, Colorize.None); () }
 
     evalFail(
       List("""
@@ -1847,7 +1847,7 @@ struct Pair(first, second)
 get = \Pair { first, sec: _, ... } -> first
 
 res = get(Pair(1, "two"))
-"""), "A") { case s@PackageError.SourceConverterErrorIn(_, _) => s.message(Map.empty, Colorize.none); () }
+"""), "A") { case s@PackageError.SourceConverterErrorIn(_, _) => s.message(Map.empty, Colorize.None); () }
 
     evalFail(
       List("""
@@ -1859,7 +1859,7 @@ struct Pair(first, second)
 get = \Pair(first, _, _) -> first
 
 res = get(Pair(1, "two"))
-"""), "A") { case s@PackageError.SourceConverterErrorIn(_, _) => s.message(Map.empty, Colorize.none); () }
+"""), "A") { case s@PackageError.SourceConverterErrorIn(_, _) => s.message(Map.empty, Colorize.None); () }
 
     evalFail(
       List("""
@@ -1871,7 +1871,7 @@ struct Pair(first, second)
 get = \Pair(first, _, _, ...) -> first
 
 res = get(Pair(1, "two"))
-"""), "A") { case s@PackageError.SourceConverterErrorIn(_, _) => s.message(Map.empty, Colorize.none); () }
+"""), "A") { case s@PackageError.SourceConverterErrorIn(_, _) => s.message(Map.empty, Colorize.None); () }
   }
 
   test("exercise total matching inside of a struct with a list") {
@@ -1989,7 +1989,7 @@ external def foo(x: String) -> List[String]
 def foo(x): x
 
 """), "A") { case s@PackageError.SourceConverterErrorIn(_, _) =>
-      assert(s.message(Map.empty, Colorize.none) == "in file: <unknown source>, package A, bind names foo shadow external def\nRegion(57,71)")
+      assert(s.message(Map.empty, Colorize.None) == "in file: <unknown source>, package A, bind names foo shadow external def\nRegion(57,71)")
       ()
     }
 
@@ -2002,7 +2002,7 @@ external def foo(x: String) -> List[String]
 foo = 1
 
 """), "A") { case s@PackageError.SourceConverterErrorIn(_, _) =>
-      assert(s.message(Map.empty, Colorize.none) == "in file: <unknown source>, package A, bind names foo shadow external def\nRegion(57,65)")
+      assert(s.message(Map.empty, Colorize.None) == "in file: <unknown source>, package A, bind names foo shadow external def\nRegion(57,65)")
       ()
     }
 
@@ -2014,7 +2014,7 @@ external def foo(x: String) -> List[String]
 
 external def foo(x: String) -> List[String]
 """), "A") { case s@PackageError.SourceConverterErrorIn(_, _) =>
-      assert(s.message(Map.empty, Colorize.none) == "in file: <unknown source>, package A, foo defined multiple times\nRegion(21,55)")
+      assert(s.message(Map.empty, Colorize.None) == "in file: <unknown source>, package A, foo defined multiple times\nRegion(21,55)")
       ()
     }
   }
@@ -2044,7 +2044,7 @@ struct Foo[a](a)
 
 main = Foo(1, "2")
 """), "Err") { case sce@PackageError.SourceConverterErrorIn(_, _) =>
-      assert(sce.message(Map.empty, Colorize.none) == "in file: <unknown source>, package Err, Foo found declared: [a], not a superset of [anon0]\nRegion(14,30)")
+      assert(sce.message(Map.empty, Colorize.None) == "in file: <unknown source>, package Err, Foo found declared: [a], not a superset of [anon0]\nRegion(14,30)")
       ()
     }
 
@@ -2056,7 +2056,7 @@ struct Foo[a](a: a, b: b)
 
 main = Foo(1, "2")
 """), "Err") { case sce@PackageError.SourceConverterErrorIn(_, _) =>
-      assert(sce.message(Map.empty, Colorize.none) == "in file: <unknown source>, package Err, Foo found declared: [a], not a superset of [a, b]\nRegion(14,39)")
+      assert(sce.message(Map.empty, Colorize.None) == "in file: <unknown source>, package Err, Foo found declared: [a], not a superset of [a, b]\nRegion(14,39)")
       ()
     }
 
@@ -2068,7 +2068,7 @@ enum Enum[a]: Foo(a)
 
 main = Foo(1, "2")
 """), "Err") { case sce@PackageError.SourceConverterErrorIn(_, _) =>
-      assert(sce.message(Map.empty, Colorize.none) == "in file: <unknown source>, package Err, Enum found declared: [a], not a superset of [anon0]\nRegion(14,34)")
+      assert(sce.message(Map.empty, Colorize.None) == "in file: <unknown source>, package Err, Enum found declared: [a], not a superset of [anon0]\nRegion(14,34)")
       ()
     }
 
@@ -2080,7 +2080,7 @@ enum Enum[a]: Foo(a: a), Bar(a: b)
 
 main = Foo(1, "2")
 """), "Err") { case sce@PackageError.SourceConverterErrorIn(_, _) =>
-      assert(sce.message(Map.empty, Colorize.none) == "in file: <unknown source>, package Err, Enum found declared: [a], not a superset of [a, b]\nRegion(14,48)")
+      assert(sce.message(Map.empty, Colorize.None) == "in file: <unknown source>, package Err, Enum found declared: [a], not a superset of [a, b]\nRegion(14,48)")
       ()
     }
   }
@@ -2094,7 +2094,7 @@ import Bosatsu/Predef [ foldLeft ]
 
 main = 1
 """), "Err") { case sce@PackageError.DuplicatedImport(_) =>
-      assert(sce.message(Map.empty, Colorize.none) == "duplicate import in <unknown source> package Bosatsu/Predef imports foldLeft as foldLeft")
+      assert(sce.message(Map.empty, Colorize.None) == "duplicate import in <unknown source> package Bosatsu/Predef imports foldLeft as foldLeft")
       ()
     }
   }

--- a/core/src/test/scala/org/bykn/bosatsu/TestUtils.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/TestUtils.scala
@@ -70,7 +70,7 @@ object TestUtils {
       case Parsed.Success(stmts, _) =>
         Package.inferBody(PackageName.parts("Test"), Nil, stmts) match {
           case Validated.Invalid(errs) =>
-            fail("inference failure: " + errs.toList.map(_.message(Map.empty, LocationMap.Colorize.none)).mkString("\n"))
+            fail("inference failure: " + errs.toList.map(_.message(Map.empty, LocationMap.Colorize.None)).mkString("\n"))
           case Validated.Valid(program) =>
             // make sure all the TypedExpr are valid
             program.lets.foreach { case (_, _, te) => assertValid(te) }
@@ -118,11 +118,11 @@ object TestUtils {
     val files = packages.zipWithIndex.map(_.swap)
 
     module.runWith(files)("test" :: "--test_package" :: mainPackS :: makeInputArgs(files)) match {
-      case Right(module.Output.TestOutput(results)) =>
+      case Right(module.Output.TestOutput(results, _)) =>
         results.collect { case (_, Some(t)) => t } match {
           case t :: Nil =>
             assert(t.assertions == assertionCount, s"${t.assertions} != $assertionCount")
-            val (suc, failcount, message) = Test.report(t)
+            val (suc, failcount, message) = Test.report(t, LocationMap.Colorize.None)
             assert(t.failures.map(_.assertions).getOrElse(0) == failcount)
             if (failcount > 0) fail(message.render(80))
             else succeed
@@ -149,7 +149,7 @@ object TestUtils {
       case Validated.Valid(vs) => vs
       case Validated.Invalid(errs) =>
         errs.toList.foreach { p =>
-          p.showContext(LocationMap.Colorize.none).foreach(System.err.println)
+          p.showContext(LocationMap.Colorize.None).foreach(System.err.println)
         }
         sys.error("failed to parse") //errs.toString)
     }
@@ -246,7 +246,7 @@ object TestUtils {
       case (sm, Validated.Invalid(errs)) if errs.collect(errFn).nonEmpty =>
         // make sure we can print the messages:
         val sm = PackageMap.buildSourceMap(withPre)
-        errs.toList.foreach(_.message(sm, LocationMap.Colorize.none))
+        errs.toList.foreach(_.message(sm, LocationMap.Colorize.None))
         assert(true)
       case (_, Validated.Invalid(errs)) =>
           fail(s"failed, but no type errors: $errs")

--- a/test_workspace/Bar.bosatsu
+++ b/test_workspace/Bar.bosatsu
@@ -1,0 +1,9 @@
+import Foo [ x ]
+
+def eq(cmp):
+  match cmp:
+    EQ: True
+    _: False
+
+test = Assertion(
+  eq(string_Order_fn(x, "this is Foo")), "got the right string")

--- a/test_workspace/Foo.bosatsu
+++ b/test_workspace/Foo.bosatsu
@@ -1,0 +1,5 @@
+export [ x, ]
+
+# testing an implicit package name
+
+x = "this is Foo"


### PR DESCRIPTION
This was plane code done to improve the usability of the CLI:

1. compiling bosatsu with native-image makes the CLI much nicer to use, so it would be nice not to have to use bazel for basic things, without compromising the correctness of the bazel operation.
2. for a python-like experience, it is nice to run a file, and have a `--search` mode for to automatically look for files based on package name. `--search` should probably be the default when you give a package_root, so I think that should be changed to `--no-search` to disable.
3. colorization flag should work for `test`.
4. test should find the last test value, not the last value. This is more general, so shouldn't break anything. By doing this you can do both tests and json for a single file.
5. `write-json` should have an optional file output. Without a file output, write to standard out
6. don't duplicate the test suite summary if there is only one suite and all the items are in that suite.
7. add a script to build the native-image bosatsu, add a script to run the assembly

After you build the native-image, you can do, for example
```
./bosatsu test --package_root ex --search --test_file ex/Nat.bosatsu
```
And it will instantly compile and run the tests in ex/Nat.bosatsu (including compiling any dependencies that are placed in the correct locations `package Foo/Bar` should be at `root/Foo/Bar.bosatsu`

cc @snoble take a look at this.... it's amazing how much more fun it is.