### PR TITLE
Add quicksort implementation to List

### DIFF
--- a/cli/src/test/scala/org/bykn/bosatsu/PathModuleTest.scala
+++ b/cli/src/test/scala/org/bykn/bosatsu/PathModuleTest.scala
@@ -83,7 +83,7 @@ class PathModuleTest extends FunSuite {
     }
 
   test("test direct run of a file") {
-    val out = run("test --input test_workspace/List.bosatsu --input test_workspace/Bool.bosatsu --test_file test_workspace/Queue.bosatsu".split("\\s+"): _*)
+    val out = run("test --input test_workspace/List.bosatsu --input test_workspace/Nat.bosatsu --input test_workspace/Bool.bosatsu --test_file test_workspace/Queue.bosatsu".split("\\s+"): _*)
     out match {
       case PathModule.Output.TestOutput(results, _) =>
         val res = results.collect { case (pn, Some(t)) if pn.asString == "Queue" => t }

--- a/core/src/main/resources/bosatsu/predef.bosatsu
+++ b/core/src/main/resources/bosatsu/predef.bosatsu
@@ -9,7 +9,7 @@ export [
   String,
   Test(),
   TupleCons(),
-  Order,
+  Order(),
   Unit(),
   Dict,
   add,
@@ -46,8 +46,7 @@ struct Unit
 struct TupleCons(first, second)
 
 enum Bool:
-  False
-  True
+  False, True
 
 enum List:
   EmptyList, NonEmptyList(head: a, tail: List[a])
@@ -84,15 +83,12 @@ def uncurry3(f: t1 -> t2 -> t3 -> r) -> (t1, t2, t3) -> r:
   \(x1, x2, x3) -> f(x1, x2, x3)
 
 enum Comparison:
-  LT
-  EQ
-  GT
+    LT, EQ, GT
 
 enum Option:
-  None
-  Some(v)
+  None, Some(v)
 
-struct Order(fn: a -> a -> Comparison)
+struct Order(to_Fn: a -> a -> Comparison)
 
 external struct Dict[k, v]
 external def clear_Dict(dict: Dict[k, v]) -> Dict[k, v]

--- a/test_workspace/BUILD
+++ b/test_workspace/BUILD
@@ -66,7 +66,7 @@ bosatsu_library(
 bosatsu_library(
     name = "list",
     srcs = ["List.bosatsu"],
-    deps = [":bool"],
+    deps = [":bool", ":nat"],
     )
 
 bosatsu_library(

--- a/test_workspace/List.bosatsu
+++ b/test_workspace/List.bosatsu
@@ -63,6 +63,16 @@ def size(list: List[a]) -> Nat:
 def sort(ord: Order[a], list: List[a]) -> List[a]:
     Order { to_Fn } = ord
 
+    def lt(x, h):
+        match to_Fn(x, h):
+            LT: True
+            _: False
+
+    def gteq(x, h):
+        match to_Fn(x, h):
+            LT: False
+            _: True
+
     def loop(list: List[a], sz: Nat):
         recur sz:
             Zero: list
@@ -70,14 +80,8 @@ def sort(ord: Order[a], list: List[a]) -> List[a]:
                 match list:
                     []: []
                     [h, *t]:
-                        def lt(x): match to_Fn(x, h):
-                                     LT: True
-                                     _: False
-                        def gt(x): match to_Fn(x, h):
-                                     GT: True
-                                     _: False
-                        lesser = [ ta for ta in t if lt(ta) ]
-                        greater = [ ta for ta in t if gt(ta) ]
+                        lesser = [ ta for ta in t if lt(ta, h) ]
+                        greater = [ ta for ta in t if gteq(ta, h) ]
                         # each of the above are at most size n
                         [ *loop(lesser, n), h, *loop(greater, n) ]
     loop(list, size(list))
@@ -135,10 +139,15 @@ def sortTest:
                 [1, 2, 3]: True
                 _: False
 
+    test4 = match sort_Int([1, 2, 1]):
+                [1, 1, 2]: True
+                _: False
+
     TestSuite("sort tests", [
       Assertion(test1, "3, 1, 2"),
       Assertion(test2, "1, 2, 3"),
       Assertion(test3, "2, 3, 1"),
+      Assertion(test4, "1, 2, 1"),
     ])
 
 tests = TestSuite("List tests", [

--- a/test_workspace/List.bosatsu
+++ b/test_workspace/List.bosatsu
@@ -1,7 +1,8 @@
 package Bosatsu/List
 
 import Bosatsu/Bool [ not ]
-export [ eq_List, exists, head, for_all, sum, uncons, zip ]
+import Bosatsu/Nat [ Nat, Zero, Succ ]
+export [ eq_List, exists, head, for_all, size, sum, sort, uncons, zip ]
 
 def for_all(xs: List[a], fn: a -> Bool) -> Bool:
   recur xs:
@@ -50,6 +51,37 @@ def zip(left: List[a], right: List[b]) -> List[(a, b)]:
                 []: []
                 [bh, *bt]: [(ah, bh), *zip(at, bt)]
 
+# tail recursive size implementation
+def size1(list, acc):
+    recur list:
+        []: acc
+        [_, *t]: size1(t, Succ(acc))
+
+def size(list: List[a]) -> Nat:
+    size1(list, Zero)
+
+def sort(ord: Order[a], list: List[a]) -> List[a]:
+    Order { to_Fn } = ord
+
+    def loop(list: List[a], sz: Nat):
+        recur sz:
+            Zero: list
+            Succ(n):
+                match list:
+                    []: []
+                    [h, *t]:
+                        def lt(x): match to_Fn(x, h):
+                                     LT: True
+                                     _: False
+                        def gt(x): match to_Fn(x, h):
+                                     GT: True
+                                     _: False
+                        lesser = [ ta for ta in t if lt(ta) ]
+                        greater = [ ta for ta in t if gt(ta) ]
+                        # each of the above are at most size n
+                        [ *loop(lesser, n), h, *loop(greater, n) ]
+    loop(list, size(list))
+
 ##########################
 # Test code below
 ##########################
@@ -89,6 +121,25 @@ def zipTest:
       Assertion(test3, "right smaller"),
     ])
 
+def sortTest:
+    sort_Int = sort(Order(cmp_Int))
+    test1 = match sort_Int([3, 1, 2]):
+                [1, 2, 3]: True
+                _: False
+
+    test2 = match sort_Int([1, 2, 3]):
+                [1, 2, 3]: True
+                _: False
+
+    test3 = match sort_Int([2, 3, 1]):
+                [1, 2, 3]: True
+                _: False
+
+    TestSuite("sort tests", [
+      Assertion(test1, "3, 1, 2"),
+      Assertion(test2, "1, 2, 3"),
+      Assertion(test3, "2, 3, 1"),
+    ])
 
 tests = TestSuite("List tests", [
   Assertion([1, 2, 3] =*= [1, 2, 3], "list [1, 2, 3]"),
@@ -99,5 +150,6 @@ tests = TestSuite("List tests", [
   headTest,
   unconsTest,
   zipTest,
+  sortTest,
   ])
 


### PR DESCRIPTION
This stumped me at first, but the solution is quite instructive and I think rather general: find some companion structure that proves the computation terminates and carry that through with you in the recursion. This can be removed from the API by computing the companion structure internally.