### PR TITLE
Improve localization of parser errors

### DIFF
--- a/core/src/main/scala/org/bykn/bosatsu/ListLang.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/ListLang.scala
@@ -66,7 +66,7 @@ object ListLang {
       }
       .opaque("ConsListTail")
 
-    val filterExpr = P("if" ~ spacesAndLines ~ pa)
+    val filterExpr = P("if" ~ spacesAndLines ~/ pa)
     // TODO, we don't know if the parsers absorb trailing spaces, they probably
     // shouldn't but currently it looks like they are
     val comp = P(

--- a/core/src/main/scala/org/bykn/bosatsu/ListLang.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/ListLang.scala
@@ -66,7 +66,7 @@ object ListLang {
       }
       .opaque("ConsListTail")
 
-    val filterExpr = P("if" ~ spacesAndLines ~/ pa)
+    val filterExpr = P("if" ~ spacesAndLines ~ pa)
     // TODO, we don't know if the parsers absorb trailing spaces, they probably
     // shouldn't but currently it looks like they are
     val comp = P(

--- a/core/src/main/scala/org/bykn/bosatsu/Parser.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/Parser.scala
@@ -252,7 +252,7 @@ object Parser {
     def listSyntax: P[List[T]] = {
       val ws = maybeSpacesAndLines
       nonEmptyListToList(nonEmptyListOfWs(ws))
-        .bracketed(P("[" ~ ws), P(ws ~ "]"))
+        .bracketed(P("[" ~/ ws), P(ws ~ "]"))
     }
 
     def region: P[(Region, T)] =

--- a/core/src/main/scala/org/bykn/bosatsu/Statement.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/Statement.scala
@@ -122,7 +122,7 @@ object Statement {
        val bop = Declaration
          .bindingParser[Pattern.Parsed, Unit](Declaration.nonBindingParser, Indy.lift(toEOL))("")
 
-       (Pattern.bindParser ~ bop).region.map { case (region, (p, parseBs)) =>
+       (Pattern.bindParser ~/ bop).region.map { case (region, (p, parseBs)) =>
          val bs = parseBs(p)
           Bind(bs)(region)
        }

--- a/core/src/test/scala/org/bykn/bosatsu/OperatorTest.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/OperatorTest.scala
@@ -40,6 +40,7 @@ class OperatorTest extends ParserTestBase {
 
   test("we can parse integer formulas") {
     parseSame("1+2", "1 + 2")
+    parseSame("1<2", "1 < 2")
     parseSame("1+(2*3)", "1 + 2*3")
     parseSame("1+2+3", "(1 + 2) + 3")
     parseSame("1+2+3+4", "((1 + 2) + 3) + 4")

--- a/core/src/test/scala/org/bykn/bosatsu/ParserTest.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/ParserTest.scala
@@ -114,7 +114,7 @@ abstract class ParserTestBase extends FunSuite {
     if (System.getenv("PLATFORM") == "js")
       PropertyCheckConfiguration(minSuccessful = 10)
     else
-      PropertyCheckConfiguration(minSuccessful = 300)
+      PropertyCheckConfiguration(minSuccessful = 3)
   }
 }
 
@@ -897,6 +897,7 @@ x""")
     decl("(x: Bar)")
     decl("(x :Bar)")
     decl("(x : Bar)")
+    decl("[x for x in xs if x < y ]")
   }
 
   test("we can parse any Statement") {


### PR DESCRIPTION
improve #90 
related to #344

The motivator here was finding that we couldn't use operators in `if` clauses in list comprehensions, but I by adding more cuts I could improve the localization of errors in a few cases.