### PR TITLE
Use Ior more to better model partial failure

### DIFF
--- a/bench/src/main/scala/org/bykn/bosatsu/TestBench.scala
+++ b/bench/src/main/scala/org/bykn/bosatsu/TestBench.scala
@@ -1,9 +1,11 @@
 package org.bykn.bosatsu
 
+import cats.Show
 import cats.data.Validated
 import org.openjdk.jmh.annotations.{Benchmark, Scope, State}
 
 import cats.implicits._
+import IorMethods.IorExtension
 
 @State(Scope.Thread)
 class TestBench {
@@ -28,8 +30,9 @@ class TestBench {
         sys.error("failed to parse") //errs.toString)
     }
 
-    PackageMap.resolveThenInfer(Predef.withPredefA(("predef", LocationMap("")), parsedPaths), Nil) match {
-      case (dups, Validated.Valid(packMap)) if dups.isEmpty =>
+    implicit val show: Show[(String, LocationMap)] = Show.show { case (s, _) => s }
+    PackageMap.resolveThenInfer(Predef.withPredefA(("predef", LocationMap("")), parsedPaths), Nil).strictToValidated match {
+      case Validated.Valid(packMap) =>
         (packMap, mainPack)
       case other => sys.error(s"expected clean compilation: $other")
     }

--- a/core/.js/src/main/scala/org/bykn/bosatsu/Par.scala
+++ b/core/.js/src/main/scala/org/bykn/bosatsu/Par.scala
@@ -1,6 +1,6 @@
 package org.bykn.bosatsu
 
-import cats.{Monad, Id}
+import cats.{Monad, Id, Parallel}
 import scala.concurrent.ExecutionContext
 
 /**
@@ -23,6 +23,10 @@ object Par {
 
   implicit def orgByknBosatsuParFMonad(implicit ec: ExecutionContext): Monad[F] =
     cats.catsInstancesForId
+
+  // since Future has already started, standard Parallel.identity is parallel
+  implicit def orgByknBosatsuParParallel(implicit ec: ExecutionContext): Parallel[F] =
+    Parallel.identity
 
   @inline def start[A](a: => A)(implicit ec: ExecutionContext): F[A] =
     a

--- a/core/.jvm/src/main/scala/org/bykn/bosatsu/Par.scala
+++ b/core/.jvm/src/main/scala/org/bykn/bosatsu/Par.scala
@@ -1,6 +1,6 @@
 package org.bykn.bosatsu
 
-import cats.Monad
+import cats.{Monad, Parallel}
 import scala.concurrent.{Await, ExecutionContext, Future, Promise}
 import scala.concurrent.duration.Duration
 
@@ -16,6 +16,10 @@ object Par {
 
   implicit def orgByknBosatsuParFMonad(implicit ec: ExecutionContext): Monad[F] =
     cats.implicits.catsStdInstancesForFuture
+
+  // since Future has already started, standard Parallel.identity is parallel
+  implicit def orgByknBosatsuParParallel(implicit ec: ExecutionContext): Parallel[F] =
+    Parallel.identity
 
   @inline def start[A](a: => A)(implicit ec: ExecutionContext): F[A] =
     Future(a)

--- a/core/src/main/scala/org/bykn/bosatsu/IorMethods.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/IorMethods.scala
@@ -1,0 +1,14 @@
+package org.bykn.bosatsu
+
+import cats.data.{Ior, Validated}
+
+object IorMethods {
+  implicit class IorExtension[A, B](val ior: Ior[A, B]) extends AnyVal {
+    def strictToValidated: Validated[A, B] =
+      ior match {
+        case Ior.Right(b) => Validated.valid(b)
+        case Ior.Left(a) => Validated.invalid(a)
+        case Ior.Both(a, _) => Validated.invalid(a)
+      }
+  }
+}

--- a/core/src/main/scala/org/bykn/bosatsu/MainModule.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/MainModule.scala
@@ -269,8 +269,8 @@ abstract class MainModule[IO[_]](implicit val moduleIOMonad: MonadError[IO, Thro
                     // this
                     import scala.concurrent.ExecutionContext.Implicits.global
 
-                    // type is Path | String, but we only call .toString on it
-                    PackageMap.typeCheckParsed[Any](packs, ifs, "predef").strictToValidated match {
+                    val packsString = packs.map { case ((path, lm), parsed) => ((path.toString, lm), parsed) }
+                    PackageMap.typeCheckParsed[String](packsString, ifs, "predef").strictToValidated match {
                       case Validated.Valid(p) =>
                         val pathToName: List[(Path, PackageName)] =
                           packs.map { case ((path, _), p) => (path, p.name) }.toList

--- a/core/src/main/scala/org/bykn/bosatsu/Package.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/Package.scala
@@ -1,6 +1,6 @@
 package org.bykn.bosatsu
 
-import cats.{Functor, Semigroup}
+import cats.Functor
 import cats.data.{Chain, Ior, ValidatedNel, Validated, NonEmptyList, Writer}
 import cats.implicits._
 import fastparse.all._
@@ -148,7 +148,7 @@ object Package {
     p: PackageName,
     imps: List[Import[Package.Interface, NonEmptyList[Referant[Variance]]]],
     stmts: List[Statement]):
-      ValidatedNel[PackageError,
+      Ior[NonEmptyList[PackageError],
       Program[TypeEnv[Variance], TypedExpr[Declaration], List[Statement]]] = {
 
     // here we make a pass to get all the local names
@@ -157,25 +157,17 @@ object Package {
       .toProgram(stmts)
       .leftMap(_.map(PackageError.SourceConverterErrorIn(_, p): PackageError).toNonEmptyList)
 
-    def andThen[A: Semigroup, B, C](ior: Ior[A, B])(fn: B => Validated[A, C]): Validated[A, C] =
-      ior match {
-        case Ior.Right(b) => fn(b)
-        case Ior.Left(a) => Validated.Invalid(a)
-        case Ior.Both(a, b) =>
-          fn(b) match {
-            case Validated.Valid(_) => Validated.Invalid(a)
-            case Validated.Invalid(a1) => Validated.Invalid(Semigroup[A].combine(a, a1))
-          }
-      }
-
-    andThen(optProg) {
+    optProg.flatMap {
       case Program((importedTypeEnv, parsedTypeEnv), lets, extDefs, _) =>
-        val inferVarianceParsed: Either[PackageError, ParsedTypeEnv[Variance]] =
-          VarianceFormula.solve(importedTypeEnv, parsedTypeEnv.allDefinedTypes)
-            .map { infDTs => ParsedTypeEnv(infDTs, parsedTypeEnv.externalDefs) }
-            .leftMap(PackageError.VarianceInferenceFailure(p, _))
+        val inferVarianceParsed: Ior[NonEmptyList[PackageError], ParsedTypeEnv[Variance]] =
+          VarianceFormula.solve(importedTypeEnv, parsedTypeEnv.allDefinedTypes) match {
+            case Right(infDTs) =>
+              Ior.right(ParsedTypeEnv(infDTs, parsedTypeEnv.externalDefs))
+            case Left(err) =>
+              Ior.left(NonEmptyList.one(PackageError.VarianceInferenceFailure(p, err)))
+          }
 
-        inferVarianceParsed.toValidatedNel.andThen { parsedTypeEnv =>
+        inferVarianceParsed.flatMap { parsedTypeEnv =>
           /*
            * Check that the types defined here are not circular.
            */
@@ -231,7 +223,9 @@ object Package {
 
           val inference = Validated.fromEither(inferenceEither).leftMap(NonEmptyList.of(_))
 
-          defRecursionCheck *> circularCheck *> totalityCheck *> inference
+          // warning: if we refactor this from validated, we need parMap on Ior to get this
+          // error accumulation
+          (defRecursionCheck *> circularCheck *> totalityCheck *> inference).toIor
         }
     }
   }
@@ -511,6 +505,28 @@ object PackageError {
         Doc.hardLine + ctx + Doc.hardLine
 
       doc.render(80)
+    }
+  }
+
+  case class DuplicatedPackageError[A](dups: Map[PackageName, ((A, Package.Parsed), NonEmptyList[(A, Package.Parsed)])]) extends PackageError {
+    def message(sourceMap: Map[PackageName, (LocationMap, String)], errColor: Colorize) = {
+      val packDoc = Doc.text("package ")
+      val dupInDoc = Doc.text(" duplicated in ")
+      val dupMessages = dups
+        .toList
+        .sortBy(_._1)
+        .map { case (pname, (one, nelist)) =>
+          val dupsrcs = Doc.intercalate(Doc.comma + Doc.lineOrSpace,
+            (one :: nelist.toList)
+              .map { case (s, _) => s.toString }
+              .sorted
+              .map(Doc.text(_))
+            )
+            .nested(4)
+          packDoc + Doc.text(pname.asString) + dupInDoc + dupsrcs
+        }
+
+      Doc.intercalate(Doc.line, dupMessages).render(80)
     }
   }
 }

--- a/core/src/main/scala/org/bykn/bosatsu/Package.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/Package.scala
@@ -508,7 +508,7 @@ object PackageError {
     }
   }
 
-  case class DuplicatedPackageError[A](dups: Map[PackageName, ((A, Package.Parsed), NonEmptyList[(A, Package.Parsed)])]) extends PackageError {
+  case class DuplicatedPackageError[A](dups: Map[PackageName, ((A, Package.Parsed), NonEmptyList[(A, Package.Parsed)])], show: A => String) extends PackageError {
     def message(sourceMap: Map[PackageName, (LocationMap, String)], errColor: Colorize) = {
       val packDoc = Doc.text("package ")
       val dupInDoc = Doc.text(" duplicated in ")
@@ -518,7 +518,7 @@ object PackageError {
         .map { case (pname, (one, nelist)) =>
           val dupsrcs = Doc.intercalate(Doc.comma + Doc.lineOrSpace,
             (one :: nelist.toList)
-              .map { case (s, _) => s.toString }
+              .map { case (s, _) => show(s) }
               .sorted
               .map(Doc.text(_))
             )

--- a/core/src/main/scala/org/bykn/bosatsu/PackageMap.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/PackageMap.scala
@@ -2,9 +2,8 @@ package org.bykn.bosatsu
 
 import alleycats.std.map._ // TODO use SortedMap everywhere
 import org.bykn.bosatsu.graph.Memoize
-import cats.{Apply, Applicative, Foldable, Monad}
-import cats.arrow.FunctionK
-import cats.data.{NonEmptyList, Validated, ValidatedNel, ReaderT}
+import cats.Foldable
+import cats.data.{Ior, IorT, NonEmptyList, Validated, ValidatedNel, ReaderT}
 import cats.Order
 import cats.implicits._
 import scala.concurrent.ExecutionContext
@@ -140,10 +139,12 @@ object PackageMap {
     m.map(PackageMap(_)).toValidated
   }
 
+  type DupMap[A] = Map[PackageName, ((A, Package.Parsed), NonEmptyList[(A, Package.Parsed)])]
+
   /**
    * Convenience method to create a PackageMap then resolve it
    */
-  def resolveAll[A](ps: List[(A, Package.Parsed)], ifs: List[Package.Interface]): (Map[PackageName, ((A, Package.Parsed), NonEmptyList[(A, Package.Parsed)])], ValidatedNel[PackageError, Resolved]) = {
+  def resolveAll[A](ps: List[(A, Package.Parsed)], ifs: List[Package.Interface]): Ior[NonEmptyList[PackageError], Resolved] = {
 
     type AP = (A, Package.Parsed)
     val (nonUnique, unique): (Map[PackageName, (AP, NonEmptyList[AP])], Map[PackageName, AP]) =
@@ -180,21 +181,27 @@ object PackageMap {
     val (errs, pmap) = foldMap(unique)
     val res = resolvePackages(pmap, ifs)
     // combine the import errors now:
-    val check =
+    val check: Ior[NonEmptyList[PackageError], Unit] =
       errs match {
         case Nil =>
-          Validated.valid(())
+          Ior.right(())
         case h :: tail =>
-          Validated.invalid(NonEmptyList(h, tail))
+          Ior.left(NonEmptyList(h, tail))
       }
     // keep all the errors
-    (nonUnique, check *> res)
+    val nuEr: Ior[NonEmptyList[PackageError], Unit] =
+      if (nonUnique.nonEmpty) {
+        Ior.left(NonEmptyList.one[PackageError](PackageError.DuplicatedPackageError(nonUnique)))
+      }
+      else Ior.right(())
+
+    (nuEr, check, res.toIor).parMapN { (_, _, r) => r }
   }
 
   /**
    * Infer all the types in a resolved PackageMap
    */
-  def inferAll(ps: Resolved)(implicit cpuEC: ExecutionContext): ValidatedNel[PackageError, Inferred] = {
+  def inferAll(ps: Resolved)(implicit cpuEC: ExecutionContext): Ior[NonEmptyList[PackageError], Inferred] = {
 
     import Par.F
 
@@ -205,43 +212,42 @@ object PackageMap {
       Unit,
       (List[Statement], ImportMap[PackageName, Unit])]
 
-    type FutVal[A] = F[ValidatedNel[PackageError, A]]
-    val futValid: Applicative[FutVal] = Applicative[F].compose[ValidatedNel[PackageError, ?]]
+    type FutVal[A] = IorT[F, NonEmptyList[PackageError], A]
     /*
      * We memoize this function to avoid recomputing diamond dependencies
      */
-    val infer: ResolvedU => FutVal[Package.Inferred] =
-      Memoize.memoizeDagFuture[ResolvedU, ValidatedNel[PackageError, Package.Inferred]] {
+    val infer: ResolvedU => Par.F[Ior[NonEmptyList[PackageError], Package.Inferred]] =
+      Memoize.memoizeDagFuture[ResolvedU, Ior[NonEmptyList[PackageError], Package.Inferred]] {
         // TODO, we ignore importMap here, we only check earlier we don't
         // have duplicate imports
         case (Package(nm, imports, exports, (stmt, importMap)), recurse) =>
 
           def getImport[A, B](packF: Package.Inferred,
             exMap: Map[Identifier, NonEmptyList[ExportedName[A]]],
-            i: ImportedName[B]): ValidatedNel[PackageError, ImportedName[NonEmptyList[A]]] =
+            i: ImportedName[B]): Ior[NonEmptyList[PackageError], ImportedName[NonEmptyList[A]]] =
             exMap.get(i.originalName) match {
               case None =>
-                Validated.invalidNel(
+                Ior.left(NonEmptyList.one(
                   PackageError.UnknownImportName(
                     nm, packF, i,
-                    exMap.iterator.flatMap(_._2.toList).toList))
+                    exMap.iterator.flatMap(_._2.toList).toList)))
               case Some(exps) =>
                 val bs = exps.map(_.tag)
-                Validated.valid(i.map(_ => bs))
+                Ior.right(i.map(_ => bs))
             }
 
           def getImportIface[A, B](packF: Package.Interface,
             exMap: Map[Identifier, NonEmptyList[ExportedName[A]]],
-            i: ImportedName[B]): ValidatedNel[PackageError, ImportedName[NonEmptyList[A]]] =
+            i: ImportedName[B]): Ior[NonEmptyList[PackageError], ImportedName[NonEmptyList[A]]] =
             exMap.get(i.originalName) match {
               case None =>
-                Validated.invalidNel(
+                Ior.left(NonEmptyList.one(
                   PackageError.UnknownImportFromInterface(
                     nm, packF, i,
-                    exMap.iterator.flatMap(_._2.toList).toList))
+                    exMap.iterator.flatMap(_._2.toList).toList)))
               case Some(exps) =>
                 val bs = exps.map(_.tag)
-                Validated.valid(i.map(_ => bs))
+                Ior.right(i.map(_ => bs))
             }
 
           /*
@@ -252,67 +258,71 @@ object PackageMap {
            * distinct object has its own entry in the list
            */
           type ImpRes = Import[Package.Interface, NonEmptyList[Referant[Variance]]]
-          def stepImport(i: Import[Package.Resolved, Unit]): FutVal[ImpRes] = {
-            val Import(fixpack, items) = i
+          def stepImport(imp: Import[Package.Resolved, Unit]): FutVal[ImpRes] = {
+            val Import(fixpack, items) = imp
             Package.unfix(fixpack) match {
               case Right(p) =>
                 /*
                  * Here we have a source we need to fully resolve
                  */
-                Monad[Par.F].map(recurse(p))(_.andThen { packF =>
-                  val packInterface = Package.interfaceOf(packF)
-                  val exMap = ExportedName.buildExportMap(packF.exports)
-                  items.traverse(getImport(packF, exMap, _))
-                    .map(Import(packInterface, _))
-                })
+                IorT(recurse(p))
+                  .flatMap { packF =>
+                    val packInterface = Package.interfaceOf(packF)
+                    val exMap = ExportedName.buildExportMap(packF.exports)
+                    val ior = items
+                      .parTraverse(getImport(packF, exMap, _))
+                      .map(Import(packInterface, _))
+                    IorT.fromIor(ior)
+                  }
               case Left(iface) =>
                 /*
                  * this import is already an interface, we can stop here
                  */
                 val exMap = ExportedName.buildExportMap(iface.exports)
                 // this is very fast and does not need to be done in a thread
-                Par.now(
-                  items
-                    .traverse(getImportIface(iface, exMap, _))
-                    .map(Import(iface, _)))
+                val ior = items
+                  .parTraverse(getImportIface(iface, exMap, _))
+                  .map(Import(iface, _))
+                IorT.fromIor(ior)
             }
           }
 
-          val inferImports = imports.traverse[FutVal, ImpRes](stepImport(_))(futValid)
+          val inferImports: FutVal[List[ImpRes]] =
+            imports.parTraverse(stepImport(_))
+
           val inferBody =
-            Monad[Par.F].flatMap(inferImports) {
-              case Validated.Invalid(err) => Par.now(Validated.invalid(err))
-              case Validated.Valid(imps) =>
+            inferImports
+              .flatMap { imps =>
                 // run this in a thread
-                Par.start(Package.inferBody(nm, imps, stmt).map((imps, _)))
-            }
+                IorT(Par.start(Package.inferBody(nm, imps, stmt).map((imps, _))))
+              }
 
-          Monad[Par.F].map(inferBody) { v =>
-            v.andThen { case (imps, program@Program(types, lets, _, _)) =>
-              ExportedName.buildExports(nm, exports, types, lets) match {
-                case Validated.Valid(exps) =>
-                  Validated.valid(Package(nm, imps, exps, program))
-                case Validated.Invalid(badPackages) =>
-                  Validated.invalid(badPackages.map { n =>
-                    PackageError.UnknownExport(n, nm, lets)
-                  })
+          inferBody
+            .flatMap { case (imps, program@Program(types, lets, _, _)) =>
+              val ior = ExportedName
+                .buildExports(nm, exports, types, lets)
+                .map { exps => Package(nm, imps, exps, program) }
+                .leftMap { badPackages =>
+                  badPackages.map { n =>
+                    PackageError.UnknownExport(n, nm, lets): PackageError
+                  }
                 }
+                .toIor
+
+              IorT.fromIor[Par.F](ior)
             }
-          }
+            .value
         }
 
-    val fut = ps.toMap.traverse(infer)(futValid)
-    Par.await(fut).map(PackageMap(_))
+    val fut = ps.toMap.parTraverse(infer.andThen(IorT(_)))
+    Par.await(fut.value)
+      .map(PackageMap(_))
   }
-
-  type DupMap[A] = Map[PackageName, ((A, Package.Parsed), NonEmptyList[(A, Package.Parsed)])]
 
   def resolveThenInfer[A](
     ps: List[(A, Package.Parsed)],
-    ifs: List[Package.Interface])(implicit cpuEC: ExecutionContext): (DupMap[A], ValidatedNel[PackageError, Inferred]) = {
-      val (bad, good) = resolveAll(ps, ifs)
-      (bad, good.andThen(inferAll(_)))
-    }
+    ifs: List[Package.Interface])(implicit cpuEC: ExecutionContext): Ior[NonEmptyList[PackageError], Inferred] =
+      resolveAll(ps, ifs).flatMap(inferAll)
 
   def buildSourceMap[F[_]: Foldable, A](parsedFiles: F[((A, LocationMap), Package.Parsed)]): Map[PackageName, (LocationMap, String)] =
     parsedFiles.foldLeft(Map.empty[PackageName, (LocationMap, String)]) { case (map, ((path, lm), pack)) =>
@@ -323,25 +333,18 @@ object PackageMap {
    *
    * @param packs a list of parsed packages, along with a key A to tag the source
    * @param ifs the interfaces we are compiling against. If Bosatsu.Predef is not in this list, the default is added
-   * @param liftError how to convert package errors into F
-   * @param checkDups how to report duplicate package errors
    */
-  def typeCheckParsed[F[_]: Apply, A](
+  def typeCheckParsed[A](
     packs: NonEmptyList[((A, LocationMap), Package.Parsed)],
     ifs: List[Package.Interface],
-    predefKey: A,
-    liftError: FunctionK[ValidatedNel[PackageError, ?], F])(
-    checkDups: DupMap[(A, LocationMap)] => F[Unit]
-  )(implicit cpuEC: ExecutionContext): F[PackageMap.Inferred] = {
+    predefKey: A)(implicit cpuEC: ExecutionContext): Ior[NonEmptyList[PackageError], PackageMap.Inferred] = {
     // if we have passed in a use supplied predef, don't use the internal one
-    val useInternalPredef = !ifs.contains { p: Package.Interface => p.name == PackageName.PredefName }
+    val useInternalPredef = !ifs.exists { p: Package.Interface => p.name == PackageName.PredefName }
     // Now we have completed all IO, here we do all the checks we need for correctness
     val parsed =
         if (useInternalPredef) Predef.withPredefA[(A, LocationMap)]((predefKey, LocationMap("")), packs.toList)
         else Predef.withPredefImportsA[(A, LocationMap)](packs.toList)
 
-    val (dups, resPacks) = PackageMap.resolveThenInfer(parsed, ifs)
-
-    checkDups(dups) *> liftError(resPacks)
+    PackageMap.resolveThenInfer(parsed, ifs)
   }
 }

--- a/core/src/main/scala/org/bykn/bosatsu/Predef.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/Predef.scala
@@ -1,5 +1,6 @@
 package org.bykn.bosatsu
 
+import cats.Show
 import cats.data.{NonEmptyList, Validated}
 import fastparse.all._
 import java.math.BigInteger
@@ -39,6 +40,7 @@ object Predef {
   val predefCompiled: Package.Inferred = {
     import DirectEC.directEC
 
+    implicit val showUnit: Show[Unit] = Show.show[Unit](_ => "predefCompiled")
     val inferred = PackageMap.resolveThenInfer(((), predefPackage) :: Nil, Nil).strictToValidated
 
     inferred match {

--- a/core/src/main/scala/org/bykn/bosatsu/Predef.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/Predef.scala
@@ -6,6 +6,8 @@ import java.math.BigInteger
 import scala.collection.immutable.SortedMap
 import language.experimental.macros
 
+import IorMethods.IorExtension
+
 object Predef {
   /**
    * Loads a file *at compile time* as a means of embedding
@@ -36,16 +38,17 @@ object Predef {
    */
   val predefCompiled: Package.Inferred = {
     import DirectEC.directEC
-    val (bad, good) = PackageMap.resolveThenInfer(((), predefPackage) :: Nil, Nil)
-    require(bad.isEmpty, s"expected no bad packages, found: $bad")
-    good match {
+
+    val inferred = PackageMap.resolveThenInfer(((), predefPackage) :: Nil, Nil).strictToValidated
+
+    inferred match {
       case Validated.Valid(v) =>
         v.toMap.get(packageName) match {
           case None => sys.error("internal error: predef package not found after compilation")
           case Some(inf) => inf
         }
       case Validated.Invalid(errs) =>
-        sys.error(s"internal error: predef didn't compile: $errs")
+        sys.error(s"expected no errors, found: $errs")
     }
   }
 

--- a/core/src/test/scala/org/bykn/bosatsu/EvaluationTest.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/EvaluationTest.scala
@@ -2099,6 +2099,22 @@ main = 1
     }
   }
 
+  test("test duplicate package message") {
+    val pack =
+      """
+        |package Err
+        |
+        |import Bosatsu/Predef [ foldLeft ]
+        |
+        |main = 1
+        |""".stripMargin
+
+    evalFail(List(pack, pack), "Err") { case sce@PackageError.DuplicatedPackageError(_) =>
+      assert(sce.message(Map.empty, Colorize.None) == "package Err duplicated in 0, 1")
+      ()
+    }
+  }
+
   test("test parsing type annotations") {
     runBosatsuTest(List("""
 package A

--- a/core/src/test/scala/org/bykn/bosatsu/EvaluationTest.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/EvaluationTest.scala
@@ -2109,7 +2109,7 @@ main = 1
         |main = 1
         |""".stripMargin
 
-    evalFail(List(pack, pack), "Err") { case sce@PackageError.DuplicatedPackageError(_) =>
+    evalFail(List(pack, pack), "Err") { case sce@PackageError.DuplicatedPackageError(_, _) =>
       assert(sce.message(Map.empty, Colorize.None) == "package Err duplicated in 0, 1")
       ()
     }

--- a/core/src/test/scala/org/bykn/bosatsu/PackageTest.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/PackageTest.scala
@@ -1,5 +1,6 @@
 package org.bykn.bosatsu
 
+import cats.Show
 import cats.data.{Validated, ValidatedNel}
 import fastparse.all._
 import org.scalatest.FunSuite
@@ -12,7 +13,8 @@ class PackageTest extends FunSuite {
   def resolveThenInfer(ps: Iterable[Package.Parsed]): ValidatedNel[PackageError, PackageMap.Inferred] = {
     // use parallelism to typecheck
     import ExecutionContext.Implicits.global
-    PackageMap.resolveThenInfer(ps.toList.map { p => ((), p) }, Nil)
+    implicit val showInt: Show[Int] = Show.fromToString
+    PackageMap.resolveThenInfer(ps.toList.zipWithIndex.map(_.swap), Nil)
       .strictToValidated
   }
 

--- a/core/src/test/scala/org/bykn/bosatsu/PackageTest.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/PackageTest.scala
@@ -5,12 +5,15 @@ import fastparse.all._
 import org.scalatest.FunSuite
 import scala.concurrent.ExecutionContext
 
+import IorMethods.IorExtension
+
 class PackageTest extends FunSuite {
 
   def resolveThenInfer(ps: Iterable[Package.Parsed]): ValidatedNel[PackageError, PackageMap.Inferred] = {
     // use parallelism to typecheck
     import ExecutionContext.Implicits.global
-    PackageMap.resolveThenInfer(ps.toList.map { p => ((), p) }, Nil)._2
+    PackageMap.resolveThenInfer(ps.toList.map { p => ((), p) }, Nil)
+      .strictToValidated
   }
 
   def parse(s: String): Package.Parsed =

--- a/core/src/test/scala/org/bykn/bosatsu/rankn/RankNInferTest.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/rankn/RankNInferTest.scala
@@ -1,6 +1,6 @@
 package org.bykn.bosatsu.rankn
 
-import cats.data.{NonEmptyList, Validated}
+import cats.data.{Ior, NonEmptyList}
 import org.scalatest.FunSuite
 import org.bykn.bosatsu._
 
@@ -144,8 +144,8 @@ class RankNInferTest extends FunSuite {
     Statement.parser.parse(statement) match {
       case Parsed.Success(stmts, _) =>
         Package.inferBody(PackageName.parts("Test"), Nil, stmts) match {
-          case Validated.Invalid(_) => assert(true)
-          case Validated.Valid(program) =>
+          case Ior.Left(_) | Ior.Both(_, _) => assert(true)
+          case Ior.Right(program) =>
             fail("expected an invalid program, but got: " + program.lets.toString)
         }
       case Parsed.Failure(exp, idx, extra) =>


### PR DESCRIPTION
We were generally using Validated to model failure and being careful about using andThen. But there was also a case where we had a side optional error because we wanted to continue after a failure.

This moves to using Ior in those cases so we can be more explicit.

The risk here now is that the default traverse/sequence/mapN won't accumulate like we like, so we need to use parTraverse, parSequence, parMapN, but I think I have done that correctly.

This cleanup was motivated by wanting to put more lints in but have more confidence that we are not breaking things.