### PR TITLE
Make unused bindings an error

### DIFF
--- a/core/src/main/resources/bosatsu/predef.bosatsu
+++ b/core/src/main/resources/bosatsu/predef.bosatsu
@@ -26,7 +26,6 @@ export [
   get_key,
   int_loop,
   items,
-  ignore_binding,
   map_List,
   mod_Int,
   range,
@@ -76,10 +75,6 @@ def concat(front: List[a], back: List[a]) -> List[a]:
   match back:
     []: front
     _: reverse_concat(reverse(front), back)
-
-# since we error on unused bindings, we need this to declare it
-# it is safe to ignore
-def ignore_binding(_): Unit
 
 def uncurry2(f: t1 -> t2 -> r) -> (t1, t2) -> r:
   \(x1, x2) -> f(x1, x2)

--- a/core/src/main/resources/bosatsu/predef.bosatsu
+++ b/core/src/main/resources/bosatsu/predef.bosatsu
@@ -26,6 +26,7 @@ export [
   get_key,
   int_loop,
   items,
+  ignore_binding,
   map_List,
   mod_Int,
   range,
@@ -75,6 +76,10 @@ def concat(front: List[a], back: List[a]) -> List[a]:
   match back:
     []: front
     _: reverse_concat(reverse(front), back)
+
+# since we error on unused bindings, we need this to declare it
+# it is safe to ignore
+def ignore_binding(_): Unit
 
 def uncurry2(f: t1 -> t2 -> r) -> (t1, t2) -> r:
   \(x1, x2) -> f(x1, x2)

--- a/core/src/main/scala/org/bykn/bosatsu/MainModule.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/MainModule.scala
@@ -276,7 +276,8 @@ abstract class MainModule[IO[_]](implicit val moduleIOMonad: MonadError[IO, Thro
                           packs.map { case ((path, _), p) => (path, p.name) }.toList
                         Success((p, pathToName))
                       case Validated.Invalid(errs) =>
-                        errors(errs.map(_.message(sourceMap, errColor)).toList)
+                        val distinct = errs.toList.distinct
+                        errors(distinct.map(_.message(sourceMap, errColor)))
                     }
                   case None =>
                     Success((PackageMap.empty, Nil))

--- a/core/src/main/scala/org/bykn/bosatsu/MainModule.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/MainModule.scala
@@ -237,7 +237,7 @@ abstract class MainModule[IO[_]](implicit val moduleIOMonad: MonadError[IO, Thro
           // we should still return the predef
           // if it is not in ifs
           val useInternalPredef =
-            !ifs.contains { p: Package.Interface => p.name == PackageName.PredefName }
+            !ifs.exists { p: Package.Interface => p.name == PackageName.PredefName }
 
           if (useInternalPredef) {
             moduleIOMonad.pure((PackageMap.fromIterable(Predef.predefCompiled :: Nil), Nil))

--- a/core/src/main/scala/org/bykn/bosatsu/Package.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/Package.scala
@@ -237,9 +237,17 @@ object Package {
               NonEmptyList.one(PackageError.UnusedLetError(p, errs.toNonEmptyList))
             }
 
+          /**
+           * Checks accumulate errors, but have no return value:
+           */
+          val checks = List(
+              defRecursionCheck, circularCheck, checkUnusedLets, totalityCheck
+            )
+            .sequence_
+
           val inference = Validated.fromEither(inferenceEither).leftMap(NonEmptyList.of(_))
 
-          defRecursionCheck *> circularCheck *> checkUnusedLets *> totalityCheck *> inference
+          checks *> inference
         }
     }
   }

--- a/core/src/main/scala/org/bykn/bosatsu/Package.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/Package.scala
@@ -229,7 +229,7 @@ object Package {
               NonEmptyList.one(PackageError.UnusedLetError(p, errs.toNonEmptyList))
             }
 
-          /**
+          /*
            * Checks accumulate errors, but have no return value:
            */
           val checks = List(

--- a/core/src/main/scala/org/bykn/bosatsu/Region.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/Region.scala
@@ -1,5 +1,7 @@
 package org.bykn.bosatsu
 
+import cats.Order
+
 case class Region(start: Int, end: Int) {
   def +(that: Region): Region =
     Region(start, that.end)
@@ -8,6 +10,9 @@ case class Region(start: Int, end: Int) {
 object Region {
   implicit val ordering: Ordering[Region] =
     Ordering.by { r: Region => (r.start, r.end) }
+
+  implicit val regionOrder: Order[Region] =
+    Order.fromOrdering(ordering)
 }
 
 trait HasRegion[T] {

--- a/core/src/main/scala/org/bykn/bosatsu/SourceConverter.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/SourceConverter.scala
@@ -802,7 +802,12 @@ final class SourceConverter(
               { t => success(toType(t)) })
 
           lam.map { l =>
-            (defstmt.name, RecursionKind.Recursive, l) :: Nil
+            // We rely on DefRecursionCheck to rule out bad recursions
+            val boundName = defstmt.name
+            val rec =
+              if (UnusedLetCheck.freeBound(l).contains(boundName)) RecursionKind.Recursive
+              else RecursionKind.NonRecursive
+            (boundName, rec, l) :: Nil
           }
         case ExternalDef(_, _, _) =>
           success(Nil)

--- a/core/src/main/scala/org/bykn/bosatsu/TypedExpr.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/TypedExpr.scala
@@ -958,7 +958,24 @@ object TypedExpr {
               (changed0, branches1)
           }
         val a1 = normalize1(arg).get
-        if ((a1 eq arg) && (changed1 == 0)) None
+        if (changed1 == 0) {
+          // if only the arg changes, there
+          // is no need to rerun the normalization
+          // because normalization of branches
+          // does not depend on the arg
+          //
+          // This needs to be rethought if we have
+          // a normalization like:
+          // match (x, y):
+          //   (z, w): fn
+          //
+          // to
+          //  z = x
+          //  w = y
+          //  fn
+          if (a1 eq arg) None
+          else Some(Match(a1, branches, tag))
+        }
         else {
           // there has been some change, so
           // see if that unlocked any new changes

--- a/core/src/main/scala/org/bykn/bosatsu/UnusedLetCheck.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/UnusedLetCheck.scala
@@ -4,78 +4,77 @@ import cats.Applicative
 import cats.data.{Chain, Validated, ValidatedNec, Writer, NonEmptyChain}
 import cats.implicits._
 
+import Expr._
 import Identifier.Bindable
 
 object UnusedLetCheck {
-  def check[A: HasRegion](e: Expr[A]): ValidatedNec[(Bindable, Region), Unit] = {
-    import Expr._
 
-    val ap = Applicative[Writer[Chain[(Bindable, Region)], ?]]
-    val empty: Writer[Chain[(Bindable, Region)], Set[Bindable]] = ap.pure(Set.empty)
+  private[this] val ap = Applicative[Writer[Chain[(Bindable, Region)], ?]]
+  private[this] val empty: Writer[Chain[(Bindable, Region)], Set[Bindable]] = ap.pure(Set.empty)
 
-    def loop(e: Expr[A]): Writer[Chain[(Bindable, Region)], Set[Bindable]] =
-      e match {
-        case Annotation(expr, _, _) =>
-          loop(expr)
-        case AnnotatedLambda(arg, _, expr, _) =>
-          loop(expr).flatMap { free =>
-            if (free(arg)) ap.pure(free - arg)
-            else {
-              // this arg is free:
-              ap.pure(free).tell(Chain.one((arg, HasRegion.region(e))))
-            }
-          }
-        case Lambda(arg, expr, _) =>
-          loop(expr).flatMap { free =>
-            if (free(arg)) ap.pure(free - arg)
-            else {
-              // this arg is free:
-              ap.pure(free).tell(Chain.one((arg, HasRegion.region(e))))
-            }
-          }
-        case Let(arg, expr, in, rec, _) =>
-          val exprCheck = loop(expr)
-          val inCheck = loop(in)
-          // before typechecking, we make all defs recursive
-          // TODO: be more precise earlier
-          val exprRes = if (rec.isRecursive) exprCheck.map(_ - arg) else exprCheck
-          val inRes = inCheck.flatMap { free =>
-            if (free(arg)) ap.pure(free - arg)
-            else {
-              // this arg is free:
-              // TODO we need a region on the arg
-              ap.pure(free).tell(Chain.one((arg, HasRegion.region(e))))
-            }
-          }
-          (exprRes, inRes).mapN(_ ++ _)
-        case Var(None, name: Bindable, _) =>
-          // this is a free variable:
-          ap.pure(Set(name))
-        case Var(_, _, _) | Literal(_, _) => empty
-        case App(fn, arg, _) =>
-          (loop(fn), loop(arg)).mapN(_ ++ _)
-        case Match(arg, branches, _) =>
-          // TODO: patterns need their own region
-          val argCheck = loop(arg)
-          val bcheck = branches.traverse { case (pat, expr) =>
-            val region = HasRegion.region(expr)
-            loop(expr).flatMap { frees =>
-              val thisPatNames = pat.names
-              val unused = thisPatNames.filterNot(frees)
-              val nextFrees = frees -- thisPatNames
-
-              ap.pure(nextFrees).tell(Chain.fromSeq(unused.map((_, region))))
-            }
-          }
-          .map(_.combineAll)
-
-        (argCheck, bcheck).mapN(_ ++ _)
+  private[this] def checkArg(arg: Bindable, reg: => Region, w: Writer[Chain[(Bindable, Region)], Set[Bindable]]) =
+    w.flatMap { free =>
+      if (free(arg)) ap.pure(free - arg)
+      else {
+        // this arg is free:
+        ap.pure(free).tell(Chain.one((arg, reg)))
       }
+    }
 
+  private[this] def loop[A: HasRegion](e: Expr[A]): Writer[Chain[(Bindable, Region)], Set[Bindable]] =
+    e match {
+      case Annotation(expr, _, _) =>
+        loop(expr)
+      case AnnotatedLambda(arg, _, expr, _) =>
+        checkArg(arg, HasRegion.region(e), loop(expr))
+      case Lambda(arg, expr, _) =>
+        checkArg(arg, HasRegion.region(e), loop(expr))
+      case Let(arg, expr, in, rec, _) =>
+        val exprCheck = loop(expr)
+        val exprRes =
+          // if it is recursive, it is definitely used, because
+          // that is automatically applied in source conversions
+          if (rec.isRecursive) exprCheck.map(_ - arg) else exprCheck
+        val inCheck = checkArg(arg, HasRegion.region(e), loop(in))
+        (exprRes, inCheck).mapN(_ ++ _)
+      case Var(None, name: Bindable, _) =>
+        // this is a free variable:
+        ap.pure(Set(name))
+      case Var(_, _, _) | Literal(_, _) => empty
+      case App(fn, arg, _) =>
+        (loop(fn), loop(arg)).mapN(_ ++ _)
+      case Match(arg, branches, _) =>
+        // TODO: patterns need their own region
+        val argCheck = loop(arg)
+        val bcheck = branches.traverse { case (pat, expr) =>
+          val region = HasRegion.region(expr)
+          loop(expr).flatMap { frees =>
+            val thisPatNames = pat.names
+            val unused = thisPatNames.filterNot(frees)
+            val nextFrees = frees -- thisPatNames
+
+            ap.pure(nextFrees).tell(Chain.fromSeq(unused.map((_, region))))
+          }
+        }
+        .map(_.combineAll)
+
+      (argCheck, bcheck).mapN(_ ++ _)
+    }
+
+  /**
+   * Check for any unused lets, defs, or pattern bindings
+   */
+  def check[A: HasRegion](e: Expr[A]): ValidatedNec[(Bindable, Region), Unit] = {
     val (chain, _) = loop(e).run
     NonEmptyChain.fromChain(chain) match {
       case None => Validated.valid(())
       case Some(nec) => Validated.invalid(nec.distinct)
     }
   }
+
+  /**
+   * Return the free Bindable names in this expression
+   */
+  def freeBound[A](e: Expr[A]): Set[Bindable] =
+    loop(e)(HasRegion.instance(_ => Region(0, 0))).run._2
 }

--- a/core/src/main/scala/org/bykn/bosatsu/UnusedLetCheck.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/UnusedLetCheck.scala
@@ -1,0 +1,81 @@
+package org.bykn.bosatsu
+
+import cats.Applicative
+import cats.data.{Chain, Validated, ValidatedNec, Writer, NonEmptyChain}
+import cats.implicits._
+
+import Identifier.Bindable
+
+object UnusedLetCheck {
+  def check[A: HasRegion](e: Expr[A]): ValidatedNec[(Bindable, Region), Unit] = {
+    import Expr._
+
+    val ap = Applicative[Writer[Chain[(Bindable, Region)], ?]]
+    val empty: Writer[Chain[(Bindable, Region)], Set[Bindable]] = ap.pure(Set.empty)
+
+    def loop(e: Expr[A]): Writer[Chain[(Bindable, Region)], Set[Bindable]] =
+      e match {
+        case Annotation(expr, _, _) =>
+          loop(expr)
+        case AnnotatedLambda(arg, _, expr, _) =>
+          loop(expr).flatMap { free =>
+            if (free(arg)) ap.pure(free - arg)
+            else {
+              // this arg is free:
+              ap.pure(free).tell(Chain.one((arg, HasRegion.region(e))))
+            }
+          }
+        case Lambda(arg, expr, _) =>
+          loop(expr).flatMap { free =>
+            if (free(arg)) ap.pure(free - arg)
+            else {
+              // this arg is free:
+              ap.pure(free).tell(Chain.one((arg, HasRegion.region(e))))
+            }
+          }
+        case Let(arg, expr, in, rec, _) =>
+          val exprCheck = loop(expr)
+          val inCheck = loop(in)
+          // before typechecking, we make all defs recursive
+          // TODO: be more precise earlier
+          val exprRes = if (rec.isRecursive) exprCheck.map(_ - arg) else exprCheck
+          val inRes = inCheck.flatMap { free =>
+            if (free(arg)) ap.pure(free - arg)
+            else {
+              // this arg is free:
+              // TODO we need a region on the arg
+              ap.pure(free).tell(Chain.one((arg, HasRegion.region(e))))
+            }
+          }
+          (exprRes, inRes).mapN(_ ++ _)
+        case Var(None, name: Bindable, _) =>
+          // this is a free variable:
+          ap.pure(Set(name))
+        case Var(_, _, _) | Literal(_, _) => empty
+        case App(fn, arg, _) =>
+          (loop(fn), loop(arg)).mapN(_ ++ _)
+        case Match(arg, branches, _) =>
+          // TODO: patterns need their own region
+          val argCheck = loop(arg)
+          val bcheck = branches.traverse { case (pat, expr) =>
+            val region = HasRegion.region(expr)
+            loop(expr).flatMap { frees =>
+              val thisPatNames = pat.names
+              val unused = thisPatNames.filterNot(frees)
+              val nextFrees = frees -- thisPatNames
+
+              ap.pure(nextFrees).tell(Chain.fromSeq(unused.map((_, region))))
+            }
+          }
+          .map(_.combineAll)
+
+        (argCheck, bcheck).mapN(_ ++ _)
+      }
+
+    val (chain, _) = loop(e).run
+    NonEmptyChain.fromChain(chain) match {
+      case None => Validated.valid(())
+      case Some(nec) => Validated.invalid(nec.distinct)
+    }
+  }
+}

--- a/core/src/test/scala/org/bykn/bosatsu/EvaluationTest.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/EvaluationTest.scala
@@ -285,7 +285,8 @@ package Foo
 x = (1, "1")
 
 def go(u):
-  _ = ignore_binding(u)
+  # ignore that u is unused
+  _ = u
   (_, y) = x
   match y:
     "1": "good"
@@ -716,7 +717,7 @@ main = plus(1, 2)
 """), "A"){ case le@PackageError.UnusedLetError(_, _) =>
       val msg = le.message(Map.empty, Colorize.None)
       assert(!msg.contains("Name("))
-      assert(msg.contains("unused let binding: z\nRegion(68,84)"))
+      assert(msg.contains("unused let binding: z\n  Region(68,84)"))
       ()
     }
   }
@@ -959,11 +960,13 @@ def bad_len(list):
     []: 0
     [2] | [3]: -1
     [*_, four@4]:
-      _ = ignore_binding(four)
+      #ignore_binding,
+      _ = four
       -1
     [100, *_]: -1
     [*init, last@(_: Int)]:
-      _ = ignore_binding(last)
+      #ignore binding
+      _ = last
       bad_len(init).add(1)
 
 main = bad_len([1, 2, 3, 5])
@@ -2051,7 +2054,8 @@ struct Build[f]
 struct File
 
 def useList(args: List[Build[File]]):
-  _ = ignore_binding(args)
+  # ignore args
+  _ = args
   True
 
 check = useList([])
@@ -2171,7 +2175,8 @@ fn = \x -> f(x)
 
 # trigger an optimization to remove y
 tests = Assertion(fn((y = 1
-_ = ignore_binding(y)
+# ignore y
+_ = y
 2)), "t1")
 """), "A", 1)
 

--- a/core/src/test/scala/org/bykn/bosatsu/NormalizationTest.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/NormalizationTest.scala
@@ -56,7 +56,7 @@ package Recur/Some
 def foo(x):
   recur x:
     []: ["a","b","c"]
-    [h, *t]: NonEmptyList("zero", foo(t))
+    [_, *t]: NonEmptyList("zero", foo(t))
 
 out = foo
 """
@@ -81,7 +81,7 @@ out = \x -> x
       List("""
 package Lambda/Always
 
-out = \x -> \y -> x
+out = \x -> \_ -> x
 """
       ), "Lambda/Always", NormalExpressionTag(
         Lambda(Lambda(LambdaVar(1))), Set(Lambda(LambdaVar(1)), LambdaVar(1))
@@ -194,7 +194,7 @@ out=match None:
 package Match/List
 
 out = match [1,2,3]:
-  [first, second, last]: last
+  [_, _, last]: last
   _: 0
 """
       ), "Match/List",
@@ -205,7 +205,7 @@ out = match [1,2,3]:
 package Match/List
 
 out = match [1,2,3,4,5]:
-  [*first_few, _, _, last]: last
+  [*_, _, _, last]: last
   _: 0
 """
       ), "Match/List",
@@ -359,7 +359,7 @@ package Extern/List
 external def foo(x: String) -> List[String]
 
 out = match foo("arg"):
-  [*first_few, _, _, last]: last
+  [*_, _, _, last]: last
   _: "'zero\\'"
 """
       ), "Extern/List",
@@ -440,7 +440,7 @@ package Substitution/Lambda
 def rec_fn(lst1):
   recur lst1:
     []: True
-    [h1, *t1]: rec_fn(t1)
+    [_, *t1]: rec_fn(t1)
 
 lst1 = ["zooom"]
 main = (rec_fn(lst1), rec_fn(lst1))

--- a/core/src/test/scala/org/bykn/bosatsu/NormalizationTest.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/NormalizationTest.scala
@@ -62,7 +62,7 @@ out = foo
 """
       ), "Recur/Some", Recursion(Lambda(Lambda(Match(LambdaVar(0),NonEmptyList.fromList(List(
         (ListPat(List()),Struct(1,List(Literal(Str("a")), Struct(1,List(Literal(Str("b")), Struct(1,List(Literal(Str("c")), Struct(0,List())))))))),
-        (ListPat(List(Right(Var(1)), Left(Some(0)))),Lambda(Lambda(Struct(1,List(Literal(Str("zero")), App(LambdaVar(3),LambdaVar(0)))))))
+        (ListPat(List(Right(WildCard), Left(Some(0)))),Lambda(Struct(1,List(Literal(Str("zero")), App(LambdaVar(2),LambdaVar(0))))))
       )).get))))
     )
   }
@@ -91,7 +91,7 @@ out = \x -> \_ -> x
       List("""
 package Lambda/Always
 
-out = \x -> \y -> y
+out = \_ -> \y -> y
 """
       ), "Lambda/Always", NormalExpressionTag(
         Lambda(Lambda(LambdaVar(0))), Set(Lambda(LambdaVar(0)), LambdaVar(0))
@@ -127,7 +127,7 @@ out = foo
       List("""
 package Lambda/Always
 
-def foo(x,y):
+def foo(x, _):
   x
 out = foo
 """
@@ -139,7 +139,7 @@ out = foo
       List("""
 package Lambda/Always
 
-def foo(x,y):
+def foo(_, y):
   y
 out = foo
 """
@@ -366,11 +366,11 @@ out = match foo("arg"):
       Match(
         App(ExternalVar(PackageName(NonEmptyList.fromList(List("Extern", "List")).get),Identifier.Name("foo")),Literal(Str("arg"))),
         NonEmptyList.fromList(List(
-          (ListPat(List(Left(Some(0)), Right(WildCard), Right(WildCard), Right(Var(1)))),Lambda(Lambda(LambdaVar(1)))),
+          (ListPat(List(Left(None), Right(WildCard), Right(WildCard), Right(Var(0)))),Lambda(LambdaVar(0))),
         (WildCard,Literal(Str("'zero\\'")))
         )).get
       ),
-      Some("Match(App(ExternalVar('Extern/List','foo'),Literal('arg')),ListPat(Left(0),Right(WildCard),Right(WildCard),Right(Var(1))),Lambda(Lambda(LambdaVar(1))),WildCard,Literal('\\'zero\\\\\\''))")
+      Some("Match(App(ExternalVar('Extern/List','foo'),Literal('arg')),ListPat(Left(),Right(WildCard),Right(WildCard),Right(Var(0))),Lambda(LambdaVar(0)),WildCard,Literal('\\'zero\\\\\\''))")
     )
     normalExpressionTest(
       List("""
@@ -379,14 +379,14 @@ package Extern/List
 external def foo(x: String) -> List[String]
 
 out = match foo("arg"):
-  [*first_few, _, _, last]: last
+  [*_, _, _, last]: last
   _: "zero"
 """
         ), "Extern/List",
       Match(
         App(ExternalVar(PackageName(NonEmptyList.fromList(List("Extern", "List")).get),Identifier.Name("foo")),Literal(Str("arg"))),
         NonEmptyList.fromList(List(
-          (ListPat(List(Left(Some(0)), Right(WildCard), Right(WildCard), Right(Var(1)))),Lambda(Lambda(LambdaVar(1)))),
+          (ListPat(List(Left(None), Right(WildCard), Right(WildCard), Right(Var(0)))),Lambda(LambdaVar(0))),
           (WildCard,Literal(Str("zero")))
         )).get
       )
@@ -400,14 +400,14 @@ external def foo(x: String) -> List[String]
 struct Stuff(a,b)
 
 out = match Stuff(foo("c"), "d"):
-  Stuff(lst@[x], _): lst
+  Stuff(lst@[_], _): lst
   Stuff(_, y): [y]
 """
         ), "Extern/NamedMatch",
       Match(
         Struct(0,List(App(ExternalVar(PackageName(NonEmptyList.fromList(List("Extern", "NamedMatch")).get),Identifier.Name("foo")),Literal(Str("c"))), Literal(Str("d")))),
         NonEmptyList.fromList(List(
-          (PositionalStruct(None,List(Named(0,ListPat(List(Right(Var(1))))), WildCard)),Lambda(Lambda(LambdaVar(0)))),
+          (PositionalStruct(None,List(Named(0,ListPat(List(Right(WildCard)))), WildCard)),Lambda(LambdaVar(0))),
           (PositionalStruct(None,List(WildCard, Var(0))),Lambda(Struct(1,List(LambdaVar(0), Struct(0,List())))))
         )).get
       )
@@ -448,9 +448,9 @@ main = (rec_fn(lst1), rec_fn(lst1))
       ), "Substitution/Lambda",
       Struct(0,
         List(
-          App(Recursion(Lambda(Lambda(Match(LambdaVar(0),NonEmptyList.of((ListPat(List()),Struct(1,List())), (ListPat(List(Right(Var(1)), Left(Some(0)))),Lambda(Lambda(App(LambdaVar(3), LambdaVar(0)))))))))),Struct(1,List(Literal(Str("zooom")),Struct(0,List())))),
+          App(Recursion(Lambda(Lambda(Match(LambdaVar(0),NonEmptyList.of((ListPat(List()),Struct(1,List())), (ListPat(List(Right(WildCard), Left(Some(0)))),Lambda(App(LambdaVar(2), LambdaVar(0))))))))),Struct(1,List(Literal(Str("zooom")),Struct(0,List())))),
           Struct(0,List(
-            App(Recursion(Lambda(Lambda(Match(LambdaVar(0),NonEmptyList.of((ListPat(List()),Struct(1,List())),(ListPat(List(Right(Var(1)), Left(Some(0)))),Lambda(Lambda(App(LambdaVar(3), LambdaVar(0)))))))))),Struct(1,List(Literal(Str("zooom")), Struct(0,List())))),
+            App(Recursion(Lambda(Lambda(Match(LambdaVar(0),NonEmptyList.of((ListPat(List()),Struct(1,List())),(ListPat(List(Right(WildCard), Left(Some(0)))),Lambda(App(LambdaVar(2), LambdaVar(0))))))))),Struct(1,List(Literal(Str("zooom")), Struct(0,List())))),
             Struct(0,List())
           ))
         )

--- a/core/src/test/scala/org/bykn/bosatsu/PackageTest.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/PackageTest.scala
@@ -95,13 +95,13 @@ def head(list):
   match list:
     Empty:
       None
-    NonEmpty(h, tail):
+    NonEmpty(h, _):
       Some(h)
 
 def tail(list):
   match list:
     Empty: None
-    NonEmpty(h, t): Some(t)
+    NonEmpty(_, t): Some(t)
 """)
 
     val p6 = parse(

--- a/core/src/test/scala/org/bykn/bosatsu/PatternTest.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/PatternTest.scala
@@ -3,10 +3,18 @@ package org.bykn.bosatsu
 import cats.data.NonEmptyList
 import org.scalacheck.Gen
 import org.scalatest.FunSuite
-import org.scalatest.prop.PropertyChecks.forAll
+import org.scalatest.prop.PropertyChecks.{forAll, PropertyCheckConfiguration}
 
 class PatternTest extends FunSuite {
+  implicit val generatorDrivenConfig = PropertyCheckConfiguration(minSuccessful = 300)
+
   val patGen = Gen.choose(0, 5).flatMap(Generators.genPattern(_))
+
+  def pat(s: String): Pattern.Parsed =
+    Pattern.bindParser.parse(s) match {
+      case fastparse.all.Parsed.Success(p, idx) if idx == s.length => p
+      case other => sys.error(s"could not parse $s, $other")
+    }
 
   test("Pattern.unbind is the same as filterVars(Set.empty)") {
     forAll(patGen) { p =>
@@ -31,6 +39,56 @@ class PatternTest extends FunSuite {
     forAll(patGen) { p =>
       p.substructures.toSet.subsetOf(p.names.toSet)
     }
+  }
+
+  test("singlynamed implies there is exacly one name") {
+    forAll(patGen) { p =>
+      p match {
+        case Pattern.SinglyNamed(n) =>
+          assert(p.names == (n :: Nil))
+          // we can name with the same name, and still be singly named
+          assert(Pattern.SinglyNamed.unapply(Pattern.Named(n, p)) == Some(n))
+          // we can annotate and not lose singly named-ness
+          assert(Pattern.SinglyNamed.unapply(Pattern.Annotation(p, null)) == Some(n))
+          // we can make a union and not lose singly named-ness
+          assert(Pattern.SinglyNamed.unapply(Pattern.union(Pattern.Var(n), p :: Nil)) == Some(n))
+        case _ =>
+      }
+    }
+  }
+
+  test("test some examples for singly named") {
+    def check(str: String, nm: String) =
+      pat(str) match {
+        case Pattern.SinglyNamed(n) => assert(n == Identifier.unsafe(nm))
+        case other => fail(s"expected singlynamed: $other")
+      }
+
+    def checkNot(str: String) =
+      pat(str) match {
+        case Pattern.SinglyNamed(n) => fail(s"unexpected singlynamed: $n")
+        case other => succeed
+      }
+
+    check("foo", "foo")
+    check("foo@foo", "foo")
+    check("foo@(foo@foo)", "foo")
+    check("foo@Foo(_, _)", "foo")
+    check("foo: T", "foo")
+    check("foo@(_: T)", "foo")
+    check("foo@(_, _)", "foo")
+    check("foo | foo", "foo")
+    check("foo@[*_]", "foo")
+    check("(foo@X) | (foo@Y)", "foo")
+
+    checkNot("foo | bar")
+    checkNot("foo@Foo(x, y)")
+    checkNot("foo@(x, y)")
+    checkNot("_")
+    checkNot("[foo]")
+    checkNot("Foo(x, y)")
+    checkNot("foo@bar")
+    checkNot("Foo(foo)")
   }
 
   test("substructures don't include total matches") {

--- a/test_workspace/ApplicativeTraverse.bosatsu
+++ b/test_workspace/ApplicativeTraverse.bosatsu
@@ -97,7 +97,7 @@ operator == = eq_opt_list_int
 test = TestSuite("applicative/traverse tests",
   [
     Assertion(trav_list_opt(\x -> Some(2.times(x)), [1, 2, 3]) == Some([2, 4, 6]), "double"),
-    Assertion(trav_list_opt(\x -> None, [1, 2, 3]) == None, "all to None"),
+    Assertion(trav_list_opt(\_ -> None, [1, 2, 3]) == None, "all to None"),
     Assertion(trav_list_opt(\x -> None if x.eq_Int(3) else Some(x), [1, 2, 3]) == None, "3 to None"),
     Assertion(trav_list_opt(\x -> None if x.eq_Int(3) else Some(x), []) == Some([]), "empty to Some"),
   ])

--- a/test_workspace/BinNat.bosatsu
+++ b/test_workspace/BinNat.bosatsu
@@ -137,7 +137,6 @@ def fold_left_BinNat(fn: a -> BinNat -> a, init: a, cnt: BinNat) -> a:
 
 # fibonacci using the fuel pattern
 def fib(b: BinNat) -> BinNat:
-    bnat = toNat(b)
     def loop(n: Nat, cur: BinNat, next: BinNat) -> BinNat:
         recur n:
             NatZero: cur

--- a/test_workspace/TreeList.bosatsu
+++ b/test_workspace/TreeList.bosatsu
@@ -33,15 +33,15 @@ def cons(head: a, TreeList(tail): TreeList[a]) -> TreeList[a]:
     []: TreeList([Single(head)])
     [s1 @ Single(_)]:
       TreeList([Single(head), s1])
-    [s1 @ Single(_), b1 @Branch(_, _, _, _), *t]:
+    [ Single(_), b1 @Branch(_, _, _, _), *t]:
       TreeList([Single(head), b1, *t])
     [s1 @ Single(_), s2 @ Single(_), *t]:
       TreeList([Branch(3, head, s1, s2), *t])
-    [Branch(_, _, _, _), Single(_), *t]:
+    [Branch(_, _, _, _), Single(_), *_]:
       # illegal state, we can just return empty
       empty
     [branch @ Branch(_, _, _, _)]: TreeList([Single(head), branch])
-    [Branch(_, _, _, _), Single(_), *t]: empty
+    [Branch(_, _, _, _), Single(_), *_]: empty
     [b1@Branch(s1, _, _, _), b2@Branch(s2, _, _, _), *t]:
       if (eq_Int(s1, s2)):
         TreeList([Branch(s1 + s2 + 1, head, b1, b2), *t])

--- a/test_workspace/euler2.bosatsu
+++ b/test_workspace/euler2.bosatsu
@@ -17,7 +17,7 @@ import Bosatsu/List [ sum ]
 # so n = 35 is enough
 
 def fib(n):
-  range(n).foldLeft([], \revFib, item ->
+  range(n).foldLeft([], \revFib, _ ->
     match revFib:
       []: [1]
       [h]: [2, h]

--- a/test_workspace/euler3.bosatsu
+++ b/test_workspace/euler3.bosatsu
@@ -17,7 +17,7 @@ def smallest_factor(n):
   match n:
     1: 1
     _:
-      int_loop(n, -1, \i, res ->
+      int_loop(n, -1, \i, _ ->
         trial = n - i + 2
         if trial.divides(n): (0, trial)
         else: (i - 1, -1))

--- a/test_workspace/euler4.bosatsu
+++ b/test_workspace/euler4.bosatsu
@@ -30,7 +30,7 @@ def max_of(n, fn):
 # return the first defined value from largest to smallest
 # of the given function, if it is defined
 def first_of(n, fn):
-  int_loop(n, None, \i, res ->
+  int_loop(n, None, \i, _ ->
     match fn(i):
       None: (i - 1, None)
       nonNone: (0, nonNone))

--- a/test_workspace/euler5.bosatsu
+++ b/test_workspace/euler5.bosatsu
@@ -35,7 +35,7 @@ factors = range(10)
 
 def keep(n): for_all(factors, \f -> (f + 1).divides(n))
 
-div_all = int_loop_up(bound, 0, \i, res ->
+div_all = int_loop_up(bound, 0, \i, _ ->
   cand = i.add(1)
   if keep(cand): (bound, cand)
   else: (i + 1, 0))

--- a/test_workspace/recordset.bosatsu
+++ b/test_workspace/recordset.bosatsu
@@ -26,12 +26,12 @@ def get(sh: shape[RecordValue], RecordGetter(_, getter): RecordGetter[shape, t])
   result
 
 def create_field(rf: RecordField[t], fn: shape[RecordValue] -> t):
-  RecordGetter(\sh -> rf, \sh -> RecordValue(fn(sh)))
+  RecordGetter(\_ -> rf, \sh -> RecordValue(fn(sh)))
 
 def list_of_rows(RecordSet(fields, rows, getters, traverse, record_to_list): RecordSet[shape]):
   def getter_to_row_entry(row: shape[RecordValue]):
     (result_fn: forall tt. RecordGetter[shape, tt] -> RecordRowEntry[RecordValue, tt]) = \RecordGetter(get_field, get_value) ->
-      RecordField(name, to_entry) = get_field(fields)
+      RecordField(_, to_entry) = get_field(fields)
       RecordRowEntry(to_entry(get_value(row)))
     result_fn
   [record_to_list(getters.traverse(getter_to_row_entry(row))) for row in rows]
@@ -53,14 +53,14 @@ def concat_records(RecordSet(fields, rows, getters, traverse, record_to_list), m
 struct NilShape[w]
 struct PS[t,rest,w](left: w[t], right: rest[w])
 
-new_record_set = RecordSet(NilShape, [], NilShape, \NilShape,fn -> NilShape, \NilShape -> [])
+new_record_set = RecordSet(NilShape, [], NilShape, \NilShape, _ -> NilShape, \NilShape -> [])
 
 (ps_end: forall t. RestructureOutput[t, NilShape]) = RestructureOutput(
-  \ns -> NilShape,
-  \ns -> NilShape,
+  \_ -> NilShape,
+  \_ -> NilShape,
   NilShape,
-  \ns,fn -> NilShape,
-  \ns -> []
+  \_, _ -> NilShape,
+  \_ -> []
 )
 
 def ps(
@@ -117,7 +117,7 @@ equal_rows = equal_List(equal_RowEntry)
 
 ##################################################
 
-rs_empty = new_record_set.restructure(\ns -> ps("String field".string_field(\_ -> ""), ps("Int field".int_field(\_ -> 0), ps("Bool field".bool_field(\_ -> True), ps_end))))
+rs_empty = new_record_set.restructure(\_ -> ps("String field".string_field(\_ -> ""), ps("Int field".int_field(\_ -> 0), ps("Bool field".bool_field(\_ -> True), ps_end))))
 
 rs = rs_empty.concat_records([PS(RecordValue("a"), PS(RecordValue(1), PS(RecordValue(False), NilShape)))])
 


### PR DESCRIPTION
close #419 

This makes unused bindings an error. This is purely a change to make it easier to write correct code.

We cannot remove the unused let normalization because other changes in the graph can make a let unused. This is only a naive check that a variable is literally never used. It may still be removable by optimizations and normalizations.

Our goal here is simply to error on cases where trivial syntactic analysis we should something is unused.