### PR TITLE
Allow newline after =, allow any file trailing whitespace

### DIFF
--- a/core/src/main/scala/org/bykn/bosatsu/Statement.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/Statement.scala
@@ -118,15 +118,13 @@ object Statement {
 
   // Parse a single item
   final val parser1: P[Statement] = {
-     val bindingP: P[Statement] = {
-       val bop = Declaration
-         .bindingParser[Pattern.Parsed, Unit](Declaration.nonBindingParser, Indy.lift(toEOL))("")
-
-       (Pattern.bindParser ~/ bop).region.map { case (region, (p, parseBs)) =>
-         val bs = parseBs(p)
-          Bind(bs)(region)
-       }
-     }
+     val bindingP: P[Statement] =
+       Declaration
+         .bindingParser[Unit](Declaration.nonBindingParser, Indy.lift(toEOL), cutPattern = true)("")
+         .region
+         .map { case (region, bs) =>
+            Bind(bs)(region)
+         }
 
      val paddingSP: P[Statement] =
        Padding
@@ -221,7 +219,7 @@ object Statement {
    * This parses the *rest* of the string (it must end with End)
    */
   val parser: P[List[Statement]] =
-    parser1.rep().map(_.toList) ~ End
+    parser1.rep().map(_.toList) ~ Parser.maybeSpacesAndLines ~ End
 
   private def constructor(name: Constructor, taDoc: Doc, args: List[(Bindable, Option[TypeRef])]): Doc =
     Document[Identifier].document(name) + taDoc +

--- a/core/src/test/scala/org/bykn/bosatsu/Gen.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/Gen.scala
@@ -16,6 +16,9 @@ object Generators {
   val num: Gen[Char] = Gen.oneOf('0' to '9')
   val identC: Gen[Char] = Gen.frequency((10, lower), (1, upper), (1, num))
 
+  val whiteSpace: Gen[String] =
+    Gen.listOf(Gen.oneOf(' ', '\t', '\n')).map(_.mkString)
+
   private val emptyRegion: Region = Region(0, 0)
 
   def nonEmpty[T](t: Gen[T]): Gen[NonEmptyList[T]] =

--- a/core/src/test/scala/org/bykn/bosatsu/ParserTest.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/ParserTest.scala
@@ -679,6 +679,11 @@ x""",
 x""",
     Binding(BindingStatement(Pattern.Var(Identifier.Name("x")),Apply(mkVar("foo"),NonEmptyList.of(Literal(Lit.fromInt(4))), ApplyKind.Parens),Padding(0,Comment(CommentStatement(NonEmptyList.of(" x is really great"),Padding(0,mkVar("x"))))))))
 
+    // allow indentation after =
+    roundTrip(parser(""),
+      """x =
+        |  foo
+        |x""".stripMargin)
   }
 
   test("we can parse if") {
@@ -986,6 +991,18 @@ x = ( foo )
 
 """)
 
+    // we can add spaces at the end of the file
+    roundTrip(Statement.parser,
+"""# header
+def foo(x: forall f. f[a] -> f[b], y: a) -> b:
+  x(y)
+
+# here is a lambda
+fn = \x, y -> x.plus(y)
+
+x = ( foo )
+      """)
+
     roundTrip(Statement.parser,
 """#
 
@@ -1058,9 +1075,9 @@ def foo(
       case _ => false
     }.reverse
 
-  test("Any statement may append a newline and continue to parse") {
-    forAll(Generators.genStatement(5)) { s =>
-      val str = Document[Statement].document(s).render(80) + "\n"
+  test("Any statement may append trailing whitespace and continue to parse") {
+    forAll(Generators.genStatement(5), Generators.whiteSpace) { (s, ws) =>
+      val str = Document[Statement].document(s).render(80) + ws
       roundTrip(Statement.parser.map(dropTrailingPadding(_)), str)
     }
   }

--- a/test_workspace/euler7.bosatsu
+++ b/test_workspace/euler7.bosatsu
@@ -51,7 +51,9 @@ def ith_prime(total):
     [h, *_]: h
     []: -1
 
-test = TestSuite("euler 7", [
-  Assertion(is_prime(13), "6th prime is 13"),
-  Assertion(ith_prime(6) == 13, "6th prime is 13"),
-  Assertion(ith_prime(11) == 31, "11th prime is 31")])
+test =
+    TestSuite("euler 7", [
+        Assertion(is_prime(13), "6th prime is 13"),
+        Assertion(ith_prime(6) == 13, "6th prime is 13"),
+        Assertion(ith_prime(11) == 31, "11th prime is 31"),
+    ])


### PR DESCRIPTION
I accidentally had trailing whitespace in a file and got a parse error, which was not great. Trailing whitespace isn't awesome, but it shouldn't cause a parse failure.

Also, this allows us to use `=` to make a block simliar to `:` so you can do:
```
x = Foo(some, really, long, call)

# instead:
x = 
    Foo(
       some,
       really,
       long,
       call,
    )
```
as long as there is indentation after the `=` on the next line.