### PR TITLE
Support for string interpolation and matching

### DIFF
--- a/cli/src/main/protobuf/bosatsu/TypedAst.proto
+++ b/cli/src/main/protobuf/bosatsu/TypedAst.proto
@@ -196,6 +196,18 @@ message ListPat {
   repeated ListPart parts = 1;
 }
 
+message StrPart {
+  oneof value {
+    WildCardPat unnamedStr = 1;
+    int32 namedStr = 2;
+    int32 literalStr = 3;
+  }
+}
+
+message StrPat {
+  repeated StrPart parts = 1;
+}
+
 message AnnotationPat {
   int32 pattern = 1;
   int32 typeOfPattern = 2;
@@ -221,6 +233,7 @@ message Pattern {
     AnnotationPat annotationPat = 6;
     StructPattern structPat = 7;
     UnionPattern unionPat = 8;
+    StrPat strPat = 9;
   }
 }
 

--- a/cli/src/main/scala/org/bykn/bosatsu/PathModule.scala
+++ b/cli/src/main/scala/org/bykn/bosatsu/PathModule.scala
@@ -111,7 +111,7 @@ object PathModule extends MainModule[IO] {
       case Output.EvaluationResult(res, tpe) =>
         IO.suspend {
           val r = res.value
-          print(s"$res: $tpe")
+          print(s"$r: $tpe")
         }
       case Output.JsonOutput(json, pathOpt) =>
         val jdoc = json.toDoc

--- a/core/src/main/resources/bosatsu/predef.bosatsu
+++ b/core/src/main/resources/bosatsu/predef.bosatsu
@@ -16,6 +16,7 @@ export [
   add_key,
   cmp_Int,
   concat,
+  concat_String,
   div,
   clear_Dict,
   empty_Dict,
@@ -124,6 +125,7 @@ def range_fold(inclusiveLower: Int, exclusiveUpper: Int, init: a, fn: a -> Int -
 external struct String
 external def string_Order_fn(str0: String, str1: String) -> Comparison
 string_Order = Order(string_Order_fn)
+external def concat_String(items: List[String]) -> String
 
 enum Test:
   Assertion(value: Bool, message: String)

--- a/core/src/main/scala/org/bykn/bosatsu/Declaration.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/Declaration.scala
@@ -477,6 +477,14 @@ object Declaration {
       case Literal(lit) => Some(Pattern.Literal(lit))
       case StringDecl(NonEmptyList(Right((_, s)), Nil)) =>
         Some(Pattern.Literal(Lit.Str(s)))
+      case StringDecl(items) =>
+        def toStrPart(p: Either[NonBinding, (Region, String)]): Option[Pattern.StrPart] =
+          p match {
+            case Right((_, str)) => Some(Pattern.StrPart.LitStr(str))
+            case Left(Var(v: Bindable)) => Some(Pattern.StrPart.NamedStr(v))
+            case _ => None
+          }
+        items.traverse(toStrPart).map(Pattern.StrPat(_))
       case ListDecl(ListLang.Cons(elems)) =>
         val optParts: Option[List[Pattern.ListPart[Pattern.Parsed]]] =
           elems.traverse {

--- a/core/src/main/scala/org/bykn/bosatsu/Declaration.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/Declaration.scala
@@ -191,6 +191,11 @@ sealed abstract class Declaration {
           items.foldLeft(acc) { (acc0, d) => loop(d, bound, acc0) }
         case Var(name: Bindable) if !bound(name) => acc + name
         case Var(_) => acc
+        case StringDecl(items) =>
+          items.foldLeft(acc) {
+            case (acc, Left(nb)) => loop(nb, bound, acc)
+            case (acc, _) => acc
+          }
         case ListDecl(ListLang.Cons(items)) =>
           items.foldLeft(acc) { (acc0, sori) =>
             loop(sori.value, bound, acc0)

--- a/core/src/main/scala/org/bykn/bosatsu/DefRecursionCheck.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/DefRecursionCheck.scala
@@ -349,6 +349,11 @@ object DefRecursionCheck {
               if (ir.defNamesContain(v)) failSt(InvalidRecursion(v, decl.region))
               else unitSt
           }
+        case StringDecl(parts) =>
+          parts.traverse_ {
+            case Left(nb) => checkDecl(nb)
+            case Right(_) => unitSt
+          }
         case ListDecl(ll) =>
           ll match {
             case ListLang.Cons(items) =>

--- a/core/src/main/scala/org/bykn/bosatsu/Evaluation.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/Evaluation.scala
@@ -325,8 +325,29 @@ case class Evaluation[T](pm: PackageMap.Typed[T], externals: Externals) {
                 case Some(env1) => Some(env1.updated(n, Eval.now(v)))
               }
             }
-          case Pattern.StrPat(items) =>
-            sys.error(s"TODO: deal with string patterns")
+          case pat@Pattern.StrPat(_) =>
+            val spat = pat.toSimple
+            val nameMap = spat.toList.collect {
+              case SimpleStringPattern.Var(n) => (n, Identifier.unsafe(n))
+            }.toMap
+
+            if (nameMap.isEmpty) {
+              { (v, env) =>
+                // this casts should be safe if we have typechecked
+                val str = v.asInstanceOf[ExternalValue].toAny.asInstanceOf[String]
+                if (spat.doesMatch(str)) Some(env)
+                else None
+              }
+            }
+            else {
+              { (v, env) =>
+                // this casts should be safe if we have typechecked
+                val str = v.asInstanceOf[ExternalValue].toAny.asInstanceOf[String]
+                spat.matches(str).map { vars =>
+                  env ++ vars.iterator.map { case (k, v) => (nameMap(k), Eval.now(ExternalValue(v))) }
+                }
+              }
+            }
           case Pattern.ListPat(items) =>
             items match {
               case Nil =>

--- a/core/src/main/scala/org/bykn/bosatsu/Evaluation.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/Evaluation.scala
@@ -325,6 +325,8 @@ case class Evaluation[T](pm: PackageMap.Typed[T], externals: Externals) {
                 case Some(env1) => Some(env1.updated(n, Eval.now(v)))
               }
             }
+          case Pattern.StrPat(items) =>
+            sys.error(s"TODO: deal with string patterns")
           case Pattern.ListPat(items) =>
             items match {
               case Nil =>

--- a/core/src/main/scala/org/bykn/bosatsu/ListLang.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/ListLang.scala
@@ -13,10 +13,16 @@ sealed abstract class ListLang[F[_], A, +B]
 object ListLang {
   sealed abstract class SpliceOrItem[A] {
     def value: A
+
+    def map[B](fn: A => B): SpliceOrItem[B]
   }
   object SpliceOrItem {
-    case class Splice[A](value: A) extends SpliceOrItem[A]
-    case class Item[A](value: A) extends SpliceOrItem[A]
+    case class Splice[A](value: A) extends SpliceOrItem[A] {
+      def map[B](fn: A => B): Splice[B] = Splice(fn(value))
+    }
+    case class Item[A](value: A) extends SpliceOrItem[A] {
+      def map[B](fn: A => B): Item[B] = Item(fn(value))
+    }
 
     def parser[A](pa: P[A]): P[SpliceOrItem[A]] =
       P("*" ~ pa).map(Splice(_)) | pa.map(Item(_))
@@ -28,7 +34,9 @@ object ListLang {
       }
   }
 
-  case class KVPair[A](key: A, value: A)
+  case class KVPair[A](key: A, value: A) {
+    def map[B](fn: A => B): KVPair[B] = KVPair(fn(key), fn(value))
+  }
 
   object KVPair {
     private[this] val sep: Doc = Doc.text(": ")

--- a/core/src/main/scala/org/bykn/bosatsu/Lit.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/Lit.scala
@@ -17,6 +17,8 @@ object Lit {
   case class Integer(toBigInteger: BigInteger) extends Lit
   case class Str(toStr: String) extends Lit
 
+  val EmptyStr: Str = Str("")
+
   def fromInt(i: Int): Lit = Integer(BigInteger.valueOf(i.toLong))
   def apply(i: Long): Lit = apply(BigInteger.valueOf(i))
   def apply(bi: BigInteger): Lit = Integer(bi)

--- a/core/src/main/scala/org/bykn/bosatsu/Normalization.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/Normalization.scala
@@ -578,6 +578,7 @@ case class NormalizePackageMap(pm: PackageMap.Inferred) {
         case Pattern.Literal(lit) => NormalPattern.Literal(lit)
         case Pattern.Var(v) => NormalPattern.Var(names.indexOf(v))
         case Pattern.Named(n, p) => NormalPattern.Named(names.indexOf(n), loop(p))
+        case Pattern.StrPat(items) => sys.error(s"TODO: deal with StrPat($items) in normalization")
         case Pattern.ListPat(items) =>
           NormalPattern.ListPat(items.map {
             case Pattern.ListPart.NamedList(n) =>Left(Some(names.indexOf(n)))

--- a/core/src/main/scala/org/bykn/bosatsu/OptIndent.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/OptIndent.scala
@@ -19,6 +19,13 @@ sealed abstract class OptIndent[A] {
       case OptIndent.NotSameLine(_) => Doc.empty
     }
 
+  def map[B](fn: A => B): OptIndent[B] =
+    this match {
+      case OptIndent.SameLine(a) => OptIndent.SameLine(fn(a))
+      case OptIndent.NotSameLine(Padding(p, Indented(i, a))) =>
+        OptIndent.NotSameLine(Padding(p, Indented(i, fn(a))))
+    }
+
   def traverse[F[_]: Functor, B](fn: A => F[B]): F[OptIndent[B]] =
     this match {
       case OptIndent.SameLine(a) => fn(a).map(OptIndent.SameLine(_))

--- a/core/src/main/scala/org/bykn/bosatsu/Package.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/Package.scala
@@ -499,7 +499,11 @@ object PackageError {
               Doc.text(s"arity mismatch: ${n.asString} expected $exp parameters, found $found")
             case UnknownConstructor((_, n), _, _) =>
               Doc.text(s"unknown constructor: ${n.asString}")
-            case MultipleSplicesInPattern(_, _) =>
+            case InvalidStrPat(pat, _) =>
+              Doc.text(s"invalid string pattern: ") +
+                Document[Pattern.Parsed].document(pat) +
+                Doc.text(" (adjacent bindings aren't allowed)")
+            case MultipleSplicesInPattern(pat, _) =>
               Doc.text("multiple splices in pattern, only one per match allowed")
           }
       }

--- a/core/src/main/scala/org/bykn/bosatsu/Padding.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/Padding.scala
@@ -6,7 +6,10 @@ import org.typelevel.paiges.{ Doc, Document }
 import Parser.maybeSpace
 
 // Represents vertical padding
-case class Padding[T](lines: Int, padded: T)
+case class Padding[T](lines: Int, padded: T) {
+  def map[B](fn: T => B): Padding[B] =
+    Padding(lines, fn(padded))
+}
 object Padding {
   implicit def document[T: Document]: Document[Padding[T]] =
     Document.instance[Padding[T]] { padding =>

--- a/core/src/main/scala/org/bykn/bosatsu/Pattern.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/Pattern.scala
@@ -335,16 +335,12 @@ object Pattern {
         case _ => false
       }
 
-    def toLiteralString: Option[String] = {
-      toSimple.normalize.toList match {
+    def toLiteralString: Option[String] =
+      toSimple.toList match {
         case Nil => Some("")
         case SimpleStringPattern.Lit(s) :: Nil => Some(s)
         case _ => None
       }
-    }
-
-    def toLiteral: Option[Literal] =
-      toLiteralString.map { str => Literal(Lit.Str(str)) }
   }
 
   /**
@@ -372,7 +368,6 @@ object Pattern {
     // this is either a Literal string or a StrPat
     def fromSimple(ssp: SimpleStringPattern.Pattern): Pattern[Nothing, Nothing] = {
       val parts = ssp
-        .normalize
         .toList
         .map {
           case SimpleStringPattern.Var(w) =>

--- a/core/src/main/scala/org/bykn/bosatsu/Pattern.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/Pattern.scala
@@ -192,8 +192,12 @@ object Pattern {
     final case class NamedStr(name: Bindable) extends StrPart
     final case class LitStr(asString: String) extends StrPart
 
-    private[this] val wildDoc = Doc.text("""${_}""")
-    private[this] val prefix = Doc.text("""${""")
+    // this is to circumvent scala warnings because these bosatsu
+    // patterns like right.
+    private[this] val dollar = "$"
+    private[this] val wildDoc = Doc.text(s"$dollar{_}")
+    private[this] val prefix = Doc.text(s"$dollar{")
+
     def document(q: Char): Document[StrPart] =
       Document.instance {
         case WildStr => wildDoc

--- a/core/src/main/scala/org/bykn/bosatsu/Pattern.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/Pattern.scala
@@ -35,6 +35,9 @@ sealed abstract class Pattern[+N, +T] {
         case Pattern.Named(v, p) :: tail =>
           if (seen(v)) loop(p :: tail, seen, acc)
           else loop(p :: tail, seen + v, v :: acc)
+        case Pattern.StrPat(items) :: tail =>
+          val names = items.collect { case Pattern.StrPart.NamedStr(n) => n }.filterNot(seen)
+          loop(tail, seen ++ names, names reverse_::: acc)
         case Pattern.ListPat(items) :: tail =>
           val globs = items.collect { case Pattern.ListPart.NamedList(glob) => glob }.filterNot(seen)
           val next = items.collect { case Pattern.ListPart.Item(inner) => inner }
@@ -57,7 +60,7 @@ sealed abstract class Pattern[+N, +T] {
     def cheat(stack: List[(Pattern[N, T], Boolean)], seen: Set[Bindable], acc: List[Bindable]): List[Bindable] =
       loop(stack, seen, acc)
 
-    import Pattern.ListPart
+    import Pattern.{ListPart, StrPart}
 
     @annotation.tailrec
     def loop(stack: List[(Pattern[N, T], Boolean)], seen: Set[Bindable], acc: List[Bindable]): List[Bindable] =
@@ -70,6 +73,12 @@ sealed abstract class Pattern[+N, +T] {
         case (Pattern.Named(v, p), isTop) :: tail =>
           if (seen(v) || isTop) loop((p, isTop) :: tail, seen, acc)
           else loop((p, isTop) :: tail, seen + v, v :: acc)
+        case (Pattern.StrPat(NonEmptyList(StrPart.NamedStr(_), Nil)), true) :: tail =>
+            // this is a total match at the top level, not a substructure
+            loop(tail, seen, acc)
+        case (Pattern.StrPat(items), _) :: tail =>
+          val globs = items.collect { case StrPart.NamedStr(glob) => glob }.filterNot(seen)
+          loop(tail, seen ++ globs, globs reverse_::: acc)
         case (Pattern.ListPat(ListPart.NamedList(_) :: Nil), true) :: tail =>
             // this is a total match at the top level, not a substructure
             loop(tail, seen, acc)
@@ -109,6 +118,13 @@ sealed abstract class Pattern[+N, +T] {
         val inner = p.filterVars(keep)
         if (keep(v)) Pattern.Named(v, inner)
         else inner
+      case Pattern.StrPat(items) =>
+        Pattern.StrPat(items.map {
+          case wl@(Pattern.StrPart.WildStr | Pattern.StrPart.LitStr(_)) => wl
+          case in@Pattern.StrPart.NamedStr(n) =>
+            if (keep(n)) in
+            else Pattern.StrPart.WildStr
+        })
       case Pattern.ListPat(items) =>
         Pattern.ListPat(items.map {
           case Pattern.ListPart.WildList => Pattern.ListPart.WildList
@@ -170,6 +186,22 @@ object Pattern {
     final case class NamedPartial(name: Constructor, style: Style) extends NamedKind
   }
 
+  sealed abstract class StrPart
+  object StrPart {
+    final case object WildStr extends StrPart
+    final case class NamedStr(name: Bindable) extends StrPart
+    final case class LitStr(asString: String) extends StrPart
+
+    private[this] val wildDoc = Doc.text("""${_}""")
+    private[this] val prefix = Doc.text("""${""")
+    def document(q: Char): Document[StrPart] =
+      Document.instance {
+        case WildStr => wildDoc
+        case NamedStr(b) => prefix + Document[Bindable].document(b) + Doc.char('}')
+        case LitStr(s) => Doc.text(s)
+      }
+  }
+
   /**
    * represents items in a list pattern
    */
@@ -222,6 +254,7 @@ object Pattern {
         case Pattern.Literal(lit) => Applicative[F].pure(Pattern.Literal(lit))
         case Pattern.Var(v) => Applicative[F].pure(Pattern.Var(v))
         case Pattern.Named(n, p) => p.traverseType(fn).map(Pattern.Named(n, _))
+        case Pattern.StrPat(items) => Applicative[F].pure(Pattern.StrPat(items))
         case Pattern.ListPat(items) =>
           items.traverse {
             case ListPart.Item(p) =>
@@ -254,6 +287,7 @@ object Pattern {
           case Pattern.WildCard => pwild
           case Pattern.Literal(lit) => Applicative[F].pure(Pattern.Literal(lit))
           case Pattern.Var(v) => Applicative[F].pure(Pattern.Var(v))
+          case Pattern.StrPat(s) => Applicative[F].pure(Pattern.StrPat(s))
           case Pattern.Named(v, p) =>
             go(p).map(Pattern.Named(v, _))
           case Pattern.ListPat(items) =>
@@ -283,6 +317,30 @@ object Pattern {
   case object WildCard extends Pattern[Nothing, Nothing]
   case class Literal(toLit: Lit) extends Pattern[Nothing, Nothing]
   case class Var(name: Bindable) extends Pattern[Nothing, Nothing]
+  case class StrPat(parts: NonEmptyList[StrPart]) extends Pattern[Nothing, Nothing] {
+
+    private lazy val simplePat: SimpleStringPattern.Pattern =
+      StrPat.toSimple(this)
+
+    def matches(str: String): Boolean =
+      isTotal || SimpleStringPattern.matches(simplePat, str).isDefined
+
+    lazy val isTotal: Boolean =
+      !parts.exists {
+        case Pattern.StrPart.LitStr(_) => true
+        case _ => false
+      }
+
+    def toLiteral: Option[Literal] = {
+      parts.foldLeft(Option(List.empty[String])) {
+        case (Some(revList), StrPart.LitStr(p)) =>
+          Some(p :: revList)
+        case (_, _) => None
+      }
+      .map { revList => Literal(Lit.Str(revList.reverse.mkString)) }
+    }
+  }
+
   /**
    * Patterns like foo @ Some(_)
    * @ binds tighter than |, so use ( ) with groups you want to bind
@@ -292,6 +350,23 @@ object Pattern {
   case class Annotation[N, T](pattern: Pattern[N, T], tpe: T) extends Pattern[N, T]
   case class PositionalStruct[N, T](name: N, params: List[Pattern[N, T]]) extends Pattern[N, T]
   case class Union[N, T](head: Pattern[N, T], rest: NonEmptyList[Pattern[N, T]]) extends Pattern[N, T]
+
+  object StrPat {
+    def toSimple(strPat: StrPat): SimpleStringPattern.Pattern = {
+      def loop(parts: NonEmptyList[StrPart]): SimpleStringPattern.Pattern =
+        parts match {
+          case NonEmptyList((StrPart.WildStr | StrPart.NamedStr(_)), Nil) =>
+            SimpleStringPattern.Wildcard
+          case NonEmptyList(StrPart.LitStr(s), Nil) => SimpleStringPattern.Lit(s)
+          case NonEmptyList((StrPart.WildStr | StrPart.NamedStr(_)), h :: tail) =>
+            SimpleStringPattern.Cat(SimpleStringPattern.Wildcard, loop(NonEmptyList(h, tail)))
+          case NonEmptyList(StrPart.LitStr(s), h :: tail) =>
+            SimpleStringPattern.Cat(SimpleStringPattern.Lit(s), loop(NonEmptyList(h, tail)))
+        }
+
+      loop(strPat.parts)
+    }
+  }
 
   /**
    * If this pattern is:
@@ -322,9 +397,9 @@ object Pattern {
       val ordN = implicitly[Ordering[N]]
       val ordT = implicitly[Ordering[T]]
       val list = ListOrdering.onType(this)
+      val ordBin = implicitly[Ordering[Bindable]]
       def partOrd[A](ordA: Ordering[A]): Ordering[ListPart[A]] =
         new Ordering[ListPart[A]] {
-          val ordBin = implicitly[Ordering[Bindable]]
           def compare(a: ListPart[A], b: ListPart[A]) =
             (a, b) match {
               case (ListPart.WildList, ListPart.WildList) => 0
@@ -339,6 +414,22 @@ object Pattern {
         }
 
       val listE = ListOrdering.onType(partOrd(this))
+
+      val ordStrPart = new Ordering[StrPart] {
+        import StrPart._
+
+        def compare(a: StrPart, b: StrPart) =
+          (a, b) match {
+            case (WildStr, WildStr) => 0
+            case (WildStr, _) => -1
+            case (LitStr(_), WildStr) => 1
+            case (LitStr(sa), LitStr(sb)) => sa.compareTo(sb)
+            case (LitStr(_), NamedStr(_)) => -1
+            case (NamedStr(na), NamedStr(nb)) => ordBin.compare(na, nb)
+            case (NamedStr(_), _) => 1
+          }
+      }
+      val strOrd = ListOrdering.onType(ordStrPart)
 
       val compIdent: Ordering[Identifier] = implicitly[Ordering[Identifier]]
 
@@ -357,7 +448,10 @@ object Pattern {
             val c = compIdent.compare(n1, n2)
             if (c == 0) compare(p1, p2) else c
           case (Named(_, _), _) => -1
-          case (ListPat(_), WildCard | Literal(_) | Var(_) | Named(_, _)) => 1
+          case (StrPat(_), WildCard | Literal(_) | Var(_) | Named(_, _)) => 1
+          case (StrPat(as), StrPat(bs)) => strOrd.compare(as.toList, bs.toList)
+          case (StrPat(_), _) => -1
+          case (ListPat(_), WildCard | Literal(_) | Var(_) | Named(_, _) | StrPat(_)) => 1
           case (ListPat(as), ListPat(bs)) => listE.compare(as, bs)
           case (ListPat(_), _) => -1
           case (Annotation(_, _), PositionalStruct(_, _) | Union(_, _)) => -1
@@ -387,6 +481,16 @@ object Pattern {
         Document[Identifier].document(n) + Doc.char('@') + Doc.char('(') + document.document(u) + Doc.char(')')
       case Named(n, p) =>
         Document[Identifier].document(n) + Doc.char('@') + document.document(p)
+      case StrPat(items) =>
+        // prefer ' if possible, else use "
+        val useDouble = items.exists {
+          case StrPart.LitStr(str) => str.contains('\'') && !str.contains('"')
+          case _ => false
+        }
+        val q = if (useDouble) '"' else '\''
+        val sd = StrPart.document(q)
+        val inner = Doc.intercalate(Doc.empty, items.toList.map(sd.document(_)))
+        Doc.char(q) + inner + Doc.char(q)
       case ListPat(items) =>
         Doc.char('[') + Doc.intercalate(Doc.text(", "),
           items.map {
@@ -499,6 +603,7 @@ object Pattern {
         Document[Identifier].document(n) + Doc.char('@') + Doc.char('(') + doc.document(u) + Doc.char(')')
       case Named(n, p) =>
         Document[Identifier].document(n) + Doc.char('@') + doc.document(p)
+      case StrPat(items) => document.document(StrPat(items))
       case ListPat(items) =>
         Doc.char('[') + Doc.intercalate(Doc.text(", "),
           items.map {
@@ -576,6 +681,14 @@ object Pattern {
         case Named(n, p1) =>
           val e1 = loop(p1, typeOf, env)
           update(e1, n, typeOf)
+        case StrPat(items) =>
+          // the type annotation typeOf applies to all the current names, which must be strings
+          items
+            .foldLeft(env) {
+              case (env, StrPart.NamedStr(n)) => update(env, n, typeOf)
+              case (env, _) => env
+            }
+
         case ListPat(items) =>
           type L = ListPart[Pattern[C, T]]
           items.foldLeft(env) {
@@ -599,7 +712,32 @@ object Pattern {
   }
 
   private[this] val pwild = P("_").map(_ => WildCard)
-  private[this] val plit = Lit.parser.map(Literal(_))
+  private[this] val plit: P[Pattern[Nothing, Nothing]] = {
+    val intp = Lit.integerParser.map(Literal(_))
+    val start = P("${")
+    val end = P("}")
+
+    val pwild = P("_").map(_ => StrPart.WildStr)
+    val pname = Identifier.bindableParser.map(StrPart.NamedStr(_))
+
+    def strp(q: Char): P[List[StrPart]] = {
+      StringUtil.interpolatedString(q, start, pwild | pname, end)
+        .map(_.map {
+          case Left(p) => p
+          case Right((_, str)) => StrPart.LitStr(str)
+        })
+    }
+
+    val eitherString = strp('\'') | strp('"')
+    // don't emit complex patterns for simple strings:
+    val str = eitherString.map {
+      case Nil => Literal(Lit.EmptyStr)
+      case StrPart.LitStr(str) :: Nil => Literal(Lit.Str(str))
+      case h :: tail => StrPat(NonEmptyList(h, tail))
+    }
+
+    str | intp
+  }
 
   /**
    * This does not allow a top-level type annotation which would be ambiguous

--- a/core/src/main/scala/org/bykn/bosatsu/Predef.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/Predef.scala
@@ -87,6 +87,7 @@ object Predef {
       .add(packageName, "get_key", FfiCall.Fn2(PredefImpl.get_key(_, _)))
       .add(packageName, "items", FfiCall.Fn1(PredefImpl.items(_)))
       .add(packageName, "remove_key", FfiCall.Fn2(PredefImpl.remove_key(_, _)))
+      .add(packageName, "concat_String", FfiCall.Fn1(PredefImpl.concat_String(_)))
 
   def withPredef(ps: List[Package.Parsed]): List[Package.Parsed] =
     predefPackage :: ps.map(_.withImport(predefImports))
@@ -194,6 +195,24 @@ object PredefImpl {
       case (Value.Str(sa), Value.Str(sb)) =>
         Value.Comparison.fromInt(sa.compareTo(sb))
       case other => sys.error(s"type error: $other")
+    }
+
+  def concat_String(items: Value): Value =
+    items match {
+      case Value.VList(parts) =>
+        Value.Str(parts.iterator.map {
+          case Value.Str(s) => s
+          case other =>
+            //$COVERAGE-OFF$
+            sys.error(s"type error: $other")
+            //$COVERAGE-ON$
+        }
+        .mkString)
+
+      case other =>
+        //$COVERAGE-OFF$
+        sys.error(s"type error: $other")
+        //$COVERAGE-ON$
     }
 
   def clear_Dict(dictv: Value): Value = {

--- a/core/src/main/scala/org/bykn/bosatsu/SimpleStringPattern.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/SimpleStringPattern.scala
@@ -2,9 +2,6 @@ package org.bykn.bosatsu
 
 object SimpleStringPattern {
   sealed trait Pattern {
-    def unapply(str: String): Option[Map[String, String]] =
-      matches(str)
-
     def matchesAny: Boolean = {
       val list = toList
 
@@ -66,15 +63,9 @@ object SimpleStringPattern {
               case other =>
                 loop(ctail, chead :: other)
             }
-          case Lit("") :: ctail =>
-            loop(ctail, front)
           case (chead@Lit(s1)) :: ctail =>
-            front match {
-              case Lit(s0) :: ftail =>
-                loop(ctail, Lit(s0 ++ s1) :: ftail)
-              case other =>
-                loop(ctail, chead :: other)
-            }
+            // tolist combines Lit values already
+            loop(ctail, chead :: front)
         }
 
       Pattern.fromList(loop(parts, Nil))
@@ -279,7 +270,10 @@ object SimpleStringPattern {
 
       ppat.map(toPat(_)).parse(str) match {
         case Parsed.Success(pat, _) => pat
-        case other => sys.error(s"could not parse: $other")
+        case other =>
+          // $COVERAGE-OFF$
+          sys.error(s"could not parse: $other")
+          // $COVERAGE-ON$
       }
     }
 

--- a/core/src/main/scala/org/bykn/bosatsu/SimpleStringPattern.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/SimpleStringPattern.scala
@@ -1,0 +1,126 @@
+package org.bykn.bosatsu
+
+object SimpleStringPattern {
+  sealed trait Pattern {
+    def unapply(str: String): Option[Map[String, String]] =
+      matches(this, str)
+  }
+
+  sealed trait Pattern1 extends Pattern
+
+  case class Lit(str: String) extends Pattern1
+  case class Var(name: String) extends Pattern1
+  case object Wildcard extends Pattern1
+  case class Cat(head: Pattern1, tail: Pattern) extends Pattern
+
+  /**
+   * If two vars are adjacent, the left one will always match empty string
+   * this normalize just removes the left var
+   */
+  def normalize(p: Pattern): Pattern =
+    p match {
+      case lvw@(Lit(_) | Var(_) | Wildcard) => lvw
+      case Cat(Var(_) | Wildcard, tail@Cat(Var(_) | Wildcard, _)) =>
+        normalize(tail)
+      case Cat(h, tail) =>
+        Cat(h, normalize(tail))
+    }
+
+
+  def render(p: Pattern, vars: Map[String, String]): Option[String] =
+    p match {
+      case Lit(str) => Some(str)
+      case Var(x) => vars.get(x)
+      case Wildcard => None
+      case Cat(head, rest) =>
+        for {
+          hstr <- render(head, vars)
+          tstr <- render(rest, vars)
+        } yield hstr ++ tstr
+    }
+
+  object Pattern {
+    def apply(str: String): Pattern = {
+      import fastparse.all._
+
+      val varWild = Identifier.nameParser.map { n => Var(n.asString) } | P("_").map(_ => Wildcard)
+      val ppat = StringUtil.interpolatedString('\'', P("${"), varWild, P("}"))
+
+      def toPat(l: List[Either[Pattern1, (Region, String)]]): Pattern =
+        l match {
+          case Nil => Lit("")
+          case Left(p1) :: tail =>
+            Cat(p1, toPat(tail))
+          case Right((_, lit)) :: tail =>
+            Cat(Lit(lit), toPat(tail))
+        }
+
+      ppat.map(toPat(_)).parse(str) match {
+        case Parsed.Success(pat, _) => pat
+        case other => sys.error(s"could not parse: $other")
+      }
+    }
+  }
+
+  private[this] val sme = Some(Map.empty[String, String])
+
+  def matches(p: Pattern, str: String): Option[Map[String, String]] =
+    p match {
+      case Lit(s0) =>
+        if (s0 == str) sme
+        else None
+      case Var(n) => Some(Map(n -> str))
+      case Wildcard => sme
+      case Cat(Lit(s0), rest) =>
+        if (str.startsWith(s0)) matches(rest, str.drop(s0.length))
+        else None
+      case Cat(Var(n), rest) =>
+        matchEnd(rest, str) match {
+          case None => None
+          case Some((offset, m1)) =>
+            if (m1.contains(n)) Some(m1)
+            else {
+              val s0 = str.substring(0, offset)
+              Some(m1.updated(n, s0))
+            }
+        }
+      case Cat(Wildcard, rest) =>
+        matchEnd(rest, str).map(_._2)
+    }
+
+  // return the offset in str of the first match of p
+  def matchEnd(p: Pattern, str: String): Option[(Int, Map[String, String])] =
+    p match {
+      case Lit(s0) =>
+        if (str.endsWith(s0)) Some((str.length - s0.length, Map.empty))
+        else None
+      case Var(n) => Some((0, Map(n -> str)))
+      case Wildcard => Some((0, Map.empty))
+      case Cat(Lit(""), rest) => matchEnd(rest, str)
+      case Cat(Lit(s0), rest) =>
+        val idx0 = str.indexOf(s0)
+        if (idx0 < 0) None
+        else {
+          // there is at least one match
+          val nextStr = str.drop(idx0 + s0.length)
+          matches(rest, nextStr) match {
+            case Some(res) => Some((idx0, res))
+            case None =>
+              // if r1 is no good, try searching at idx0 + 1
+              val nextIdx = idx0 + 1
+              if (nextIdx < str.length) {
+                val str1 = str.substring(idx0 + 1)
+                matchEnd(p, str1).map { case (idx, m) => (idx + idx0 + 1, m) }
+              }
+              else None
+            }
+        }
+      case Cat(Var(n), rest) =>
+        matchEnd(rest, str).map { case res@(idx, m) =>
+          if (m.contains(n)) res
+          else (0, m.updated(n, str.substring(0, idx)))
+        }
+      case Cat(Wildcard, rest) =>
+        matchEnd(rest, str).map { case (_, m) => (0, m) }
+    }
+}

--- a/core/src/main/scala/org/bykn/bosatsu/SimpleStringPattern.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/SimpleStringPattern.scala
@@ -4,6 +4,45 @@ object SimpleStringPattern {
   sealed trait Pattern {
     def unapply(str: String): Option[Map[String, String]] =
       matches(this, str)
+/*
+    // if this must start with string s,
+    // return the rest of the pattern
+    def take(s: String): Option[Pattern] =
+      if (s.isEmpty) Some(this)
+      else {
+        this match {
+          case Lit(s0) =>
+            if (s0.startsWith(s)) Some(Lit(s0.drop(s.length)))
+            else None
+          case Var(_) | Wildcard => None
+          case Cat(Lit(s0), tail) =>
+            if (s0.isEmpty) tail.take(s)
+            else {
+              // we can only match as much of s as s0 is long
+              val subs = s.take(s0.length)
+              if (s0.startsWith(subs)) {
+                // s0 does match the start of s
+                if (subs.length == s0.length) {
+                  // we matched all of s0, the rest of s has to match the tail
+                  tail.take(s.drop(subs.length))
+                }
+                else {
+                  // this implies s.length < s0.length
+                  Some(Cat(Lit(s0.drop(subs.length)), tail))
+                }
+              }
+              else None
+            }
+          case Cat(Var(_) | Wildcard, _) => None
+        }
+    }
+*/
+    def onlyMatchesEmpty: Boolean =
+      this match {
+        case Lit("") => true
+        case Lit(_) | Var(_) | Wildcard => false
+        case Cat(h, t) => h.onlyMatchesEmpty && t.onlyMatchesEmpty
+      }
   }
 
   sealed trait Pattern1 extends Pattern

--- a/core/src/main/scala/org/bykn/bosatsu/SimpleStringPattern.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/SimpleStringPattern.scala
@@ -3,7 +3,7 @@ package org.bykn.bosatsu
 object SimpleStringPattern {
   sealed trait Pattern {
     def unapply(str: String): Option[Map[String, String]] =
-      matches(this, str)
+      matches(str)
 
     def matchesAny: Boolean = {
       val list = toList
@@ -13,6 +13,9 @@ object SimpleStringPattern {
         case _ => false
       }
     }
+
+    def matches(str: String): Option[Map[String, String]] =
+      SimpleStringPattern.matches(this, str)
 
     def toList: List[Pattern1] =
       this match {
@@ -42,7 +45,7 @@ object SimpleStringPattern {
       }
 
     def doesMatch(str: String): Boolean =
-      matches(this, str).isDefined
+      matches(str).isDefined
 
     /**
      * If two vars are adjacent, the left one will always match empty string

--- a/core/src/main/scala/org/bykn/bosatsu/Statement.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/Statement.scala
@@ -19,6 +19,30 @@ sealed abstract class Statement {
    * of statements
    */
   def region: Region
+
+  def replaceRegions(r: Region): Statement = {
+    import Statement._
+
+    this match {
+      case Bind(BindingStatement(p, v, in)) =>
+        Bind(BindingStatement(p, v.replaceRegionsNB(r), in))(r)
+      case Comment(c) =>
+        Comment(c)(r)
+      case Def(d) =>
+        Def(d.copy(result = d.result.map(_.replaceRegions(r))))(r)
+      case PaddingStatement(p) =>
+        // this will just be some number of lines
+        PaddingStatement(p)(r)
+      case Struct(nm, typeArgs, args) =>
+        Struct(nm, typeArgs, args)(r)
+      case Enum(nm, typeArgs, parts) =>
+        Enum(nm, typeArgs, parts)(r)
+      case ExternalDef(name, args, res) =>
+        ExternalDef(name, args, res)(r)
+      case ExternalStruct(nm, targs) =>
+        ExternalStruct(nm, targs)(r)
+    }
+  }
 }
 
 sealed abstract class TypeDefinitionStatement extends Statement {

--- a/core/src/main/scala/org/bykn/bosatsu/TotalityCheck.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/TotalityCheck.scala
@@ -19,6 +19,7 @@ object TotalityCheck {
   case class ArityMismatch(cons: Cons, in: Pattern[Cons, Type], env: TypeEnv[Any], expected: Int, found: Int) extends Error
   case class UnknownConstructor(cons: Cons, in: Pattern[Cons, Type], env: TypeEnv[Any]) extends Error
   case class MultipleSplicesInPattern(pat: ListPat[Cons, Type], env: TypeEnv[Any]) extends Error
+  case class InvalidStrPat(pat: StrPat, env: TypeEnv[Any]) extends Error
 
   sealed abstract class ExprError[A] {
     def matchExpr: Expr.Match[A]
@@ -263,18 +264,25 @@ case class TotalityCheck(inEnv: TypeEnv[Any]) {
           difference0List(lp, rp)
       case (Literal(_), ListPat(_) | PositionalStruct(_, _)) =>
         Right(left :: Nil)
-      case (Literal(Lit.Str(str)), p@StrPat(_)) if p.matches(str) => Right(Nil)
+      case (Literal(Lit.Str(str)), p@StrPat(_)) if p.matches(str) =>
+        checkStrPat(p) >> Right(Nil)
       case (sa@StrPat(_), Literal(Lit.Str(str))) =>
-        Right(sa.toSimple.difference(SimpleStringPattern.Lit(str))
-          .map { p => StrPat.fromSimple(p.normalize): Pattern[Cons, Type] }
-          .sorted)
+        checkStrPat(sa) >> {
+          Right(sa.toSimple.difference(SimpleStringPattern.Lit(str))
+            .map { p => StrPat.fromSimple(p.normalize): Pattern[Cons, Type] }
+            .sorted)
+        }
       case (sa@StrPat(_), sb@StrPat(_)) =>
-        Right(sa.toSimple.difference(sb.toSimple)
-          .map { p => StrPat.fromSimple(p.normalize): Pattern[Cons, Type] }
-          .sorted)
+        checkStrPat(sa) >> checkStrPat(sb) >> {
+          Right(sa.toSimple.difference(sb.toSimple)
+            .map { p => StrPat.fromSimple(p.normalize): Pattern[Cons, Type] }
+            .sorted)
+        }
       case (_, StrPat(_)) =>
+        // ill-typed
         Right(left :: Nil)
       case (StrPat(_), _) =>
+        // ill-typed
         Right(left :: Nil)
       case (ListPat(_), Literal(_) | PositionalStruct(_, _)) =>
         Right(left :: Nil)
@@ -333,6 +341,13 @@ case class TotalityCheck(inEnv: TypeEnv[Any]) {
     }
   }
 
+  private def checkStrPat(pat: StrPat): Res[Unit] = {
+    // we cannot have two adjacent bindings like ${foo}${bar} because
+    // the left one can never match, so it is better to make this an error
+    if (pat.toSimple.normalize == pat.toSimple) Right(())
+    else Left(NonEmptyList(InvalidStrPat(pat, inEnv), Nil))
+  }
+
   def intersection(
     left: Pattern[Cons, Type],
     right: Pattern[Cons, Type]): Res[List[Pattern[Cons, Type]]] =
@@ -362,27 +377,33 @@ case class TotalityCheck(inEnv: TypeEnv[Any]) {
           if (a == b) Right(List(left))
           else Right(Nil)
         case (Literal(Lit.Str(s)), p@StrPat(_)) =>
-          if (p.matches(s)) Right(left :: Nil)
-          else Right(Nil)
+          checkStrPat(p) >> {
+            if (p.matches(s)) Right(left :: Nil)
+            else Right(Nil)
+          }
         case (p@StrPat(_), Literal(Lit.Str(s))) =>
-          if (p.matches(s)) Right(right :: Nil)
-          else Right(Nil)
+          checkStrPat(p) >> {
+            if (p.matches(s)) Right(right :: Nil)
+            else Right(Nil)
+          }
         case (p1@StrPat(_), p2@StrPat(_)) =>
-          val n1 = p1.toSimple.normalize.unname
-          val n2 = p2.toSimple.normalize.unname
-          val intr =
-            if (n1 == n2) (implicitly[Ordering[Pattern[Cons, Type]]].min(p1, p2) :: Nil)
-            else n1
-              .intersection(n2)
-              .map(_.normalize)
-              .distinct
-              .map { part =>
-                StrPat.fromSimple(part)
-              }
+          checkStrPat(p1) >> checkStrPat(p2) >> {
+            val n1 = p1.toSimple.normalize.unname
+            val n2 = p2.toSimple.normalize.unname
+            val intr =
+              if (n1 == n2) (implicitly[Ordering[Pattern[Cons, Type]]].min(p1, p2) :: Nil)
+              else n1
+                .intersection(n2)
+                .map(_.normalize)
+                .distinct
+                .map { part =>
+                  StrPat.fromSimple(part)
+                }
 
-          Right(intr.sorted)
-        case (StrPat(_), _) => Right(Nil)
-        case (_, StrPat(_)) => Right(Nil)
+            Right(intr.sorted)
+          }
+        case (p@StrPat(_), _) => checkStrPat(p) >> Right(Nil)
+        case (_, p@StrPat(_)) => checkStrPat(p) >> Right(Nil)
         case (Literal(_), _) => Right(Nil)
         case (_, Literal(_)) => Right(Nil)
         case (lp@ListPat(leftL), rp@ListPat(rightL)) =>
@@ -793,8 +814,7 @@ case class TotalityCheck(inEnv: TypeEnv[Any]) {
       case Pattern.WildCard | Pattern.Var(_) => Right(true)
       case Pattern.Named(_, p) => isTotal(p)
       case Pattern.Literal(_) => Right(false) // literals are not total
-      case s@Pattern.StrPat(_) =>
-        Right(s.isTotal)
+      case s@Pattern.StrPat(_) => checkStrPat(s).as(s.isTotal)
       case Pattern.ListPat((_: ListPart.Glob) :: rest) =>
         Right(matchesEmpty(rest))
       case Pattern.ListPat(_) =>

--- a/core/src/main/scala/org/bykn/bosatsu/rankn/Infer.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/rankn/Infer.scala
@@ -850,6 +850,15 @@ object Infer {
             pair1 <- inner(p0)
             (p1, t1) = pair1
           } yield (p1, (n, t1) :: ts0)
+        case GenPattern.StrPat(items) =>
+          val tpe = Type.StrType
+          val check = sigma match {
+            case Expected.Check((t, tr)) => subsCheck(tpe, t, reg, tr)
+          }
+          val names = items.collect {
+            case GenPattern.StrPart.NamedStr(n) => (n, tpe)
+          }
+          check.as((pat, names))
         case GenPattern.ListPat(items) =>
           import GenPattern.ListPart
           /*

--- a/core/src/main/scala/org/bykn/bosatsu/rankn/Infer.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/rankn/Infer.scala
@@ -858,7 +858,9 @@ object Infer {
           val names = items.collect {
             case GenPattern.StrPart.NamedStr(n) => (n, tpe)
           }
-          check.as((pat, names))
+          // we need to apply the type so the names are well typed
+          val anpat = GenPattern.Annotation(pat, tpe)
+          check.as((anpat, names))
         case GenPattern.ListPat(items) =>
           import GenPattern.ListPart
           /*

--- a/core/src/test/scala/org/bykn/bosatsu/EvaluationTest.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/EvaluationTest.scala
@@ -2144,6 +2144,42 @@ main = 1
       ()
     }
   }
+/* TODO: make this fail
+  test("test bad list pattern message") {
+    evalFail(
+      List("""
+package Err
+
+x = [1, 2, 3]
+
+main = match x:
+  [*_, *_]: "bad"
+  _: "still bad"
+
+"""), "Err") { case sce@PackageError.DuplicatedImport(_) =>
+      assert(sce.message(Map.empty, Colorize.None) == "duplicate import in <unknown source> package Bosatsu/Predef imports foldLeft as foldLeft")
+      ()
+    }
+  }
+
+  test("test bad string pattern message") {
+    val dollar = '$'
+    evalFail(
+      List(s"""
+package Err
+
+x = "foo bar"
+
+main = match x:
+  "$dollar{_}$dollar{_}": "bad"
+  _: "still bad"
+
+"""), "Err") { case sce@PackageError.DuplicatedImport(_) =>
+      assert(sce.message(Map.empty, Colorize.None) == "duplicate import in <unknown source> package Bosatsu/Predef imports foldLeft as foldLeft")
+      ()
+    }
+  }
+*/
 
   test("test parsing type annotations") {
     runBosatsuTest(List("""

--- a/core/src/test/scala/org/bykn/bosatsu/Gen.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/Gen.scala
@@ -602,6 +602,11 @@ object Generators {
           case TupleCons(Nil) => Stream.empty
           case TupleCons(h :: tail) => h #:: TupleCons(tail)(emptyRegion) #:: apply(TupleCons(tail)(emptyRegion))
           case Var(_) => Stream.empty
+          case StringDecl(parts) =>
+            parts.toList.toStream.map {
+              case Left(nb) => nb
+              case Right((r, str)) => Literal(Lit.Str(str))(r)
+            }
           case ListDecl(ListLang.Cons(items)) =>
             items.map(_.value).toStream
           case ListDecl(ListLang.Comprehension(a, _, c, d)) =>

--- a/core/src/test/scala/org/bykn/bosatsu/Gen.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/Gen.scala
@@ -184,10 +184,10 @@ object Generators {
       nel1 = removeAdj(nel) { (a1, a2) => a1.isRight && a2.isRight }
     } yield Declaration.StringDecl(nel1)(emptyRegion)
 
-    res.flatMap {
+    res.filter {
       case Declaration.StringDecl(NonEmptyList(Right(_), Nil)) =>
-        res
-      case a => Gen.const(a)
+        false
+      case a => true
     }
   }
 
@@ -544,7 +544,7 @@ object Generators {
       (2, lambdaGen(recur)),
       (2, applyGen(recur)),
       (1, applyOpGen(recur)),
-      //(1, genStringDecl(recur)),
+      (1, genStringDecl(recur)),
       (1, listGen(recur)),
       (1, dictGen(recur)),
       (1, annGen(recur)),
@@ -585,7 +585,7 @@ object Generators {
       (2, applyGen(recNon)),
       (1, applyOpGen(simpleDecl(depth - 1))),
       (1, ifElseGen(recNon, recur)),
-      //(1, genStringDecl(recNon)),
+      (1, genStringDecl(recNon)),
       (1, listGen(recNon)),
       (1, dictGen(recNon)),
       (1, matchGen(recNon, recur)),

--- a/core/src/test/scala/org/bykn/bosatsu/ParserTest.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/ParserTest.scala
@@ -219,7 +219,14 @@ class ParserTest extends ParserTestBase {
 
   test("we can parse interpolated strings") {
     def singleq(str1: String, res: List[Either[Json, String]]) =
-      parseTestAll(StringUtil.interpolatedString('\'', P("${"), Json.parser, P("}")), str1, res)
+      parseTestAll(
+        StringUtil
+          .interpolatedString('\'', P("${"), Json.parser, P("}"))
+          .map(_.map {
+            case Right((_, str)) => Right(str)
+            case Left(l) => Left(l)
+          })
+        , str1, res)
 
     // scala complains about things that look like interpolation strings that aren't interpolated
     val dollar = '$'.toString

--- a/core/src/test/scala/org/bykn/bosatsu/ParserTest.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/ParserTest.scala
@@ -951,7 +951,7 @@ x""")
   }
 
   test("we can parse any Declaration") {
-    forAll(Generators.genDeclaration(5))(law(Declaration.parser("")))
+    forAll(Generators.genDeclaration(5))(law(Declaration.parser("").map(_.replaceRegions(emptyRegion))))
 
     def decl(s: String) = roundTrip(Declaration.parser(""), s)
 
@@ -968,7 +968,7 @@ x""")
   }
 
   test("we can parse any Statement") {
-    forAll(Generators.genStatements(4, 10))(law(Statement.parser))
+    forAll(Generators.genStatements(4, 10))(law(Statement.parser.map(_.map(_.replaceRegions(emptyRegion)))))
 
     roundTrip(Statement.parser,
 """#
@@ -1149,7 +1149,8 @@ export [foo]
 foo = 1
 """)
 
-    forAll(Generators.packageGen(4))(law(Package.parser(None)))
+    val pp = Package.parser(None).map { pack => pack.copy(program = pack.program.map(_.replaceRegions(emptyRegion))) }
+    forAll(Generators.packageGen(4))(law(pp))
 
     roundTripExact(Package.parser(None),
 """package Foo

--- a/core/src/test/scala/org/bykn/bosatsu/SimpleStringPatternTest.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/SimpleStringPatternTest.scala
@@ -134,4 +134,13 @@ class SimpleStringPatternTest extends FunSuite {
       }
     }
   }
+
+  test("onlyMatchesEmpty works") {
+    forAll { (p0: Pattern, s: String) =>
+      if (p0.onlyMatchesEmpty) {
+        assert(matches(p0, "").isDefined)
+        if (s != "") assert(matches(p0, s).isEmpty)
+      }
+    }
+  }
 }

--- a/core/src/test/scala/org/bykn/bosatsu/SimpleStringPatternTest.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/SimpleStringPatternTest.scala
@@ -1,0 +1,137 @@
+package org.bykn.bosatsu
+
+import org.scalacheck.{Arbitrary, Gen}
+import org.scalatest.prop.PropertyChecks.{ forAll, PropertyCheckConfiguration }
+import org.scalatest.FunSuite
+
+class SimpleStringPatternTest extends FunSuite {
+  import SimpleStringPattern._
+
+  implicit val generatorDrivenConfig =
+    //PropertyCheckConfiguration(minSuccessful = 50000)
+    PropertyCheckConfiguration(minSuccessful = 5000)
+    //PropertyCheckConfiguration(minSuccessful = 5)
+
+  def genPattern(names: Set[String]): Gen[(Set[String], Pattern)] = {
+    val lit: Gen[(Set[String], Pattern1)] =
+      Gen.identifier.map { str => (names, Lit(str)) }
+
+    val varP: Gen[(Set[String], Pattern1)] =
+      Gen.identifier.filter { s => !names(s) }.map { n => (names + n, Var(n)) }
+
+    val cat = for {
+      (n1, ph) <- Gen.oneOf(lit, varP)
+      (n2, ptail) <- genPattern(n1)
+    } yield (n2, Cat(ph, ptail))
+
+    Gen.frequency(
+      (2, lit),
+      (1, Gen.const((names, Wildcard))),
+      (2, varP),
+      (15, cat))
+  }
+
+  def unvar(p: Pattern): String =
+    p match {
+      case Lit(str) => str
+      case Var(_) | Wildcard => ""
+      case Cat(h, tail) => unvar(h) ++ unvar(tail)
+    }
+
+  def unwild(p: Pattern): Pattern =
+    p match {
+      case l@(Lit(_) | Var(_)) => l
+      case Wildcard => Lit("")
+      case Cat(lv@(Lit(_) | Var(_)), tail) => Cat(lv, unwild(tail))
+      case Cat(Wildcard, tail) => unwild(tail)
+    }
+
+  def unlit(p: Pattern): Pattern =
+    p match {
+      case Lit(_) => Wildcard
+      case vw@(Wildcard | Var(_)) => vw
+      case Cat(Lit(_), tail) => unlit(tail)
+      case Cat(vw@(Wildcard | Var(_)), tail) => unlit(tail)
+    }
+
+  implicit val arbPattern: Arbitrary[Pattern] =
+    Arbitrary(genPattern(Set.empty).map(_._2))
+
+  test("matched patterns round trip when rendered") {
+    forAll(arbPattern.arbitrary, Gen.identifier) { (p0: Pattern, str: String) =>
+      val p = unwild(p0)
+      matches(p, str) match {
+        case None => ()
+        case Some(vars) =>
+          // if the unwild matches, the wild must match
+          assert(matches(p0, str).isDefined)
+          val rendered = render(p, vars)
+          assert(rendered == Some(str), s"${rendered.get.length} != ${str.length}, ${rendered.get.toArray.toList.map(_.toInt)} != ${str.toArray.toList.map(_.toInt)}")
+      }
+    }
+  }
+
+  test("if we unvar, we always match") {
+    forAll { p0: Pattern =>
+      val p = unwild(p0)
+      val str = unvar(p)
+      matches(p, str) match {
+        case None => fail("expected to match")
+        case Some(m) => m.foreach { case (k, v) =>
+          assert(v == "", s"key: $k, $v")
+        }
+      }
+    }
+  }
+
+  test("unlit patterns match everything") {
+    forAll { (p0: Pattern, str: String) =>
+      val p = unlit(p0)
+      assert(matches(p, str).isDefined)
+    }
+  }
+
+  test("test some examples") {
+    val p1 = Pattern("'foo${x}bar${y}'")
+
+    assert(matches(p1, "foobar") == Some(Map("x" -> "", "y" -> "")))
+    assert(matches(p1, "foobopbarbopbar") == Some(Map("x" -> "bop", "y" -> "bopbar")))
+    assert(matches(p1, "foobarbar") == Some(Map("x" -> "", "y" -> "bar")))
+    assert(matches(p1, "foobarbarbar") == Some(Map("x" -> "", "y" -> "barbar")))
+
+    val p2 = Pattern("'${front}foo${middle}bar${rest}'")
+
+    assert(matches(p2, "0foo1foo2bar3") == Some(Map("front" -> "0", "middle" -> "1foo2", "rest" -> "3")))
+  }
+
+  test("wildcard on either side is the same as contains") {
+    forAll { (ps: String, s: String) =>
+      assert(matches(Cat(Wildcard, Cat(Lit(ps), Wildcard)), s).isDefined == s.contains(ps))
+    }
+  }
+  test("wildcard on front side is the same as endsWith") {
+    forAll { (ps: String, s: String) =>
+      assert(matches(Cat(Wildcard, Lit(ps)), s).isDefined == s.endsWith(ps))
+    }
+  }
+  test("wildcard on back side is the same as startsWith") {
+    forAll { (ps: String, s: String) =>
+      assert(matches(Cat(Lit(ps), Wildcard), s).isDefined == s.startsWith(ps))
+    }
+  }
+  test("normalized patterns have the same matches as unnormalized ones") {
+    forAll { (p0: Pattern, s: String) =>
+      val pnorm = normalize(p0)
+      val nm = matches(pnorm, s)
+      val m = matches(p0, s)
+      assert(m.isDefined == nm.isDefined)
+      if (m.isDefined) {
+        m.get.keys.foreach { k =>
+          val mv = m.get(k)
+          val nv = nm.get.getOrElse(k, "")
+          assert(mv == nv, s"key: $k $m, $nm")
+        }
+      }
+    }
+  }
+}

--- a/core/src/test/scala/org/bykn/bosatsu/SimpleStringPatternTest.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/SimpleStringPatternTest.scala
@@ -109,6 +109,8 @@ class SimpleStringPatternTest extends FunSuite {
           // if the unwild matches, the wild must match
           assert(matches(p0, str).isDefined)
           val rendered = p.render(vars)
+          val renderWild = p0.render(vars)
+          assert(renderWild.isEmpty == (p0 != p))
           assert(rendered == Some(str), s"${rendered.get.length} != ${str.length}, ${rendered.get.toArray.toList.map(_.toInt)} != ${str.toArray.toList.map(_.toInt)}")
       }
     }
@@ -181,14 +183,14 @@ class SimpleStringPatternTest extends FunSuite {
 
   test("normalized patterns don't have adjacent Var/Wildcard or adjacent Lit") {
     forAll { p0: Pattern =>
-      p0.normalize.toList.sliding(2).foreach {
+      val list = p0.normalize.toList
+      list.sliding(2).foreach {
         case bad@Seq(Var(_) | Wildcard, Var(_) | Wildcard) =>
           fail(s"saw adjacent: $bad in ${p0.normalize}")
         case bad@Seq(Lit(_), Lit(_)) =>
           fail(s"saw adjacent: $bad in ${p0.normalize}")
         case _ => ()
       }
-
     }
   }
 

--- a/core/src/test/scala/org/bykn/bosatsu/SimpleStringPatternTest.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/SimpleStringPatternTest.scala
@@ -135,14 +135,15 @@ class SimpleStringPatternTest extends FunSuite {
   }
 
   test("test some examples") {
-    val p1 = Pattern("'foo${x}bar${y}'")
+    val dollar = "$"
+    val p1 = Pattern(s"'foo$dollar{x}bar$dollar{y}'")
 
     assert(matches(p1, "foobar") == Some(Map("x" -> "", "y" -> "")))
     assert(matches(p1, "foobopbarbopbar") == Some(Map("x" -> "bop", "y" -> "bopbar")))
     assert(matches(p1, "foobarbar") == Some(Map("x" -> "", "y" -> "bar")))
     assert(matches(p1, "foobarbarbar") == Some(Map("x" -> "", "y" -> "barbar")))
 
-    val p2 = Pattern("'${front}foo${middle}bar${rest}'")
+    val p2 = Pattern(s"'$dollar{front}foo$dollar{middle}bar$dollar{rest}'")
 
     assert(matches(p2, "0foo1foo2bar3") == Some(Map("front" -> "0", "middle" -> "1foo2", "rest" -> "3")))
   }
@@ -245,7 +246,7 @@ class SimpleStringPatternTest extends FunSuite {
       assert(p1.intersection(p2).exists(_.doesMatch(x)) ==
         p2.intersection(p1).exists(_.doesMatch(x)))
 
-    forAll(law(_, _, _))
+    forAll(law(_: Pattern, _: Pattern, _: String))
   }
 
   test("intersection is associative") {

--- a/test_workspace/PatternExamples.bosatsu
+++ b/test_workspace/PatternExamples.bosatsu
@@ -1,0 +1,37 @@
+package PatternExamples
+
+foo = "this is foo"
+bar = "this is bar"
+
+combine = "foo: ${foo} bar: ${bar}"
+
+def operator ==(a, b):
+    match string_Order_fn(a, b):
+        EQ: True
+        _: False
+
+def operator &&(a, b):
+    if a: b
+    else: False
+
+fb = match combine:
+    "foo: ${f} bar: ${b}":
+        (f == foo) && (b == bar)
+    _: False
+
+test0 = Assertion(fb, "foo-bar match")
+
+def get_foos(s) -> List[String]:
+    recur s:
+        "${_}foo: (${foo})${rest}": [foo, *get_foos(rest)]
+        _: []
+
+test1 = match get_foos("foo: (1) foo: (2)"):
+            ["1", "2"]: Assertion(True, "get_foos")
+            [one]: Assertion(True, "get_foos: ${one}")
+            _: Assertion(False, "get_foos")
+
+tests = TestSuite("PatternExamples", [
+    test0,
+    test1,
+])

--- a/test_workspace/PatternExamples.bosatsu
+++ b/test_workspace/PatternExamples.bosatsu
@@ -31,7 +31,14 @@ test1 = match get_foos("foo: (1) foo: (2)"):
             [one]: Assertion(False, "get_foos: ${one}")
             _: Assertion(False, "get_foos")
 
+test2_bool = match "unnamed match example":
+            "unnamed ${_} example": True
+            _: False
+
+test2 = Assertion(test2_bool, "test unnamed match")
+
 tests = TestSuite("PatternExamples", [
     test0,
     test1,
+    test2,
 ])

--- a/test_workspace/PatternExamples.bosatsu
+++ b/test_workspace/PatternExamples.bosatsu
@@ -28,7 +28,7 @@ def get_foos(s) -> List[String]:
 
 test1 = match get_foos("foo: (1) foo: (2)"):
             ["1", "2"]: Assertion(True, "get_foos")
-            [one]: Assertion(True, "get_foos: ${one}")
+            [one]: Assertion(False, "get_foos: ${one}")
             _: Assertion(False, "get_foos")
 
 tests = TestSuite("PatternExamples", [

--- a/test_workspace/StrConcatExample.bosatsu
+++ b/test_workspace/StrConcatExample.bosatsu
@@ -1,0 +1,26 @@
+package StrConcatExample
+
+x = "hello"
+y = "atticus"
+z = "mahina"
+
+def ident(x): x
+
+def m2s(m):
+    match m:
+        "mahina": "sarah"
+        _: m
+
+res0 = match "${x} ${y} and ${z}":
+        "hello atticus and mahina": True
+        _: False
+
+res1 = match "${ident(x)} ${y} and ${m2s(z)}":
+        "hello atticus and sarah": True
+        _: False
+
+test = TestSuite("interpolation", [
+    Assertion(res0, "res0"),
+    Assertion(res1, "res1"),
+])
+

--- a/test_workspace/StrConcatExample.bosatsu
+++ b/test_workspace/StrConcatExample.bosatsu
@@ -19,8 +19,13 @@ res1 = match "${ident(x)} ${y} and ${m2s(z)}":
         "hello atticus and sarah": True
         _: False
 
+res2 = match "${x}":
+    "hello": True
+    _: False
+
 test = TestSuite("interpolation", [
     Assertion(res0, "res0"),
     Assertion(res1, "res1"),
+    Assertion(res2, "res2"),
 ])
 


### PR DESCRIPTION
closes #426 

Since pattern and declaration parsing are related, it is not easy to add part of this, so this PR adds everything, expressions for interpolation as well as pattern matching for pattern strings.

Along the way, I improved my understanding of the set algebra of sequences so I think we can leverage this to check totality when we have multiple variable patterns in lists as well, which is probably complex to reason about, but at least doesn't create a difference with string patterns.