### PR TITLE
Allow a new form of apply

### DIFF
--- a/core/src/main/scala/org/bykn/bosatsu/Declaration.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/Declaration.scala
@@ -765,8 +765,10 @@ object Declaration {
       val applied: P[NonBinding] = {
         val params = recNonBind.parensLines1Cut
         // here we are using . syntax foo.bar(1, 2)
+        // we also allow foo.(anyExpression)(1, 2)
+        val fn = varP | (recNonBind.parensCut)
         val dotApply: P[NonBinding => NonBinding] =
-          P("." ~ varP ~ params.?)
+          P("." ~/ fn ~ params.?)
             .region
             .map { case (r2, (fn, argsOpt)) =>
               val args = argsOpt.fold(List.empty[NonBinding])(_.toList)

--- a/core/src/main/scala/org/bykn/bosatsu/Parser.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/Parser.scala
@@ -323,6 +323,9 @@ object Parser {
     def parens: P[T] =
       wrappedSpace("(", ")")
 
+    def parensCut: P[T] =
+      P("(" ~/ maybeSpacesAndLines ~ item ~ maybeSpacesAndLines ~ ")")
+
     def parensLines1: P[NonEmptyList[T]] = {
       val nel = item.nonEmptyListOfWs(maybeSpacesAndLines)
       P("(" ~ maybeSpacesAndLines ~ nel ~ maybeSpacesAndLines ~ ")")

--- a/core/src/test/scala/org/bykn/bosatsu/EvaluationTest.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/EvaluationTest.scala
@@ -2295,4 +2295,14 @@ def substitute:
 test = Assertion(substitute.eq_Int(42), "basis substitution")
 """), "A", 1)
   }
+
+  test("we can use .( ) to get |> like syntax for lambdas") {
+  runBosatsuTest(List("""
+package A
+
+three = 2.(\x -> add(x, 1))
+
+test = Assertion(three.eq_Int(3), "let inside apply")
+"""), "A", 1)
+  }
 }


### PR DESCRIPTION
related to #396 

It occurred to me if we had the `\if Foo(x) -> fn(x)` syntax for making partial functions, then we could generate `Option` values with:

```
x.(\if Foo(y) -> fn(y)): Option[a]
```

maybe the syntax is too dense, but `|>` type compositions which do `x |> f = f(x)` which is what we have `x.f` doing, but we only allow names for `f` not any other form. Since `.(f)` is unambiguous to parse, we could allow more which can be useful in some cases...

