### PR TITLE
Add support for converting values to Doc

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,7 @@ matrix:
       language: scala
       jdk: openjdk8
       env: PLATFORM=js
-      script: sbt "++ ${TRAVIS_SCALA_VERSION}" coreJS/test jsapiJS/fastOptJS && ./elmui/build.sh
+      script: sbt "++ ${TRAVIS_SCALA_VERSION}" coreJS/test && sbt "++ ${TRAVIS_SCALA_VERSION}" jsapiJS/fullOptJS && ./elmui/build.sh
       deploy:
         provider: pages:git
         deploy_key: bosatsu_deploy_key

--- a/cli/src/main/scala/org/bykn/bosatsu/PathModule.scala
+++ b/cli/src/main/scala/org/bykn/bosatsu/PathModule.scala
@@ -108,10 +108,13 @@ object PathModule extends MainModule[IO] {
 
           print(fullOut.render(80)) *> IO.raiseError(new Exception(excepMessage))
         }
-      case Output.EvaluationResult(res, tpe) =>
+      case Output.EvaluationResult(_, tpe, resDoc) =>
         IO.suspend {
-          val r = res.value
-          print(s"$r: $tpe")
+          val tMap = TypeRef.fromTypes(None, tpe :: Nil)
+          val tDoc = tMap(tpe).toDoc
+
+          val doc = resDoc.value + (Doc.lineOrEmpty + Doc.text(": ") + tDoc).nested(4)
+          print(doc.render(100))
         }
       case Output.JsonOutput(json, pathOpt) =>
         val jdoc = json.toDoc

--- a/core/src/main/scala/org/bykn/bosatsu/Evaluation.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/Evaluation.scala
@@ -721,4 +721,17 @@ case class Evaluation[T](pm: PackageMap.Typed[T], externals: Externals) {
         dt <- pack.program.types.getType(pn, t)
       } yield dt
   })
+
+  /**
+   * Convert a typechecked value to Doc
+   * this code ASSUMES the type is correct. If not, we may throw or return
+   * incorrect data.
+   */
+  val valueToDoc: ValueToDoc = ValueToDoc({
+    case Type.Const.Defined(pn, t) =>
+      for {
+        pack <- pm.toMap.get(pn)
+        dt <- pack.program.types.getType(pn, t)
+      } yield dt
+  })
 }

--- a/core/src/main/scala/org/bykn/bosatsu/Evaluation.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/Evaluation.scala
@@ -238,7 +238,7 @@ case class Evaluation[T](pm: PackageMap.Typed[T], externals: Externals) {
 
   def evalTest(ps: PackageName): Option[Test] =
     lastTest(ps).map { ea =>
-      def toAssert(a: Value): Test =
+      def toAssert(a: ProductValue): Test =
         a match {
           case ConsValue(True, ConsValue(Str(message), UnitValue)) =>
             Test.Assertion(true, message)
@@ -249,7 +249,7 @@ case class Evaluation[T](pm: PackageMap.Typed[T], externals: Externals) {
             sys.error(s"expected test value: $other")
             // $COVERAGE-ON$
         }
-      def toSuite(a: Value): Test =
+      def toSuite(a: ProductValue): Test =
         a match {
           case ConsValue(Str(name), ConsValue(VList(tests), UnitValue)) =>
             Test.Suite(name, tests.map(toTest(_)))

--- a/core/src/main/scala/org/bykn/bosatsu/TypeName.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/TypeName.scala
@@ -12,10 +12,3 @@ object TypeName {
   implicit val typeNameOrdering: Ordering[TypeName] =
     Ordering.by { tn: TypeName => tn.ident }
 }
-
-case class Unique(id: Long) {
-  def next: Unique =
-    if (id == Long.MaxValue) sys.error("overflow")
-    else Unique(id + 1L)
-}
-

--- a/core/src/main/scala/org/bykn/bosatsu/Unique.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/Unique.scala
@@ -1,0 +1,7 @@
+package org.bykn.bosatsu
+
+case class Unique(id: Long) {
+  def next: Unique =
+    if (id == Long.MaxValue) sys.error("overflow")
+    else Unique(id + 1L)
+}

--- a/core/src/main/scala/org/bykn/bosatsu/Unique.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/Unique.scala
@@ -1,7 +1,0 @@
-package org.bykn.bosatsu
-
-case class Unique(id: Long) {
-  def next: Unique =
-    if (id == Long.MaxValue) sys.error("overflow")
-    else Unique(id + 1L)
-}

--- a/core/src/main/scala/org/bykn/bosatsu/ValueToDoc.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/ValueToDoc.scala
@@ -1,0 +1,258 @@
+package org.bykn.bosatsu
+
+import cats.Eval
+import cats.implicits._
+import java.math.BigInteger
+import org.bykn.bosatsu.rankn.{DefinedType, Type}
+import org.typelevel.paiges.{Doc, Document}
+import scala.collection.mutable.{Map => MMap}
+
+import Value._
+import Identifier.Constructor
+
+import JsonEncodingError.IllTyped
+
+case class ValueToDoc(getDefinedType: Type.Const => Option[DefinedType[Any]]) {
+
+  /**
+   * Convert a typechecked value to a Document representation
+   *
+   * Note, we statically build the conversion function if it is possible at
+   * all, after that, only value errors can occur
+   *
+   * this code ASSUMES the type is correct. If not, we may return
+   * incorrect data if it is not clearly illtyped
+   */
+  def toDoc(tpe: Type): Value => Either[IllTyped, Doc] = {
+
+    type Fn = Value => Either[IllTyped, Doc]
+    // when we complete a custom type, we put it in here
+    val successCache: MMap[Type, Eval[Fn]] = MMap()
+
+    def commaBlock(items: Iterable[Doc]): Doc =
+      Doc.intercalate(Doc.char(',') + Doc.line, items).grouped
+
+    def loop(tpe: Type, revPath: List[Type]): Eval[Fn] =
+      // we know we can support this, so when we recurse it
+      // is safe to call .right.get
+      successCache.get(tpe) match {
+        case Some(fn) => fn
+        case None =>
+          val res: Eval[Fn] = Eval.later(tpe match {
+            case Type.IntType =>
+              {
+                case ExternalValue(v: BigInteger) =>
+                  Right(Doc.str(v))
+                case other =>
+                  // $COVERAGE-OFF$this should be unreachable
+                  Left(IllTyped(revPath.reverse, tpe, other))
+                  // $COVERAGE-ON$
+              }
+            case Type.StrType =>
+              {
+                case ExternalValue(v: String) =>
+                  Right(Document[Lit].document(Lit.Str(v)))
+                case other =>
+                  // $COVERAGE-OFF$this should be unreachable
+                  Left(IllTyped(revPath.reverse, tpe, other))
+                  // $COVERAGE-ON$
+              }
+            case Type.UnitType =>
+              // encode this as null
+              {
+                case UnitValue => Right(Doc.text("()"))
+                case other =>
+                  // $COVERAGE-OFF$this should be unreachable
+                  Left(IllTyped(revPath.reverse, tpe, other))
+                  // $COVERAGE-ON$
+                }
+            case Type.ListT(t1) =>
+              lazy val inner = loop(t1, tpe :: revPath).value
+
+              {
+                case VList(vs) =>
+                  vs.traverse(inner)
+                    .map { inners =>
+                      Doc.char('[') + (Doc.lineOrEmpty + commaBlock(inners) + Doc.lineOrEmpty).aligned + Doc.char(']')
+                    }
+                case other =>
+                  // $COVERAGE-OFF$this should be unreachable
+                  Left(IllTyped(revPath.reverse, tpe, other))
+                  // $COVERAGE-ON$
+              }
+            case Type.DictT(Type.StrType, vt) =>
+              lazy val inner = loop(vt, tpe :: revPath).value
+              val docStr = Document[Lit]
+
+              {
+                case VDict(d) =>
+                  d.toList.traverse { case (k, v) =>
+                    k match {
+                      case Str(kstr) =>
+                        inner(v).map { vdoc =>
+                          (docStr.document(Lit.Str(kstr)) + (Doc.char(':') + Doc.line + vdoc).nested(4)).grouped
+                        }
+                      case other =>
+                        // $COVERAGE-OFF$this should be unreachable
+                        Left(IllTyped(revPath.reverse, tpe, other))
+                        // $COVERAGE-ON$
+                    }
+                  }
+                  .map { kvs =>
+                    Doc.char('{') + (Doc.lineOrEmpty + commaBlock(kvs) + Doc.lineOrEmpty).aligned + Doc.char('}')
+                  }
+                case other =>
+                  // $COVERAGE-OFF$this should be unreachable
+                  Left(IllTyped(revPath.reverse, tpe, other))
+                  // $COVERAGE-ON$
+              }
+            case Type.Tuple(ts) =>
+              val p1 = tpe :: revPath
+              lazy val inners = ts.traverse { t => loop(t, p1) }.value
+              val tsize = ts.size
+
+              {
+                case Tuple(as) if as.size == tsize =>
+                  as.zip(inners)
+                    .toVector
+                    .traverse { case (a, fn) => fn(a) }
+                    .map { items =>
+                      Doc.char('(') + (Doc.lineOrEmpty + commaBlock(items) + Doc.char(',') + Doc.lineOrEmpty).aligned + Doc.char(')')
+                    }
+                case other =>
+                  // $COVERAGE-OFF$this should be unreachable
+                  Left(IllTyped(revPath.reverse, tpe, other))
+                  // $COVERAGE-ON$
+              }
+
+            case Type.ForAll(_, inner) =>
+              // we assume the generic positions don't matter and to continue
+              loop(inner, tpe :: revPath).value
+            case Type.TyVar(_) =>
+              // we don't really know what to do with
+              { v => Right(Doc.text("<unknown>")) }
+            case fn@Type.Fun(_, _) =>
+              def arity(fn: Type): Int =
+                fn match {
+                  case Type.Fun(_, dest) =>
+                    arity(dest) + 1
+                  case Type.ForAll(_, inner) =>
+                    arity(inner)
+                  case _ => 0
+                }
+
+              {
+                case FnValue(_) =>
+                  Right(Doc.text(s"<fn arity=${arity(fn)}>"))
+                case other =>
+                  // $COVERAGE-OFF$this should be unreachable
+                  Left(IllTyped(revPath.reverse, tpe, other))
+                  // $COVERAGE-ON$
+              }
+            case otherType =>
+              // We can have complicated recursion here, we
+              // need to be careful with Eval.later/lazy to tie the knot
+              val fullPath = tpe :: revPath
+
+              val dtOpt =
+                Type.rootConst(tpe).flatMap {
+                  case Type.TyConst(const) =>
+                    getDefinedType(const)
+                  case _ => None
+                }
+
+              dtOpt match {
+                case None =>
+                  // an unknown type, just print unknown
+                  { _ => Right(Doc.text("<unknown>")) }
+                case Some(dt) =>
+                  val cons = dt.constructors
+                  val (_, targs) = Type.applicationArgs(tpe)
+                  val replaceMap = dt.typeParams.zip(targs).toMap[Type.Var, Type]
+
+                  lazy val resInner: Map[Int, (Constructor, List[(String, Fn)])] =
+                    cons.zipWithIndex
+                      .traverse { case (cf, idx) =>
+                        val rec = cf.args.traverse { case (field, t) =>
+                          val subsT = Type.substituteVar(t, replaceMap)
+                          val next = loop(subsT, fullPath)
+                          next.map { fn => (field.asString, fn) }
+                        }
+                        rec.map { fields => (idx, (cf.name, fields)) }
+                      }
+                      .map(_.toMap)
+                      .value
+
+                  def params(variant: Int, params: List[Value], src: Value): Either[IllTyped, Doc] =
+                    resInner.get(variant) match {
+                      case None =>
+                        Left(IllTyped(revPath.reverse, tpe, src))
+                      case Some((name, fields)) =>
+                        if (fields.size == params.size) {
+                          params
+                            .zip(fields)
+                            .traverse { case (v, (nm, fn)) =>
+                              fn(v).map { vdoc =>
+                                (Doc.text(nm) + Doc.char(':') + Doc.lineOrSpace + vdoc).nested(4)
+                              }
+                            }
+                            .map { paramsDoc =>
+                              val nm = Doc.text(name.asString)
+                              if (paramsDoc.isEmpty) nm
+                              else {
+                                nm  + Doc.space +
+                                  (Doc.char('{') + (Doc.line + commaBlock(paramsDoc)).nested(4) + Doc.line + Doc.char('}')).grouped
+                              }
+                            }
+                        }
+                        else Left(IllTyped(revPath.reverse, tpe, src))
+                    }
+
+
+                  dt.natLike match {
+                    case DefinedType.NatLike.Not =>
+                      if (dt.isNewType) {
+                        // the outer wrapping is so we add it back
+
+                        { v => params(0, v :: Nil, v) }
+                      }
+                      else if (dt.isStruct) {
+                        {
+                          case prod: ProductValue =>
+                            val plist = prod.toList
+                            params(0, prod.toList, prod)
+
+                          case other =>
+                            Left(IllTyped(revPath.reverse, tpe, other))
+                        }
+                      }
+                      else {
+                        {
+                          case s: SumValue =>
+                            params(s.variant, s.value.toList, s)
+                          case a =>
+                            Left(IllTyped(revPath.reverse, tpe, a))
+                         }
+                       }
+                    case _ =>
+                      // this is nat-like
+                      // TODO, maybe give a warning
+                      {
+                        case ExternalValue(b: BigInteger) =>
+                          Right(Doc.str(b))
+                        case other =>
+                          Left(IllTyped(revPath.reverse, tpe, other))
+                      }
+                  }
+                }
+            })
+          // put the result in the cache before we compute it
+          // so we can recurse
+          successCache.put(tpe, res)
+          res
+        }
+
+      loop(tpe, Nil).value
+    }
+
+}

--- a/core/src/main/scala/org/bykn/bosatsu/ValueToJson.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/ValueToJson.scala
@@ -111,7 +111,7 @@ case class ValueToJson(getDefinedType: Type.Const => Option[DefinedType[Any]]) {
                   Right(Json.JNumberStr(v.toString))
                 case other =>
                   // $COVERAGE-OFF$this should be unreachable
-                  Left(JsonEncodingError.IllTyped(revPath.reverse, tpe, other))
+                  Left(IllTyped(revPath.reverse, tpe, other))
                   // $COVERAGE-ON$
               }
             case Type.StrType =>
@@ -120,7 +120,7 @@ case class ValueToJson(getDefinedType: Type.Const => Option[DefinedType[Any]]) {
                   Right(Json.JString(v))
                 case other =>
                   // $COVERAGE-OFF$this should be unreachable
-                  Left(JsonEncodingError.IllTyped(revPath.reverse, tpe, other))
+                  Left(IllTyped(revPath.reverse, tpe, other))
                   // $COVERAGE-ON$
               }
             case Type.BoolType =>
@@ -129,7 +129,7 @@ case class ValueToJson(getDefinedType: Type.Const => Option[DefinedType[Any]]) {
                 case False => Right(Json.JBool(false))
                 case other =>
                   // $COVERAGE-OFF$this should be unreachable
-                  Left(JsonEncodingError.IllTyped(revPath.reverse, tpe, other))
+                  Left(IllTyped(revPath.reverse, tpe, other))
                   // $COVERAGE-ON$
               }
             case Type.UnitType =>
@@ -138,7 +138,7 @@ case class ValueToJson(getDefinedType: Type.Const => Option[DefinedType[Any]]) {
                 case UnitValue => Right(Json.JNull)
                 case other =>
                   // $COVERAGE-OFF$this should be unreachable
-                  Left(JsonEncodingError.IllTyped(revPath.reverse, tpe, other))
+                  Left(IllTyped(revPath.reverse, tpe, other))
                   // $COVERAGE-ON$
                 }
             case opt@Type.OptionT(t1) =>
@@ -151,7 +151,7 @@ case class ValueToJson(getDefinedType: Type.Const => Option[DefinedType[Any]]) {
                   case VOption(None) => Right(Json.JNull)
                   case VOption(Some(a)) => inner(a)
                   case other =>
-                    Left(JsonEncodingError.IllTyped(revPath.reverse, tpe, other))
+                    Left(IllTyped(revPath.reverse, tpe, other))
                 }
               }
               else {
@@ -160,7 +160,7 @@ case class ValueToJson(getDefinedType: Type.Const => Option[DefinedType[Any]]) {
                   case VOption(None) => Right(Json.JArray(Vector.empty))
                   case VOption(Some(a)) => inner(a).map { j => Json.JArray(Vector(j)) }
                   case other =>
-                    Left(JsonEncodingError.IllTyped(revPath.reverse, tpe, other))
+                    Left(IllTyped(revPath.reverse, tpe, other))
                 }
               }
             case Type.ListT(t1) =>
@@ -173,7 +173,7 @@ case class ValueToJson(getDefinedType: Type.Const => Option[DefinedType[Any]]) {
                     .map(Json.JArray(_))
                 case other =>
                   // $COVERAGE-OFF$this should be unreachable
-                  Left(JsonEncodingError.IllTyped(revPath.reverse, tpe, other))
+                  Left(IllTyped(revPath.reverse, tpe, other))
                   // $COVERAGE-ON$
               }
             case Type.DictT(Type.StrType, vt) =>
@@ -186,14 +186,14 @@ case class ValueToJson(getDefinedType: Type.Const => Option[DefinedType[Any]]) {
                       case Str(kstr) => inner(v).map((kstr, _))
                       case other =>
                         // $COVERAGE-OFF$this should be unreachable
-                        Left(JsonEncodingError.IllTyped(revPath.reverse, tpe, other))
+                        Left(IllTyped(revPath.reverse, tpe, other))
                         // $COVERAGE-ON$
                     }
                   }
                   .map(Json.JObject(_))
                 case other =>
                   // $COVERAGE-OFF$this should be unreachable
-                  Left(JsonEncodingError.IllTyped(revPath.reverse, tpe, other))
+                  Left(IllTyped(revPath.reverse, tpe, other))
                   // $COVERAGE-ON$
               }
             case Type.Tuple(ts) =>
@@ -209,7 +209,7 @@ case class ValueToJson(getDefinedType: Type.Const => Option[DefinedType[Any]]) {
                     .map(Json.JArray(_))
                 case other =>
                   // $COVERAGE-OFF$this should be unreachable
-                  Left(JsonEncodingError.IllTyped(revPath.reverse, tpe, other))
+                  Left(IllTyped(revPath.reverse, tpe, other))
                   // $COVERAGE-ON$
               }
 
@@ -235,11 +235,11 @@ case class ValueToJson(getDefinedType: Type.Const => Option[DefinedType[Any]]) {
 
               dt.natLike match {
                 case DefinedType.NatLike.Not =>
-                  val resInner: Eval[Map[Int, List[(String, Fn)]]] = {
-                    val cons = dt.constructors
-                    val (_, targs) = Type.applicationArgs(tpe)
-                    val replaceMap = dt.typeParams.zip(targs).toMap[Type.Var, Type]
+                  val cons = dt.constructors
+                  val (_, targs) = Type.applicationArgs(tpe)
+                  val replaceMap = dt.typeParams.zip(targs).toMap[Type.Var, Type]
 
+                  val resInner: Eval[Map[Int, List[(String, Fn)]]] =
                     cons.zipWithIndex
                       .traverse { case (cf, idx) =>
                         val rec = cf.args.traverse { case (field, t) =>
@@ -250,7 +250,6 @@ case class ValueToJson(getDefinedType: Type.Const => Option[DefinedType[Any]]) {
                         rec.map { fields => (idx, fields) }
                       }
                       .map(_.toMap)
-                  }
 
                   if (dt.isNewType) {
                     lazy val inner = resInner.value.head._2.head._2
@@ -273,11 +272,11 @@ case class ValueToJson(getDefinedType: Type.Const => Option[DefinedType[Any]]) {
                             .map { ps => Json.JObject(ps) }
                         }
                         else {
-                          Left(JsonEncodingError.IllTyped(revPath.reverse, tpe, prod))
+                          Left(IllTyped(revPath.reverse, tpe, prod))
                         }
 
                       case other =>
-                        Left(JsonEncodingError.IllTyped(revPath.reverse, tpe, other))
+                        Left(IllTyped(revPath.reverse, tpe, other))
                     }
                   }
                   else {
@@ -297,12 +296,12 @@ case class ValueToJson(getDefinedType: Type.Const => Option[DefinedType[Any]]) {
                                 }
                                 .map { ps => Json.JObject(ps) }
                             }
-                            else Left(JsonEncodingError.IllTyped(revPath.reverse, tpe, s))
+                            else Left(IllTyped(revPath.reverse, tpe, s))
                           case None =>
-                            Left(JsonEncodingError.IllTyped(revPath.reverse, tpe, s))
+                            Left(IllTyped(revPath.reverse, tpe, s))
                         }
                       case a =>
-                        Left(JsonEncodingError.IllTyped(revPath.reverse, tpe, a))
+                        Left(IllTyped(revPath.reverse, tpe, a))
                      }
                    }
                 case _ =>
@@ -311,7 +310,7 @@ case class ValueToJson(getDefinedType: Type.Const => Option[DefinedType[Any]]) {
                     case ExternalValue(b: BigInteger) =>
                       Right(Json.JNumberStr(b.toString))
                     case other =>
-                      Left(JsonEncodingError.IllTyped(revPath.reverse, tpe, other))
+                      Left(IllTyped(revPath.reverse, tpe, other))
                   }
               }
             })

--- a/core/src/test/scala/org/bykn/bosatsu/JsonTest.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/JsonTest.scala
@@ -200,7 +200,7 @@ enum MyNat: Z, S(prev: MyNat)
             case Left(_) => succeed
             case Right(v) => fail(s"expected $json to be ill-typed: $v")
           }
-        case Left(err) => fail(s"could not handle to Value: $tpe, $t, $toJ")
+        case Left(err) => fail(s"could not handle to Value: $tpe, $t, $err")
       }
     }
 

--- a/core/src/test/scala/org/bykn/bosatsu/TestUtils.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/TestUtils.scala
@@ -91,8 +91,8 @@ object TestUtils {
     val files = packages.zipWithIndex.map(_.swap)
 
     module.runWith(files)("eval" :: "--main" :: mainPackS :: makeInputArgs(files)) match {
-      case Right(module.Output.EvaluationResult(got, _)) =>
-        assert(got.value == expected, s"${got.value} != $expected")
+      case Right(module.Output.EvaluationResult(got, _, gotDoc)) =>
+        assert(got.value == expected, s"${gotDoc.value.render(80)}\n\n$got != $expected")
       case Right(other) =>
         fail(s"got an unexpected success: $other")
       case Left(err) =>

--- a/core/src/test/scala/org/bykn/bosatsu/ValueToDocTest.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/ValueToDocTest.scala
@@ -3,7 +3,8 @@ package org.bykn.bosatsu
 import org.scalatest.prop.PropertyChecks.{forAll, PropertyCheckConfiguration }
 import org.scalatest.FunSuite
 
-import rankn.NTypeGen
+import rankn.{NTypeGen, Type}
+import TestUtils.typeEnvOf
 
 class ValueToDocTest extends FunSuite {
 
@@ -18,5 +19,55 @@ class ValueToDocTest extends FunSuite {
       succeed
     }
   }
-  // TODO it would be nice to test some handwritten examples
+
+  test("some hand written cases round trip") {
+    val te = typeEnvOf(PackageName.parts("Test"), """
+
+struct MyUnit
+# wrappers are removed
+struct MyWrapper(item)
+struct MyPair(fst, snd)
+
+enum MyEither: L(left), R(right)
+
+enum MyNat: Z, S(prev: MyNat)
+""")
+    val conv = ValueToDoc(te.toDefinedType(_))
+
+    def stringToType(t: String): Type = {
+      val tr = TypeRef.parser.parse(t) match {
+        case fastparse.all.Parsed.Success(tr, l) if l == t.length => tr
+        case other => sys.error(s"could not parse: $t, $other")
+      }
+
+      TypeRefConverter[cats.Id](tr) { cons =>
+        te.referencedPackages.toList.flatMap { pack =>
+          val const = Type.Const.Defined(pack, TypeName(cons))
+          te.toDefinedType(const).map(_ => const)
+        }
+        .headOption
+        .getOrElse(Type.Const.predef(cons.asString))
+      }
+    }
+
+    def law(tpe: String, v: Value, str: String) = {
+      val t = stringToType(tpe)
+      val toDoc = conv.toDoc(t)
+
+      toDoc(v) match {
+        case Right(doc) => assert(doc.render(80) == str)
+        case Left(err) => fail(s"could not handle to Value: $tpe, $v, $err")
+      }
+    }
+
+    law("Int", Value.VInt(42), "42")
+    law("String", Value.Str("hello world"), "'hello world'")
+    law("MyUnit", Value.UnitValue, "MyUnit")
+    law("MyWrapper[MyUnit]", Value.UnitValue, "MyWrapper { item: MyUnit }")
+    law("MyWrapper[MyWrapper[MyUnit]]", Value.UnitValue, "MyWrapper { item: MyWrapper { item: MyUnit } }")
+    law("MyPair[MyUnit, MyUnit]", Value.ProductValue.fromList(List(Value.UnitValue, Value.UnitValue)),
+        "MyPair { fst: MyUnit, snd: MyUnit }")
+    law("MyEither[MyUnit, MyUnit]", Value.SumValue(0, Value.ProductValue.fromList(List(Value.UnitValue))), "L { left: MyUnit }")
+    law("MyEither[MyUnit, MyUnit]", Value.SumValue(1, Value.ProductValue.fromList(List(Value.UnitValue))), "R { right: MyUnit }")
+  }
 }

--- a/core/src/test/scala/org/bykn/bosatsu/ValueToDocTest.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/ValueToDocTest.scala
@@ -1,0 +1,22 @@
+package org.bykn.bosatsu
+
+import org.scalatest.prop.PropertyChecks.{forAll, PropertyCheckConfiguration }
+import org.scalatest.FunSuite
+
+import rankn.NTypeGen
+
+class ValueToDocTest extends FunSuite {
+
+  implicit val generatorDrivenConfig =
+    PropertyCheckConfiguration(minSuccessful = 1000)
+
+  test("never throw when converting to doc") {
+    val vd = ValueToDoc({ _ => None})
+
+    forAll(NTypeGen.genPredefType, GenValue.genValue) { (t, v) =>
+      vd.toDoc(t)(v)
+      succeed
+    }
+  }
+  // TODO it would be nice to test some handwritten examples
+}

--- a/elmui/Makefile
+++ b/elmui/Makefile
@@ -3,8 +3,11 @@ all: main.js bosatsu.js
 main.js: src/Main.elm
 	elm make src/Main.elm --optimize --output out/main.js
 
-bosatsu.js: ../jsapi/.js/target/scala-2.12/bosatsu-jsapi-fastopt.js
-	cp ../jsapi/.js/target/scala-2.12/bosatsu-jsapi-fastopt.js out/bosatsu.js
+../jsapi/.js/target/scala-2.12/bosatsu-jsapi-opt.js:
+	cd .. && sbt jsapiJS/fullOptJS && cd elmui
+
+bosatsu.js: ../jsapi/.js/target/scala-2.12/bosatsu-jsapi-opt.js
+	cp ../jsapi/.js/target/scala-2.12/bosatsu-jsapi-opt.js out/bosatsu.js
 
 format: src/*
 	elm-format --yes src/

--- a/elmui/index.html
+++ b/elmui/index.html
@@ -6,12 +6,27 @@
     <script type="text/javascript" src="out/main.js"></script>
     <div id="elm"></div>
     <script>
+      function escapeHtml(unsafe) {
+        let r = unsafe.result;
+        if (typeof r === "string") {
+          let r1 = r
+               .replace(/&/g, "&amp;")
+               .replace(/</g, "&lt;")
+               .replace(/>/g, "&gt;")
+               .replace(/"/g, "&quot;")
+               .replace(/'/g, "&#039;");
+          unsafe.result = r1;
+        }
+        return unsafe;
+       }
+
+
       let app = Elm.Main.init({
         node: document.getElementById('elm')
       });
       app.ports.toJS.subscribe(function (msg) {
-        let res = Bosatsu.evaluateJson(null, "/file", {"/file": msg })
-        app.ports.toElm.send(res)
+        let res = Bosatsu.evaluate(null, "/file", {"/file": msg })
+        app.ports.toElm.send(escapeHtml(res))
       });
     </script>
   </body>

--- a/elmui/src/Main.elm
+++ b/elmui/src/Main.elm
@@ -195,7 +195,7 @@ view model =
                             Json.Encode.encode 4 v
                     in
                     column []
-                        [ text "last value as json:"
+                        [ text "last value:"
                         , Element.html (span [] (textHtml (String.concat [ "<pre>", j, "</pre>" ])))
                         ]
 

--- a/jsapi/src/main/scala/org/bykn/bosatsu/jsapi/JsApi.scala
+++ b/jsapi/src/main/scala/org/bykn/bosatsu/jsapi/JsApi.scala
@@ -1,6 +1,8 @@
 package org.bykn.bosatsu
 package jsapi
 
+import org.typelevel.paiges.Doc
+
 import scala.scalajs.js
 
 import js.|
@@ -36,8 +38,11 @@ object JsApi {
     module.runWith(files)("eval" :: main ::: makeInputArgs(files.keys)) match {
       case Left(err) =>
         new Error(s"error: ${err.getMessage}")
-      case Right(module.Output.EvaluationResult(res, tpe)) =>
-        new EvalSuccess(res.value.toString)
+      case Right(module.Output.EvaluationResult(res, tpe, resDoc)) =>
+          val tMap = TypeRef.fromTypes(None, tpe :: Nil)
+          val tDoc = tMap(tpe).toDoc
+          val doc = resDoc.value + (Doc.lineOrEmpty + Doc.text(": ") + tDoc).nested(4)
+        new EvalSuccess(doc.render(80))
       case Right(other) =>
         new Error(s"internal error. got unexpected result: $other")
     }


### PR DESCRIPTION
close #431 

This makes eval much nicer to work with, and I adjusted the js API to use it as well, rather than json output (it could be an option we control in the UI).

The testing isn't great, but I did a lot of spot checks at the CLI. I think there may be some evolution, but I liked where we got. For instance:
```
./bosatsuj eval --search --package_root test_workspace/ --input_dir test_workspace/ --main GenDeps

gives:

Config {
    options: Options {
            buildHeader: ['load("@io_bazel_rules_scala//scala:scala_import.bzl", "scala_import")'],
            languages: ['java', 'scala:2.11.11'],
            resolvers: [Resolver {
                            id: 'mavencentral',
                            type: 'default',
                            url: 'https://repo.maven.apache.org/maven2/'
                        }],
            transitivity: 'runtime_deps',
            resolverType: 'coursier',
            versionConflictPolicy: 'highest'
        },
    dependencies: {'com.lihaoyi':
                       {'fastparse':
                            Artifact {
                                modules: ['', 'utils'],
                                lang: 'scala',
                                version: '1.0.0',
                                exports: ['com.lihaoyi:sourcecode']
                            },
                        'sourcecode':
                            Artifact { modules: [], lang: 'scala', version: '0.1.4', exports: [] }},
                   'com.monovore':
                       {'decline':
                            Artifact { modules: [], lang: 'scala', version: '1.0.0', exports: [] }},
                   'org.bykn':
                       {'fastparse-cats-core':
                            Artifact { modules: [], lang: 'scala', version: '0.1.0', exports: [] }},
                   'org.scala-lang.modules':
                       {'scala-xml':
                            Artifact { modules: [], lang: 'scala', version: '1.0.6', exports: [] }},
                   'org.scalacheck':
                       {'scalacheck':
                            Artifact { modules: [], lang: 'scala', version: '1.13.5', exports: [] }
                        },
                   'org.scalactic':
                       {'scalactic':
                            Artifact { modules: [], lang: 'scala', version: '3.0.1', exports: [] }},
                   'org.scalatest':
                       {'scalatest':
                            Artifact {
                                modules: [''],
                                lang: 'scala',
                                version: '3.0.1',
                                exports: ['org.scalactic:scalactic']
                            }},
                   'org.spire-math':
                       {'kind-projector':
                            Artifact { modules: [], lang: 'scala', version: '0.9.4', exports: [] }},
                   'org.typelevel':
                       {'alleycats-core':
                            Artifact { modules: [], lang: 'scala', version: '2.0.0', exports: [] },
                        'cats':
                            Artifact {
                                modules: ['core', 'free', 'kernel', 'macros'],
                                lang: 'scala',
                                version: '2.0.0',
                                exports: []
                            },
                        'cats-effect':
                            Artifact { modules: [], lang: 'scala', version: '2.0.0', exports: [] },
                        'paiges-core':
                            Artifact { modules: [], lang: 'scala', version: '0.3.0', exports: [] }}
                   },
    replacements: {'org.scala-lang':
                       {'scala-compiler':
                            Replacement {
                                lang: 'scala/unmangled',
                                target:
                                    '@io_bazel_rules_scala_scala_compiler//:io_bazel_rules_scala_scala_compiler'
                            },
                        'scala-library':
                            Replacement {
                                lang: 'scala/unmangled',
                                target:
                                    '@io_bazel_rules_scala_scala_library//:io_bazel_rules_scala_scala_library'
                            },
                        'scala-reflect':
                            Replacement {
                                lang: 'scala/unmangled',
                                target:
                                    '@io_bazel_rules_scala_scala_reflect//:io_bazel_rules_scala_scala_reflect'
                            }},
                   'org.scala-lang.modules':
                       {'scala-parser-combinators':
                            Replacement {
                                lang: 'scala',
                                target:
                                    '@io_bazel_rules_scala_scala_parser_combinators//:io_bazel_rules_scala_scala_parser_combinators'
                            },
                        'scala-xml':
                            Replacement {
                                lang: 'scala',
                                target:
                                    '@io_bazel_rules_scala_scala_xml//:io_bazel_rules_scala_scala_xml'
                            }}}
}: BazelDepsApi::Config

```

which isn't bad.