### PR TITLE
Improve error message on arity mismatch

### DIFF
--- a/core/src/main/scala/org/bykn/bosatsu/Package.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/Package.scala
@@ -401,10 +401,21 @@ object PackageError {
           val context1 =
             lm.showRegion(r1, 2, errColor).getOrElse(Doc.str(r1)) // we should highlight the whole region
 
+          val fnHint =
+            (t0, t1) match {
+              case (Type.Fun(_, _), Type.Fun(_, _)) =>
+                // both are functions
+                Doc.empty
+              case (Type.Fun(_, _), _) | (_, Type.Fun(_, _)) =>
+                Doc.text("hint: this often happens when you apply the wrong number of arguments to a function.") + Doc.hardLine
+              case _ =>
+                Doc.empty
+            }
+
           val tmap = showTypes(pack, List(t0, t1))
           val doc = Doc.text("type error: expected type ") + Doc.text(tmap(t0)) +
             context0 + Doc.text("to be the same as type ") + Doc.text(tmap(t1)) +
-            Doc.hardLine + context1
+            Doc.hardLine + fnHint + context1
 
           doc.render(80)
         case Infer.Error.VarNotInScope((pack, name), scope, region) =>

--- a/core/src/test/scala/org/bykn/bosatsu/EvaluationTest.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/EvaluationTest.scala
@@ -1536,6 +1536,21 @@ main = fn
       List("""
 package A
 
+def fn(x, y):
+  match x:
+    0: y
+    x: x
+
+main = fn(0, 1, 2)
+"""), "A") { case te@PackageError.TypeErrorIn(_, _) =>
+      val b = assert(te.message(Map.empty, Colorize.None) == "in file: <unknown source>, package A, type error: expected type Bosatsu/Predef::Int to be the same as type ?a -> ?b\nhint: this often happens when you apply the wrong number of arguments to a function.\nRegion(63,74)")
+      ()
+    }
+
+    evalFail(
+      List("""
+package A
+
 export [ foo ]
 
 foo = 3


### PR DESCRIPTION
close #449 for now. At least print the hint that a function failing to unify with a non-function is usually an arity mismatch.