### PR TITLE
Optimize tail recursion in Evaluation

### DIFF
--- a/core/src/main/scala/org/bykn/bosatsu/Evaluation.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/Evaluation.scala
@@ -711,6 +711,8 @@ case class Evaluation[T](pm: PackageMap.Typed[T], externals: Externals) {
     import TypedExpr._
 
     expr match {
+      case _ if arity == 0 =>
+        Some((Nil, expr))
       case Generic(_, e, _) => toArgsBody(arity, e)
       case Annotation(e, _, _) => toArgsBody(arity, e)
       case AnnotatedLambda(name, _, expr, _) =>
@@ -737,7 +739,9 @@ case class Evaluation[T](pm: PackageMap.Typed[T], externals: Externals) {
           toArgsBody(arity, b).flatMap { case (n, b1) =>
             val nset = n.toSet
             if (p.names.exists(nset)) {
-              // shadow:
+              // this we shadow, so we
+              // can't lift, we could alpha-rename to
+              // deal with this case
               None
             }
             else {
@@ -754,11 +758,6 @@ case class Evaluation[T](pm: PackageMap.Typed[T], externals: Externals) {
             None
           }
         }
-      case _ if arity == 0 =>
-        // TODO: we could do something similar as Let with Match
-        // if there are functions on all the branches and
-        // we can rename the bindings
-        Some((Nil, expr))
       case _ => None
     }
   }

--- a/core/src/main/scala/org/bykn/bosatsu/TypedExpr.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/TypedExpr.scala
@@ -108,10 +108,7 @@ object TypedExpr {
   case class Var[T](pack: Option[PackageName], name: Identifier, tpe: Type, tag: T) extends TypedExpr[T]
   case class App[T](fn: TypedExpr[T], arg: TypedExpr[T], result: Type, tag: T) extends TypedExpr[T]
   case class Let[T](arg: Bindable, expr: TypedExpr[T], in: TypedExpr[T], recursive: RecursionKind, tag: T) extends TypedExpr[T] {
-    def selfCallKind: SelfCallKind = {
-      if (recursive.isRecursive) TypedExpr.selfCallKind(arg, expr)
-      else SelfCallKind.NoCall
-    }
+    def selfCallKind: SelfCallKind = TypedExpr.selfCallKind(arg, expr)
   }
   // TODO, this shouldn't have a type, we know the type from Lit currently
   case class Literal[T](lit: Lit, tpe: Type, tag: T) extends TypedExpr[T]

--- a/core/src/main/scala/org/bykn/bosatsu/Value.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/Value.scala
@@ -80,6 +80,19 @@ object Value {
   case class FnValue(toFn: Eval[Value] => Eval[Value]) extends Value
   object FnValue {
     val identity: FnValue = FnValue(v => v)
+
+    def curry(arity: Int)(vs: List[Eval[Value]] => Eval[Value]): Eval[Value] = {
+      // TODO: this is a obviously terrible
+      // the encoding is inefficient, the implementation is inefficient
+      def loop(param: Int, args: List[Eval[Value]]): Eval[Value] =
+        if (param == 0) vs(args.reverse)
+        else Eval.now(FnValue { ea =>
+          loop(param - 1, ea :: args)
+        })
+
+      loop(arity, Nil)
+    }
+
   }
   case class ExternalValue(toAny: Any) extends Value
 

--- a/core/src/main/scala/org/bykn/bosatsu/rankn/Type.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/rankn/Type.scala
@@ -219,6 +219,13 @@ object Type {
     def apply(from: Type, to: Type): Type.Rho =
       TyApply(TyApply(FnType, from), to)
 
+    def arity(t: Type): Int =
+      t match {
+        case ForAll(_, t) => arity(t)
+        case fn@Fun(_, _) =>
+          uncurry(fn).fold(0)(_._1.length)
+        case _ => 0
+      }
     /**
      * a -> b -> c .. -> d to [a, b, c, ..] -> d
      */

--- a/core/src/test/scala/org/bykn/bosatsu/TypedExprTest.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/TypedExprTest.scala
@@ -191,7 +191,11 @@ y = match x:
     } {
       assert(a.merge(b) == b.merge(a))
       assert(a.merge(b.merge(c)) == a.merge(b).merge(c))
+    }
+
+    scs.foreach { a =>
       assert(a.merge(a) == a)
+      assert((a.ifNoCallThen(null) eq null) == (a == NoCall))
       assert(NoCall.merge(a) == a)
       assert(NonTailCall.merge(a) == NonTailCall)
       assert(a.callNotTail != TailCall)
@@ -290,6 +294,13 @@ def foo:
   _ = x
   42
 """) { te => assert(countLet(te) == 0) }
+  }
+
+  test("toArgsBody always terminates") {
+    forAll(Gen.choose(0, 10), genTypedExpr) { (arity, te) =>
+      // this is a pretty weak test.
+      assert(TypedExpr.toArgsBody(arity, te) ne null)
+    }
   }
 
   test("test selfCallKind") {

--- a/core/src/test/scala/org/bykn/bosatsu/TypedExprTest.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/TypedExprTest.scala
@@ -173,6 +173,32 @@ y = match x:
     }
   }
 
+  test("TypedExpr.Let.selfCallKind terminates and doesn't throw") {
+    // pretty weak test, but just to make sure nothing ever blows up
+    forAll(Generators.bindIdentGen, genTypedExpr) { (b, te) =>
+      assert(TypedExpr.selfCallKind(b, te) ne null)
+    }
+  }
+
+  test("SelfCallKind forms a lattice") {
+    import TypedExpr.SelfCallKind._
+    val scs = List(NoCall, TailCall, NonTailCall)
+
+    for {
+      a <- scs
+      b <- scs
+      c <- scs
+    } {
+      assert(a.merge(b) == b.merge(a))
+      assert(a.merge(b.merge(c)) == a.merge(b).merge(c))
+      assert(a.merge(a) == a)
+      assert(NoCall.merge(a) == a)
+      assert(NonTailCall.merge(a) == NonTailCall)
+      assert(a.callNotTail != TailCall)
+      assert((a.callNotTail == NoCall) == (a == NoCall))
+    }
+  }
+
   test("TypedExpr.substituteTypeVar is not an identity function") {
     // if we replace all the current types with some bound types, things won't be the same
     forAll(genTypedExpr) { te =>

--- a/core/src/test/scala/org/bykn/bosatsu/rankn/TypeTest.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/rankn/TypeTest.scala
@@ -178,10 +178,14 @@ class TypeTest extends FunSuite {
     assert(curry(NonEmptyList.of(b("a"), b("b")), b("c")) == Type.Fun(b("a"), Type.Fun(b("b"), b("c"))))
 
     forAll(NTypeGen.genDepth03) { t =>
+      assert(Type.Fun.arity(t) >= 0)
+
       uncurry(t) match {
         case Some((a, r)) =>
+          assert(Type.Fun.arity(t) == a.length)
           assert(curry(a, r) == t)
-        case None => ()
+        case None =>
+          ()
       }
     }
   }


### PR DESCRIPTION
close #434 

This should allow us to remove using Eval internally, which could be a huge performance improvement.