### PR TITLE
Make FnValue Value to Value not Eval to Eval

### DIFF
--- a/bench/src/main/scala/org/bykn/bosatsu/TestBench.scala
+++ b/bench/src/main/scala/org/bykn/bosatsu/TestBench.scala
@@ -95,7 +95,7 @@ def max_of(n, fn):
 # return the first defined value from largest to smallest
 # of the given function, if it is defined
 def first_of(n, fn):
-  int_loop(n, None, \i, res ->
+  int_loop(n, None, \i, _ ->
     match fn(i):
       None: (i - 1, None)
       nonNone: (0, nonNone))

--- a/cli/src/main/scala/org/bykn/bosatsu/PathModule.scala
+++ b/cli/src/main/scala/org/bykn/bosatsu/PathModule.scala
@@ -67,7 +67,7 @@ object PathModule extends MainModule[IO] {
     out match {
       case Output.TestOutput(resMap, color) =>
         val noTests = resMap.collect { case (p, None) => p }.toList
-        val results = resMap.collect { case (p, Some(t)) => (p, Test.report(t, color)) }.toList.sortBy(_._1)
+        val results = resMap.collect { case (p, Some(t)) => (p, Test.report(t.value, color)) }.toList.sortBy(_._1)
 
         val successes = results.iterator.map { case (_, (s, _, _)) => s }.sum
         val failures = results.iterator.map { case (_, (_, f, _)) => f }.sum

--- a/cli/src/test/scala/org/bykn/bosatsu/PathModuleTest.scala
+++ b/cli/src/test/scala/org/bykn/bosatsu/PathModuleTest.scala
@@ -87,7 +87,7 @@ class PathModuleTest extends FunSuite {
     val out = run("test --input test_workspace/List.bosatsu --input test_workspace/Nat.bosatsu --input test_workspace/Bool.bosatsu --test_file test_workspace/Queue.bosatsu".split("\\s+"): _*)
     out match {
       case PathModule.Output.TestOutput(results, _) =>
-        val res = results.collect { case (pn, Some(t)) if pn.asString == "Queue" => t }
+        val res = results.collect { case (pn, Some(t)) if pn.asString == "Queue" => t.value }
         assert(res.length == 1)
       case other => fail(s"expected test output: $other")
     }
@@ -97,7 +97,7 @@ class PathModuleTest extends FunSuite {
     val out = run("test --package_root test_workspace --search --test_file test_workspace/Bar.bosatsu".split("\\s+"): _*)
     out match {
       case PathModule.Output.TestOutput(results, _) =>
-        val res = results.collect { case (pn, Some(t)) if pn.asString == "Bar" => t }
+        val res = results.collect { case (pn, Some(t)) if pn.asString == "Bar" => t.value }
         assert(res.length == 1)
         assert(res.head.assertions == 1)
         assert(res.head.failureCount == 0)
@@ -183,7 +183,7 @@ class PathModuleTest extends FunSuite {
       case PathModule.Output.TestOutput(res, _) =>
         val noTests = res.collect { case (pn, None) => pn }.toList
         assert(noTests == Nil)
-        val failures = res.collect { case (pn, Some(t)) if t.failureCount > 0 => pn }
+        val failures = res.collect { case (pn, Some(t)) if t.value.failureCount > 0 => pn }
         assert(failures == Nil)
       case other => fail(s"expected test output: $other")
     }

--- a/core/src/main/scala/org/bykn/bosatsu/MainModule.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/MainModule.scala
@@ -61,7 +61,7 @@ abstract class MainModule[IO[_]](implicit val moduleIOMonad: MonadError[IO, Thro
 
   sealed abstract class Output
   object Output {
-    case class TestOutput(tests: List[(PackageName, Option[Test])], colorize: Colorize) extends Output
+    case class TestOutput(tests: List[(PackageName, Option[Eval[Test]])], colorize: Colorize) extends Output
     case class EvaluationResult(value: Eval[Value], tpe: rankn.Type, doc: Eval[Doc]) extends Output
     case class JsonOutput(json: Json, output: Option[Path]) extends Output
     case class CompileOut(packList: List[Package.Typed[Any]], ifout: Option[Path], output: Option[Path]) extends Output

--- a/core/src/main/scala/org/bykn/bosatsu/Predef.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/Predef.scala
@@ -169,8 +169,8 @@ object PredefImpl {
     def loop(biValue: Value, bi: BigInteger, state: Value): Value =
       if (bi.compareTo(BigInteger.ZERO) <= 0) state
       else {
-        val fn0 = fnT(biValue).value.asFn
-        fn0(state).value match {
+        val fn0 = fnT(biValue).asFn
+        fn0(state) match {
           case ConsValue(nextI, ConsValue(ConsValue(nextA, _), _)) =>
             val n = i(nextI)
             if (n.compareTo(bi) >= 0) {
@@ -231,20 +231,14 @@ object PredefImpl {
       new Ordering[Value] {
         val fnV = ord.asFn
         def compare(a: Value, b: Value): Int = {
-          val v = fnV(a).flatMap(_.asFn(b)).value
-          // this should be Comparison ADT
-          v.asInstanceOf[SumValue].variant - 1
+          fnV(a).asFn(b).asSum.variant - 1
         }
       }
     ExternalValue(SortedMap.empty[Value, Value])
   }
 
   def toDict(v: Value): SortedMap[Value, Value] =
-    v match {
-      case ExternalValue(sm) =>
-        sm.asInstanceOf[SortedMap[Value, Value]]
-      case other => sys.error(s"type error: $other")
-    }
+    v.asExternal.toAny.asInstanceOf[SortedMap[Value, Value]]
 
   def add_key(dict: Value, k: Value, value: Value): Value =
     ExternalValue(toDict(dict).updated(k, value))

--- a/core/src/main/scala/org/bykn/bosatsu/TypedExpr.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/TypedExpr.scala
@@ -107,9 +107,7 @@ object TypedExpr {
   case class AnnotatedLambda[T](arg: Bindable, tpe: Type, expr: TypedExpr[T], tag: T) extends TypedExpr[T]
   case class Var[T](pack: Option[PackageName], name: Identifier, tpe: Type, tag: T) extends TypedExpr[T]
   case class App[T](fn: TypedExpr[T], arg: TypedExpr[T], result: Type, tag: T) extends TypedExpr[T]
-  case class Let[T](arg: Bindable, expr: TypedExpr[T], in: TypedExpr[T], recursive: RecursionKind, tag: T) extends TypedExpr[T] {
-    def selfCallKind: SelfCallKind = TypedExpr.selfCallKind(arg, expr)
-  }
+  case class Let[T](arg: Bindable, expr: TypedExpr[T], in: TypedExpr[T], recursive: RecursionKind, tag: T) extends TypedExpr[T]
   // TODO, this shouldn't have a type, we know the type from Lit currently
   case class Literal[T](lit: Lit, tpe: Type, tag: T) extends TypedExpr[T]
   case class Match[T](arg: TypedExpr[T], branches: NonEmptyList[(Pattern[(PackageName, Constructor), Type], TypedExpr[T])], tag: T) extends TypedExpr[T]

--- a/core/src/main/scala/org/bykn/bosatsu/ValueToJson.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/ValueToJson.scala
@@ -585,24 +585,24 @@ case class ValueToJson(getDefinedType: Type.Const => Option[DefinedType[Any]]) {
           val argsFnVector = argsFn.toList.toVector
 
           (arity, {
-            case Value.FnValue(evalToEval) =>
+            case Value.FnValue(fn) =>
 
               // if we get into here, we know the inputs have
               // the right size and type, but we don't verify
               // locally (but in the type checked code) that
               // the type matches the FnValue, so here we
               // still pass it along if we see it
-              def applyAll(fn: Eval[Value] => Eval[Value], args: NonEmptyList[Value]): Eval[Either[DataError, Value]] = {
-                val nextValue = fn(Eval.now(args.head))
+              def applyAll(fn: Value => Value, args: NonEmptyList[Value]): Either[DataError, Value] = {
+                val nextValue = fn(args.head)
                 args.tail match {
-                  case Nil => nextValue.map(Right(_))
+                  case Nil => Right(nextValue)
                   case h :: tail =>
-                    nextValue.flatMap {
+                    nextValue match {
                       case Value.FnValue(nextFn) =>
                         applyAll(nextFn, NonEmptyList(h, tail))
                       case other =>
                         // TODO: we could propagate the type we expect this to be
-                        Eval.now(Left(IllTyped(Nil, t, other)))
+                        Left(IllTyped(Nil, t, other))
                     }
                 }
               }
@@ -614,7 +614,7 @@ case class ValueToJson(getDefinedType: Type.Const => Option[DefinedType[Any]]) {
                   inputs.toVector
                     .zip(argsFnVector)
                     .traverse { case (a, fn) => fn(a) }
-                    .flatMap { vect => applyAll(evalToEval, NonEmptyList.fromListUnsafe(vect.toList)).value }
+                    .flatMap { vect => applyAll(fn, NonEmptyList.fromListUnsafe(vect.toList)) }
                     .flatMap(resFn)
                 }
               }

--- a/core/src/test/scala/org/bykn/bosatsu/GenValue.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/GenValue.scala
@@ -30,10 +30,7 @@ object GenValue {
     val genFn: Gen[FnValue] = {
       val fn: Gen[Value => Value] = Gen.function1(recur)(cogenValue)
 
-      fn.map { valueFn =>
-
-        FnValue { eval => eval.map(valueFn(_)) }
-      }
+      fn.map(FnValue(_))
     }
 
     Gen.oneOf(genEnumLike, genProd, genSum, genExt, genFn)

--- a/core/src/test/scala/org/bykn/bosatsu/TestUtils.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/TestUtils.scala
@@ -118,7 +118,7 @@ object TestUtils {
 
     module.runWith(files)("test" :: "--test_package" :: mainPackS :: makeInputArgs(files)) match {
       case Right(module.Output.TestOutput(results, _)) =>
-        results.collect { case (_, Some(t)) => t } match {
+        results.collect { case (_, Some(t)) => t.value } match {
           case t :: Nil =>
             assert(t.assertions == assertionCount, s"${t.assertions} != $assertionCount")
             val (suc, failcount, message) = Test.report(t, LocationMap.Colorize.None)


### PR DESCRIPTION
Since we have solved #434 we don't need Eval to make any loop stack safe. More over, by forcing us to use that more, we work any bugs out of that system before we make a backend that would almost certainly want to not put trampolines everywhere.

There is still some laziness here in the environment since setting up a recursive value is using it. That could still probably be removed or reduced for more performance improvements.

benchmarks show 80% faster on the most time consuming benchmark.
```
[info] Benchmark          Mode  Cnt      Score      Error  Units    
[info] TestBench.bench0  thrpt    3  13190.738 ±  463.814  ops/s    
[info] TestBench.bench1  thrpt    3  10599.481 ± 5759.104  ops/s    
[info] TestBench.bench2  thrpt    3      2.706 ±    0.574  ops/s    
     

[info] Benchmark          Mode  Cnt      Score      Error  Units
[info] TestBench.bench0  thrpt    3  14192.600 ± 3202.505  ops/s
[info] TestBench.bench1  thrpt    3  12457.443 ±  387.050  ops/s
[info] TestBench.bench2  thrpt    3      4.867 ±    0.511  ops/s

```