### PR TITLE
Add support for backlash continuation of apply chains

### DIFF
--- a/core/src/main/scala/org/bykn/bosatsu/Declaration.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/Declaration.scala
@@ -767,8 +767,9 @@ object Declaration {
         // here we are using . syntax foo.bar(1, 2)
         // we also allow foo.(anyExpression)(1, 2)
         val fn = varP | (recNonBind.parensCut)
+        val slashcontinuation = P(maybeSpace ~ "\\" ~/ toEOL ~ Parser.maybeSpacesAndLines).?
         val dotApply: P[NonBinding => NonBinding] =
-          P("." ~/ fn ~ params.?)
+          P(slashcontinuation ~ "." ~/ fn ~ params.?)
             .region
             .map { case (r2, (fn, argsOpt)) =>
               val args = argsOpt.fold(List.empty[NonBinding])(_.toList)

--- a/core/src/test/scala/org/bykn/bosatsu/EvaluationTest.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/EvaluationTest.scala
@@ -33,7 +33,6 @@ package Foo
 # exercise calling directly a lambda
 x = (\y -> y)("hello")
 """), "Foo", Str("hello"))
-  }
 
     runBosatsuTest(
       List("""
@@ -58,6 +57,7 @@ test = TestSuite("three trivial tests", [ Assertion(True, "t0"),
     Assertion(True, "t2"),
     ])
 """), "Foo", 3)
+  }
 
   test("test if/else") {
     evalTest(
@@ -370,7 +370,7 @@ main = 6.gcd_Int(3)
 package Foo
 
 three = [0, 1]
-# exercise the built-in range function (not implementable in bosatsu)
+# exercise the built-in range function
 threer = range(3)
 
 def zip(as, bs):

--- a/core/src/test/scala/org/bykn/bosatsu/ParserTest.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/ParserTest.scala
@@ -965,6 +965,16 @@ x""")
     decl("[x for x in xs if x < y ]")
     decl("[x for x in xs if x < y else xy ]")
     decl("y = [x for x in xs if x < y ]\ny")
+
+    decl("x.f(y).g(z)")
+    decl("""|x.f(y) \
+            | .g(z)""".stripMargin)
+    decl("""|x.f(y) \
+            | .g(z) \
+            | .h(w)""".stripMargin)
+    decl("""|x \
+            | .g(z) \
+            | .h(w)""".stripMargin)
   }
 
   test("we can parse any Statement") {


### PR DESCRIPTION
close #274 

@snoble 

I decided to keep it simple: copy python and always use the `\` to continue. So you can write:

```
x         \
  .foo    \
  .bar(y) \
```
to do method chaining.

The `\` means a few things:
1. discourages long chains slightly.
2. there is only one way (vs. allowing but also inferring, but inferring doesn't work in a repl session)
3. matches python.

Sorry it took so long. It was really only a few lines of code.