### PR TITLE
implement matches syntax

### DIFF
--- a/core/src/main/scala/org/bykn/bosatsu/Declaration.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/Declaration.scala
@@ -105,6 +105,15 @@ sealed abstract class Declaration {
         // TODO this isn't quite right
         kindDoc + typeName.toDoc + Doc.char(':') + args.sepDoc +
           piPat.document(args)
+      case m@Matches(arg, p) =>
+        val da = arg match {
+          // matches binds tighter than all these
+          case Lambda(_, _) | IfElse(_, _) | ApplyOp(_, _, _) | Match(_, _, _) =>
+            Parens(arg)(m.region).toDoc
+          case _ =>
+            arg.toDoc
+        }
+        da + Doc.text(" matches ") + Document[Pattern.Parsed].document(p)
       case Parens(p) =>
         Doc.char('(') + p.toDoc + Doc.char(')')
       case TupleCons(h :: Nil) =>
@@ -263,6 +272,8 @@ sealed abstract class Declaration {
           args.get.foldLeft(acc1) { case (acc0, (pat, res)) =>
             loop(res.get, acc0 ++ pat.names)
           }
+        case Matches(a, p) =>
+          loop(a, acc ++ p.names)
         case Parens(p) => loop(p, acc)
         case TupleCons(items) =>
           items.foldLeft(acc) { (acc0, d) => loop(d, acc0) }
@@ -379,6 +390,8 @@ object Declaration {
           Match(rec,
             arg.replaceRegionsNB(r),
             branches.map(_.map { case (p, x) => (p, x.map(_.replaceRegions(r))) }))(r)
+        case Matches(a, p) =>
+          Matches(a.replaceRegionsNB(r), p)(r)
         case Parens(p) => Parens(p.replaceRegions(r))(r)
         case TupleCons(items) =>
           TupleCons(items.map(_.replaceRegionsNB(r)))(r)
@@ -440,6 +453,7 @@ object Declaration {
     arg: NonBinding,
     cases: OptIndent[NonEmptyList[(Pattern.Parsed, OptIndent[Declaration])]])(
     implicit val region: Region) extends NonBinding
+  case class Matches(arg: NonBinding, pattern: Pattern.Parsed)(implicit val region: Region) extends NonBinding
   case class Parens(of: Declaration)(implicit val region: Region) extends NonBinding
   case class TupleCons(items: List[NonBinding])(implicit val region: Region) extends NonBinding
   case class Var(name: Identifier)(implicit val region: Region) extends NonBinding
@@ -647,7 +661,7 @@ object Declaration {
    * that cannot be used by identifiers
    */
   val keywords: Set[String] =
-    Set("if", "else", "elif", "match", "def", "recur", "struct", "enum")
+    Set("if", "else", "elif", "match", "matches", "def", "recur", "struct", "enum")
 
   /**
    * A Parser that matches keywords
@@ -806,9 +820,25 @@ object Declaration {
           applied.maybeAp(an)
         }
 
+      // matched
+      val matched: P[NonBinding] = {
+        // x matches p
+        val matchesOp =
+          (maybeSpace ~ P("matches") ~/ maybeSpace ~ Pattern.matchParser)
+            .region
+            .map { case (region, pat) =>
+
+              { nb: NonBinding => Matches(nb, pat)(nb.region + region) }
+            }
+            .rep(min = 1)
+            .map { fns => fns.reduceLeft(_.andThen(_)) }
+
+        annotated.maybeAp(matchesOp)
+      }
+
       // Applying is higher precedence than any operators
       // now parse an operator apply
-      val postOperators: P[NonBinding] = {
+      def postOperators(nb: P[NonBinding]): P[NonBinding] = {
 
         def convert(form: Operators.Formula[NonBinding]): NonBinding =
           form match {
@@ -822,7 +852,7 @@ object Declaration {
 
         // one or more operators
         val ops: P[NonBinding => Operators.Formula[NonBinding]] =
-          Operators.Formula.infixOps1(annotated)
+          Operators.Formula.infixOps1(nb)
 
         // This already parses as many as it can, so we don't need repFn
         val form = ops.map { fn =>
@@ -830,7 +860,7 @@ object Declaration {
           { d: NonBinding => convert(fn(d)) }
         }
 
-        annotated.maybeAp(form)
+        nb.maybeAp(form)
       }
 
       // here is if/ternary operator
@@ -849,7 +879,7 @@ object Declaration {
           }.opaque("ternary operator")
 
 
-      val finalNonBind: P[NonBinding] = postOperators.maybeAp(spaces ~ ternary)
+      val finalNonBind: P[NonBinding] = postOperators(matched).maybeAp(spaces ~ ternary)
 
       if (pm != ParseMode.Decl) finalNonBind
       else {

--- a/core/src/main/scala/org/bykn/bosatsu/Declaration.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/Declaration.scala
@@ -195,6 +195,8 @@ sealed abstract class Declaration {
             val bound1 = bound ++ pat.names
             loop(res.get, bound1, acc0)
           }
+        case Matches(a, _) =>
+          loop(a, bound, acc)
         case Parens(p) => loop(p, bound, acc)
         case TupleCons(items) =>
           items.foldLeft(acc) { (acc0, d) => loop(d, bound, acc0) }

--- a/core/src/main/scala/org/bykn/bosatsu/DefRecursionCheck.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/DefRecursionCheck.scala
@@ -333,6 +333,9 @@ object DefRecursionCheck {
                 }
               }
             }
+        case Matches(a, _) =>
+          // patterns don't use values
+          checkDecl(a)
         case Parens(p) =>
           checkDecl(p)
         case TupleCons(tups) =>

--- a/core/src/main/scala/org/bykn/bosatsu/SourceConverter.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/SourceConverter.scala
@@ -157,6 +157,8 @@ final class SourceConverter(
           newPattern.product(apply(decl))
         }
         (apply(arg), expBranches).mapN(Expr.Match(_, _, decl))
+      case Matches(a, p) =>
+        sys.error(s"TODO: support Matches($a, $p)")
       case tc@TupleCons(its) =>
         val tup0: Expr[Declaration] = Expr.Var(Some(PackageName.PredefName), Identifier.Constructor("Unit"), tc)
         val tup2: Expr[Declaration] = Expr.Var(Some(PackageName.PredefName), Identifier.Constructor("TupleCons"), tc)

--- a/core/src/test/scala/org/bykn/bosatsu/EvaluationTest.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/EvaluationTest.scala
@@ -455,9 +455,7 @@ main = headOption([1])
 package Foo
 
 def exists(as):
-  match as:
-    [*_, True, *_]: True
-    _: False
+  as matches [*_, True, *_]
 
 def not(x): False if x else True
 

--- a/test_workspace/AvlTree.bosatsu
+++ b/test_workspace/AvlTree.bosatsu
@@ -8,9 +8,7 @@ enum Tree[a]:
 enum Rotation: LeftRo, NoRo, RightRo
 
 def operator >(i, j):
-    match cmp_Int(i, j):
-        GT: True
-        _: False
+    cmp_Int(i, j) matches GT
 
 def rotation(left: Int, right: Int, max_diff: Int) -> Rotation:
     if left.sub(right) > max_diff:
@@ -207,9 +205,7 @@ def contains_test:
     ])
 
 def eq_i(a, b):
-    match cmp_Int(a, b):
-        EQ: True
-        _ : False
+    cmp_Int(a, b) matches EQ
 
 def add_increases_size(t, i, msg):
     s0 = size(t)
@@ -250,9 +246,7 @@ def height_tests:
         h = height(t)
         n = size(t)
         bound2 = 3.times(log2(n.add(2)))
-        good = match h.times(2).cmp_Int(bound2):
-            LT: True
-            _: False
+        good = h.times(2).cmp_Int(bound2) matches LT
         Assertion(good, "size_law for range(${int_to_String(n)})")
 
 

--- a/test_workspace/Bar.bosatsu
+++ b/test_workspace/Bar.bosatsu
@@ -1,9 +1,4 @@
 import Foo [ x ]
 
-def eq(cmp):
-  match cmp:
-    EQ: True
-    _: False
-
 test = Assertion(
-  eq(string_Order_fn(x, "this is Foo")), "got the right string")
+  string_Order_fn(x, "this is Foo") matches EQ, "got the right string")

--- a/test_workspace/List.bosatsu
+++ b/test_workspace/List.bosatsu
@@ -33,10 +33,7 @@ def head(xs: List[a]) -> Option[a]:
 
 def eq_List(fn: a -> a -> Bool, a: List[a], b: List[a]) -> Bool:
   recur a:
-    []:
-      match b:
-        []: True
-        _: False
+    []: b matches []
     [ah, *at]:
       match b:
         []: False
@@ -63,15 +60,8 @@ def size(list: List[a]) -> Nat:
 def sort(ord: Order[a], list: List[a]) -> List[a]:
     Order { to_Fn } = ord
 
-    def lt(x, h):
-        match to_Fn(x, h):
-            LT: True
-            _: False
-
-    def gteq(x, h):
-        match to_Fn(x, h):
-            LT: False
-            _: True
+    def lt(x, h): to_Fn(x, h) matches LT
+    def gteq(x, h): to_Fn(x, h) matches (GT | EQ)
 
     def loop(list: List[a], sz: Nat):
         recur sz:
@@ -95,29 +85,19 @@ operator =*= = eq_List(eq_Int)
 def not(x): False if x else True
 
 def headTest:
-    res = match head([1, 2, 3]):
-        Some(1): True
-        _: False
+    res = head([1, 2, 3]) matches Some(1)
     Assertion(res, "head test")
 
 def unconsTest:
-    res = match uncons([1, 2, 3]):
-        Some((1, [2, 3])): True
-        _: False
+    res = uncons([1, 2, 3]) matches Some((1, [2, 3]))
     Assertion(res, "uncons test")
 
 def zipTest:
-    test1 = match zip([1, 2], ["1", "2"]):
-        [(1, "1"), (2, "2")]: True
-        _: False
+    test1 = zip([1, 2], ["1", "2"]) matches [(1, "1"), (2, "2")]
 
-    test2 = match zip([1], ["1", "2"]):
-        [(1, "1")]: True
-        _: False
+    test2 = zip([1], ["1", "2"]) matches [(1, "1")]
 
-    test3 = match zip([1, 2], ["1"]):
-        [(1, "1")]: True
-        _: False
+    test3 = zip([1, 2], ["1"]) matches [(1, "1")]
 
     TestSuite("zip tests", [
       Assertion(test1, "same size"),
@@ -127,21 +107,10 @@ def zipTest:
 
 def sortTest:
     sort_Int = sort(Order(cmp_Int))
-    test1 = match sort_Int([3, 1, 2]):
-                [1, 2, 3]: True
-                _: False
-
-    test2 = match sort_Int([1, 2, 3]):
-                [1, 2, 3]: True
-                _: False
-
-    test3 = match sort_Int([2, 3, 1]):
-                [1, 2, 3]: True
-                _: False
-
-    test4 = match sort_Int([1, 2, 1]):
-                [1, 1, 2]: True
-                _: False
+    test1 = sort_Int([3, 1, 2]) matches [1, 2, 3]
+    test2 = sort_Int([1, 2, 3]) matches [1, 2, 3]
+    test3 = sort_Int([2, 3, 1]) matches [1, 2, 3]
+    test4 = sort_Int([1, 2, 1]) matches [1, 1, 2]
 
     TestSuite("sort tests", [
       Assertion(test1, "3, 1, 2"),

--- a/test_workspace/Nat.bosatsu
+++ b/test_workspace/Nat.bosatsu
@@ -56,9 +56,7 @@ n5 = Succ(n4)
 n6 = Succ(n5)
 
 def operator ==(i0: Int, i1: Int):
-  match cmp_Int(i0, i1):
-    EQ: True
-    _: False
+    cmp_Int(i0, i1) matches EQ
 
 def addLaw(n1: Nat, n2: Nat, label: String) -> Test:
   Assertion(add(n1, n2).to_Int == (n1.to_Int + n2.to_Int), label)

--- a/test_workspace/PatternExamples.bosatsu
+++ b/test_workspace/PatternExamples.bosatsu
@@ -6,9 +6,7 @@ bar = "this is bar"
 combine = "foo: ${foo} bar: ${bar}"
 
 def operator ==(a, b):
-    match string_Order_fn(a, b):
-        EQ: True
-        _: False
+  string_Order_fn(a, b) matches EQ
 
 def operator &&(a, b):
     if a: b
@@ -31,9 +29,7 @@ test1 = match get_foos("foo: (1) foo: (2)"):
             [one]: Assertion(False, "get_foos: ${one}")
             _: Assertion(False, "get_foos")
 
-test2_bool = match "unnamed match example":
-            "unnamed ${_} example": True
-            _: False
+test2_bool = "unnamed match example" matches "unnamed ${_} example"
 
 test2 = Assertion(test2_bool, "test unnamed match")
 

--- a/test_workspace/Queue.bosatsu
+++ b/test_workspace/Queue.bosatsu
@@ -47,13 +47,13 @@ def reverse_Queue(Queue(f, b): Queue[a]) -> Queue[a]:
 
 def eq_Queue(eq_fn: a -> a -> Bool, left: Queue[a], right: Queue[a]) -> Bool:
   res = left.fold_Queue((True, right), \(g, right), al ->
-    match g:
-      False: (False, empty)
-      True:
+    if g:
         match unpush(right):
           None: (False, empty)
           Some((ar, right)):
             (eq_fn(al, ar), right)
+    else:
+          (False, empty)
     )
   match res:
     (True, Queue([], [])): True

--- a/test_workspace/euler4.bosatsu
+++ b/test_workspace/euler4.bosatsu
@@ -10,9 +10,7 @@ import Bosatsu/Nat [ Nat, Succ, Zero, to_Nat ]
 # Find the largest palindrome made from the product of two 3-digit numbers.
 
 def operator >(a, b):
-  match a.cmp_Int(b):
-    GT: True
-    _ : False
+  a.cmp_Int(b) matches GT
 
 operator - = sub
 


### PR DESCRIPTION
close #396 

take a look @avibryant @snoble if you have time.

I like this syntax and think it is pretty useful as you can see in the examples I changed.

The fact that rust recently added a macro for this seals the deal for me since I didn't know about that when I was thinking about this. The fact that it was independently considered by the rust folks seems like good evidence.