### PR TITLE
Snoble/fix recurrsion ne bug

### DIFF
--- a/core/src/main/scala/org/bykn/bosatsu/Normalization.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/Normalization.scala
@@ -332,7 +332,6 @@ object Normalization {
 
   def normalOrderReduction(expr: NormalExpression): NormalExpression = {
     import NormalExpression._
-
     val res = headReduction(expr) match {
       case App(fn, arg) =>
         App(normalOrderReduction(fn), normalOrderReduction(arg))
@@ -542,10 +541,11 @@ case class NormalizePackageMap(pm: PackageMap.Inferred) {
           val originalLambda = AnnotatedLambda(arg=l.arg, tpe=l.expr.getType, expr=l.in, tag=l.tag)
           for {
             ee <- normalizeExpr(l.expr, nextEnv, p)
-            nextNextEnv: Env = (nextEnv._1 + (l.arg -> ee.tag._2), nextEnv._2)
-            eIn <- normalizeExpr(l.in, nextEnv, p)
-            ne = neWrapper(eIn.tag._2.ne)
-          } yield Let(l.arg, ee, eIn, l.recursive, (l.tag, NormalExpressionTag(ne, eIn.tag._2.children)))
+            eeNe = neWrapper(ee.tag._2.ne)
+            eeNeTag = NormalExpressionTag(eeNe, ee.tag._2.children)
+            nextNextEnv: Env = (nextEnv._1 + (l.arg -> eeNeTag), nextEnv._2)
+            eIn <- normalizeExpr(l.in, nextNextEnv, p)
+          } yield Let(l.arg, ee, eIn, l.recursive, (l.tag, eIn.tag._2))
         case _ =>
           for {
             ee <- normalizeExpr(l.expr, env, p)

--- a/core/src/main/scala/org/bykn/bosatsu/Normalization.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/Normalization.scala
@@ -543,7 +543,7 @@ case class NormalizePackageMap(pm: PackageMap.Inferred) {
             ee <- normalizeExpr(l.expr, nextEnv, p)
             eeNe = neWrapper(ee.tag._2.ne)
             eeNeTag = NormalExpressionTag(eeNe, ee.tag._2.children)
-            nextNextEnv: Env = (nextEnv._1 + (l.arg -> eeNeTag), nextEnv._2)
+            nextNextEnv: Env = (env._1 + (l.arg -> eeNeTag), env._2)
             eIn <- normalizeExpr(l.in, nextNextEnv, p)
           } yield Let(l.arg, ee, eIn, l.recursive, (l.tag, eIn.tag._2))
         case _ =>

--- a/core/src/test/scala/org/bykn/bosatsu/NormalizationTest.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/NormalizationTest.scala
@@ -62,7 +62,7 @@ out = foo
 """
       ), "Recur/Some", Recursion(Lambda(Lambda(Match(LambdaVar(0),NonEmptyList.of(
         (PositionalStruct(Some(0), Nil),Struct(1,List(Literal(Str("a")), Struct(1,List(Literal(Str("b")), Struct(1,List(Literal(Str("c")), Struct(0,List())))))))),
-        (PositionalStruct(Some(1), List(WildCard, Var(0))),Lambda(Struct(1,List(Literal(Str("zero")), App(LambdaVar(2),LambdaVar(0))))))
+      (PositionalStruct(Some(1), List(WildCard, Var(0))),Lambda(Struct(1,List(Literal(Str("zero")), App(LambdaVar(2),LambdaVar(0))))))
       )))))
     )
   }
@@ -127,16 +127,19 @@ def foldLeft(lst: List[a], item: b, fn: b -> a -> b) -> b:
 
 out = foldLeft
 """
-      ), "Recur/FoldLeft", Lambda(Lambda(Lambda(App(App(Recursion(Lambda(Lambda(Match(LambdaVar(0),NonEmptyList.of(
+      ), "Recur/FoldLeft",
+      Lambda(Lambda(Lambda(App(App(Recursion(Lambda(Lambda(Match(LambdaVar(0),NonEmptyList.of(
         (PositionalStruct(Some(0),List()),Lambda(LambdaVar(0))),
         (PositionalStruct(Some(1),List(Var(0), Var(1))),Lambda(Lambda(Lambda(App(App(LambdaVar(4),LambdaVar(2)),App(App(LambdaVar(5),LambdaVar(0)),LambdaVar(1)))))))
-      ))))),LambdaVar(3)),LambdaVar(2)))))
+      ))))),LambdaVar(2)),LambdaVar(1)))))
     )
   }
   test("foldLeft applied") {
     normalExpressionTest(
       List("""
 package Recur/FoldLeft
+
+lst = [1,2,3]
 
 def foldLeft(lst: List[a], item: b, fn: b -> a -> b) -> b:
   # make the loop function as small as possible
@@ -146,23 +149,13 @@ def foldLeft(lst: List[a], item: b, fn: b -> a -> b) -> b:
       NonEmptyList(head, tail): loop(tail, fn(item, head))
   loop(lst, item)
 
-out = [1,2,3].foldLeft(4, add)
+out = lst.foldLeft(9, add)
 """
       ), "Recur/FoldLeft",
-    App(
-      App(
-        Recursion(Lambda(Lambda(Match(LambdaVar(0),NonEmptyList.of(
-          (PositionalStruct(Some(0),List()),Lambda(LambdaVar(0))),
-          (PositionalStruct(Some(1),List(Var(0), Var(1))),
-            Lambda(Lambda(Lambda(
-              App(App(LambdaVar(4),LambdaVar(2)),App(App(ExternalVar(PackageName(NonEmptyList.of("Bosatsu", "Predef")),Identifier.Name("add")),LambdaVar(0)),LambdaVar(1)))
-            )))
-          )
-        ))))),
-        LambdaVar(0)
-      ),
-      Struct(1,List(Literal(Integer(BigInteger.valueOf(1))), Struct(1,List(Literal(Integer(BigInteger.valueOf(2))), Struct(1,List(Literal(Integer(BigInteger.valueOf(3))), Struct(0,List())))))))
-    )
+      App(App(Recursion(Lambda(Lambda(Match(LambdaVar(0),NonEmptyList.of(
+        (PositionalStruct(Some(0),List()),Lambda(LambdaVar(0))),
+        (PositionalStruct(Some(1),List(Var(0), Var(1))),Lambda(Lambda(Lambda(App(App(LambdaVar(4),LambdaVar(2)),App(App(ExternalVar(PackageName(NonEmptyList.of("Bosatsu", "Predef")),Identifier.Name("add")),LambdaVar(0)),LambdaVar(1)))))))
+      ))))),Struct(1,List(Literal(Integer(BigInteger.valueOf(1))), Struct(1,List(Literal(Integer(BigInteger.valueOf(2))), Struct(1,List(Literal(Integer(BigInteger.valueOf(3))), Struct(0,List())))))))),Literal(Integer(BigInteger.valueOf(9))))
     )
   }
   test("Lambda") {

--- a/core/src/test/scala/org/bykn/bosatsu/NormalizationTest.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/NormalizationTest.scala
@@ -133,6 +133,38 @@ out = foldLeft
       ))))),LambdaVar(3)),LambdaVar(2)))))
     )
   }
+  test("foldLeft applied") {
+    normalExpressionTest(
+      List("""
+package Recur/FoldLeft
+
+def foldLeft(lst: List[a], item: b, fn: b -> a -> b) -> b:
+  # make the loop function as small as possible
+  def loop(lst, item):
+    recur lst:
+      EmptyList: item
+      NonEmptyList(head, tail): loop(tail, fn(item, head))
+  loop(lst, item)
+
+out = [1,2,3].foldLeft(4, add)
+"""
+      ), "Recur/FoldLeft",
+    App(
+      App(
+        Recursion(Lambda(Lambda(Match(LambdaVar(0),NonEmptyList.of(
+          (PositionalStruct(Some(0),List()),Lambda(LambdaVar(0))),
+          (PositionalStruct(Some(1),List(Var(0), Var(1))),
+            Lambda(Lambda(Lambda(
+              App(App(LambdaVar(4),LambdaVar(2)),App(App(ExternalVar(PackageName(NonEmptyList.of("Bosatsu", "Predef")),Identifier.Name("add")),LambdaVar(0)),LambdaVar(1)))
+            )))
+          )
+        ))))),
+        LambdaVar(0)
+      ),
+      Struct(1,List(Literal(Integer(BigInteger.valueOf(1))), Struct(1,List(Literal(Integer(BigInteger.valueOf(2))), Struct(1,List(Literal(Integer(BigInteger.valueOf(3))), Struct(0,List())))))))
+    )
+    )
+  }
   test("Lambda") {
     normalTagTest(
       List("""

--- a/core/src/test/scala/org/bykn/bosatsu/NormalizationTest.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/NormalizationTest.scala
@@ -66,6 +66,73 @@ out = foo
       )))))
     )
   }
+  test("foldLeft w/o loop") {
+    normalExpressionTest(
+      List("""
+package Recur/FoldLeft
+
+def foldLeft(lst: List[a], item: b, fn: b -> a -> b) -> b:
+  recur lst:
+    EmptyList: item
+    NonEmptyList(head, tail): foldLeft(tail, fn(item, head), fn)
+
+out = foldLeft
+"""
+      ), "Recur/FoldLeft", Recursion(Lambda(Lambda(Match(LambdaVar(0),NonEmptyList.of(
+        (PositionalStruct(Some(0),List()),Lambda(Lambda(LambdaVar(1)))),
+        (PositionalStruct(Some(1),List(Var(0), Var(1))),Lambda(Lambda(Lambda(Lambda(App(App(App(LambdaVar(5),LambdaVar(3)),App(App(LambdaVar(0),LambdaVar(1)),LambdaVar(2))),LambdaVar(0)))))))
+      )))))
+    )
+  }
+  test("foldLeft w/o loop applied") {
+    normalExpressionTest(
+      List("""
+package Recur/FoldLeft
+
+def foldLeft(lst: List[a], item: b, fn: b -> a -> b) -> b:
+  recur lst:
+    EmptyList: item
+    NonEmptyList(head, tail): foldLeft(tail, fn(item, head), fn)
+
+out = [1,2,3].foldLeft(4, add)
+"""
+      ), "Recur/FoldLeft",
+      App(
+        App(
+          App(
+            Recursion(Lambda(Lambda(Match(LambdaVar(0),NonEmptyList.of(
+              (PositionalStruct(Some(0),List()),Lambda(Lambda(LambdaVar(1)))),
+              (PositionalStruct(Some(1),List(Var(0), Var(1))),Lambda(Lambda(Lambda(Lambda(App(App(App(LambdaVar(5),LambdaVar(3)),App(App(LambdaVar(0),LambdaVar(1)),LambdaVar(2))),LambdaVar(0)))))))
+            ))))),
+            Struct(1,List(Literal(Integer(BigInteger.valueOf(1))), Struct(1,List(Literal(Integer(BigInteger.valueOf(2))), Struct(1,List(Literal(Integer(BigInteger.valueOf(3))), Struct(0,List())))))))
+          ),
+          Literal(Integer(BigInteger.valueOf(4)))
+        ),
+        ExternalVar(PackageName(NonEmptyList.of("Bosatsu", "Predef")),Identifier.Name("add"))
+      )
+    )
+  }
+  test("foldLeft") {
+    normalExpressionTest(
+      List("""
+package Recur/FoldLeft
+
+def foldLeft(lst: List[a], item: b, fn: b -> a -> b) -> b:
+  # make the loop function as small as possible
+  def loop(lst, item):
+    recur lst:
+      EmptyList: item
+      NonEmptyList(head, tail): loop(tail, fn(item, head))
+  loop(lst, item)
+
+out = foldLeft
+"""
+      ), "Recur/FoldLeft", Lambda(Lambda(Lambda(App(App(Recursion(Lambda(Lambda(Match(LambdaVar(0),NonEmptyList.of(
+        (PositionalStruct(Some(0),List()),Lambda(LambdaVar(0))),
+        (PositionalStruct(Some(1),List(Var(0), Var(1))),Lambda(Lambda(Lambda(App(App(LambdaVar(4),LambdaVar(2)),App(App(LambdaVar(5),LambdaVar(0)),LambdaVar(1)))))))
+      ))))),LambdaVar(3)),LambdaVar(2)))))
+    )
+  }
   test("Lambda") {
     normalTagTest(
       List("""


### PR DESCRIPTION
I was wrapping the `in` with a `Recursion` expression when what I wanted was to wrap the `arg` and then add the `arg` to the `in`'s environment