### PR TITLE
Improve SeqPattern testing

### DIFF
--- a/core/src/main/scala/org/bykn/bosatsu/TotalityCheck.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/TotalityCheck.scala
@@ -257,12 +257,16 @@ case class TotalityCheck(inEnv: TypeEnv[Any]) {
             case (PositionalStruct(n, as), rp@ListPat(_)) =>
               structToList(n, as) match {
                 case Some(lp) => intersection(lp, rp)
-                case None => Nil
+                case None =>
+                  if (isTop(rp)) left :: Nil
+                  else Nil
               }
             case (lp@ListPat(_), PositionalStruct(n, as)) =>
               structToList(n, as) match {
                 case Some(rp) => intersection(lp, rp)
-                case None => Nil
+                case None =>
+                  if (isTop(lp)) right :: Nil
+                  else Nil
               }
             case (PositionalStruct(ln, lps), PositionalStruct(rn, rps)) =>
               if (ln == rn) {

--- a/core/src/main/scala/org/bykn/bosatsu/pattern/Matcher.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/pattern/Matcher.scala
@@ -29,13 +29,19 @@ object Matcher {
       }
   }
 
+  private[this] val someUnit = Some(())
+
   def eqMatcher[A](implicit eqA: Eq[A]): Matcher[A, A, Unit] =
     new Matcher[A, A, Unit] {
-      val someUnit = Some(())
-
       def apply(a: A): A => Option[Unit] =
           { (s: A) => if (eqA.eqv(a, s)) someUnit else None }
     }
 
   val charMatcher: Matcher[Char, Char, Unit] = eqMatcher(Eq.fromUniversalEquals[Char])
+
+  def fnMatch[A]: Matcher[A => Boolean, A, Unit] =
+    new Matcher[A => Boolean, A, Unit] {
+      def apply(p: A => Boolean) =
+      { a: A => if (p(a)) someUnit else None }
+    }
 }

--- a/core/src/main/scala/org/bykn/bosatsu/pattern/SeqPart.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/pattern/SeqPart.scala
@@ -2,6 +2,7 @@ package org.bykn.bosatsu.pattern
 
 sealed trait SeqPart[+Elem] {
   def notWild: Boolean = false
+  def isWild: Boolean = !notWild
 }
 object SeqPart {
   sealed trait SeqPart1[+Elem] extends SeqPart[Elem] {

--- a/core/src/main/scala/org/bykn/bosatsu/pattern/SeqPart.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/pattern/SeqPart.scala
@@ -76,7 +76,7 @@ object SeqPart {
           case AnyElem => true
           case Lit(c2) =>
             p1 match {
-              case Lit(c1) => setOpsA.subset(c2, c1)
+              case Lit(c1) => setOpsA.subset(c1, c2)
               case AnyElem => setOpsA.isTop(c2)
             }
         }

--- a/core/src/main/scala/org/bykn/bosatsu/pattern/SeqPattern.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/pattern/SeqPattern.scala
@@ -294,16 +294,16 @@ object SeqPattern {
           case (_, Cat(Wildcard, t2@Cat(Wildcard, _))) =>
             // unnormalized
             intersection(p1, t2)
-          case (c1@Cat(Wildcard, _), c2@Cat(Wildcard, _)) if c1.rightMost.notWild || c2.rightMost.notWild =>
-            // let's avoid the most complex case of both having
-            // wild on the front if possible
-            intersection(c1.reverse, c2.reverse).map(_.reverse)
           case (Cat(Wildcard, Cat(a1, t1)), _) if isAny(a1) =>
             // *. == .*, push Wildcards to the end
             intersection(Cat(AnyElem, Cat(Wildcard, t1)), p2)
           case (_, Cat(Wildcard, Cat(a2, t2))) if isAny(a2) =>
             // *. == .*, push Wildcards to the end
             intersection(p1, Cat(AnyElem, Cat(Wildcard, t2)))
+          case (c1@Cat(Wildcard, _), c2@Cat(Wildcard, _)) if c1.rightMost.notWild || c2.rightMost.notWild =>
+            // let's avoid the most complex case of both having
+            // wild on the front if possible
+            intersection(c1.reverse, c2.reverse).map(_.reverse)
           case (c1@Cat(Wildcard, t1), c2@Cat(Wildcard, t2)) =>
             // both start and end with wild
             //

--- a/core/src/main/scala/org/bykn/bosatsu/pattern/SetOps.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/pattern/SetOps.scala
@@ -91,7 +91,8 @@ trait SetOps[A] {
 
     // all permutations can blow up fast, so we only
     // take a fixed number
-    val lookahead = 4
+    // 3! = 6
+    val lookahead = 3
 
     def loop(union: List[A], diffs: List[A]): List[A] =
       if (union.isEmpty) Nil
@@ -106,14 +107,14 @@ trait SetOps[A] {
               (ulen, peeks)
             }
             val smallest = trials.iterator.map(_._1).min
-            // choose the diff that ends up the smallest
+            // choose a diff that ends up the smallest
             // the most times
             val best = trials
               .collect { case (ulen, p) if ulen == smallest => p }
               .flatten
               .groupBy(identity)
               .map { case (k, v) => (k, v.size) }
-              .minBy(_._2)
+              .maxBy(_._2)
               ._1
 
             val u1 = differenceAll(union, best :: Nil)

--- a/core/src/main/scala/org/bykn/bosatsu/pattern/SetOps.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/pattern/SetOps.scala
@@ -24,6 +24,12 @@ trait SetOps[A] {
   def intersection(a1: A, a2: A): List[A]
 
   /**
+   * Return true if a1 and a2 are disjoint
+   */
+  def disjoint(a1: A, a2: A): Boolean =
+    intersection(a1, a2).isEmpty
+
+  /**
    * remove a2 from a1 return a union represented as a list
    *
    * this should be the tightest upperbound we can find

--- a/core/src/main/scala/org/bykn/bosatsu/pattern/SetOps.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/pattern/SetOps.scala
@@ -104,14 +104,13 @@ trait SetOps[A] {
             val trials = allPerms(peek).map { peeks =>
               val u1 = differenceAll(union, peeks)
               val ulen = u1.size
-              (ulen, peeks)
+              (ulen, peek.head)
             }
             val smallest = trials.iterator.map(_._1).min
-            // choose a diff that ends up the smallest
-            // the most times
+            // choose a diff that starts the most
+            // number of results that are the smallest
             val best = trials
               .collect { case (ulen, p) if ulen == smallest => p }
-              .flatten
               .groupBy(identity)
               .map { case (k, v) => (k, v.size) }
               .maxBy(_._2)

--- a/core/src/main/scala/org/bykn/bosatsu/pattern/SetOps.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/pattern/SetOps.scala
@@ -123,6 +123,29 @@ object SetOps {
       def subset(a: A, b: A): Boolean = ordA.equiv(a, b)
     }
 
+  def fromFinite[A](items: Iterable[A]): SetOps[Set[A]] =
+    new SetOps[Set[A]] {
+      require(items.nonEmpty, "the empty set is not allowed")
+
+      val itemsSet = items.toSet
+      val top: Option[Set[A]] = Some(itemsSet)
+      def isTop(a: Set[A]): Boolean = a == itemsSet
+
+      def toList(s: Set[A]): List[Set[A]] =
+        if (s.isEmpty) Nil else s :: Nil
+
+      def intersection(a1: Set[A], a2: Set[A]): List[Set[A]] =
+        toList(a1.intersect(a2))
+
+      def difference(a1: Set[A], a2: Set[A]): List[Set[A]] =
+        toList(a1 -- a2)
+
+      def unifyUnion(u: List[Set[A]]): List[Set[A]] =
+        toList(u.foldLeft(Set.empty[A])(_ | _))
+
+      def subset(a: Set[A], b: Set[A]): Boolean = a.subsetOf(b)
+    }
+
   // for types with only one value, Null, Unit, Nil
   def unit[A](topA: A): SetOps[A] =
     new SetOps[A] {

--- a/core/src/test/scala/org/bykn/bosatsu/TotalityTest.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/TotalityTest.scala
@@ -25,7 +25,7 @@ class TotalityTest extends SetOpsLaws[Pattern[(PackageName, Constructor), Type]]
 
   implicit val generatorDrivenConfig =
     //PropertyCheckConfiguration(minSuccessful = 500000)
-    PropertyCheckConfiguration(minSuccessful = 50000)
+    PropertyCheckConfiguration(minSuccessful = 5000)
     //PropertyCheckConfiguration(minSuccessful = 50)
 
   val genPattern: Gen[Pattern[(PackageName, Constructor), Type]] =

--- a/core/src/test/scala/org/bykn/bosatsu/TotalityTest.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/TotalityTest.scala
@@ -22,7 +22,8 @@ class TotalityTest extends SetOpsLaws[Pattern[(PackageName, Constructor), Type]]
 
   implicit val generatorDrivenConfig =
     //PropertyCheckConfiguration(minSuccessful = 500000)
-    PropertyCheckConfiguration(minSuccessful = 5000)
+    //PropertyCheckConfiguration(minSuccessful = 5000)
+    PropertyCheckConfiguration(minSuccessful = 50)
 
   val genPattern: Gen[Pattern[(PackageName, Constructor), Type]] =
     Generators.genCompiledPattern(5, useAnnotation = false)
@@ -229,6 +230,7 @@ enum Either: Left(l), Right(r)
     testTotality(predefTE, patterns("[[], [h, *tail]]"), tight = true)
     testTotality(predefTE, patterns("[[], [h, *tail], [h0, h1, *tail]]"), tight = true)
     testTotality(predefTE, patterns("[[], [*tail, _]]"), tight = true)
+    testTotality(predefTE, patterns("[[*_, True, *_], [] | [False, *_]]"), tight = true)
 
     notTotal(predefTE, patterns("[[], [h, *tail, _]]"))
   }

--- a/core/src/test/scala/org/bykn/bosatsu/TotalityTest.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/TotalityTest.scala
@@ -22,8 +22,8 @@ class TotalityTest extends SetOpsLaws[Pattern[(PackageName, Constructor), Type]]
 
   implicit val generatorDrivenConfig =
     //PropertyCheckConfiguration(minSuccessful = 500000)
-    //PropertyCheckConfiguration(minSuccessful = 5000)
-    PropertyCheckConfiguration(minSuccessful = 50)
+    PropertyCheckConfiguration(minSuccessful = 50000)
+    //PropertyCheckConfiguration(minSuccessful = 50)
 
   val genPattern: Gen[Pattern[(PackageName, Constructor), Type]] =
     Generators.genCompiledPattern(5, useAnnotation = false)

--- a/core/src/test/scala/org/bykn/bosatsu/pattern/SeqPatternTest.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/pattern/SeqPatternTest.scala
@@ -428,7 +428,7 @@ class BoolSeqPatternTest extends SeqPatternLaws[Set[Boolean], Boolean, List[Bool
       List(
         SeqPattern.fromList(Wildcard :: Lit(Set(true)) :: Wildcard :: Nil),
         SeqPattern.fromList(Lit(Set(false)) :: Wildcard :: Nil),
-        SeqPattern.fromList(Nil),
+        SeqPattern.fromList(Nil)
       ))
 
     assert(missing == Nil)

--- a/core/src/test/scala/org/bykn/bosatsu/pattern/SeqPatternTest.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/pattern/SeqPatternTest.scala
@@ -321,7 +321,7 @@ abstract class SeqPatternLaws[E, I, S, R] extends FunSuite {
   def diffUBRegressions: List[(Pattern, Pattern, S)] = Nil
 
   test("difference is an upper bound") {
-    //forAll(genPattern, genPattern, genSeq) { case (p1, p2, s) => differenceUBLaw(p1, p2, s) }
+    forAll(genPattern, genPattern, genSeq) { case (p1, p2, s) => differenceUBLaw(p1, p2, s) }
 
     diffUBRegressions.foreach { case (p1, p2, s) =>
       differenceUBLaw(p1, p2, s)

--- a/core/src/test/scala/org/bykn/bosatsu/pattern/SetOpsLaws.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/pattern/SetOpsLaws.scala
@@ -230,9 +230,14 @@ abstract class SetOpsLaws[A] extends FunSuite {
     }
   }
 
+  /*
+   * This isn't true in general because difference is an upper-bound
+   * and you have differences on both sides of the equation.
+   * It is *usually* true, but we can't write a law for that
   test("(a - b) n c = (a n c) - (b n c)") {
     forAll(genItem, genItem, genItem)(diffIntersectionLaw(_, _, _))
   }
+  */
 
   test("missing branches, if added are total and none of the missing are unreachable") {
 

--- a/core/src/test/scala/org/bykn/bosatsu/pattern/SetOpsLaws.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/pattern/SetOpsLaws.scala
@@ -318,3 +318,72 @@ class UnitSetOpsTest extends SetOpsLaws[Unit] {
       left.toSet == right.toSet
   })
 }
+
+
+class SetOpsTests extends FunSuite {
+  test("allPerms is correct") {
+    forAll(Gen.choose(0, 6).flatMap(Gen.listOfN(_, Arbitrary.arbitrary[Int]))) { is0 =>
+      // make everything distinct
+      val is = is0.zipWithIndex
+      val perms = SetOps.allPerms(is)
+
+      def fact(i: Int, acc: Int): Int =
+        if (i <= 1) acc
+        else fact(i - 1, i * acc)
+
+      assert(perms.length == fact(is0.size, 1))
+
+      perms.foreach { p =>
+        assert(p.sorted == is.sorted)
+      }
+      val pi = perms.zipWithIndex
+
+      for {
+        (p1, i1) <- pi
+        (p2, i2) <- pi
+      } assert((i1 >= i2 || (p1 != p2)))
+    }
+  }
+
+  test("greedySearch finds the optimal path if lookahead is greater than size") {
+    // we need a non-commutative operation to test this
+    // use 2x2 matrix multiplication
+    def mult(left: Vector[Vector[Double]], right: Vector[Vector[Double]]): Vector[Vector[Double]] = {
+      def dot(v1: Vector[Double], v2: Vector[Double]) =
+        v1.iterator.zip(v2.iterator).map { case (a, b) => a*b }.sum
+
+      def trans(v1: Vector[Vector[Double]]) =
+        Vector(Vector(v1(0)(0), v1(1)(0)), Vector(v1(0)(1), v1(1)(1)))
+
+      val res = Vector(Vector(0.0, 0.0), Vector(0.0, 0.0))
+
+      val data = for {
+        (r, ri) <- left.zipWithIndex
+        (c, ci) <- trans(right).zipWithIndex
+      } yield ((ri, ci), dot(r, c))
+
+      data.foldLeft(res) { case (v, ((r, c), d)) => v.updated(r, v(r).updated(c, d)) }
+    }
+
+    def norm(left: Vector[Vector[Double]]): Double =
+      left.map(_.map { x => x*x }.sum).sum
+
+
+    val genMat: Gen[Vector[Vector[Double]]] = {
+      val elem = Gen.choose(-1.0, 1.0)
+      Gen.listOfN(4, elem).map { vs =>
+        Vector(
+          Vector(vs(0), vs(1)),
+          Vector(vs(2), vs(3))
+        )
+      }
+    }
+
+    forAll(genMat, Gen.listOfN(5, genMat)) { (v0, prods) =>
+      val res = SetOps.greedySearch(5, v0, prods)({(v, ps) => ps.foldLeft(v)(mult(_, _))})(norm(_))
+      val normRes = norm(res)
+      val naive = norm(prods.foldLeft(v0)(mult(_, _)))
+      assert(normRes <= naive)
+    }
+  }
+}

--- a/core/src/test/scala/org/bykn/bosatsu/pattern/StringSeqPatternSetLaws.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/pattern/StringSeqPatternSetLaws.scala
@@ -81,6 +81,16 @@ class StringSeqPatternSetLaws extends SetOpsLaws[SeqPattern[Char]] {
       (Cat(Wildcard, Cat(Lit('q'), Cat(Wildcard, Empty))),
         Cat(Wildcard, Empty),
         Cat(Wildcard, Cat(Lit('p'), Cat(Wildcard, Empty)))) ::
+      /*
+       * This fails currently
+       * see: https://github.com/johnynek/bosatsu/issues/486
+      {
+        val p1 = Cat(Wildcard,Cat(Lit('1'),Cat(Lit('0'),Cat(Lit('0'),Empty))))
+        val p2  = Cat(AnyElem,Cat(Lit('1'),Cat(Wildcard,Cat(Lit('0'),Empty))))
+        val p3 = Cat(Lit('1'),Cat(Lit('1'),Cat(Wildcard,Cat(Lit('0'),Empty))))
+        (p1, p2, p3)
+      } ::
+      */
       Nil
 
     regressions.foreach { case (a, b, c) => diffIntersectionLaw(a, b, c) }


### PR DESCRIPTION
This is an attempt to fix #491 #486 #480 #475.

The problem is that difference is an upper bound for SeqPattern with wildcards at both ends.

I think this is not a soundness problem because it rejects some patterns that are total, but it can't see that they are. It would be nice to minimize those however.

This code fixes a couple of real bugs, comments out one law that is only approximately true, and adds a heuristic for improving the checks for missing branches (which can be pessimistic, but should never report that a match is total when it isn't).