### PR TITLE
fix bugs in freeVars, allVars and substitute in Declaration

### DIFF
--- a/core/src/main/scala/org/bykn/bosatsu/Declaration.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/Declaration.scala
@@ -232,7 +232,11 @@ sealed abstract class Declaration {
           // A constructor doesn't introduce new bindings
           args.foldLeft(acc) {
             case (acc, RecordArg.Pair(_, v)) => loop(v, bound, acc)
-            case (acc, RecordArg.Simple(n)) => acc
+            case (acc, RecordArg.Simple(n)) =>
+              // TODO this is wrong,
+              // this is the same as Pair(n, Var(n))
+              // and thus n can be free
+              acc
           }
       }
 
@@ -511,7 +515,6 @@ object Declaration {
               Comment(CommentStatement(c.message, p1))(decl.region)
             }
         case DefFn(DefStatement(nm, args, rtype, (body, rest))) =>
-          // nm is in scope in result
           def go(scope: List[Bindable], d0: Declaration): Option[Declaration] =
             if (scope.exists(masks)) None
             else if (scope.exists(shadows)) Some(d0)

--- a/core/src/main/scala/org/bykn/bosatsu/Declaration.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/Declaration.scala
@@ -214,29 +214,29 @@ sealed abstract class Declaration {
           items.foldLeft(acc) { (acc0, sori) =>
             loop(sori.value, bound, acc0)
           }
-        case ListDecl(ListLang.Comprehension(ex, b, in, _)) =>
+        case ListDecl(ListLang.Comprehension(ex, b, in, filter)) =>
           val acc1 = loop(in, bound, acc)
           val bound1 = bound ++ b.names
-          loop(ex.value, bound1, acc1)
+          val acc2 = loop(ex.value, bound1, acc1)
+          filter.fold(acc2)(loop(_, bound1, acc2))
         case DictDecl(ListLang.Cons(items)) =>
           items.foldLeft(acc) { (acc0, kv) =>
             val acc1 = loop(kv.key, bound, acc0)
             loop(kv.value, bound, acc1)
           }
-        case DictDecl(ListLang.Comprehension(ex, b, in, _)) =>
+        case DictDecl(ListLang.Comprehension(ex, b, in, filter)) =>
           val acc1 = loop(in, bound, acc)
           val bound1 = bound ++ b.names
           val acc2 = loop(ex.key, bound1, acc1)
-          loop(ex.value, bound1, acc2)
+          val acc3 = loop(ex.value, bound1, acc2)
+          filter.fold(acc3)(loop(_, bound1, acc3))
         case RecordConstructor(_, args) =>
           // A constructor doesn't introduce new bindings
           args.foldLeft(acc) {
-            case (acc, RecordArg.Pair(_, v)) => loop(v, bound, acc)
-            case (acc, RecordArg.Simple(n)) =>
-              // TODO this is wrong,
-              // this is the same as Pair(n, Var(n))
-              // and thus n can be free
-              acc
+            case (acc, RecordArg.Pair(_, v)) =>
+              loop(v, bound, acc)
+            case (acc, RecordArg.Simple(v)) =>
+              loop(Var(v)(decl.region), bound, acc)
           }
       }
 
@@ -319,18 +319,20 @@ sealed abstract class Declaration {
           items.foldLeft(acc) { (acc0, sori) =>
             loop(sori.value, acc0)
           }
-        case ListDecl(ListLang.Comprehension(ex, b, in, _)) =>
+        case ListDecl(ListLang.Comprehension(ex, b, in, filter)) =>
           val acc1 = loop(in, acc)
-          loop(ex.value, acc1 ++ b.names)
+          val acc2 = loop(ex.value, acc1 ++ b.names)
+          filter.fold(acc2)(loop(_, acc2))
         case DictDecl(ListLang.Cons(items)) =>
           items.foldLeft(acc) { (acc0, kv) =>
             val acc1 = loop(kv.key, acc0)
             loop(kv.value, acc1)
           }
-        case DictDecl(ListLang.Comprehension(ex, b, in, _)) =>
+        case DictDecl(ListLang.Comprehension(ex, b, in, filter)) =>
           val acc1 = loop(in, acc)
           val acc2 = loop(ex.key, acc1 ++ b.names)
-          loop(ex.value, acc2)
+          val acc3 = loop(ex.value, acc2)
+          filter.fold(acc3)(loop(_, acc3))
         case RecordConstructor(_, args) =>
           args.foldLeft(acc) {
             case (acc, RecordArg.Pair(_, v)) => loop(v, acc)
@@ -407,8 +409,14 @@ object Declaration {
           loop(a).map(RecordArg.Pair(fn, _))
         case RecordArg.Simple(fn) =>
           if (fn === ident) {
-            // This is no longer a simple RecordArg
-            Some(RecordArg.Pair(fn, ex))
+            ex match {
+              case Var(newIdent) if newIdent === fn =>
+                // this is identity
+                Some(ra)
+              case _ =>
+                // This is no longer a simple RecordArg
+                Some(RecordArg.Pair(fn, ex))
+            }
           }
           else Some(ra)
       }

--- a/core/src/test/scala/org/bykn/bosatsu/DeclarationTest.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/DeclarationTest.scala
@@ -11,9 +11,9 @@ class DeclarationTest extends FunSuite {
   import Generators.shrinkDecl
 
   implicit val generatorDrivenConfig =
-    //PropertyCheckConfiguration(minSuccessful = 5000)
-    //PropertyCheckConfiguration(minSuccessful = 500)
-    PropertyCheckConfiguration(minSuccessful = 200)
+    //PropertyCheckConfiguration(minSuccessful = 50000)
+    PropertyCheckConfiguration(minSuccessful = 500)
+    //PropertyCheckConfiguration(minSuccessful = 200)
 
   implicit val emptyRegion: Region = Region(0, 0)
 

--- a/core/src/test/scala/org/bykn/bosatsu/DeclarationTest.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/DeclarationTest.scala
@@ -11,9 +11,9 @@ class DeclarationTest extends FunSuite {
   import Generators.shrinkDecl
 
   implicit val generatorDrivenConfig =
-    //PropertyCheckConfiguration(minSuccessful = 50000)
-    PropertyCheckConfiguration(minSuccessful = 500)
-    //PropertyCheckConfiguration(minSuccessful = 200)
+    //PropertyCheckConfiguration(minSuccessful = 5000)
+    PropertyCheckConfiguration(minSuccessful = 200)
+    //PropertyCheckConfiguration(minSuccessful = 50)
 
   implicit val emptyRegion: Region = Region(0, 0)
 
@@ -155,6 +155,17 @@ class DeclarationTest extends FunSuite {
     }
 
     forAll(genFrees) { case (d, b) => law(b, d) }
+
+    val regressions: List[(String, String)] =
+      List(
+        ("Foo { a }", "a")
+      )
+
+    regressions.foreach { case (decl, v) =>
+      val d = TestParseUtils.parseUnsafe(Declaration.parser(""), decl)
+      val bind = TestParseUtils.parseUnsafe(Identifier.bindableParser, v)
+      law(bind, d)
+    }
   }
 
   test("test example substitutions") {
@@ -177,6 +188,28 @@ x"""))
     law("b", "12", """[b for b in b]""", Some("""[b for b in 12]"""))
     law("b", "12", """[b for b in b if b]""", Some("""[b for b in 12 if b]"""))
     law("b", "12", """Foo { b }""", Some("Foo { b: 12 }"))
+  }
+
+  test("test freeVars with explicit examples") {
+    def law(decls: String, frees: List[String], all: List[String]) = {
+      val binds = frees.map(TestParseUtils.parseUnsafe(Identifier.bindableParser, _))
+      val alls = all.map(TestParseUtils.parseUnsafe(Identifier.bindableParser, _))
+      val decl = TestParseUtils.parseUnsafe(Declaration.parser(""), decls)
+
+      assert(decl.freeVars.toSet == binds.toSet, "freeVars don't match")
+      assert(decl.allNames.toSet == alls.toSet, "allVars don't match")
+    }
+
+    law("a", List("a"), List("a"))
+    law("[a for b in c]", List("a", "c"), List("a", "b", "c"))
+    law("[a for b in c if d]", List("a", "c", "d"), List("a", "b", "c", "d"))
+    law("[a for b in c if b]", List("a", "c"), List("a", "b", "c"))
+    law("[b for b in c if d]", List("c", "d"), List("b", "c", "d"))
+    law("[b for b in c if b]", List("c"), List("b", "c"))
+    law("{ k: a for b in c if d}", List("k", "a", "c", "d"), List("k", "a", "b", "c", "d"))
+    law("{ k: a for b in c if b}", List("k", "a", "c"), List("k", "a", "b", "c"))
+    law("Foo { a }", List("a"), List("a"))
+    law("Foo { a: b }", List("b"), List("b"))
   }
 
   test("isCheap is constant under Annotation or Parens") {


### PR DESCRIPTION
close #493 

The main bug here was that the short form of records `Foo { x }` meaning `Foo { x: x }` was seen in substitution, but overlooked in freeVars and allVars, so one of the scalacheck tests caught that. *yay*.

freeVars and allVars had copied code that was ignoring the filter condition which I noticed while looking for more bugs.

I added tests that triggered all the bugs I saw, then made sure they were green. I also turned up the number of trials to 5000 and made sure it passed locally before turning back down to 200 (since these tests are slow, since, I believe the declarations are sometimes getting really deep).

cc @snoble thanks for reporting this bug. With your report, it was easy to fix the error.