### PR TITLE
Creates LetFreeExprFn for LetFreeEvaluation

### DIFF
--- a/core/src/main/scala/org/bykn/bosatsu/Externals.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/Externals.scala
@@ -44,7 +44,7 @@ object FfiCall {
 
     private[this] def evalExprFn(t: rankn.Type): ExprFnValue = ExprFnValue({ (e1, cache, eval) => Value.ExternalValue(wrapper(e1, t, cache, eval)) })
 
-    def call(t: rankn.Type): Value = evalExprFn(t)
+    def call(t: rankn.Type): Value = new Value.FnValue(evalExprFn(t))
   }
 
   def getJavaType(t: rankn.Type): List[Class[_]] = {

--- a/core/src/main/scala/org/bykn/bosatsu/Externals.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/Externals.scala
@@ -39,6 +39,14 @@ object FfiCall {
     def call(t: rankn.Type): Value = evalFn
   }
 
+  final case class ExprFn(wrapper: (LetFreeEvaluation.LetFreeValue, rankn.Type, LetFreeEvaluation.Cache, LetFreeEvaluation.ToLFV) => Any) extends FfiCall {
+    import Value.LetFreeExprFnValue
+
+    private[this] def evalExprFn(t: rankn.Type): LetFreeExprFnValue = LetFreeExprFnValue({ (e1, cache, eval) => Value.ExternalValue(wrapper(e1, t, cache, eval)) })
+
+    def call(t: rankn.Type): Value = evalExprFn(t)
+  }
+
   def getJavaType(t: rankn.Type): List[Class[_]] = {
     def loop(t: rankn.Type, top: Boolean): List[Class[_]] = {
       t match {

--- a/core/src/main/scala/org/bykn/bosatsu/Externals.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/Externals.scala
@@ -40,9 +40,9 @@ object FfiCall {
   }
 
   final case class ExprFn(wrapper: (LetFreeEvaluation.LetFreeValue, rankn.Type, LetFreeEvaluation.Cache, LetFreeEvaluation.ToLFV) => Any) extends FfiCall {
-    import Value.LetFreeExprFnValue
+    import LetFreeEvaluation.ExprFnValue
 
-    private[this] def evalExprFn(t: rankn.Type): LetFreeExprFnValue = LetFreeExprFnValue({ (e1, cache, eval) => Value.ExternalValue(wrapper(e1, t, cache, eval)) })
+    private[this] def evalExprFn(t: rankn.Type): ExprFnValue = ExprFnValue({ (e1, cache, eval) => Value.ExternalValue(wrapper(e1, t, cache, eval)) })
 
     def call(t: rankn.Type): Value = evalExprFn(t)
   }

--- a/core/src/main/scala/org/bykn/bosatsu/LetFreeEvaluation.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/LetFreeEvaluation.scala
@@ -9,7 +9,7 @@ object LetFreeEvaluation {
   case class ComputedValue(value: Value) extends LetFreeValue
 
   case class ExprFnValue(toExprFn: (LetFreeValue, Cache, ToLFV) => Value)
-      extends Value.FnValue {
+      extends FnValueBox {
     val toFn: Value => Value = { v: Value =>
       toExprFn(ComputedValue(v), None, None)
     }
@@ -19,7 +19,7 @@ object LetFreeEvaluation {
       v: Value
   ): Either[(LetFreeValue, Cache, ToLFV) => Value, Value => Value] = v match {
     case fv @ Value.FnValue(f) =>
-      fv match {
+      fv.fnValue match {
         case ExprFnValue(ef) => Left(ef)
         case _               => Right(f)
       }

--- a/core/src/main/scala/org/bykn/bosatsu/LetFreeEvaluation.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/LetFreeEvaluation.scala
@@ -8,6 +8,28 @@ object LetFreeEvaluation {
   sealed trait LetFreeValue {}
   case class ComputedValue(value: Value) extends LetFreeValue
 
+  case class ExprFnValue(toExprFn: (LetFreeValue, Cache, ToLFV) => Value)
+      extends Value.FnValue {
+    val toFn: Value => Value = { v: Value =>
+      toExprFn(ComputedValue(v), None, None)
+    }
+  }
+
+  def attemptExprFn(
+      v: Value
+  ): Either[(LetFreeValue, Cache, ToLFV) => Value, Value => Value] = v match {
+    case fv @ Value.FnValue(f) =>
+      fv match {
+        case ExprFnValue(ef) => Left(ef)
+        case _               => Right(f)
+      }
+    case other =>
+      // $COVERAGE-OFF$this should be unreachable
+      sys.error(s"invalid cast to Fn: $other")
+    // $COVERAGE-ON$
+
+  }
+
   type Cache = Option[CMap[String, (Future[Value], Type)]]
   type ToLFV = Option[LetFreeValue => Future[Value]]
 }

--- a/core/src/main/scala/org/bykn/bosatsu/LetFreeEvaluation.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/LetFreeEvaluation.scala
@@ -9,7 +9,7 @@ object LetFreeEvaluation {
   case class ComputedValue(value: Value) extends LetFreeValue
 
   case class ExprFnValue(toExprFn: (LetFreeValue, Cache, ToLFV) => Value)
-      extends Value.FnValueBox {
+      extends Value.FnValueArg {
     val toFn: Value => Value = { v: Value =>
       toExprFn(ComputedValue(v), None, None)
     }
@@ -19,7 +19,7 @@ object LetFreeEvaluation {
       v: Value
   ): Either[(LetFreeValue, Cache, ToLFV) => Value, Value => Value] = v match {
     case fv @ Value.FnValue(f) =>
-      fv.box match {
+      fv.arg match {
         case ExprFnValue(ef) => Left(ef)
         case _               => Right(f)
       }

--- a/core/src/main/scala/org/bykn/bosatsu/LetFreeEvaluation.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/LetFreeEvaluation.scala
@@ -1,0 +1,13 @@
+package org.bykn.bosatsu
+
+import rankn.Type
+import scala.concurrent.Future
+import scala.collection.concurrent.{Map => CMap}
+
+object LetFreeEvaluation {
+  sealed trait LetFreeValue {}
+  case class ComputedValue(value: Value) extends LetFreeValue
+
+  type Cache = Option[CMap[String, (Future[Value], Type)]]
+  type ToLFV = Option[LetFreeValue => Future[Value]]
+}

--- a/core/src/main/scala/org/bykn/bosatsu/LetFreeEvaluation.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/LetFreeEvaluation.scala
@@ -9,7 +9,7 @@ object LetFreeEvaluation {
   case class ComputedValue(value: Value) extends LetFreeValue
 
   case class ExprFnValue(toExprFn: (LetFreeValue, Cache, ToLFV) => Value)
-      extends FnValueBox {
+      extends Value.FnValueBox {
     val toFn: Value => Value = { v: Value =>
       toExprFn(ComputedValue(v), None, None)
     }
@@ -19,7 +19,7 @@ object LetFreeEvaluation {
       v: Value
   ): Either[(LetFreeValue, Cache, ToLFV) => Value, Value => Value] = v match {
     case fv @ Value.FnValue(f) =>
-      fv.fnValue match {
+      fv.box match {
         case ExprFnValue(ef) => Left(ef)
         case _               => Right(f)
       }

--- a/core/src/main/scala/org/bykn/bosatsu/Value.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/Value.scala
@@ -3,10 +3,6 @@ package org.bykn.bosatsu
 import java.math.BigInteger
 import scala.collection.immutable.SortedMap
 
-trait FnValueBox {
-  def toFn: Value => Value
-}
-
 /**
  * If we later determine that this performance matters
  * and this wrapping is hurting, we could replace
@@ -88,6 +84,10 @@ object Value {
     def apply(variant: Int, value: ProductValue): SumValue =
       if ((value == UnitValue) && ((variant & sizeMask) == 0)) constants(variant)
       else new SumValue(variant, value)
+  }
+
+  trait FnValueBox {
+    def toFn: Value => Value
   }
 
   case class SimpleFnValue(toFn: Value => Value) extends FnValueBox

--- a/core/src/main/scala/org/bykn/bosatsu/Value.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/Value.scala
@@ -86,20 +86,20 @@ object Value {
       else new SumValue(variant, value)
   }
 
-  trait FnValueBox {
+  trait FnValueArg {
     def toFn: Value => Value
   }
 
-  case class SimpleFnValue(toFn: Value => Value) extends FnValueBox
+  case class SimpleFnValue(toFn: Value => Value) extends FnValueArg
 
-  class FnValue(fnValueArg: FnValueBox) extends Value {
-    val box = fnValueArg
+  class FnValue(fnValueArg: FnValueArg) extends Value {
+    val arg = fnValueArg
   }
 
   object FnValue {
     def apply(toFn: Value => Value) = new FnValue(SimpleFnValue(toFn))
 
-    def unapply(fnValue: FnValue): Some[Value => Value] = Some(fnValue.box.toFn)
+    def unapply(fnValue: FnValue): Some[Value => Value] = Some(fnValue.arg.toFn)
 
     val identity: FnValue = FnValue(v => v)
 


### PR DESCRIPTION
I'm starting with the most invasive part of https://github.com/johnynek/bosatsu/pull/488. This creates a Value class that an Evaluator can either treat as a function (`asFn`) or it can pass it a let-free expression for a value so the external function can determine its own strategy for how to produce the output (which may not require full evaluation of the argument Value, eg it may use a cached return value).