### PR TITLE
Add DataRepr to improve factoring of code

### DIFF
--- a/core/src/main/scala/org/bykn/bosatsu/Evaluation.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/Evaluation.scala
@@ -568,19 +568,34 @@ case class Evaluation[T](pm: PackageMap.Typed[T], externals: Externals) {
               case DataRepr.SuccNat =>
                 // We are expecting non-zero
                 val succMatch = itemFns.head
-
-                { (arg: Value) =>
-                  arg match {
-                    case ExternalValue(b: BigInteger) =>
-                      if (b != BigInteger.ZERO) {
-                        succMatch(ExternalValue(b.subtract(BigInteger.ONE)))
-                      }
-                      else None
-                    case other =>
-                      // $COVERAGE-OFF$this should be unreachable
-                      val itemStr = items.mkString("(", ", ", ")")
-                      sys.error(s"ill typed in match (${ctor.asString}$itemStr\n\n$other\n\n")
-                      // $COVERAGE-ON$
+                if (itemsWild) {
+                  { (arg: Value) =>
+                    arg match {
+                      case ExternalValue(b: BigInteger) =>
+                        if (b != BigInteger.ZERO) emptyEnv
+                        else None
+                      case other =>
+                        // $COVERAGE-OFF$this should be unreachable
+                        val itemStr = items.mkString("(", ", ", ")")
+                        sys.error(s"ill typed in match (${ctor.asString}$itemStr\n\n$other\n\n")
+                        // $COVERAGE-ON$
+                    }
+                  }
+                }
+                else {
+                  { (arg: Value) =>
+                    arg match {
+                      case ExternalValue(b: BigInteger) =>
+                        if (b != BigInteger.ZERO) {
+                          succMatch(ExternalValue(b.subtract(BigInteger.ONE)))
+                        }
+                        else None
+                      case other =>
+                        // $COVERAGE-OFF$this should be unreachable
+                        val itemStr = items.mkString("(", ", ", ")")
+                        sys.error(s"ill typed in match (${ctor.asString}$itemStr\n\n$other\n\n")
+                        // $COVERAGE-ON$
+                    }
                   }
                 }
               }

--- a/core/src/main/scala/org/bykn/bosatsu/Evaluation.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/Evaluation.scala
@@ -6,7 +6,7 @@ import org.bykn.bosatsu.graph.Memoize
 import org.bykn.bosatsu.pattern.Matcher
 import java.math.BigInteger
 import org.bykn.bosatsu.pattern.{NamedSeqPattern, Splitter}
-import org.bykn.bosatsu.rankn.{DefinedType, Type}
+import org.bykn.bosatsu.rankn.{DefinedType, Type, DataRepr}
 import scala.collection.mutable.{Map => MMap}
 
 import cats.implicits._
@@ -502,22 +502,61 @@ case class Evaluation[T](pm: PackageMap.Typed[T], externals: Externals) {
              */
             val dt: DefinedType[Any] = definedForCons(pc)
 
-            if (dt.isNewType) {
-              // we erase this entirely, and just match the underlying item
-              itemFns.head
-            }
-            else if (dt.isStruct) {
-              if (itemsWild) anyMatch
-              else
-                // this is a struct, which means we expect it
+            dt.dataRepr(ctor) match {
+              case DataRepr.NewType =>
+                // we erase this entirely, and just match the underlying item
+                itemFns.head
+              case DataRepr.Struct(_) =>
+                if (itemsWild) anyMatch
+                else
+                  // this is a struct, which means we expect it
+                  { (arg: Value) =>
+                    arg match {
+                      case p: ProductValue =>
+                        // this is the pattern
+                        // note passing in a List here we could have union patterns
+                        // if all the pattern bindings were known to be of the same type
+                        processArgs(p.toList)
+
+                      case other =>
+                        // $COVERAGE-OFF$this should be unreachable
+                        val itemStr = items.mkString("(", ", ", ")")
+                        sys.error(s"ill typed in match (${ctor.asString}$itemStr\n\n$other\n\n")
+                        // $COVERAGE-ON$
+                    }
+                  }
+              case DataRepr.Enum(idx, _) =>
+                if (itemsWild)
+                  { (arg: Value) =>
+                    arg match {
+                      case s: SumValue =>
+                        if (s.variant == idx) emptyEnv
+                        else None
+                      case other =>
+                        // $COVERAGE-OFF$this should be unreachable
+                        sys.error(s"ill typed in match: $other")
+                        // $COVERAGE-ON$
+                    }
+                  }
+                else
+                  { (arg: Value) =>
+                    arg match {
+                      case s: SumValue =>
+                        if (s.variant == idx) processArgs(s.value.toList)
+                        else None
+                      case other =>
+                        // $COVERAGE-OFF$this should be unreachable
+                        sys.error(s"ill typed in match: $other")
+                        // $COVERAGE-ON$
+                    }
+                  }
+
+              case DataRepr.ZeroNat =>
                 { (arg: Value) =>
                   arg match {
-                    case p: ProductValue =>
-                      // this is the pattern
-                      // note passing in a List here we could have union patterns
-                      // if all the pattern bindings were known to be of the same type
-                      processArgs(p.toList)
-
+                    case ExternalValue(b: BigInteger) =>
+                      if (b == BigInteger.ZERO) emptyEnv
+                      else None
                     case other =>
                       // $COVERAGE-OFF$this should be unreachable
                       val itemStr = items.mkString("(", ", ", ")")
@@ -525,77 +564,28 @@ case class Evaluation[T](pm: PackageMap.Typed[T], externals: Externals) {
                       // $COVERAGE-ON$
                   }
                 }
-            }
-            else {
-              // compute the index of ctor, so we can compare integers later
-              val idx = dt.constructors.indexWhere(_.name == ctor)
 
-              dt.natLike match {
-                case isz: DefinedType.NatLike.Is =>
-                  // we represent Nats with java BigInteger
-                  val isZero = isz.idxIsZero(idx)
+              case DataRepr.SuccNat =>
+                // We are expecting non-zero
+                val succMatch = itemFns.head
 
-                  if (isZero)
-                    { (arg: Value) =>
-                      arg match {
-                        case ExternalValue(b: BigInteger) =>
-                          if (b == BigInteger.ZERO) emptyEnv
-                          else None
-                        case other =>
-                          // $COVERAGE-OFF$this should be unreachable
-                          val itemStr = items.mkString("(", ", ", ")")
-                          sys.error(s"ill typed in match (${ctor.asString}$itemStr\n\n$other\n\n")
-                          // $COVERAGE-ON$
+                { (arg: Value) =>
+                  arg match {
+                    case ExternalValue(b: BigInteger) =>
+                      if (b != BigInteger.ZERO) {
+                        succMatch(ExternalValue(b.subtract(BigInteger.ONE)))
                       }
-                    }
-                  else {
-                    // We are expecting non-zero
-                    val succMatch = itemFns.head
-
-                    { (arg: Value) =>
-                      arg match {
-                        case ExternalValue(b: BigInteger) =>
-                          if (b != BigInteger.ZERO) {
-                            succMatch(ExternalValue(b.subtract(BigInteger.ONE)))
-                          }
-                          else None
-                        case other =>
-                          // $COVERAGE-OFF$this should be unreachable
-                          val itemStr = items.mkString("(", ", ", ")")
-                          sys.error(s"ill typed in match (${ctor.asString}$itemStr\n\n$other\n\n")
-                          // $COVERAGE-ON$
-                      }
-                    }
+                      else None
+                    case other =>
+                      // $COVERAGE-OFF$this should be unreachable
+                      val itemStr = items.mkString("(", ", ", ")")
+                      sys.error(s"ill typed in match (${ctor.asString}$itemStr\n\n$other\n\n")
+                      // $COVERAGE-ON$
                   }
-                case DefinedType.NatLike.Not =>
-                  if (itemsWild)
-                    { (arg: Value) =>
-                      arg match {
-                        case s: SumValue =>
-                          if (s.variant == idx) emptyEnv
-                          else None
-                        case other =>
-                          // $COVERAGE-OFF$this should be unreachable
-                          sys.error(s"ill typed in match: $other")
-                          // $COVERAGE-ON$
-                      }
-                    }
-                  else
-                    { (arg: Value) =>
-                      arg match {
-                        case s: SumValue =>
-                          if (s.variant == idx) processArgs(s.value.toList)
-                          else None
-                        case other =>
-                          // $COVERAGE-OFF$this should be unreachable
-                          sys.error(s"ill typed in match: $other")
-                          // $COVERAGE-ON$
-                      }
-                    }
+                }
               }
             }
-        }
-      }
+          }
 
   private def evalBranch(
     branches: NonEmptyList[(Pattern[(PackageName, Constructor), Type], TypedExpr[T])],
@@ -710,41 +700,30 @@ case class Evaluation[T](pm: PackageMap.Typed[T], externals: Externals) {
     }
 
   private[this] val zeroNat: Value = ExternalValue(BigInteger.ZERO)
+  private[this] val succNat: Value = {
+    def inc(v: Value): Value = {
+      val bi = v.asExternal.toAny.asInstanceOf[BigInteger]
+      ExternalValue(bi.add(BigInteger.ONE))
+    }
+    FnValue(inc(_))
+  }
 
   private def constructor(c: Constructor, dt: rankn.DefinedType[Any]): Value = {
-    val (enum, arity) = dt.constructors
-      .toList
-      .iterator
-      .zipWithIndex
-      .collectFirst { case (cf, idx) if cf.name == c => (idx, cf.args.size) }
-      .get // the ctor must be in the list or we wouldn't typecheck
-
     // partially erase new-types
     // more advanced new-type erasure would
     // make Apply(Foo, x) into x, but this
     // does not yet do that
-    if (dt.isNewType) FnValue.identity
-    else {
-      val singleItemStruct = dt.isStruct
-
-      dt.natLike match {
-        case isz: DefinedType.NatLike.Is =>
-          // we represent Nats with java BigInteger
-          val isZero = isz.idxIsZero(enum)
-          def inc(v: Value): Value = {
-            val bi = v.asExternal.toAny.asInstanceOf[BigInteger]
-            ExternalValue(bi.add(BigInteger.ONE))
-          }
-          if (isZero) zeroNat
-          else FnValue(inc(_))
-
-        case DefinedType.NatLike.Not =>
-          FnValue.curry(arity) { args =>
-            val prod = ProductValue.fromList(args)
-            if (singleItemStruct) prod
-            else SumValue(enum, prod)
-          }
-      }
+    dt.dataRepr(c) match {
+      case DataRepr.NewType => FnValue.identity
+      case DataRepr.Struct(arity) =>
+        FnValue.curry(arity)(ProductValue.fromList(_))
+      case DataRepr.Enum(variant, arity) =>
+        FnValue.curry(arity) { args =>
+          val prod = ProductValue.fromList(args)
+          SumValue(variant, prod)
+        }
+      case DataRepr.ZeroNat => zeroNat
+      case DataRepr.SuccNat => succNat
     }
   }
 

--- a/core/src/main/scala/org/bykn/bosatsu/rankn/ConstructorFn.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/rankn/ConstructorFn.scala
@@ -17,6 +17,8 @@ final case class ConstructorFn(
       case (_, t0) :: Nil => t == t0
       case _ => false
     }
+
+  def arity: Int = args.length
 }
 
 object ConstructorFn {

--- a/core/src/main/scala/org/bykn/bosatsu/rankn/DataRepr.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/rankn/DataRepr.scala
@@ -1,0 +1,33 @@
+package org.bykn.bosatsu.rankn
+
+/**
+ * How is a non-external data type
+ * represented
+ */
+
+sealed abstract class DataRepr
+
+object DataRepr {
+  sealed abstract class Nat extends DataRepr
+
+  case object ZeroNat extends Nat
+  case object SuccNat extends Nat
+
+  case class Enum(variant: Int, arity: Int) extends DataRepr
+  // a struct with arity 1 can be elided, and is called a new-type
+  case class Struct(arity: Int) extends DataRepr {
+    require(arity != 1)
+  }
+  case object NewType extends DataRepr
+
+  // todo: optimize cases where all enum variants have arity 0
+}
+
+sealed abstract class DataFamily
+
+object DataFamily {
+  case object Nat extends DataFamily
+  case object Enum extends DataFamily
+  case object Struct extends DataFamily
+  case object NewType extends DataFamily
+}


### PR DESCRIPTION
this makes an ADT where we previously had some access functions on DefinedType.

The goal here is to use the same ADTs in the matchless IR #478 and then we should be able to swap out Evaluation
to be an interpreter for the Matchless IR which removes duplication. 