### PR TITLE
Replace Evaluation logic with Matchless

### DIFF
--- a/core/src/main/scala/org/bykn/bosatsu/Evaluation.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/Evaluation.scala
@@ -1,154 +1,14 @@
 package org.bykn.bosatsu
 
 import cats.Eval
-import cats.data.NonEmptyList
-import org.bykn.bosatsu.graph.Memoize
-import org.bykn.bosatsu.pattern.Matcher
-import java.math.BigInteger
-import org.bykn.bosatsu.pattern.{NamedSeqPattern, Splitter}
-import org.bykn.bosatsu.rankn.{DefinedType, Type, DataRepr}
+import org.bykn.bosatsu.rankn.{Type, DataRepr}
 import scala.collection.mutable.{Map => MMap}
 
 import cats.implicits._
 
 import Identifier.{Bindable, Constructor}
 
-object Evaluation {
-  import Value._
-
-  type Env = Map[Bindable, Eval[Value]]
-
-  sealed abstract class Scoped {
-    import Scoped.fromFn
-
-    def inEnv(env: Env): Value
-
-    def letNameIn(name: Bindable, in: Scoped): Scoped =
-      Scoped.Let(name, this, in)
-
-    def branch(fn: (Value, Env) => Value): Scoped =
-      fromFn { env =>
-        val v1 = inEnv(env)
-        fn(v1, env)
-      }
-
-    def asLambda(name: Bindable): Scoped =
-      fromFn { env =>
-        FnValue { v => inEnv(env.updated(name, Eval.now(v))) }
-      }
-
-    def applyArg(arg: Scoped): Scoped =
-      fromFn { env =>
-        val fnE = inEnv(env)
-        val argE = arg.inEnv(env)
-        // safe because we typecheck
-        fnE.asFn(argE)
-      }
-  }
-
-  object Scoped {
-    def const(e: => Value): Scoped = {
-      lazy val computedE = e
-      fromFn(_ => computedE)
-    }
-
-    def fromEnv(identifier: Bindable): Scoped =
-      fromFn { env =>
-        env.get(identifier) match {
-          case Some(e) => e.value
-          case None => sys.error(s"could not find $identifier in the environment with keys: ${env.keys.toList.sorted}")
-        }
-      }
-
-    def recursive(name: Bindable, item: Scoped): Scoped =
-      fromFn { env =>
-        lazy val res: Eval[Value] =
-          Eval.later(item.inEnv(env1))
-        lazy val env1: Env =
-          env.updated(name, res)
-
-        res.value
-      }
-
-
-    private def continueScoped(names: List[Bindable], registers: MMap[Bindable, Value]): Value =
-      FnValue.curry(names.size) { eargs =>
-        var n = names
-        var a = eargs
-        while (n.nonEmpty) {
-          registers(n.head) = a.head
-          n = n.tail
-          a = a.tail
-        }
-
-        null
-      }
-
-    def loop(arg: Bindable, params: List[Bindable], body: Scoped): Scoped = {
-
-      def loopBody(args: List[Bindable])(bodyFn: MMap[Bindable, Value] => Scoped): Scoped =
-        fromFn { env =>
-          var res: Value = null
-          var first = true
-          val registers: MMap[Bindable, Value] =
-            MMap(args.map { a => (a, env(a).value) } :_*)
-
-          val body = bodyFn(registers)
-          while(res eq null) {
-            val e1 =
-              if (!first) {
-                registers.foldLeft(env) { case (e, (k, v)) => e.updated(k, Eval.now(v)) }
-              }
-              else env
-
-            res = body.inEnv(e1)
-            first = false
-          }
-
-          res
-        }
-
-       val bodyScoped = loopBody(params) { regs =>
-         // in the body, we call the continueScoped
-         // to update the mutable variables in the loop
-         // and just return null, above we loop the while
-         // loop with the result is null
-         Scoped.const(Scoped.continueScoped(params, regs))
-           .letNameIn(arg, body)
-       }
-
-       Scoped.fromFn { env =>
-         FnValue.curry(params.size) { eargs =>
-           var n = params
-           var a = eargs
-           var env1 = env
-           while (n.nonEmpty) {
-             env1 = env1.updated(n.head, Eval.now(a.head))
-             n = n.tail
-             a = a.tail
-           }
-           bodyScoped.inEnv(env1)
-         }
-       }
-    }
-
-    private case class Let(name: Bindable, arg: Scoped, in: Scoped) extends Scoped {
-      def inEnv(env: Env) =
-        in.inEnv(env.updated(name, Eval.later(arg.inEnv(env))))
-    }
-
-    private def fromFn(fn: Env => Value): Scoped =
-      FromFn(fn)
-
-    private case class FromFn(fn: Env => Value) extends Scoped {
-      def inEnv(env: Env) = fn(env)
-    }
-  }
-
-}
-
 case class Evaluation[T](pm: PackageMap.Typed[T], externals: Externals) {
-  import Evaluation.{Scoped, Env}
   import Value._
 
   /**
@@ -180,58 +40,51 @@ case class Evaluation[T](pm: PackageMap.Typed[T], externals: Externals) {
     .toMap
   }
 
-  private def constructorEnv(p: Package.Typed[T]): Map[Identifier, Eval[Value]] =
-    p.program
-      .types
-      .allDefinedTypes
-      .iterator
-      .filter(_.packageName == p.name)
-      .flatMap { dt =>
-        dt.constructors.iterator.map { cf =>
-          (cf.name, Eval.later(constructor(cf.name, dt)))
-        }
+  private def evalLets(thisPack: PackageName, lets: List[(Bindable, RecursionKind, TypedExpr[T])]): List[(Bindable, Eval[Value])] = {
+    val exprs: List[(Bindable, Matchless.Expr)] =
+      rankn.RefSpace
+        .allocCounter
+        .flatMap { c =>
+          lets
+            .traverse {
+              case (name, rec, te) =>
+                Matchless.fromLet(name, rec, te, getDataRepr, c)
+                 .map((name, _))
+            }
       }
-      .toMap
+      .run
+      .value
 
-  private def evalLet(let: (Bindable, RecursionKind, TypedExpr[T])): Eval[Value] =
-    // These are added lazily
-    Eval.later {
-      val (name, rec, e) = let
-      val eres = evalLetValue(name, e, rec)(eval)
+    val evalFn: (PackageName, Identifier) => Eval[Value] =
+      { (p, i) =>
+        if (p == thisPack) Eval.defer(evaluate(p)(i))
+        else evaluate(p)(i)
+      }
 
-      eres.inEnv(Map.empty)
-    }
+    type F[A] = List[(Bindable, A)]
+    val ffunc = cats.Functor[List].compose(cats.Functor[(Bindable, ?)])
+    MatchlessToValue.traverse[F](exprs)(evalFn)(ffunc)
+  }
 
-  private def evaluate(pack: Package.Typed[T]): Map[Identifier, Eval[Value]] =
-    envCache.getOrElseUpdate(pack.name, {
-      constructorEnv(pack) ++
-      externalEnv(pack) ++
-      pack.program.lets.iterator.map { case brt@(name, _, _) =>
-          // there are no free variables at the top level
-          (name, evalLet(brt))
-        }
+  private def evaluate(packName: PackageName): Map[Identifier, Eval[Value]] =
+    envCache.getOrElseUpdate(packName, {
+      val pack = pm.toMap(packName)
+      externalEnv(pack) ++ evalLets(packName, pack.program.lets)
     })
-
-  private def getValue(pack: Package.Typed[T], name: Identifier): Eval[Value] =
-    evaluate(pack)
-      .get(name)
-      // error shouldn't happen due to typechecking
-      .getOrElse(sys.error(s"unknown value: $name in ${pack.name}"))
 
   def evaluateLast(p: PackageName): Option[(Eval[Value], Type)] =
     for {
       pack <- pm.toMap.get(p)
       (name, _, tpe) <- pack.program.lets.lastOption
-      value <- evaluate(pack).get(name)
+      value <- evaluate(p).get(name)
     } yield (value, tpe.getType)
 
-  // TODO: this only works for lets, not externals, constructors or imports
-  // so, the name should be a Bindable and the name should be evaluateLet
-  def evaluateName(p: PackageName, name: Identifier): Option[(Eval[Value], Type)] =
+  // TODO: this only works for lets, not externals
+  def evaluateName(p: PackageName, name: Bindable): Option[(Eval[Value], Type)] =
     for {
       pack <- pm.toMap.get(p)
       (_, _, tpe) <- pack.program.lets.filter { case (n, _, _) => n == name }.lastOption
-      value <- evaluate(pack).get(name)
+      value <- evaluate(p).get(name)
     } yield (value, tpe.getType)
 
   /**
@@ -243,7 +96,7 @@ case class Evaluation[T](pm: PackageMap.Typed[T], externals: Externals) {
     for {
       pack <- pm.toMap.get(p)
       name <- pack.program.lets.collect { case (name, _, te) if te.getType == Type.TestType => name }.lastOption
-      value <- evaluate(pack).get(name)
+      value <- evaluate(p).get(name)
     } yield value
 
   /* TODO: this is useful for debugging, but we should probably test it and write a parser for the
@@ -320,428 +173,6 @@ case class Evaluation[T](pm: PackageMap.Typed[T], externals: Externals) {
             throw new IllegalStateException(s"could not find $cons in ${pack.program.types}")
             // $COVERAGE-ON$
         }
-  }
-
-
-  private type Ref = TypedExpr[T]
-
-  private type Pat = Pattern[(PackageName, Constructor), Type]
-
-  private val emptyEnv: Option[Env] = Some(Map.empty)
-
-  private val anyMatch: Any => Option[Env] =
-    { a: Any => emptyEnv }
-
-  private val neverMatch: Any => Option[Env] =
-    { a: Any => None }
-
-  private lazy val patListSplitter =
-    Splitter.listSplitter(patternMatcher)(
-      new cats.Monoid[Env] {
-        val empty = Map.empty[Bindable, Eval[Value]]
-
-        def combine(left: Env, right: Env) = left ++ right
-
-        override def combineAll(vs: TraversableOnce[Env]) = {
-          val eb = Map.newBuilder[Bindable, Eval[Value]]
-          vs.foreach(eb ++= _)
-          eb.result
-        }
-      })
-
-  private lazy val patternMatcher: Matcher[Pat, Value, Env] =
-    new Matcher[Pat, Value, Env] { self =>
-      def apply(pat: Pat): Value => Option[Env] =
-        pat match {
-          case Pattern.WildCard => anyMatch
-          case Pattern.Literal(lit) =>
-            val vlit = Value.fromLit(lit)
-
-            { v => if (v == vlit) emptyEnv else None }
-          case Pattern.Var(n) =>
-
-            { v => Some(Map.empty.updated(n, Eval.now(v))) }
-          case Pattern.Named(n, p) =>
-            val inner = self(p)
-
-            { v =>
-              inner(v) match {
-                case None => None
-                case Some(env1) => Some(env1.updated(n, Eval.now(v)))
-              }
-            }
-          case pat@Pattern.StrPat(_) =>
-            if (pat.names.isEmpty) {
-              // we can just use the simple matcher
-              { v =>
-                // this casts should be safe if we have typechecked
-                val str = v.asExternal.toAny.asInstanceOf[String]
-                if (pat.matches(str)) emptyEnv
-                else None
-              }
-            }
-            else {
-              val spat = pat.toNamedSeqPattern
-              val nameMap = spat.names.map { n =>
-                (n, Identifier.unsafeBindable(n))
-              }.toMap
-
-              val matcher = NamedSeqPattern.matcher[Char, Char, String, String](Splitter.stringSplitter(_.toString))(spat)
-
-              { v =>
-                // this casts should be safe if we have typechecked
-                val str = v.asExternal.toAny.asInstanceOf[String]
-                matcher(str).map { _._2.map { case (k, v) => (nameMap(k), Eval.now(ExternalValue(v))) } }
-              }
-            }
-          case lp@Pattern.ListPat(items) =>
-            val lpat = lp.toNamedSeqPattern
-
-            if (lp.names.isEmpty) {
-              // this is a cheaper operation
-              val matcher = NamedSeqPattern.matcher[Pat, Value, List[Value], Unit](
-                Splitter.listSplitter(self.map(_ => ()))
-              )
-              val fn = matcher(lpat)
-
-              {
-                case VList(vs) => if (fn(vs).isDefined) emptyEnv else None
-                case _ => None
-              }
-            }
-            else {
-              val nameMap = lpat.names.map { n =>
-                (n, Identifier.unsafe(n))
-              }.toMap
-
-              val fn: List[Value] => Option[Env] =
-                (NamedSeqPattern.matcher[Pattern[(PackageName, Constructor), Type], Value, List[Value], Env](patListSplitter)
-                  .map { case (env0, captures) =>
-                    captures.foldLeft(env0) { case (env0, (k, listV)) =>
-                      env0.updated(Identifier.unsafeBindable(k), Eval.now(VList(listV)))
-                    }
-                  })(lpat)
-
-                {
-                  case VList(vs) => fn(vs)
-                  case other =>
-                    //$COVERAGE-OFF$
-                    sys.error(s"ill-typed, expected list: $other")
-                    //$COVERAGE-ON$
-                }
-            }
-          case Pattern.Annotation(p, _) =>
-            // we don't need types to match patterns once we have fully resolved constructors
-            self(p)
-          case u@Pattern.Union(_, _) =>
-            // we can just loop expanding these out:
-            def loop(ps: List[Pattern[(PackageName, Constructor), Type]]): Value => Option[Env] =
-              ps match {
-                case Nil => neverMatch
-                case head :: tail =>
-                  val fnh = self(head)
-                  val fnt = loop(tail)
-
-                  { arg =>
-                    val rh = fnh(arg)
-                    if (rh.isDefined) rh
-                    else fnt(arg)
-                  }
-              }
-            loop(Pattern.flatten(u).toList)
-          case Pattern.PositionalStruct(pc@(_, ctor), items) =>
-            def definedForCons(pc: (PackageName, Constructor)): DefinedType[Any] =
-              pm.toMap(pc._1).program.types.getConstructor(pc._1, pc._2).get._2
-
-            val itemFns = items.map(self(_))
-
-            /*
-             * Return true if this matches everything that would typecheck and does
-             * not introduce new bindings
-             */
-            def isTotalNonBinding(p: Pattern[(PackageName, Constructor), Type]): Boolean =
-              p match {
-                case Pattern.WildCard => true
-                case Pattern.Annotation(p, _) => isTotalNonBinding(p)
-                case Pattern.PositionalStruct(pc, parts) =>
-                  definedForCons(pc).isStruct && parts.forall(isTotalNonBinding)
-                case Pattern.AnyList => true
-                case _ => false
-              }
-            val itemsWild = items.forall(isTotalNonBinding)
-
-            def processArgs(as: List[Value]): Option[Env] = {
-              // manually write out foldM hoping for performance improvements
-              @annotation.tailrec
-              def loop(vs: List[Value], fns: List[Value => Option[Env]], acc: Env): Option[Env] =
-                vs match {
-                  case Nil => Some(acc)
-                  case vh :: vt =>
-                    fns match {
-                      case fh :: ft =>
-                        fh(vh) match {
-                          case None => None
-                          case Some(env1) => loop(vt, ft, acc ++ env1)
-                        }
-                      case Nil =>
-                        // $COVERAGE-OFF$
-                        sys.error(s"mismatch in size, shouldn't happen, statically: $as, $fns")
-                        // $COVERAGE-ON$
-                    }
-                }
-              loop(as, itemFns, Map.empty)
-            }
-
-            /*
-             * The type in question is not the outer dt, but the type associated
-             * with this current constructor
-             */
-            val dt: DefinedType[Any] = definedForCons(pc)
-
-            dt.dataRepr(ctor) match {
-              case DataRepr.NewType =>
-                // we erase this entirely, and just match the underlying item
-                itemFns.head
-              case DataRepr.Struct(_) =>
-                if (itemsWild) anyMatch
-                else
-                  // this is a struct, which means we expect it
-                  { (arg: Value) =>
-                    arg match {
-                      case p: ProductValue =>
-                        // this is the pattern
-                        // note passing in a List here we could have union patterns
-                        // if all the pattern bindings were known to be of the same type
-                        processArgs(p.toList)
-
-                      case other =>
-                        // $COVERAGE-OFF$this should be unreachable
-                        val itemStr = items.mkString("(", ", ", ")")
-                        sys.error(s"ill typed in match (${ctor.asString}$itemStr\n\n$other\n\n")
-                        // $COVERAGE-ON$
-                    }
-                  }
-              case DataRepr.Enum(idx, _) =>
-                if (itemsWild)
-                  { (arg: Value) =>
-                    arg match {
-                      case s: SumValue =>
-                        if (s.variant == idx) emptyEnv
-                        else None
-                      case other =>
-                        // $COVERAGE-OFF$this should be unreachable
-                        sys.error(s"ill typed in match: $other")
-                        // $COVERAGE-ON$
-                    }
-                  }
-                else
-                  { (arg: Value) =>
-                    arg match {
-                      case s: SumValue =>
-                        if (s.variant == idx) processArgs(s.value.toList)
-                        else None
-                      case other =>
-                        // $COVERAGE-OFF$this should be unreachable
-                        sys.error(s"ill typed in match: $other")
-                        // $COVERAGE-ON$
-                    }
-                  }
-
-              case DataRepr.ZeroNat =>
-                { (arg: Value) =>
-                  arg match {
-                    case ExternalValue(b: BigInteger) =>
-                      if (b == BigInteger.ZERO) emptyEnv
-                      else None
-                    case other =>
-                      // $COVERAGE-OFF$this should be unreachable
-                      val itemStr = items.mkString("(", ", ", ")")
-                      sys.error(s"ill typed in match (${ctor.asString}$itemStr\n\n$other\n\n")
-                      // $COVERAGE-ON$
-                  }
-                }
-
-              case DataRepr.SuccNat =>
-                // We are expecting non-zero
-                val succMatch = itemFns.head
-                if (itemsWild) {
-                  { (arg: Value) =>
-                    arg match {
-                      case ExternalValue(b: BigInteger) =>
-                        if (b != BigInteger.ZERO) emptyEnv
-                        else None
-                      case other =>
-                        // $COVERAGE-OFF$this should be unreachable
-                        val itemStr = items.mkString("(", ", ", ")")
-                        sys.error(s"ill typed in match (${ctor.asString}$itemStr\n\n$other\n\n")
-                        // $COVERAGE-ON$
-                    }
-                  }
-                }
-                else {
-                  { (arg: Value) =>
-                    arg match {
-                      case ExternalValue(b: BigInteger) =>
-                        if (b != BigInteger.ZERO) {
-                          succMatch(ExternalValue(b.subtract(BigInteger.ONE)))
-                        }
-                        else None
-                      case other =>
-                        // $COVERAGE-OFF$this should be unreachable
-                        val itemStr = items.mkString("(", ", ", ")")
-                        sys.error(s"ill typed in match (${ctor.asString}$itemStr\n\n$other\n\n")
-                        // $COVERAGE-ON$
-                    }
-                  }
-                }
-              }
-            }
-          }
-
-  private def evalBranch(
-    branches: NonEmptyList[(Pattern[(PackageName, Constructor), Type], TypedExpr[T])],
-    recurse: Ref => Scoped): (Value, Env) => Value = {
-
-      def bindEnv[E](branches: List[(Pattern[(PackageName, Constructor), Type], E)]): (Value, Env) => (Env, E) =
-        branches match {
-          case Nil =>
-            // This is ruled out by typechecking, we know all our matches are total
-            // $COVERAGE-OFF$this should be unreachable
-            { (arg, env) =>
-              sys.error(s"non-total match: arg: $arg, branches: $branches")
-            }
-            // $COVERAGE-ON$
-          case (p, e) :: tail =>
-            val pfn = patternMatcher(p)
-            val fntail = bindEnv(tail)
-
-            { (arg, env) =>
-              pfn(arg) match {
-                case Some(env1) => (env ++ env1, e)
-                case None => fntail(arg, env)
-              }
-            }
-        }
-
-      // recurse on all the branches:
-      val compiledBranches = branches.map { case (pattern, branch) =>
-        (pattern, recurse(branch))
-      }
-      val bindFn = bindEnv(compiledBranches.toList)
-
-      /*
-       * Now we have fully compiled all the branches and eliminated a certain amount of runtime
-       * cost of handling pattern matching
-       */
-      { (arg, env) =>
-        val (localEnv, next) = bindFn(arg, env)
-        next.inEnv(localEnv)
-      }
-    }
-
-  private def evalLetValue(arg: Bindable, e: TypedExpr[T], rec: RecursionKind)(eval: Ref => Scoped): Scoped = {
-    lazy val e0 = eval(e)
-    if (rec.isRecursive) {
-      // this could be tail recursive
-      if (TypedExpr.selfCallKind(arg, e) == TypedExpr.SelfCallKind.TailCall) {
-        val arity = Type.Fun.arity(e.getType)
-        TypedExpr.toArgsBody(arity, e) match {
-          case Some((params, body)) =>
-            Scoped.loop(arg, params.map(_._1), eval(body))
-          case None =>
-            // TODO: I don't think this case should ever happen
-            Scoped.recursive(arg, e0)
-        }
-      }
-      else Scoped.recursive(arg, e0)
-    }
-    else e0
-  }
-
-  /**
-   * TODO, expr is a TypedExpr so we already know the type. returning it does not do any good that I
-   * can see.
-   */
-  private def evalTypedExpr(expr: TypedExpr[T], recurse: Ref => Scoped): Scoped = {
-
-    import TypedExpr._
-
-     expr match {
-       case Generic(_, e, _) =>
-         // types aren't needed to evaluate
-         evalTypedExpr(e, recurse)
-       case Annotation(e, _, _) =>
-         // types aren't needed to evaluate
-         evalTypedExpr(e, recurse)
-       case Local(ident, _, _) =>
-         Scoped.fromEnv(ident)
-       case Global(p, ident, _, _) =>
-         val pack = pm.toMap.get(p).getOrElse(sys.error(s"cannot find $p, shouldn't happen due to typechecking"))
-         // const is lazy so this won't run until needed
-         Scoped.const(getValue(pack, ident).value)
-       case App(fn, arg, _, _) =>
-         val efn = recurse(fn)
-         val earg = recurse(arg)
-
-         efn.applyArg(earg)
-       case AnnotatedLambda(name, _, expr, _) =>
-         recurse(expr).asLambda(name)
-       case l@Let(arg, e, in, rec, _) =>
-         val eres = evalLetValue(arg, e, rec)(recurse)
-         val inres = recurse(in)
-
-         eres.letNameIn(arg, inres)
-       case Literal(lit, _, _) =>
-         Scoped.const(Value.fromLit(lit))
-       case Match(arg, branches, _) =>
-         val argR = recurse(arg)
-         val branchR = evalBranch(branches, recurse)
-
-         argR.branch(branchR(_, _))
-    }
-  }
-
-  /**
-   * We only call this on typechecked names, which means we know
-   * that names resolve
-   */
-  private[this] val eval: Ref => Scoped =
-    Memoize.memoizeDagHashedConcurrent[Ref, Scoped] {
-      (expr, recurse) => evalTypedExpr(expr, recurse)
-    }
-
-  private[this] val zeroNat: Value = ExternalValue(BigInteger.ZERO)
-  private[this] val succNat: Value = {
-    def inc(v: Value): Value = {
-      val bi = v.asExternal.toAny.asInstanceOf[BigInteger]
-      ExternalValue(bi.add(BigInteger.ONE))
-    }
-    FnValue(inc(_))
-  }
-
-  private def constructor(c: Constructor, dt: rankn.DefinedType[Any]): Value = {
-    // partially erase new-types
-    // more advanced new-type erasure would
-    // make Apply(Foo, x) into x, but this
-    // does not yet do that
-    dt.dataRepr(c) match {
-      case DataRepr.NewType => FnValue.identity
-      case DataRepr.Struct(arity) =>
-        if (arity == 0) UnitValue
-        else FnValue.curry(arity)(ProductValue.fromList(_))
-      case DataRepr.Enum(variant, arity) =>
-        if (arity == 0) SumValue(variant, UnitValue)
-        else if (arity == 1) {
-          FnValue { v => SumValue(variant, ConsValue(v, UnitValue)) }
-        }
-        else
-          FnValue.curry(arity) { args =>
-            val prod = ProductValue.fromList(args)
-            SumValue(variant, prod)
-          }
-      case DataRepr.ZeroNat => zeroNat
-      case DataRepr.SuccNat => succNat
-    }
   }
 
   /**

--- a/core/src/main/scala/org/bykn/bosatsu/Identifier.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/Identifier.scala
@@ -113,6 +113,9 @@ object Identifier {
   def unsafe(str: String): Identifier =
     unsafeParse(parser, str)
 
+  def unsafeBindable(str: String): Bindable =
+    unsafeParse(bindableParser, str)
+
   def unsafeParse[A <: Identifier](pa: P[A], str: String): A =
     pa.parse(str) match {
       case Parsed.Success(ident, idx) if idx == str.length =>

--- a/core/src/main/scala/org/bykn/bosatsu/Lit.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/Lit.scala
@@ -12,10 +12,16 @@ sealed abstract class Lit {
       case Lit.Integer(i) => i.toString
       case Lit.Str(s) => "\"" + escape('"', s) + "\""
     }
+
+  def unboxToAny: Any
 }
 object Lit {
-  case class Integer(toBigInteger: BigInteger) extends Lit
-  case class Str(toStr: String) extends Lit
+  case class Integer(toBigInteger: BigInteger) extends Lit {
+    def unboxToAny: Any = toBigInteger
+  }
+  case class Str(toStr: String) extends Lit {
+    def unboxToAny: Any = toStr
+  }
 
   val EmptyStr: Str = Str("")
 

--- a/core/src/main/scala/org/bykn/bosatsu/Matchless.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/Matchless.scala
@@ -89,7 +89,7 @@ object Matchless {
 
   // string matching is complex done at a lower level
   // return a variant of either value 0, no match, or 1 with
-  // todo: we should probably make this be like SearchList and be explicit
+  // TODO: we should probably make this be like SearchList and be explicit
   // about the algorithm rather than hiding it and requiring an allocation
   // here.
   case class MatchString(arg: CheapExpr, parts: List[StrPart], binds: Int) extends Expr

--- a/core/src/main/scala/org/bykn/bosatsu/Matchless.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/Matchless.scala
@@ -22,8 +22,9 @@ object Matchless {
 
   sealed abstract class StrPart
   object StrPart {
-    case object WildStr extends StrPart
-    case object IndexStr extends StrPart
+    sealed abstract class Glob(val capture: Boolean) extends StrPart
+    case object WildStr extends Glob(false)
+    case object IndexStr extends Glob(true)
     case class LitStr(asString: String) extends StrPart
   }
 

--- a/core/src/main/scala/org/bykn/bosatsu/MatchlessToValue.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/MatchlessToValue.scala
@@ -1,0 +1,303 @@
+package org.bykn.bosatsu
+
+import cats.Eval
+import java.math.BigInteger
+import java.util.regex
+import org.bykn.bosatsu.graph.Memoize.memoizeHashedConcurrent
+import scala.collection.immutable.LongMap
+import scala.collection.mutable.{LongMap => MLongMap, Map => MMap}
+
+import Identifier.Bindable
+import Value._
+
+object MatchlessToValue {
+  import Matchless._
+
+  def apply(me: Expr)(resolve: (PackageName, Identifier) => Value): Value = {
+    val scope = new Scope(resolve)
+    scope.loop(me, Map.empty, LongMap.empty)
+  }
+
+  private[this] val zeroNat: Value = ExternalValue(BigInteger.ZERO)
+  private[this] val succNat: Value = {
+    def inc(v: Value): Value = {
+      val bi = v.asExternal.toAny.asInstanceOf[BigInteger]
+      ExternalValue(bi.add(BigInteger.ONE))
+    }
+    FnValue(inc(_))
+  }
+
+  def makeCons(c: ConsExpr): Value =
+    c match {
+      case MakeEnum(variant, arity) =>
+        if (arity == 0) SumValue(variant, UnitValue)
+        else if (arity == 1) {
+          FnValue { v => SumValue(variant, ConsValue(v, UnitValue)) }
+        }
+        else
+          FnValue.curry(arity) { args =>
+            val prod = ProductValue.fromList(args)
+            SumValue(variant, prod)
+          }
+      case MakeStruct(arity) =>
+        if (arity == 0) UnitValue
+        else if (arity == 1) FnValue.identity
+        else FnValue.curry(arity)(ProductValue.fromList(_))
+      case ZeroNat => zeroNat
+      case SuccNat => succNat
+    }
+
+  // this should be scoped to allow GC
+  val toRegex: List[StrPart] => regex.Pattern =
+    memoizeHashedConcurrent { parts: List[StrPart] =>
+      val strPattern = parts.map {
+        case StrPart.WildStr => "(?:.*)"
+        case StrPart.IndexStr => "(.*)"
+        case StrPart.LitStr(s) =>
+
+          def wrap(s: String): String =
+            if (s.isEmpty) ""
+            else "\\Q" + s + "\\E"
+
+          def escape(s: String): String = {
+            val slashE = s.indexOf("\\E")
+            if (slashE < 0) wrap(s)
+            else {
+              val head = wrap(s.substring(0, slashE))
+              val quoteSlash = "\\\\E"
+              val tail = wrap(s.substring(slashE + 2))
+              head + quoteSlash + tail
+            }
+          }
+
+          escape(s)
+      }
+      .mkString
+
+      regex.Pattern.compile(strPattern)
+    }
+
+  private class Scope(resolve: (PackageName, Identifier) => Value) {
+    val muts: MLongMap[Value] = MLongMap()
+
+    def newScope(): Scope = new Scope(resolve)
+
+    // evaluating intExpr can mutate an existing value in muts
+    private def intExpr(ix: IntExpr, locals: Map[Bindable, Eval[Value]], anon: LongMap[Value]): Int =
+      ix match {
+        case EqualsLit(expr, lit) =>
+          val left = loop(expr, locals, anon)
+            .asExternal
+            .toAny
+
+          if (left == lit.unboxToAny) 1
+          else 0
+        case EqualsInt(iexpr, v) =>
+          if (intExpr(iexpr, locals, anon) == v) 1
+          else 0
+        case EqualsNat(nat, zeroOrSucc) =>
+          val natBI = loop(nat, locals, anon).asExternal.toAny
+          val eqZero = natBI == BigInteger.ZERO
+          val isZero = zeroOrSucc.isZero
+          val zeroTrue = isZero && eqZero
+          val oneTrue = !(isZero || eqZero)
+          if (zeroTrue || oneTrue) 1
+          else 0
+
+        case AndInt(ix1, ix2) =>
+          val i1 = intExpr(ix1, locals, anon)
+          // we should be lazy
+          if (i1 == 0) 0
+          else intExpr(ix2, locals, anon)
+        case GetVariant(enumV) =>
+          loop(enumV, locals, anon).asSum.variant
+
+        case SearchList(LocalAnonMut(mutV), init, check, None) =>
+          var res = -1
+          var currentList = loop(init, locals, anon)
+          while (res < 0) {
+            muts.put(mutV, currentList)
+            // todo we have to redo this check
+            // each time, we should have intExpr return Registers => Int
+            // so we can just re-apply it on new registers
+            res = intExpr(check, locals, anon)
+            if (res == 0) {
+              currentList match {
+                case VList.Cons(_, tail) =>
+                  currentList = tail
+                case _ =>
+                  // we are done, we never matched
+              }
+            }
+          }
+          res
+        case SearchList(LocalAnonMut(mutV), init, check, Some(LocalAnonMut(left))) =>
+          var res = -1
+          var currentList = loop(init, locals, anon)
+          var leftList = VList.VNil
+          while (res < 0) {
+            muts.put(mutV, currentList)
+            muts.put(left, leftList)
+            // todo we have to redo this check
+            // each time, we should have intExpr return Registers => Int
+            // so we can just re-apply it on new registers
+            res = intExpr(check, locals, anon)
+            if (res == 0) {
+              currentList match {
+                case VList.Cons(head, tail) =>
+                  currentList = tail
+                  leftList = VList.Cons(head, leftList)
+                case _ =>
+                  // we are done, we never matched
+              }
+            }
+          }
+          res
+      }
+
+    // the locals can be recusive, so we box into Eval for laziness
+    def loop(me: Expr, locals: Map[Bindable, Eval[Value]], anon: LongMap[Value]): Value =
+      me match {
+        case Lambda(caps, arg, res) =>
+          val capLocal = caps.iterator.map { b => (b, locals(b)) }.toMap
+          FnValue { argV =>
+            // hopefully optimization/normalization has lifted anything
+            // that doesn't depend on argV above this lambda
+            newScope().loop(res, capLocal, LongMap.empty)
+          }
+        case LoopFn(caps, thisName, argshead, argstail, body) =>
+          val capLocal = caps.iterator.map { b => (b, locals(b)) }.toMap
+          FnValue.curry(argstail.length + 1) { allArgs =>
+            val registers = MMap[Bindable, Value]()
+
+            def setRegisters(values: List[Value]): Unit = {
+              registers.put(argshead, values.head)
+              var mutArgsTail = argstail
+              var mutArgs = values.tail
+              while (mutArgsTail.nonEmpty) {
+                registers.put(mutArgsTail.head, mutArgs.head)
+                mutArgsTail = mutArgsTail.tail
+                mutArgs = mutArgs.tail
+              }
+            }
+
+            // the registers are set up
+            // when we recur, that is a continue on the loop,
+            // we just update the registers and return null
+            val continueFn = FnValue.curry(argstail.length + 1) { continueArgs =>
+              setRegisters(continueArgs)
+              null
+            }
+
+            val locals1 = locals.updated(thisName, Eval.now(continueFn))
+
+            def readRegisters(): Map[Bindable, Eval[Value]] = {
+              val it = registers.iterator
+              var loc = locals1
+              while (it.hasNext) {
+                val (b, v) = it.next()
+                loc = loc.updated(b, Eval.now(v))
+              }
+              loc
+            }
+
+            var res: Value = null
+            val scope = newScope()
+            while (res eq null) {
+              // read the registers into the environment
+              val loc = readRegisters()
+              res = scope.loop(body, loc, LongMap.empty)
+            }
+
+            res
+          }
+
+        case Global(p, n) => resolve(p, n)
+        case Local(b) => locals(b).value
+        case LocalAnon(a) => anon(a)
+        case LocalAnonMut(m) => muts(m)
+        case App(expr, args) =>
+          @annotation.tailrec
+          def app(fn: Value => Value, head: Expr, tail: List[Expr]): Value = {
+            val ha = loop(head, locals, anon)
+            val res = fn(ha)
+            tail match {
+              case Nil => res
+              case h :: tail =>
+                app(res.asFn, h, tail)
+            }
+          }
+
+          val fn = loop(expr, locals, anon)
+          app(fn.asFn, args.head, args.tail)
+        case Let(localOrBind, value, in) =>
+          localOrBind match {
+            case Right((b, rec)) =>
+              if (rec.isRecursive) {
+
+                lazy val locals1: Map[Bindable, Eval[Value]] =
+                  locals.updated(b, vv)
+
+                lazy val vv = Eval.later(loop(value, locals1, anon))
+
+                loop(in, locals1, anon)
+              }
+              else {
+                val vv = Eval.now(loop(value, locals, anon))
+                loop(in, locals.updated(b, vv), anon)
+              }
+            case Left(LocalAnon(l)) =>
+              val vv = loop(value, locals, anon)
+              loop(in, locals, anon.updated(l, vv))
+            case Left(LocalAnonMut(l)) =>
+              val vv = loop(value, locals, anon)
+              muts.put(l, vv)
+              val res = loop(in, locals, anon)
+              // now we can remove this from mutable scope
+              muts.remove(l)
+              res
+          }
+        case Literal(lit) => Value.fromLit(lit)
+        case If(cond, thenExpr, elseExpr) =>
+          if (intExpr(cond, locals, anon) == 0) loop(elseExpr, locals, anon)
+          else loop(thenExpr, locals, anon)
+
+        case MatchString(str, pat, binds) =>
+          val arg = loop(str, locals, anon).asExternal.toAny.asInstanceOf[String]
+          matchString(arg, toRegex(pat), binds)
+        case GetEnumElement(expr, v, idx, sz) =>
+          val sum = loop(expr, locals, anon).asSum
+          sum.value.get(idx)
+
+        case GetStructElement(expr, idx, sz) =>
+          val prod = loop(expr, locals, anon).asProduct
+          prod.get(idx)
+        case PrevNat(expr) =>
+          val anyBI = loop(expr, locals, anon).asExternal.toAny
+          val bi = anyBI.asInstanceOf[BigInteger]
+          ExternalValue(bi.subtract(BigInteger.ONE))
+        case cons: ConsExpr => makeCons(cons)
+      }
+
+    def matchString(str: String, pat: regex.Pattern, binds: Int): SumValue = {
+      val m = pat.matcher(str)
+      if (m.matches()) {
+        if (binds == 0) Value.True
+        else {
+          var idx = binds
+          var prod: ProductValue = UnitValue
+          while (0 < idx) {
+            val item = m.group(idx)
+            idx = idx - 1
+            prod = ConsValue(ExternalValue(item), prod)
+          }
+          SumValue(1, prod)
+        }
+      }
+      else {
+        // this is (0, UnitValue)
+        Value.False
+      }
+    }
+  }
+}

--- a/core/src/main/scala/org/bykn/bosatsu/MatchlessToValue.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/MatchlessToValue.scala
@@ -5,7 +5,7 @@ import java.math.BigInteger
 import java.util.regex
 import org.bykn.bosatsu.graph.Memoize.memoizeHashedConcurrent
 import scala.collection.immutable.LongMap
-import scala.collection.mutable.{LongMap => MLongMap, Map => MMap}
+import scala.collection.mutable.{LongMap => MLongMap}
 
 import Identifier.Bindable
 import Value._
@@ -14,8 +14,9 @@ object MatchlessToValue {
   import Matchless._
 
   def apply(me: Expr)(resolve: (PackageName, Identifier) => Value): Value = {
-    val scope = new Scope(resolve)
-    scope.loop(me, Map.empty, LongMap.empty)
+    val scope = new Impl.Env(resolve)
+    val fn = scope.loop(me)
+    fn(Impl.Scope.empty)
   }
 
   private[this] val zeroNat: Value = ExternalValue(BigInteger.ZERO)
@@ -47,256 +48,351 @@ object MatchlessToValue {
       case SuccNat => succNat
     }
 
-  // this should be scoped to allow GC
-  val toRegex: List[StrPart] => regex.Pattern =
-    memoizeHashedConcurrent { parts: List[StrPart] =>
-      val strPattern = parts.map {
-        case StrPart.WildStr => "(?:.*)"
-        case StrPart.IndexStr => "(.*)"
-        case StrPart.LitStr(s) =>
+  private object Impl {
+    final case class Scope(
+      locals: Map[Bindable, Eval[Value]],
+      anon: LongMap[Value],
+      muts: MLongMap[Value]) {
 
-          def wrap(s: String): String =
-            if (s.isEmpty) ""
-            else "\\Q" + s + "\\E"
+      def let(b: Bindable, v: Eval[Value]): Scope =
+        copy(locals = locals.updated(b, v))
 
-          def escape(s: String): String = {
-            val slashE = s.indexOf("\\E")
-            if (slashE < 0) wrap(s)
-            else {
-              val head = wrap(s.substring(0, slashE))
-              val quoteSlash = "\\\\E"
-              val tail = wrap(s.substring(slashE + 2))
-              head + quoteSlash + tail
-            }
-          }
-
-          escape(s)
-      }
-      .mkString
-
-      regex.Pattern.compile(strPattern)
+      def capture(it: Iterable[Bindable]): Scope =
+        Scope(
+          it.iterator.map { b => (b, locals(b)) }.toMap,
+            LongMap.empty,
+            MLongMap())
     }
 
-  private class Scope(resolve: (PackageName, Identifier) => Value) {
-    val muts: MLongMap[Value] = MLongMap()
+    object Scope {
+      def empty(): Scope = Scope(Map.empty, LongMap.empty, MLongMap())
+    }
 
-    def newScope(): Scope = new Scope(resolve)
+    class Env(resolve: (PackageName, Identifier) => Value) {
+      val toRegex: List[StrPart] => regex.Pattern =
+        memoizeHashedConcurrent { parts: List[StrPart] =>
+          val strPattern = parts.map {
+            case StrPart.WildStr => "(?:.*)"
+            case StrPart.IndexStr => "(.*)"
+            case StrPart.LitStr(s) =>
 
-    // evaluating intExpr can mutate an existing value in muts
-    private def intExpr(ix: IntExpr, locals: Map[Bindable, Eval[Value]], anon: LongMap[Value]): Int =
-      ix match {
-        case EqualsLit(expr, lit) =>
-          val left = loop(expr, locals, anon)
-            .asExternal
-            .toAny
+              def wrap(s: String): String =
+                if (s.isEmpty) ""
+                else "\\Q" + s + "\\E"
 
-          if (left == lit.unboxToAny) 1
-          else 0
-        case EqualsInt(iexpr, v) =>
-          if (intExpr(iexpr, locals, anon) == v) 1
-          else 0
-        case EqualsNat(nat, zeroOrSucc) =>
-          val natBI = loop(nat, locals, anon).asExternal.toAny
-          val eqZero = natBI == BigInteger.ZERO
-          val isZero = zeroOrSucc.isZero
-          val zeroTrue = isZero && eqZero
-          val oneTrue = !(isZero || eqZero)
-          if (zeroTrue || oneTrue) 1
-          else 0
-
-        case AndInt(ix1, ix2) =>
-          val i1 = intExpr(ix1, locals, anon)
-          // we should be lazy
-          if (i1 == 0) 0
-          else intExpr(ix2, locals, anon)
-        case GetVariant(enumV) =>
-          loop(enumV, locals, anon).asSum.variant
-
-        case SearchList(LocalAnonMut(mutV), init, check, None) =>
-          var res = -1
-          var currentList = loop(init, locals, anon)
-          while (res < 0) {
-            muts.put(mutV, currentList)
-            // todo we have to redo this check
-            // each time, we should have intExpr return Registers => Int
-            // so we can just re-apply it on new registers
-            res = intExpr(check, locals, anon)
-            if (res == 0) {
-              currentList match {
-                case VList.Cons(_, tail) =>
-                  currentList = tail
-                case _ =>
-                  // we are done, we never matched
+              def escape(s: String): String = {
+                val slashE = s.indexOf("\\E")
+                if (slashE < 0) wrap(s)
+                else {
+                  val head = wrap(s.substring(0, slashE))
+                  val quoteSlash = "\\\\E"
+                  val tail = wrap(s.substring(slashE + 2))
+                  head + quoteSlash + tail
+                }
               }
-            }
-          }
-          res
-        case SearchList(LocalAnonMut(mutV), init, check, Some(LocalAnonMut(left))) =>
-          var res = -1
-          var currentList = loop(init, locals, anon)
-          var leftList = VList.VNil
-          while (res < 0) {
-            muts.put(mutV, currentList)
-            muts.put(left, leftList)
-            // todo we have to redo this check
-            // each time, we should have intExpr return Registers => Int
-            // so we can just re-apply it on new registers
-            res = intExpr(check, locals, anon)
-            if (res == 0) {
-              currentList match {
-                case VList.Cons(head, tail) =>
-                  currentList = tail
-                  leftList = VList.Cons(head, leftList)
-                case _ =>
-                  // we are done, we never matched
-              }
-            }
-          }
-          res
-      }
 
-    // the locals can be recusive, so we box into Eval for laziness
-    def loop(me: Expr, locals: Map[Bindable, Eval[Value]], anon: LongMap[Value]): Value =
-      me match {
-        case Lambda(caps, arg, res) =>
-          val capLocal = caps.iterator.map { b => (b, locals(b)) }.toMap
-          FnValue { argV =>
-            // hopefully optimization/normalization has lifted anything
-            // that doesn't depend on argV above this lambda
-            newScope().loop(res, capLocal, LongMap.empty)
+              escape(s)
           }
-        case LoopFn(caps, thisName, argshead, argstail, body) =>
-          val capLocal = caps.iterator.map { b => (b, locals(b)) }.toMap
-          FnValue.curry(argstail.length + 1) { allArgs =>
-            val registers = MMap[Bindable, Value]()
+          .mkString
 
-            def setRegisters(values: List[Value]): Unit = {
-              registers.put(argshead, values.head)
-              var mutArgsTail = argstail
-              var mutArgs = values.tail
-              while (mutArgsTail.nonEmpty) {
-                registers.put(mutArgsTail.head, mutArgs.head)
-                mutArgsTail = mutArgsTail.tail
-                mutArgs = mutArgs.tail
-              }
+          regex.Pattern.compile(strPattern)
+        }
+
+      // evaluating intExpr can mutate an existing value in muts
+      private def intExpr(ix: IntExpr): Scope => Int =
+        ix match {
+          case EqualsLit(expr, lit) =>
+
+            val litAny = lit.unboxToAny
+
+            loop(expr).andThen { e =>
+              val left = e
+                .asExternal
+                .toAny
+
+              if (left == litAny) 1
+              else 0
             }
+          case EqualsInt(iexpr, v) =>
+            intExpr(iexpr).andThen { i =>
+              if (i == v) 1
+              else 0
+            }
+          case EqualsNat(nat, zeroOrSucc) =>
+            val natF = loop(nat)
+
+            if (zeroOrSucc.isZero)
+              natF.andThen { v =>
+                if (v.asExternal.toAny == BigInteger.ZERO) 1
+                else 0
+              }
+            else
+              natF.andThen { v =>
+                if (v.asExternal.toAny != BigInteger.ZERO) 1
+                else 0
+              }
+
+          case AndInt(ix1, ix2) =>
+            val i1F = intExpr(ix1)
+            val i2F = intExpr(ix2)
+
+            { scope: Scope =>
+              // we should be lazy
+              if (i1F(scope) == 0) 0
+              else i2F(scope)
+            }
+
+          case GetVariant(enumV) =>
+            loop(enumV).andThen(_.asSum.variant)
+
+          case SearchList(LocalAnonMut(mutV), init, check, None) =>
+            val initF = loop(init)
+            val checkF = intExpr(check)
+
+            { scope: Scope =>
+              var res = -1
+              var currentList = initF(scope)
+              while (res < 0) {
+                scope.muts.put(mutV, currentList)
+                // this can have a side effect, so it has to be in the loop
+                res = checkF(scope)
+                if (res == 0) {
+                  currentList match {
+                    case VList.Cons(_, tail) =>
+                      currentList = tail
+                      // continue on the tail
+                      res = -1
+                    case _ =>
+                      // we are done, we never matched
+                      // and res has been set to 0
+                  }
+                }
+              }
+              res
+            }
+          case SearchList(LocalAnonMut(mutV), init, check, Some(LocalAnonMut(left))) =>
+            val initF = loop(init)
+            val checkF = intExpr(check)
+
+            { scope: Scope =>
+              var res = -1
+              var currentList = initF(scope)
+              var leftList = VList.VNil
+              while (res < 0) {
+                scope.muts.put(mutV, currentList)
+                scope.muts.put(left, leftList)
+                // todo we have to redo this check
+                // each time, we should have intExpr return Registers => Int
+                // so we can just re-apply it on new registers
+                res = checkF(scope)
+                if (res == 0) {
+                  currentList match {
+                    case VList.Cons(head, tail) =>
+                      currentList = tail
+                      leftList = VList.Cons(head, leftList)
+                      // continue on the tail
+                      res = -1
+                    case _ =>
+                      // we are done, we never matched
+                  }
+                }
+              }
+              res
+            }
+        }
+
+      def buildLoop(caps: List[Bindable], fnName: Bindable, arg0: Bindable, rest: List[Bindable], body: Scope => Value): Scope => Value = {
+        val argCount = rest.length + 1
+        val argNames: Array[Bindable] = (arg0 :: rest).toArray
+
+        { scope =>
+          val scope1 = scope.capture(caps)
+
+          FnValue.curry(argCount) { allArgs =>
+            var registers: List[Value] = allArgs
 
             // the registers are set up
             // when we recur, that is a continue on the loop,
             // we just update the registers and return null
-            val continueFn = FnValue.curry(argstail.length + 1) { continueArgs =>
-              setRegisters(continueArgs)
+            val continueFn = FnValue.curry(argCount) { continueArgs =>
+              registers = continueArgs
               null
             }
 
-            val locals1 = locals.updated(thisName, Eval.now(continueFn))
+            val scope2 = scope1.let(fnName, Eval.now(continueFn))
 
-            def readRegisters(): Map[Bindable, Eval[Value]] = {
-              val it = registers.iterator
-              var loc = locals1
-              while (it.hasNext) {
-                val (b, v) = it.next()
-                loc = loc.updated(b, Eval.now(v))
+            def readRegisters(): Scope = {
+              var idx = 0
+              var reg: List[Value] = registers
+              var s: Scope = scope2
+              while (idx < argCount) {
+                val b = argNames(idx)
+                val v = reg.head
+                reg = reg.tail
+                s = s.let(b, Eval.now(v))
+                idx = idx + 1
               }
-              loc
+              s
             }
 
             var res: Value = null
-            val scope = newScope()
             while (res eq null) {
               // read the registers into the environment
-              val loc = readRegisters()
-              res = scope.loop(body, loc, LongMap.empty)
+              val scope = readRegisters()
+              res = body(scope)
             }
 
             res
           }
-
-        case Global(p, n) => resolve(p, n)
-        case Local(b) => locals(b).value
-        case LocalAnon(a) => anon(a)
-        case LocalAnonMut(m) => muts(m)
-        case App(expr, args) =>
-          @annotation.tailrec
-          def app(fn: Value => Value, head: Expr, tail: List[Expr]): Value = {
-            val ha = loop(head, locals, anon)
-            val res = fn(ha)
-            tail match {
-              case Nil => res
-              case h :: tail =>
-                app(res.asFn, h, tail)
-            }
-          }
-
-          val fn = loop(expr, locals, anon)
-          app(fn.asFn, args.head, args.tail)
-        case Let(localOrBind, value, in) =>
-          localOrBind match {
-            case Right((b, rec)) =>
-              if (rec.isRecursive) {
-
-                lazy val locals1: Map[Bindable, Eval[Value]] =
-                  locals.updated(b, vv)
-
-                lazy val vv = Eval.later(loop(value, locals1, anon))
-
-                loop(in, locals1, anon)
-              }
-              else {
-                val vv = Eval.now(loop(value, locals, anon))
-                loop(in, locals.updated(b, vv), anon)
-              }
-            case Left(LocalAnon(l)) =>
-              val vv = loop(value, locals, anon)
-              loop(in, locals, anon.updated(l, vv))
-            case Left(LocalAnonMut(l)) =>
-              val vv = loop(value, locals, anon)
-              muts.put(l, vv)
-              val res = loop(in, locals, anon)
-              // now we can remove this from mutable scope
-              muts.remove(l)
-              res
-          }
-        case Literal(lit) => Value.fromLit(lit)
-        case If(cond, thenExpr, elseExpr) =>
-          if (intExpr(cond, locals, anon) == 0) loop(elseExpr, locals, anon)
-          else loop(thenExpr, locals, anon)
-
-        case MatchString(str, pat, binds) =>
-          val arg = loop(str, locals, anon).asExternal.toAny.asInstanceOf[String]
-          matchString(arg, toRegex(pat), binds)
-        case GetEnumElement(expr, v, idx, sz) =>
-          val sum = loop(expr, locals, anon).asSum
-          sum.value.get(idx)
-
-        case GetStructElement(expr, idx, sz) =>
-          val prod = loop(expr, locals, anon).asProduct
-          prod.get(idx)
-        case PrevNat(expr) =>
-          val anyBI = loop(expr, locals, anon).asExternal.toAny
-          val bi = anyBI.asInstanceOf[BigInteger]
-          ExternalValue(bi.subtract(BigInteger.ONE))
-        case cons: ConsExpr => makeCons(cons)
-      }
-
-    def matchString(str: String, pat: regex.Pattern, binds: Int): SumValue = {
-      val m = pat.matcher(str)
-      if (m.matches()) {
-        if (binds == 0) Value.True
-        else {
-          var idx = binds
-          var prod: ProductValue = UnitValue
-          while (0 < idx) {
-            val item = m.group(idx)
-            idx = idx - 1
-            prod = ConsValue(ExternalValue(item), prod)
-          }
-          SumValue(1, prod)
         }
       }
-      else {
-        // this is (0, UnitValue)
-        Value.False
+      // the locals can be recusive, so we box into Eval for laziness
+      def loop(me: Expr): Scope => Value =
+        me match {
+          case Lambda(caps, arg, res) =>
+            val resFn = loop(res)
+
+            { scope =>
+              val scope1 = scope.capture(caps)
+              // hopefully optimization/normalization has lifted anything
+              // that doesn't depend on argV above this lambda
+              FnValue { argV =>
+                val scope2 = scope.let(arg, Eval.now(argV))
+                resFn(scope2)
+              }
+            }
+          case LoopFn(caps, thisName, argshead, argstail, body) =>
+            val bodyFn = loop(body)
+
+            buildLoop(caps, thisName, argshead, argstail, bodyFn)
+          case Global(p, n) =>
+            val res = resolve(p, n)
+            Function.const(res)
+          case Local(b) => { scope => scope.locals(b).value }
+          case LocalAnon(a) => { scope => scope.anon(a) }
+          case LocalAnonMut(m) => { scope => scope.muts(m) }
+          case App(expr, args) =>
+            // TODO: App(LoopFn(..
+            // can be optimized into a while
+            // loop, but there isn't any prior optimization
+            // that would do this.... maybe it should
+            // be in Matchless
+            val exprFn = loop(expr)
+            val argsFn = args.map(loop(_))
+
+            { scope =>
+
+              @annotation.tailrec
+              def app(fn: Value => Value, head: Value, tail: List[Scope => Value]): Value = {
+                val res = fn(head)
+                tail match {
+                  case Nil => res
+                  case h :: tail =>
+                    app(res.asFn, h(scope), tail)
+                }
+              }
+
+              app(exprFn(scope).asFn, argsFn.head(scope), argsFn.tail)
+            }
+          case Let(localOrBind, value, in) =>
+            val valueF = loop(value)
+            val inF = loop(in)
+
+            localOrBind match {
+              case Right((b, rec)) =>
+                if (rec.isRecursive) {
+
+                  { scope =>
+                    lazy val scope1: Scope =
+                      scope.let(b, vv)
+
+                    lazy val vv = Eval.later(valueF(scope1))
+
+                    inF(scope1)
+                  }
+                }
+                else {
+                  { scope: Scope =>
+                    val vv = Eval.now(valueF(scope))
+                    inF(scope.let(b, vv))
+                  }
+                }
+              case Left(LocalAnon(l)) =>
+                { scope: Scope =>
+                  val vv = valueF(scope)
+                  val scope1 = scope.copy(anon = scope.anon.updated(l, vv))
+                  inF(scope1)
+                }
+              case Left(LocalAnonMut(l)) =>
+                { scope: Scope =>
+                  val vv = valueF(scope)
+                  scope.muts.put(l, vv)
+                  val res = inF(scope)
+                  // now we can remove this from mutable scope
+                  scope.muts.remove(l)
+                  res
+                }
+            }
+          case Literal(lit) =>
+            val v = Value.fromLit(lit)
+            Function.const(v)
+          case If(cond, thenExpr, elseExpr) =>
+            val condF = intExpr(cond)
+            val thenF = loop(thenExpr)
+            val elseF = loop(elseExpr)
+
+            { scope: Scope =>
+              val cond = condF(scope)
+              if (cond == 0) elseF(scope)
+              else thenF(scope)
+            }
+
+          case MatchString(str, pat, binds) =>
+            // do this before we evaluate the string
+            val regexPat = toRegex(pat)
+            loop(str).andThen { strV =>
+              val arg = strV.asExternal.toAny.asInstanceOf[String]
+              matchString(arg, regexPat, binds)
+            }
+          case GetEnumElement(expr, v, idx, sz) =>
+            loop(expr).andThen { e =>
+              e.asSum.value.get(idx)
+            }
+
+          case GetStructElement(expr, idx, sz) =>
+            loop(expr).andThen { p =>
+              p.asProduct.get(idx)
+            }
+          case PrevNat(expr) =>
+            loop(expr).andThen { bv =>
+              val anyBI = bv.asExternal.toAny
+              val bi = anyBI.asInstanceOf[BigInteger]
+              ExternalValue(bi.subtract(BigInteger.ONE))
+            }
+          case cons: ConsExpr =>
+            val c = makeCons(cons)
+            Function.const(c)
+        }
+
+      def matchString(str: String, pat: regex.Pattern, binds: Int): SumValue = {
+        val m = pat.matcher(str)
+        if (m.matches()) {
+          if (binds == 0) Value.True
+          else {
+            var idx = binds
+            var prod: ProductValue = UnitValue
+            while (0 < idx) {
+              val item = m.group(idx)
+              idx = idx - 1
+              prod = ConsValue(ExternalValue(item), prod)
+            }
+            SumValue(1, prod)
+          }
+        }
+        else {
+          // this is (0, UnitValue)
+          Value.False
+        }
       }
     }
   }

--- a/core/src/main/scala/org/bykn/bosatsu/MatchlessToValue.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/MatchlessToValue.scala
@@ -15,13 +15,6 @@ object MatchlessToValue {
   def traverse[F[_]: Functor](me: F[Expr])(resolve: (PackageName, Identifier) => Eval[Value]): F[Eval[Value]] = {
     val env = new Impl.Env(resolve)
     val fns = Functor[F].map(me) { expr =>
-      /*
-      if (expr.isInstanceOf[Let]) {
-        println("=" * 800)
-        println(expr)
-        println("=" * 800)
-      }
-      */
       env.loop(expr)
     }
     // now that we computed all the functions, compute the values

--- a/core/src/main/scala/org/bykn/bosatsu/Value.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/Value.scala
@@ -62,12 +62,11 @@ object Value {
       @annotation.tailrec
       def loop(self: ProductValue, ix: Int): Value =
         self match {
-          case UnitValue =>
-            //throw new IllegalArgumentException(s"exhausted index at $ix on ${this}.get($idx)")
-            UnitValue
           case ConsValue(head, tail) =>
             if (ix <= 0) head
             else loop(tail, ix - 1)
+          case UnitValue =>
+            throw new IllegalArgumentException(s"exhausted index at $ix on ${this}.get($idx)")
         }
 
       loop(this, idx)

--- a/core/src/main/scala/org/bykn/bosatsu/Value.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/Value.scala
@@ -31,6 +31,15 @@ sealed abstract class Value {
         // $COVERAGE-ON$
     }
 
+  def asProduct:ProductValue =
+    this match {
+      case p: ProductValue => p
+      case _ =>
+        // $COVERAGE-OFF$this should be unreachable
+        sys.error(s"invalid cast to ProductValue: $this")
+        // $COVERAGE-ON$
+    }
+
   def asExternal: ExternalValue =
     this match {
       case ex: ExternalValue => ex
@@ -49,6 +58,18 @@ object Value {
         case ConsValue(head, tail) => head :: tail.toList
       }
 
+    final def get(idx: Int): Value = {
+      @annotation.tailrec
+      def loop(self: ProductValue, ix: Int): Value =
+        self match {
+          case UnitValue => throw new IllegalArgumentException(s"exhausted index at $ix on ${this}.get($idx)")
+          case ConsValue(head, tail) =>
+            if (ix <= 0) head
+            else loop(tail, ix - 1)
+        }
+
+      loop(this, idx)
+    }
   }
 
   object ProductValue {
@@ -104,8 +125,8 @@ object Value {
   }
   case class ExternalValue(toAny: Any) extends Value
 
-  val False: Value = SumValue(0, UnitValue)
-  val True: Value = SumValue(1, UnitValue)
+  val False: SumValue = SumValue(0, UnitValue)
+  val True: SumValue = SumValue(1, UnitValue)
 
   object TupleCons {
     def unapply(v: Value): Option[(Value, Value)] =

--- a/core/src/main/scala/org/bykn/bosatsu/Value.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/Value.scala
@@ -62,7 +62,9 @@ object Value {
       @annotation.tailrec
       def loop(self: ProductValue, ix: Int): Value =
         self match {
-          case UnitValue => throw new IllegalArgumentException(s"exhausted index at $ix on ${this}.get($idx)")
+          case UnitValue =>
+            //throw new IllegalArgumentException(s"exhausted index at $ix on ${this}.get($idx)")
+            UnitValue
           case ConsValue(head, tail) =>
             if (ix <= 0) head
             else loop(tail, ix - 1)

--- a/core/src/main/scala/org/bykn/bosatsu/graph/Memoize.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/graph/Memoize.scala
@@ -54,6 +54,26 @@ object Memoize {
   }
 
   /**
+   * This memoizes using a hash map in a non-threadsafe manner
+   */
+  def memoizeHashedConcurrent[A, B](fn: A => B): A => B = {
+    val cache: ConcurrentHashMap[A, B] = new ConcurrentHashMap[A, B]()
+
+    { (a: A) =>
+      cache.get(a) match {
+        case null =>
+          // we have never hit this branch, compute that we are working:
+          // if we require this value while computing for a, it is an infinite
+          // loop, and we can't compute it
+          val b = fn(a)
+          cache.put(a, b)
+          b
+        case b => b
+      }
+    }
+  }
+
+  /**
    * This memoizes using a hash map in a threadsafe manner
    * it may loop forever and stack overflow if you don't have a DAG
    */

--- a/core/src/main/scala/org/bykn/bosatsu/graph/Memoize.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/graph/Memoize.scala
@@ -54,26 +54,6 @@ object Memoize {
   }
 
   /**
-   * This memoizes using a hash map in a non-threadsafe manner
-   */
-  def memoizeHashedConcurrent[A, B](fn: A => B): A => B = {
-    val cache: ConcurrentHashMap[A, B] = new ConcurrentHashMap[A, B]()
-
-    { (a: A) =>
-      cache.get(a) match {
-        case null =>
-          // we have never hit this branch, compute that we are working:
-          // if we require this value while computing for a, it is an infinite
-          // loop, and we can't compute it
-          val b = fn(a)
-          cache.put(a, b)
-          b
-        case b => b
-      }
-    }
-  }
-
-  /**
    * This memoizes using a hash map in a threadsafe manner
    * it may loop forever and stack overflow if you don't have a DAG
    */

--- a/core/src/main/scala/org/bykn/bosatsu/rankn/DataRepr.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/rankn/DataRepr.scala
@@ -8,10 +8,10 @@ package org.bykn.bosatsu.rankn
 sealed abstract class DataRepr
 
 object DataRepr {
-  sealed abstract class Nat extends DataRepr
+  sealed abstract class Nat(val isZero: Boolean) extends DataRepr
 
-  case object ZeroNat extends Nat
-  case object SuccNat extends Nat
+  case object ZeroNat extends Nat(true)
+  case object SuccNat extends Nat(false)
 
   case class Enum(variant: Int, arity: Int) extends DataRepr
   // a struct with arity 1 can be elided, and is called a new-type

--- a/core/src/main/scala/org/bykn/bosatsu/rankn/Ref.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/rankn/Ref.scala
@@ -88,4 +88,16 @@ object RefSpace {
       def flatMap[A, B](fa: RefSpace[A])(fn: A => RefSpace[B]): RefSpace[B] =
         fa.flatMap(fn)
     }
+
+
+  // a counter that starts at 0
+  val allocCounter: RefSpace[RefSpace[Long]] =
+    RefSpace.newRef(0L)
+      .map { ref =>
+        for {
+          a <- ref.get
+          _ <- ref.set(a + 1L)
+        } yield a
+      }
+
 }

--- a/core/src/test/scala/org/bykn/bosatsu/EvaluationTest.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/EvaluationTest.scala
@@ -811,7 +811,6 @@ main = big_list.foldLeft(0, \x, y -> x.add(y))
 """), "A", VInt((0 until 3000).sum))
 
   def sumFn(n: Int): Int = if (n <= 0) 0 else { sumFn(n-1) + n }
-
   evalTest(
     List("""
 package A
@@ -850,7 +849,6 @@ def sum(nat):
 
 main = sum(Succ(Succ(Succ(Zero))))
 """), "A", VInt(sumFn(3)))
-
   }
 
   test("we can mix literal and enum forms of List") {

--- a/core/src/test/scala/org/bykn/bosatsu/MatchlessTests.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/MatchlessTests.scala
@@ -6,7 +6,7 @@ import org.scalatest.FunSuite
 import org.scalatest.prop.PropertyChecks.{forAll, PropertyCheckConfiguration}
 
 import Identifier.{Bindable, Constructor}
-import rankn.{DataRepr, RefSpace}
+import rankn.DataRepr
 
 import cats.implicits._
 
@@ -49,23 +49,10 @@ class MatchlessTest extends FunSuite {
           } yield (b, r, t, fn)
       }
 
-  val genId: RefSpace[RefSpace[Long]] =
-    RefSpace.newRef(0L)
-      .map { ref =>
-        for {
-          a <- ref.get
-          _ <- ref.set(a + 1L)
-        } yield a
-      }
-
   test("matchless.fromLet is pure: f(x) == f(x)") {
     forAll(genInputs) { case (b, r, t, fn) =>
       def run(): Matchless.Expr =
-        (for {
-          alloc <- genId
-          expr <- Matchless.fromLet(b, r, t, fn, alloc)
-        } yield expr).run.value
-
+        Matchless.fromLet(b, r, t)(fn)
 
       assert(run() == run())
     }

--- a/core/src/test/scala/org/bykn/bosatsu/TestUtils.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/TestUtils.scala
@@ -94,7 +94,8 @@ object TestUtils {
 
     module.runWith(files)("eval" :: "--main" :: mainPackS :: makeInputArgs(files)) match {
       case Right(module.Output.EvaluationResult(got, _, gotDoc)) =>
-        assert(got.value == expected, s"${gotDoc.value.render(80)}\n\n$got != $expected")
+        val gv = got.value
+        assert(gv == expected, s"${gotDoc.value.render(80)}\n\n$gv != $expected")
       case Right(other) =>
         fail(s"got an unexpected success: $other")
       case Left(err) =>


### PR DESCRIPTION
The motivation of this PR is to: 

1. exercise Matchless in tests and the design
2. reduce duplication that would otherwise exist with the current interpreter/evaluation

The goal of Matchless is an AST that can be a basis for code generation since it doesn't rely on anything very fancy (still assumes certain things like allocation and delegates ADTs and lambdas to the underlying system).

It was pretty complex to get the tests passing due to the mutability that this code uses as it is evaluating the if/else that the matches compile into. As we pass parts of the match, we can set variables that were previously unset. Doing this in the wrong order gives very hard to debug issues.