### PR TITLE
Add python code generation

### DIFF
--- a/cli/src/test/scala/org/bykn/bosatsu/PathModuleTest.scala
+++ b/cli/src/test/scala/org/bykn/bosatsu/PathModuleTest.scala
@@ -74,7 +74,7 @@ class PathModuleTest extends FunSuite {
 
   def run(args: String*): PathModule.Output =
     PathModule.run(args.toList) match {
-      case Left(_) => fail(s"got help on command: ${args.toList}")
+      case Left(h) => fail(s"got help: $h on command: ${args.toList}")
       case Right(io) =>
         val output = io.unsafeRunSync()
         // This is a cheat, but at least we call the code so
@@ -102,6 +102,24 @@ class PathModuleTest extends FunSuite {
         assert(res.head.assertions == 1)
         assert(res.head.failureCount == 0)
       case other => fail(s"expected test output: $other")
+    }
+  }
+
+  test("test transpile on a few files") {
+    val files =
+      List("Nat.bosatsu",
+        "Bool.bosatsu",
+        "euler1.bosatsu",
+        "euler3.bosatsu",
+        "euler6.bosatsu")
+
+    val inputs = files.map { nm => s"--input test_workspace/$nm" }.mkString(" ")
+
+    val out = run(s"transpile $inputs --outdir pyout --lang python --externals ex.txt --package_root test_workspace".split("\\s+"): _*)
+    out match {
+      case PathModule.Output.TranspileOut(_, _) =>
+        assert(true)
+      case other => fail(s"expected transpile output: $other")
     }
   }
 

--- a/cli/src/test/scala/org/bykn/bosatsu/PathModuleTest.scala
+++ b/cli/src/test/scala/org/bykn/bosatsu/PathModuleTest.scala
@@ -115,7 +115,7 @@ class PathModuleTest extends FunSuite {
 
     val inputs = files.map { nm => s"--input test_workspace/$nm" }.mkString(" ")
 
-    val out = run(s"transpile $inputs --outdir pyout --lang python --externals ex.txt --package_root test_workspace".split("\\s+"): _*)
+    val out = run(s"transpile $inputs --outdir pyout --lang python --package_root test_workspace".split("\\s+"): _*)
     out match {
       case PathModule.Output.TranspileOut(_, _) =>
         assert(true)

--- a/cli/src/test/scala/org/bykn/bosatsu/codegen/python/CodeTest.scala
+++ b/cli/src/test/scala/org/bykn/bosatsu/codegen/python/CodeTest.scala
@@ -4,6 +4,7 @@ import cats.data.NonEmptyList
 import org.scalacheck.Gen
 import org.scalatest.prop.PropertyChecks.{ forAll, PropertyCheckConfiguration }
 import org.scalatest.FunSuite
+import org.python.core.{ParserFacade => JythonParserFacade}
 
 class CodeTest extends FunSuite {
   implicit val generatorDrivenConfig =
@@ -122,7 +123,7 @@ class CodeTest extends FunSuite {
 
   def assertParse(str: String) = {
     try {
-      val mod = org.python.core.ParserFacade.parseExpressionOrModule(new java.io.StringReader(str), "filename.py", new org.python.core.CompilerFlags())
+      val mod = JythonParserFacade.parseExpressionOrModule(new java.io.StringReader(str), "filename.py", new org.python.core.CompilerFlags())
       assert(mod != null)
     }
     catch {

--- a/cli/src/test/scala/org/bykn/bosatsu/codegen/python/PythonGenTest.scala
+++ b/cli/src/test/scala/org/bykn/bosatsu/codegen/python/PythonGenTest.scala
@@ -13,7 +13,7 @@ import org.bykn.bosatsu.DirectEC.directEC
 
 class PythonGenTest extends FunSuite {
 
-  implicit val showStr = Show[String](identity)
+  implicit val showStr: Show[String] = Show.show[String](identity)
 
   def compileFile(path: String): PackageMap.Typed[Any] = {
     val str = new String(Files.readAllBytes(Paths.get(path)), "UTF-8")

--- a/cli/src/test/scala/org/bykn/bosatsu/codegen/python/PythonGenTest.scala
+++ b/cli/src/test/scala/org/bykn/bosatsu/codegen/python/PythonGenTest.scala
@@ -1,0 +1,43 @@
+package org.bykn.bosatsu.codegen.python
+
+import cats.Show
+import cats.data.NonEmptyList
+import java.io.{ByteArrayInputStream, InputStream}
+import java.nio.file.{Paths, Files}
+import org.bykn.bosatsu.{PackageMap, MatchlessFromTypedExpr, Parser, Package, LocationMap, PackageName}
+import org.scalatest.FunSuite
+import org.python.util.PythonInterpreter
+
+
+import org.bykn.bosatsu.DirectEC.directEC
+
+class PythonGenTest extends FunSuite {
+
+  implicit val showStr = Show[String](identity)
+
+  def compileFile(path: String): PackageMap.Typed[Any] = {
+    val str = new String(Files.readAllBytes(Paths.get(path)), "UTF-8")
+
+    val pack = Parser.unsafeParse(Package.parser(None), str)
+    val packNEL = NonEmptyList((("", LocationMap(str)), pack), Nil)
+    PackageMap.typeCheckParsed(packNEL, Nil, "").right.get
+  }
+
+  def isfromString(s: String): InputStream =
+    new ByteArrayInputStream(s.getBytes("UTF-8"))
+
+  test("we can compile Nat.bosatsu") {
+    val natPathBosatu: String = "test_workspace/Nat.bosatsu"
+
+    val bosatsuPM = compileFile(natPathBosatu)
+    val matchless = MatchlessFromTypedExpr.compile(bosatsuPM)
+
+    val intr = new PythonInterpreter()
+
+    val packMap = PythonGen.renderAll(matchless, Map.empty)
+    val natDoc = packMap(PackageName.parts("Bosatsu", "Nat"))._2
+
+    intr.execfile(isfromString(natDoc.renderTrim(80)), "nat.py")
+  }
+
+}

--- a/core/src/main/scala/org/bykn/bosatsu/Identifier.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/Identifier.scala
@@ -116,7 +116,15 @@ object Identifier {
   def unsafeBindable(str: String): Bindable =
     unsafeParse(bindableParser, str)
 
-  def unsafeParse[A <: Identifier](pa: P[A], str: String): A =
+  def optionParse[A](pa: P[A], str: String): Option[A] =
+    pa.parse(str) match {
+      case Parsed.Success(ident, idx) if idx == str.length =>
+        Some(ident)
+      case _ =>
+        None
+    }
+
+  def unsafeParse[A](pa: P[A], str: String): A =
     pa.parse(str) match {
       case Parsed.Success(ident, idx) if idx == str.length =>
         ident

--- a/core/src/main/scala/org/bykn/bosatsu/Identifier.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/Identifier.scala
@@ -117,22 +117,10 @@ object Identifier {
     unsafeParse(bindableParser, str)
 
   def optionParse[A](pa: P[A], str: String): Option[A] =
-    pa.parse(str) match {
-      case Parsed.Success(ident, idx) if idx == str.length =>
-        Some(ident)
-      case _ =>
-        None
-    }
+    Parser.optionParse(pa, str)
 
   def unsafeParse[A](pa: P[A], str: String): A =
-    pa.parse(str) match {
-      case Parsed.Success(ident, idx) if idx == str.length =>
-        ident
-      case Parsed.Success(_, idx) =>
-        sys.error(s"partial parse of $str ignores: ${str.substring(idx)}")
-      case Parsed.Failure(exp, idx, extra) =>
-        sys.error(s"failed to parse: $str: $exp at $idx: (${str.substring(idx)}) with trace: ${extra.traced.trace}")
-    }
+    Parser.unsafeParse(pa, str)
 
   implicit def order[A <: Identifier]: Order[A] =
     Order.by[A, String](_.asString)

--- a/core/src/main/scala/org/bykn/bosatsu/MainModule.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/MainModule.scala
@@ -377,11 +377,11 @@ abstract class MainModule[IO[_]](implicit val moduleIOMonad: MonadError[IO, Thro
     }
 
     sealed abstract class Transpiler(val name: String) {
-      def renderAll(pm: PackageMap.Typed[Any], externals: NonEmptyList[String])(implicit ec: ExecutionContext): IO[Map[PackageName, (NonEmptyList[String], Doc)]]
+      def renderAll(pm: PackageMap.Typed[Any], externals: List[String])(implicit ec: ExecutionContext): IO[Map[PackageName, (NonEmptyList[String], Doc)]]
     }
     object Transpiler {
       case object PythonTranspiler extends Transpiler("python") {
-        def renderAll(pm: PackageMap.Typed[Any], externals: NonEmptyList[String])(implicit ec: ExecutionContext): IO[Map[PackageName, (NonEmptyList[String], Doc)]] = {
+        def renderAll(pm: PackageMap.Typed[Any], externals: List[String])(implicit ec: ExecutionContext): IO[Map[PackageName, (NonEmptyList[String], Doc)]] = {
           import codegen.python.PythonGen
 
           val cmp = MatchlessFromTypedExpr.compile(pm)
@@ -460,7 +460,7 @@ abstract class MainModule[IO[_]](implicit val moduleIOMonad: MonadError[IO, Thro
       packRes: PackageResolver,
       generator: Transpiler,
       outDir: Path,
-      exts: NonEmptyList[Path]) extends MainCommand {
+      exts: List[Path]) extends MainCommand {
 
       //case class TranspileOut(outs: Map[PackageName, (List[String], Doc)], base: Path) extends Output
       type Result = Output.TranspileOut
@@ -909,7 +909,7 @@ abstract class MainModule[IO[_]](implicit val moduleIOMonad: MonadError[IO, Thro
 
       val transpileOpt = (srcs, includes, colorOpt, packRes, Transpiler.opt,
         Opts.option[Path]("outdir", help = "directory to write all output into"),
-        Opts.options[Path]("externals", help = "external descriptors the transpiler uses to rewrite external defs"))
+        Opts.options[Path]("externals", help = "external descriptors the transpiler uses to rewrite external defs").orEmpty)
         .mapN(TranspileCommand(_, _, _, _, _, _, _))
       val evalOpt = (srcs, mainP, includes, colorOpt, packRes)
         .mapN(Evaluate(_, _, _, _, _))

--- a/core/src/main/scala/org/bykn/bosatsu/Matchless.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/Matchless.scala
@@ -419,6 +419,10 @@ object Matchless {
                   .run
                   .map { case (anons, ums) =>
                     // now we need to set up the binds if the variant is right
+                    // TODO: on a final branch we don't need to check the variant
+                    // since due to totality we know it has to match. To
+                    // leverage that we need to know if this doesMatch is
+                    // the last possible candidate match
                     val vmatch = CheckVariant(arg, vidx, size) && SetMut(res, arg)
                     // we need to check that the variant is right first
                     val cond1 = anons.foldLeft(vmatch) { case (c, (mut, expr)) =>

--- a/core/src/main/scala/org/bykn/bosatsu/Matchless.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/Matchless.scala
@@ -73,7 +73,7 @@ object Matchless {
   case class And(e1: BoolExpr, e2: BoolExpr) extends BoolExpr
   // checks if variant matches, and if so, writes to
   // a given mut
-  case class CheckVariant(expr: Expr, expect: Int) extends BoolExpr
+  case class CheckVariant(expr: Expr, expect: Int, size: Int) extends BoolExpr
   // handle list matching, this is a while loop, that is evaluting
   // lst is initialized to init, leftAcc is initialized to empty
   // tail until it is true while mutating lst => lst.tail
@@ -418,7 +418,7 @@ object Matchless {
                   .run
                   .map { case (anons, ums) =>
                     // now we need to set up the binds if the variant is right
-                    val vmatch = CheckVariant(arg, vidx) && SetMut(res, arg)
+                    val vmatch = CheckVariant(arg, vidx, size) && SetMut(res, arg)
                     // we need to check that the variant is right first
                     val cond1 = anons.foldLeft(vmatch) { case (c, (mut, expr)) =>
                       c && SetMut(mut, expr)

--- a/core/src/main/scala/org/bykn/bosatsu/Matchless.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/Matchless.scala
@@ -19,6 +19,7 @@ object Matchless {
   // these hold bindings either in the code, or temporary
   // local ones
   sealed trait CheapExpr extends Expr
+  sealed abstract class FnExpr extends Expr
 
   sealed abstract class StrPart
   object StrPart {
@@ -31,13 +32,13 @@ object Matchless {
   // we should probably allocate static slots for each bindable,
   // and replace the local with an integer offset slot access for
   // the closure state
-  case class Lambda(captures: List[Bindable], arg: Bindable, expr: Expr) extends Expr
+  case class Lambda(captures: List[Bindable], arg: Bindable, expr: Expr) extends FnExpr
 
   // this is a tail recursive function that should be compiled into a loop
   // when a call to name is done inside body, that should restart the loop
   // the type of this Expr a function with the arity of args that returns
   // the type of body
-  case class LoopFn(captures: List[Bindable], name: Bindable, argshead: Bindable, argstail: List[Bindable], body: Expr) extends Expr
+  case class LoopFn(captures: List[Bindable], name: Bindable, argshead: Bindable, argstail: List[Bindable], body: Expr) extends FnExpr
 
   case class Global(pack: PackageName, name: Bindable) extends CheapExpr
 

--- a/core/src/main/scala/org/bykn/bosatsu/Matchless.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/Matchless.scala
@@ -97,13 +97,19 @@ object Matchless {
   case class GetEnumElement(arg: Expr, variant: Int, index: Int, size: Int) extends Expr
   case class GetStructElement(arg: Expr, index: Int, size: Int) extends Expr
 
-  sealed abstract class ConsExpr extends Expr
+  sealed abstract class ConsExpr extends Expr {
+    def arity: Int
+  }
   // we need to compile calls to constructors into these
   case class MakeEnum(variant: Int, arity: Int) extends ConsExpr
   case class MakeStruct(arity: Int) extends ConsExpr
-  case object ZeroNat extends ConsExpr
+  case object ZeroNat extends ConsExpr {
+    def arity = 0
+  }
   // this is the function Nat -> Nat
-  case object SuccNat extends ConsExpr
+  case object SuccNat extends ConsExpr {
+    def arity = 1
+  }
 
   case class PrevNat(of: Expr) extends Expr
 

--- a/core/src/main/scala/org/bykn/bosatsu/MatchlessFromTypedExpr.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/MatchlessFromTypedExpr.scala
@@ -1,0 +1,42 @@
+package org.bykn.bosatsu
+
+import scala.concurrent.ExecutionContext
+
+import Identifier.Bindable
+
+import cats.implicits._
+
+object MatchlessFromTypedExpr {
+  // compile a set of packages given a set of external remappings
+  def compile[A](pm: PackageMap.Typed[A])(implicit ec: ExecutionContext): Map[PackageName, List[(Bindable, Matchless.Expr)]] = {
+
+    val gdr = pm.getDataRepr
+
+    val allItems = pm.toMap
+      .toList
+      .traverse { case (pname, pack) =>
+        val lets = pack.program.lets
+
+        Par.start {
+          val exprs: List[(Bindable, Matchless.Expr)] =
+            rankn.RefSpace
+              .allocCounter
+              .flatMap { c =>
+                lets
+                  .traverse {
+                    case (name, rec, te) =>
+                      Matchless.fromLet(name, rec, te, gdr, c)
+                       .map((name, _))
+                  }
+            }
+            .run
+            .value
+
+          (pname, exprs)
+        }
+      }
+      .map(_.toMap)
+
+    Par.await(allItems)
+  }
+}

--- a/core/src/main/scala/org/bykn/bosatsu/MatchlessFromTypedExpr.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/MatchlessFromTypedExpr.scala
@@ -12,9 +12,11 @@ object MatchlessFromTypedExpr {
 
     val gdr = pm.getDataRepr
 
-    val allItems = pm.toMap
+    // on JS Par.F[A] is actually Id[A], so we need to hold hands a bit
+
+    val allItemsList = pm.toMap
       .toList
-      .traverse { case (pname, pack) =>
+      .traverse[Par.F, (PackageName, List[(Bindable, Matchless.Expr)])] { case (pname, pack) =>
         val lets = pack.program.lets
 
         Par.start {
@@ -35,7 +37,10 @@ object MatchlessFromTypedExpr {
           (pname, exprs)
         }
       }
-      .map(_.toMap)
+
+    // JS needs this to not see through the Par.F as Id
+    // really we want Par.F to be an opaque type
+    val allItems = cats.Functor[Par.F].map(allItemsList)(_.toMap)
 
     Par.await(allItems)
   }

--- a/core/src/main/scala/org/bykn/bosatsu/MatchlessToValue.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/MatchlessToValue.scala
@@ -171,7 +171,7 @@ object MatchlessToValue {
           case And(ix1, ix2) =>
             boolExpr(ix1).and(boolExpr(ix2))
 
-          case CheckVariant(enumV, idx) =>
+          case CheckVariant(enumV, idx, _) =>
             loop(enumV).map(_.asSum.variant == idx)
 
           case SetMut(LocalAnonMut(mut), expr) =>

--- a/core/src/main/scala/org/bykn/bosatsu/PackageMap.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/PackageMap.scala
@@ -8,7 +8,9 @@ import cats.Order
 import cats.implicits._
 import scala.concurrent.ExecutionContext
 
-import rankn.TypeEnv
+import Identifier.Constructor
+
+import rankn.{DataRepr, TypeEnv}
 
 case class PackageMap[A, B, C, +D](toMap: Map[PackageName, Package[A, B, C, D]]) {
   def +[D1 >: D](pack: Package[A, B, C, D1]): PackageMap[A, B, C, D1] =
@@ -16,6 +18,17 @@ case class PackageMap[A, B, C, +D](toMap: Map[PackageName, Package[A, B, C, D]])
 
   def ++[D1 >: D](packs: Iterable[Package[A, B, C, D1]]): PackageMap[A, B, C, D1] =
     packs.foldLeft(this: PackageMap[A, B, C, D1])(_ + _)
+
+  def getDataRepr(implicit ev: D <:< Program[TypeEnv[Any], Any, Any]): (PackageName, Constructor) => Option[DataRepr] = {
+    (pname, cons) =>
+      toMap.get(pname)
+        .flatMap { pack =>
+          ev(pack.program)
+            .types
+            .getConstructor(pname, cons)
+            .map(_._2.dataRepr(cons))
+        }
+  }
 }
 
 object PackageMap {

--- a/core/src/main/scala/org/bykn/bosatsu/Parser.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/Parser.scala
@@ -378,10 +378,12 @@ object Parser {
     pa.parse(str) match {
       case Parsed.Success(a, idx) if idx == str.length =>
         a
+      // $COVERAGE-OFF$
       case Parsed.Success(_, idx) =>
         sys.error(s"partial parse of $str ignores: ${str.substring(idx)}")
       case Parsed.Failure(exp, idx, extra) =>
         sys.error(s"failed to parse: $str: $exp at $idx: (${str.substring(idx)}) with trace: ${extra.traced.trace}")
+      // $COVERAGE-ON$
     }
 
 }

--- a/core/src/main/scala/org/bykn/bosatsu/Parser.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/Parser.scala
@@ -164,12 +164,13 @@ object Parser {
     spacesAndLines.?.opaque("maybeSpacesAndLines")
 
   val lowerIdent: P[String] =
-    P(CharIn('a' to 'z').! ~ CharsWhile(identifierChar _).?.!)
-      .map { case (a, b) => a + b }
+    P(CharIn('a' to 'z') ~ CharsWhile(identifierChar _).?).!
 
   val upperIdent: P[String] =
-    P(CharIn('A' to 'Z').! ~ CharsWhile(identifierChar _).?.!)
-      .map { case (a, b) => a + b }
+    P(CharIn('A' to 'Z') ~ CharsWhile(identifierChar _).?).!
+
+  val py2Ident: P[String] =
+    P(CharIn('_' :: ('A' to 'Z').toList ::: ('a' to 'z').toList) ~ CharsWhile(identifierChar _).?).!
 
   def tokenP[T](s: String, t: T): P[T] = P(s).map(_ => t)
 
@@ -364,4 +365,23 @@ object Parser {
    * repeatedly parsing End will OOM
    */
   val toEOL: P[Unit] = P(maybeSpace ~ ("\n" | End))
+
+  def optionParse[A](pa: P[A], str: String): Option[A] =
+    pa.parse(str) match {
+      case Parsed.Success(ident, idx) if idx == str.length =>
+        Some(ident)
+      case _ =>
+        None
+    }
+
+  def unsafeParse[A](pa: P[A], str: String): A =
+    pa.parse(str) match {
+      case Parsed.Success(a, idx) if idx == str.length =>
+        a
+      case Parsed.Success(_, idx) =>
+        sys.error(s"partial parse of $str ignores: ${str.substring(idx)}")
+      case Parsed.Failure(exp, idx, extra) =>
+        sys.error(s"failed to parse: $str: $exp at $idx: (${str.substring(idx)}) with trace: ${extra.traced.trace}")
+    }
+
 }

--- a/core/src/main/scala/org/bykn/bosatsu/Program.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/Program.scala
@@ -2,7 +2,7 @@ package org.bykn.bosatsu
 
 import Identifier.Bindable
 
-case class Program[T, +D, +S](
+case class Program[+T, +D, +S](
   types: T,
   lets: List[(Bindable, RecursionKind, D)],
   externalDefs: List[Bindable],

--- a/core/src/main/scala/org/bykn/bosatsu/codegen/python/Code.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/codegen/python/Code.scala
@@ -25,6 +25,18 @@ object Code {
         case p => Code.Parens(p)
       }
 
+    def evalAnd(that: Expression): Expression =
+      that match {
+        case Const.True => this
+        case Const.False => Const.False
+        case _ =>
+          this match {
+            case Const.True => that
+            case Const.False => Const.False
+            case _ => Op(this, Const.And, that)
+          }
+      }
+
     def evalPlus(that: Expression): Expression =
       (this, that) match {
         case (Code.PyInt(a), Code.PyInt(b)) =>
@@ -340,6 +352,7 @@ object Code {
     case object And extends Operator("and")
     case object Eq extends Operator("==")
     case object Gt extends Operator(">")
+    case object Lt extends Operator("<")
 
     val True = Literal("True")
     val False = Literal("False")

--- a/core/src/main/scala/org/bykn/bosatsu/codegen/python/Code.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/codegen/python/Code.scala
@@ -25,6 +25,12 @@ object Code {
         case p => Code.Parens(p)
       }
 
+    def apply(args: Expression*): Apply =
+      Apply(this, args.toList)
+
+    def get(idx: Int): SelectItem =
+      SelectItem(this, idx)
+
     def evalAnd(that: Expression): Expression =
       that match {
         case Const.True => this
@@ -185,7 +191,10 @@ object Code {
   case class Literal(asString: String) extends Expression
   case class PyInt(toBigInteger: BigInteger) extends Expression
   case class PyString(content: String) extends Expression
-  case class Ident(name: String) extends Dotable // a kind of expression
+  case class Ident(name: String) extends Dotable { // a kind of expression
+    def :=(vl: ValueLike): Statement =
+      addAssign(this, vl)
+  }
   // Binary operator used for +, -, and, == etc...
   case class Op(left: Expression, op: Operator, right: Expression) extends Expression {
     // operators like + can associate
@@ -285,6 +294,10 @@ object Code {
           Some(addAssign(variable, elseCond))
         )
     }
+
+  def block(stmt: Statement, rest: Statement*): Statement =
+    if (rest.isEmpty) stmt
+    else Block(NonEmptyList(stmt, rest.toList))
 
   def toReturn(v: ValueLike): Statement =
     v match {

--- a/core/src/main/scala/org/bykn/bosatsu/codegen/python/Code.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/codegen/python/Code.scala
@@ -35,10 +35,21 @@ object Code {
         case notBlock => NonEmptyList(notBlock, Nil)
       }
 
-    def +:(stmt: Statement): Block =
-      Block(stmt :: statements)
-    def :+(stmt: Statement): Block =
-      Block(statements :+ stmt)
+    def +:(stmt: Statement): Statement =
+      stmt match {
+        case Pass => this
+        case _ =>
+          if (this == Pass) stmt
+          else Block(stmt :: statements)
+      }
+
+    def :+(stmt: Statement): Statement =
+      stmt match {
+        case Pass => this
+        case _ =>
+          if (this == Pass) stmt
+          else Block(statements :+ stmt)
+      }
   }
 
   private def par(d: Doc): Doc =

--- a/core/src/main/scala/org/bykn/bosatsu/codegen/python/PythonGen.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/codegen/python/PythonGen.scala
@@ -108,9 +108,7 @@ object PythonGen {
 
       implicit class EnvOps[A](val env: Env[A]) extends AnyVal {
         def state: State[EnvState, A] =
-          env match {
-            case EnvImpl(s) => s
-          }
+          env.asInstanceOf[EnvImpl[A]].state
       }
 
       def emptyState: EnvState =
@@ -627,7 +625,7 @@ object PythonGen {
                                 cont := Code.Op(Code.Op(Code.fromInt(0), Code.Const.Lt, tmp_i),
                                   Code.Const.And,
                                   Code.Op(tmp_i, Code.Const.Lt, _i)),
-                                _i := tmp_i,
+                                _i := tmp_i
                                 )
                              )
                           ),

--- a/core/src/main/scala/org/bykn/bosatsu/codegen/python/PythonGen.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/codegen/python/PythonGen.scala
@@ -540,10 +540,10 @@ object PythonGen {
         Map(
           (Identifier.unsafeBindable("add"),
             (
-              input => (Env.onLasts(input) {
+              input => Env.onLasts(input) {
                 case arg0 :: arg1 :: Nil => arg0.evalPlus(arg1)
                 case other => throw new IllegalStateException(s"expected arity 2 got: $other")
-              })
+              }
             , 2)),
           (Identifier.unsafeBindable("sub"),
             ({
@@ -584,7 +584,21 @@ object PythonGen {
                       case other => throw new IllegalStateException(s"expected arity 2 got: $other")
                     }
                   }
-            }, 2))
+            }, 2)),
+            //external def int_loop(intValue: Int, state: a, fn: Int -> a -> TupleCons[Int, TupleCons[a, Unit]]) -> a
+            // def int_loop(i, a, fn):
+            //   if i <= 0: a
+            //   else:
+            //     (i1, a1) = fn(i, a)
+            //     if i1 >= i: a
+            //     else int_loop(i1, a, fn)
+          (Identifier.unsafeBindable("int_loop"),
+            ({
+              input => Env.onLasts(input) {
+                case intV :: state :: fn :: Nil => ???
+                case other => throw new IllegalStateException(s"expected arity 3 got: $other")
+              }
+            }, 3))
           )
 
       def unapply(expr: Expr): Option[(List[ValueLike] => Env[ValueLike], Int)] =

--- a/core/src/main/scala/org/bykn/bosatsu/codegen/python/PythonGen.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/codegen/python/PythonGen.scala
@@ -1,0 +1,651 @@
+package org.bykn.bosatsu.codegen.python
+
+import org.bykn.bosatsu.{PackageName, Identifier, Matchless}
+import cats.Monad
+import cats.data.NonEmptyList
+import org.typelevel.paiges.Doc
+
+//import Identifier.Bindable
+import Matchless._
+
+object PythonGen {
+
+  sealed abstract class PythonExpr {
+    def toDoc: Doc
+  }
+
+  sealed abstract class PythonBoolExpr {
+    def toDoc: Doc
+  }
+
+  object PythonExpr {
+    def ifExpr(conds: NonEmptyList[(PythonExpr, PythonExpr)], elseCond: PythonExpr): PythonExpr = ???
+  }
+
+  sealed abstract class Env[+A]
+  object Env {
+    implicit def envMonad: Monad[Env] = ???
+
+    def render(env: Env[PythonExpr]): String = ???
+  }
+
+  def apply(me: Expr)(resolve: (PackageName, Identifier) => Env[PythonExpr]): Env[PythonExpr] = {
+    val ops = new Impl.Ops(resolve)
+    ops.loop(me)
+  }
+
+  private object Impl {
+    class Ops(resolve: (PackageName, Identifier) => Env[PythonExpr]) {
+      def makeCons(ce: ConsExpr): Env[PythonExpr] = ???
+      def boolExpr(ix: BoolExpr): Env[PythonBoolExpr] =
+        ix match {
+          case EqualsLit(expr, lit) => ???
+          case EqualsNat(nat, zeroOrSucc) => ???
+          case TrueConst => ???
+          case And(ix1, ix2) => ???
+          case CheckVariant(enumV, idx) => ???
+          case SetMut(LocalAnonMut(mut), expr) => ???
+          case SearchList(LocalAnonMut(mutV), init, check, optLeft) => ???
+        }
+
+      def loop(expr: Expr): Env[PythonExpr] =
+        expr match {
+          case Lambda(caps, arg, res) => ???
+          case LoopFn(caps, thisName, argshead, argstail, body) => ???
+          case Global(p, n) => ???
+          case Local(b) => ???
+          case LocalAnon(a) => ???
+          case LocalAnonMut(m) => ???
+          case App(expr, args) => ???
+          case Let(localOrBind, value, in) => ???
+          case LetMut(LocalAnonMut(l), in) => ???
+          case Literal(lit) => ???
+          case If(cond, thenExpr, elseExpr) => ???
+          case Always(cond, expr) => ???
+          case MatchString(str, pat, binds) => ???
+          case GetEnumElement(expr, v, idx, sz) => ???
+          case GetStructElement(expr, idx, sz) => ???
+          case PrevNat(expr) => ???
+          case cons: ConsExpr => ???
+        }
+    }
+  }
+
+/*
+  private[this] val zeroNat: Value = ExternalValue(BigInteger.ZERO)
+  private[this] val succNat: Value = {
+    def inc(v: Value): Value = {
+      val bi = v.asExternal.toAny.asInstanceOf[BigInteger]
+      ExternalValue(bi.add(BigInteger.ONE))
+    }
+    FnValue(inc(_))
+  }
+
+  def makeCons(c: ConsExpr): Value =
+    c match {
+      case MakeEnum(variant, arity) =>
+        if (arity == 0) SumValue(variant, UnitValue)
+        else if (arity == 1) {
+          FnValue { v => SumValue(variant, ConsValue(v, UnitValue)) }
+        }
+        else
+          FnValue.curry(arity) { args =>
+            val prod = ProductValue.fromList(args)
+            SumValue(variant, prod)
+          }
+      case MakeStruct(arity) =>
+        if (arity == 0) UnitValue
+        else if (arity == 1) FnValue.identity
+        else FnValue.curry(arity)(ProductValue.fromList(_))
+      case ZeroNat => zeroNat
+      case SuccNat => succNat
+    }
+
+  private object Impl {
+    case object Uninitialized
+    val uninit: Value = ExternalValue(Uninitialized)
+
+    final case class Scope(
+      locals: Map[Bindable, Eval[Value]],
+      anon: LongMap[Value],
+      muts: MLongMap[Value]) {
+
+      def let(b: Bindable, v: Eval[Value]): Scope =
+        copy(locals = locals.updated(b, v))
+
+      def updateMut(mutIdx: Long, v: Value): Unit = {
+        assert(muts.contains(mutIdx))
+        muts.put(mutIdx, v)
+        ()
+      }
+
+      def capture(it: Iterable[Bindable]): Scope = {
+        def loc(b: Bindable): Eval[Value] =
+          locals.get(b) match {
+            case Some(v) => v
+            case None => sys.error(s"couldn't find: $b in ${locals.keys.map(_.asString).toList}")
+          }
+
+        Scope(
+          it.iterator.map { b => (b, loc(b)) }.toMap,
+            LongMap.empty,
+            MLongMap())
+      }
+    }
+
+    object Scope {
+      def empty(): Scope = Scope(Map.empty, LongMap.empty, MLongMap())
+    }
+
+    sealed abstract class Scoped[A] {
+      def apply(s: Scope): A
+      def map[B](fn: A => B): Scoped[B]
+      // lazily evaluate that (only if it is static or this is false)
+      def and(that: Scoped[Boolean])(implicit ev: Is[A, Boolean]): Scoped[Boolean]
+      def toFn: Scope => A
+
+      def withScope(ws: Scope => Scope): Scoped[A]
+    }
+    case class Dynamic[A](toFn: Scope => A) extends Scoped[A] {
+      def apply(s: Scope) = toFn(s)
+      def map[B](fn: A => B): Scoped[B] = Dynamic(toFn.andThen(fn))
+      def and(that: Scoped[Boolean])(implicit ev: Is[A, Boolean]): Scoped[Boolean] =
+        that match {
+          case Static(b) =>
+            if (b) ev.substitute[Dynamic](this)
+            else {
+              // we don't need to evaluate side-effects in
+              // and chains that end in static false, so we can bail out sooner
+              that
+            }
+          case Dynamic(thatFn) =>
+            val fn = ev.substitute[Scope => ?](toFn)
+            Dynamic { scope =>
+              if (fn(scope)) thatFn(scope)
+              else false
+            }
+        }
+      def withScope(ws: Scope => Scope): Scoped[A] =
+        Dynamic(ws.andThen(toFn))
+    }
+    case class Static[A](value: A) extends Scoped[A] {
+      def apply(s: Scope) = value
+      def map[B](fn: A => B): Scoped[B] = Static(fn(value))
+      def and(that: Scoped[Boolean])(implicit ev: Is[A, Boolean]): Scoped[Boolean] = {
+        val thisB = ev.substitute[Static](this)
+        if (thisB.value) that
+        else thisB
+      }
+
+      def withScope(ws: Scope => Scope): Scoped[A] = this
+      def toFn = Function.const(value)
+    }
+
+    object Scoped {
+      implicit val matchlessScopedApplicative: Applicative[Scoped] =
+        new Applicative[Scoped] {
+          def pure[A](a: A): Scoped[A] = Static(a)
+          override def map[A, B](aa: Scoped[A])(fn: A => B): Scoped[B] =
+            aa.map(fn)
+          override def map2[A, B, C](aa: Scoped[A], ab: Scoped[B])(fn: (A, B) => C): Scoped[C] =
+            (aa, ab) match {
+              case (Static(a), Static(b)) => Static(fn(a, b))
+              case (Static(a), db) =>
+                db.map(fn(a, _))
+              case (da, Static(b)) =>
+                da.map(fn(_, b))
+              case (da, db) =>
+                val fa = da.toFn
+                val fb = db.toFn
+                Dynamic { s => fn(fa(s), fb(s)) }
+            }
+          override def ap[A, B](sf: Scoped[A => B])(sa: Scoped[A]): Scoped[B] =
+            (sf, sa) match {
+              case (Static(fn), Static(a)) => Static(fn(a))
+              case (Static(fn), db) =>
+                db.map(fn)
+              case (da, Static(a)) =>
+                da.map(_(a))
+              case (df, da) =>
+                val fn = df.toFn
+                val a = da.toFn
+                Dynamic { s => fn(s).apply(a(s)) }
+            }
+        }
+    }
+
+    class Env(resolve: (PackageName, Identifier) => Eval[Value]) {
+      // evaluating boolExpr can mutate an existing value in muts
+      private def boolExpr(ix: BoolExpr): Scoped[Boolean] =
+        ix match {
+          case EqualsLit(expr, lit) =>
+
+            val litAny = lit.unboxToAny
+
+            loop(expr).map { e =>
+              e.asExternal.toAny == litAny
+            }
+
+          case EqualsNat(nat, zeroOrSucc) =>
+            val natF = loop(nat)
+
+            if (zeroOrSucc.isZero)
+              natF.map { v =>
+                v.asExternal.toAny == BigInteger.ZERO
+              }
+            else
+              natF.map { v =>
+                v.asExternal.toAny != BigInteger.ZERO
+              }
+
+          case TrueConst => Static(true)
+          case And(TrueConst, ix2) => boolExpr(ix2)
+          case And(ix1, TrueConst) => boolExpr(ix1)
+          case And(ix1, ix2) =>
+            boolExpr(ix1).and(boolExpr(ix2))
+
+          case CheckVariant(enumV, idx) =>
+            loop(enumV).map(_.asSum.variant == idx)
+
+          case SetMut(LocalAnonMut(mut), expr) =>
+            val exprF = loop(expr)
+            // this is always dynamic
+            Dynamic { scope: Scope =>
+              scope.updateMut(mut, exprF(scope))
+              true
+            }
+          case SearchList(LocalAnonMut(mutV), init, check, None) =>
+            val initF = loop(init)
+            val checkF = boolExpr(check)
+
+            // TODO we could optimize
+            // cases where checkF is Static(false) or Static(true)
+            // but that is probably so rare I don't know if it will
+            // help
+            // e.g. [*_, _] should have been normalized
+            // into [_, *_] which wouldn't trigger
+            // this branch
+            Dynamic { scope: Scope =>
+              var currentList = initF(scope)
+              var res = false
+              while (currentList ne null) {
+                currentList match {
+                  case nonempty@VList.Cons(_, tail) =>
+                    scope.updateMut(mutV, nonempty)
+                    res = checkF(scope)
+                    if (res) { currentList = null }
+                    else { currentList = tail }
+                  case _ =>
+                    currentList = null
+                    // we don't match empty lists
+                }
+              }
+              res
+            }
+          case SearchList(LocalAnonMut(mutV), init, check, Some(LocalAnonMut(left))) =>
+            val initF = loop(init)
+            val checkF = boolExpr(check)
+
+            // this is always dynamic
+            Dynamic { scope: Scope =>
+              var res = false
+              var currentList = initF(scope)
+              var leftList = VList.VNil
+              while (currentList ne null) {
+                currentList match {
+                  case nonempty@VList.Cons(head, tail) =>
+                    scope.updateMut(mutV, nonempty)
+                    scope.updateMut(left, leftList)
+                    res = checkF(scope)
+                    if (res) { currentList = null }
+                    else {
+                      currentList = tail
+                      leftList = VList.Cons(head, leftList)
+                    }
+                  case _ =>
+                    currentList = null
+                    // we don't match empty lists
+                }
+              }
+              res
+            }
+        }
+
+      def buildLoop(caps: List[Bindable], fnName: Bindable, arg0: Bindable, rest: List[Bindable], body: Scoped[Value]): Scoped[Value] = {
+        val argCount = rest.length + 1
+        val argNames: Array[Bindable] = (arg0 :: rest).toArray
+        if ((caps.lengthCompare(1) == 0) && (caps.head == fnName)) {
+          // We only capture ourself and we put that in below
+          val scope1 = Scope.empty()
+          val fn = FnValue.curry(argCount) { allArgs =>
+            var registers: List[Value] = allArgs
+
+            // the registers are set up
+            // when we recur, that is a continue on the loop,
+            // we just update the registers and return null
+            val continueFn = FnValue.curry(argCount) { continueArgs =>
+              registers = continueArgs
+              null
+            }
+
+            val scope2 = scope1.let(fnName, Eval.now(continueFn))
+
+            var res: Value = null
+
+            while (res eq null) {
+              // read the registers into the environment
+              var idx = 0
+              var reg: List[Value] = registers
+              var s: Scope = scope2
+              while (idx < argCount) {
+                val b = argNames(idx)
+                val v = reg.head
+                reg = reg.tail
+                s = s.let(b, Eval.now(v))
+                idx = idx + 1
+              }
+              res = body(s)
+            }
+
+            res
+          }
+
+          Static(fn)
+        }
+        else {
+          Dynamic { scope =>
+            // TODO this maybe isn't helpful
+            // it doesn't matter if the scope
+            // is too broad for correctness.
+            // It may make things go faster
+            // if the caps are really small
+            // or if we can GC things sooner.
+            val scope1 = scope.capture(caps)
+
+            FnValue.curry(argCount) { allArgs =>
+              var registers: List[Value] = allArgs
+
+              // the registers are set up
+              // when we recur, that is a continue on the loop,
+              // we just update the registers and return null
+              val continueFn = FnValue.curry(argCount) { continueArgs =>
+                registers = continueArgs
+                null
+              }
+
+              val scope2 = scope1.let(fnName, Eval.now(continueFn))
+
+              var res: Value = null
+
+              while (res eq null) {
+                // read the registers into the environment
+                var idx = 0
+                var reg: List[Value] = registers
+                var s: Scope = scope2
+                while (idx < argCount) {
+                  val b = argNames(idx)
+                  val v = reg.head
+                  reg = reg.tail
+                  s = s.let(b, Eval.now(v))
+                  idx = idx + 1
+                }
+                res = body(s)
+              }
+
+              res
+            }
+          }
+        }
+      }
+      // the locals can be recusive, so we box into Eval for laziness
+      def loop(me: Expr): Scoped[Value] =
+        me match {
+          case Lambda(caps, arg, res) =>
+            val resFn = loop(res)
+
+            if (caps.isEmpty) {
+              // we can allocate once if there is no closure
+              val scope1 = Scope.empty()
+              val fn = FnValue { argV =>
+                val scope2 = scope1.let(arg, Eval.now(argV))
+                resFn(scope2)
+              }
+              Static(fn)
+            }
+            else {
+              Dynamic { scope =>
+                val scope1 = scope.capture(caps)
+                // hopefully optimization/normalization has lifted anything
+                // that doesn't depend on argV above this lambda
+                FnValue { argV =>
+                  val scope2 = scope1.let(arg, Eval.now(argV))
+                  resFn(scope2)
+                }
+              }
+            }
+          case LoopFn(caps, thisName, argshead, argstail, body) =>
+            val bodyFn = loop(body)
+
+            buildLoop(caps, thisName, argshead, argstail, bodyFn)
+          case Global(p, n) =>
+            val res = resolve(p, n)
+
+            // this has to be lazy because it could be
+            // in this package, which isn't complete yet
+            Dynamic { _: Scope => res.value }
+          case Local(b) => Dynamic(_.locals(b).value)
+          case LocalAnon(a) => Dynamic(_.anon(a))
+          case LocalAnonMut(m) => Dynamic(_.muts(m))
+          case App(expr, args) =>
+            // TODO: App(LoopFn(..
+            // can be optimized into a while
+            // loop, but there isn't any prior optimization
+            // that would do this.... maybe it should
+            // be in Matchless
+            val exprFn = loop(expr)
+            val argsFn = args.traverse(loop(_))
+
+            Applicative[Scoped].map2(exprFn, argsFn) { (fn, args) =>
+              fn.applyAll(args)
+            }
+          case Let(localOrBind, value, in) =>
+            val valueF = loop(value)
+            val inF = loop(in)
+
+            localOrBind match {
+              case Right((b, rec)) =>
+                if (rec.isRecursive) {
+
+                  inF.withScope { scope =>
+                    // this is the only one that should
+                    // use lazy/Eval.later
+                    // we use it to tie the recursive knot
+                    lazy val scope1: Scope =
+                      scope.let(b, vv)
+
+                    lazy val vv = Eval.later(valueF(scope1))
+
+                    scope1
+                  }
+                }
+                else {
+                  inF.withScope { scope: Scope =>
+                    val vv = Eval.now(valueF(scope))
+                    scope.let(b, vv)
+                  }
+                }
+              case Left(LocalAnon(l)) =>
+                inF.withScope { scope: Scope =>
+                  val vv = valueF(scope)
+                  scope.copy(anon = scope.anon.updated(l, vv))
+                }
+            }
+          case LetMut(LocalAnonMut(l), in) =>
+            loop(in) match {
+              case s@Static(_) => s
+              case Dynamic(inF) =>
+                Dynamic { scope: Scope =>
+                  // we make sure there is
+                  // a value that will show up
+                  // strange in tests,
+                  // for an optimization we could
+                  // avoid this
+                  scope.muts.put(l, uninit)
+                  val res = inF(scope)
+                  // now we can remove this from mutable scope
+                  // we should be able to remove this
+                  scope.muts.remove(l)
+                  res
+                }
+            }
+          case Literal(lit) =>
+            Static(Value.fromLit(lit))
+          case If(cond, thenExpr, elseExpr) =>
+            val condF = boolExpr(cond)
+            val thenF = loop(thenExpr)
+            val elseF = loop(elseExpr)
+
+            condF match {
+              case Static(b) =>
+                if (b) thenF else elseF
+              case Dynamic(cfn) =>
+                Dynamic { scope: Scope =>
+                  val cond = cfn(scope)
+                  if (cond) thenF(scope)
+                  else elseF(scope)
+                }
+            }
+          case Always(cond, expr) =>
+            val condF = boolExpr(cond)
+            val exprF = loop(expr)
+
+            condF match {
+              case Static(b) =>
+                assert(b)
+                exprF
+              case dynC =>
+                Applicative[Scoped].map2(dynC, exprF) { (cond, res) =>
+                  assert(cond)
+                  res
+                }
+            }
+          case MatchString(str, pat, binds) =>
+            // do this before we evaluate the string
+            loop(str).map { strV =>
+              val arg = strV.asExternal.toAny.asInstanceOf[String]
+              matchString(arg, pat, binds)
+            }
+          case GetEnumElement(expr, v, idx, sz) =>
+            loop(expr).map { e =>
+              val sum = e.asSum
+              // we could assert e.asSum.variant == v
+              // we can comment this out when bugs
+              // are fixed
+              assert(sum.variant == v)
+              sum.value.get(idx)
+            }
+
+          case GetStructElement(expr, idx, sz) =>
+            val loopFn = loop(expr)
+            if (sz == 1) {
+              // this is a newtype
+              loopFn
+            }
+            else {
+              loop(expr).map { p =>
+                p.asProduct.get(idx)
+              }
+            }
+          case PrevNat(expr) =>
+            loop(expr).map { bv =>
+              // TODO we could cache
+              // small numbers to make this
+              // faster
+              val anyBI = bv.asExternal.toAny
+              val bi = anyBI.asInstanceOf[BigInteger]
+              ExternalValue(bi.subtract(BigInteger.ONE))
+            }
+          case cons: ConsExpr =>
+            val c = makeCons(cons)
+            Static(c)
+        }
+
+      def matchString(str: String, pat: List[Matchless.StrPart], binds: Int): SumValue = {
+        import Matchless.StrPart._
+
+        val results = new Array[String](binds)
+
+        def loop(offset: Int, pat: List[Matchless.StrPart], next: Int): Boolean =
+          pat match {
+            case Nil => offset == str.length
+            case LitStr(expect) :: tail =>
+              val len = expect.length
+              str.regionMatches(offset, expect, 0, len) && loop(offset + len, tail, next)
+            case (h: Glob) :: tail =>
+              tail match {
+                case Nil =>
+                  // we capture all the rest
+                  if (h.capture) {
+                    results(next) = str.substring(offset)
+                  }
+                  true
+                case LitStr(expect) :: tail2 =>
+                  val next1 = if (h.capture) next + 1 else next
+
+                  var start = offset
+                  var result = false
+                  while (start >= 0) {
+                    val candidate = str.indexOf(expect, start)
+                    if (candidate >= 0) {
+                      // we have to skip the current expect string
+                      val check1 = loop(candidate + expect.length, tail2, next1)
+                      if (check1) {
+                        // this was a match, write into next if needed
+                        if (h.capture) {
+                          results(next) = str.substring(offset, candidate)
+                        }
+                        result = true
+                        start = -1
+                      }
+                      else {
+                        // we couldn't match here, try just after candidate
+                        start = candidate + 1
+                      }
+                    }
+                    else {
+                      // no more candidates
+                      start = -1
+                    }
+                  }
+                  result
+                case (_: Glob) :: _ =>
+                  val n1 = if (h.capture) {
+                    // this index gets the empty string
+                    results(next) = ""
+                    // we match the right side first, so this wild gets nothing
+                    next + 1
+                  } else next
+
+                  loop(offset, tail, n1)
+              }
+          }
+
+        if (loop(0, pat, 0)) {
+          var idx = binds - 1
+          var prod: ProductValue = UnitValue
+          while (0 <= idx) {
+            val item = results(idx)
+            idx = idx - 1
+            prod = ConsValue(ExternalValue(item), prod)
+          }
+          SumValue(1, prod)
+        }
+        else {
+          // this is (0, UnitValue)
+          Value.False
+        }
+      }
+    }
+  }
+  */
+}

--- a/core/src/main/scala/org/bykn/bosatsu/codegen/python/PythonGen.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/codegen/python/PythonGen.scala
@@ -707,24 +707,8 @@ object PythonGen {
 
       def topLet(name: Code.Ident, expr: Expr, v: ValueLike): Env[Statement] = {
 
-        /*
-         * def anonF():
-         *   code
-         *
-         * name = anonF()
-         */
         lazy val worstCase: Env[Statement] =
-          v match {
-            case ex: Expression =>
-              Monad[Env].pure(Code.Assign(name, ex))
-            case _ =>
-              Env.newAssignableVar.map { defName =>
-                val body = Code.toReturn(v)
-                val newDef = Code.Def(defName, Nil, body)
-
-                newDef :+ Code.Assign(name, Code.Apply(defName, Nil))
-              }
-          }
+          Monad[Env].pure(Code.addAssign(name, v))
 
         expr match {
           case l@LoopFn(_, nm, h, t, b) =>

--- a/core/src/test/scala/org/bykn/bosatsu/DeclarationTest.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/DeclarationTest.scala
@@ -6,6 +6,8 @@ import org.scalatest.prop.PropertyChecks.{ forAll, PropertyCheckConfiguration }
 
 import Identifier.Bindable
 
+import Parser.unsafeParse
+
 class DeclarationTest extends FunSuite {
 
   import Generators.shrinkDecl
@@ -162,18 +164,18 @@ class DeclarationTest extends FunSuite {
       )
 
     regressions.foreach { case (decl, v) =>
-      val d = TestParseUtils.parseUnsafe(Declaration.parser(""), decl)
-      val bind = TestParseUtils.parseUnsafe(Identifier.bindableParser, v)
+      val d = unsafeParse(Declaration.parser(""), decl)
+      val bind = unsafeParse(Identifier.bindableParser, v)
       law(bind, d)
     }
   }
 
   test("test example substitutions") {
     def law(bStr: String, to: String, in: String, res: Option[String]) = {
-      val d1 = TestParseUtils.parseUnsafe(Declaration.parser(""), to)
-      val d0 = TestParseUtils.parseUnsafe(Declaration.parser(""), in)
-      val resD = res.map(TestParseUtils.parseUnsafe(Declaration.parser(""), _))
-      val b = TestParseUtils.parseUnsafe(Identifier.bindableParser, bStr)
+      val d1 = unsafeParse(Declaration.parser(""), to)
+      val d0 = unsafeParse(Declaration.parser(""), in)
+      val resD = res.map(unsafeParse(Declaration.parser(""), _))
+      val b = unsafeParse(Identifier.bindableParser, bStr)
 
 
       assert(Declaration.substitute(b, d1.toNonBinding, d0) == resD)
@@ -192,9 +194,9 @@ x"""))
 
   test("test freeVars with explicit examples") {
     def law(decls: String, frees: List[String], all: List[String]) = {
-      val binds = frees.map(TestParseUtils.parseUnsafe(Identifier.bindableParser, _))
-      val alls = all.map(TestParseUtils.parseUnsafe(Identifier.bindableParser, _))
-      val decl = TestParseUtils.parseUnsafe(Declaration.parser(""), decls)
+      val binds = frees.map(unsafeParse(Identifier.bindableParser, _))
+      val alls = all.map(unsafeParse(Identifier.bindableParser, _))
+      val decl = unsafeParse(Declaration.parser(""), decls)
 
       assert(decl.freeVars.toSet == binds.toSet, "freeVars don't match")
       assert(decl.allNames.toSet == alls.toSet, "allVars don't match")

--- a/core/src/test/scala/org/bykn/bosatsu/MatchlessTests.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/MatchlessTests.scala
@@ -13,25 +13,20 @@ import cats.implicits._
 class MatchlessTest extends FunSuite {
   implicit val generatorDrivenConfig = PropertyCheckConfiguration(minSuccessful = 1000)
 
-  type Fn = (PackageName, Constructor) => DataRepr
+  type Fn = (PackageName, Constructor) => Option[DataRepr]
 
   def fnFromTypeEnv[A](te: rankn.TypeEnv[A]): Fn =
     {
       // the list constructors *have* to be in scope or matching will generate
       // bad code
       case (PackageName.PredefName, Constructor("EmptyList")) =>
-        DataRepr.Enum(0, 0)
+        Some(DataRepr.Enum(0, 0))
       case (PackageName.PredefName, Constructor("NonEmptyList")) =>
-        DataRepr.Enum(1, 2)
+        Some(DataRepr.Enum(1, 2))
       case (pn, cons) =>
-        te.getConstructor(pn, cons) match {
-          case Some((_, dt, _)) =>
-            dt.dataRepr(cons)
-          case None =>
-            // todo, the generator *shouldn't* generate this,
-            // but it seems to
-            DataRepr.Struct(0)
-        }
+        te.getConstructor(pn, cons)
+          .map(_._2.dataRepr(cons))
+          .orElse(Some(DataRepr.Struct(0)))
     }
 
   lazy val genInputs: Gen[(Bindable, RecursionKind, TypedExpr[Unit], Fn)] =

--- a/core/src/test/scala/org/bykn/bosatsu/OperatorTest.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/OperatorTest.scala
@@ -36,7 +36,7 @@ class OperatorTest extends ParserTestBase {
     }
 
   def parseSame(left: String, right: String) =
-    assert(parseUnsafe(formP, left).toFormula == parseUnsafe(formP, right).toFormula)
+    assert(Parser.unsafeParse(formP, left).toFormula == Parser.unsafeParse(formP, right).toFormula)
 
   test("we can parse integer formulas") {
     parseSame("1+2", "1 + 2")

--- a/core/src/test/scala/org/bykn/bosatsu/codegen/python/PythonGenTest.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/codegen/python/PythonGenTest.scala
@@ -1,0 +1,33 @@
+package org.bykn.bosatsu.codegen.python
+
+import org.bykn.bosatsu.Generators.bindIdentGen
+import org.scalatest.prop.PropertyChecks.{ forAll, PropertyCheckConfiguration }
+import org.scalatest.FunSuite
+
+class PythonGenTest extends FunSuite {
+  implicit val generatorDrivenConfig =
+    //PropertyCheckConfiguration(minSuccessful = 50000)
+    PropertyCheckConfiguration(minSuccessful = 5000)
+    //PropertyCheckConfiguration(minSuccessful = 500)
+
+  test("PythonGen.escape round trips") {
+    forAll(bindIdentGen) { b =>
+      val ident = PythonGen.escape(b)
+      PythonGen.unescape(ident) match {
+        case Some(b1) => assert(b1 == b)
+        case None => assert(false, s"$b => $ident could not round trip")
+      }
+    }
+
+  }
+
+  val PythonName = "[_A-Za-z][_A-Za-z0-9]*".r.pattern
+
+  test("all escapes are valid python identifiers") {
+    forAll(bindIdentGen) { b =>
+      val str = PythonGen.escape(b).name
+
+      assert(PythonName.matcher(str).matches(), s"escaped: ${b.sourceCodeRepr} to $str")
+    }
+  }
+}

--- a/test_workspace/Nat.bosatsu
+++ b/test_workspace/Nat.bosatsu
@@ -35,11 +35,11 @@ def mult(n1: Nat, n2: Nat) -> Nat:
           Succ(mult(n1, n2).add(add(n1, n2)))
 
 def to_Int(n: Nat) -> Int:
-    def loop(n: Nat, acc: Int):
+    def loop(acc: Int, n: Nat):
       recur n:
         Zero: acc
-        Succ(n): loop(n, acc + 1)
-    loop(n, 0)
+        Succ(n): loop(acc + 1, n)
+    loop(0, n)
 
 def to_Nat(i: Int) -> Nat:
   int_loop(i, Zero, \i, nat -> (i.sub(1), Succ(nat)))


### PR DESCRIPTION
This adds a `transpile` command to bosatsu, with one language (python) supported.

done items:
1. add tests with Jython that generated code runs.
2. add some tests for explicit constructs being compiled into specific code
3. try to minimize the code somewhat, some examples look a little verbose

This is not yet complete, and fails on a few inputs, but it is already large enough and has sufficient test coverage for an alpha quality merge.

I'll continue this week to get completeness and test coverage up.