### PR TITLE
fix div and mod issues related to #153

### DIFF
--- a/core/src/main/resources/bosatsu/predef.bosatsu
+++ b/core/src/main/resources/bosatsu/predef.bosatsu
@@ -105,7 +105,7 @@ external struct Int
 external def add(a: Int, b: Int) -> Int
 external def sub(a: Int, b: Int) -> Int
 external def times(a: Int, b: Int) -> Int
-external def div(a: Int, b: Int) -> Option[Int]
+external def div(a: Int, b: Int) -> Int
 external def eq_Int(a: Int, b: Int) -> Bool
 external def gcd_Int(a: Int, b: Int) -> Int
 external def cmp_Int(a: Int, b: Int) -> Comparison

--- a/core/src/main/scala/org/bykn/bosatsu/Predef.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/Predef.scala
@@ -112,6 +112,14 @@ object PredefImpl {
   def add(a: Value, b: Value): Value =
     VInt(i(a).add(i(b)))
 
+  def divBigInteger(a: BigInteger, b: BigInteger): BigInteger =
+    if (b == BigInteger.ZERO) BigInteger.ZERO
+    else a.divide(b)
+
+  def modBigInteger(a: BigInteger, b: BigInteger): BigInteger =
+    if (b == BigInteger.ZERO) a
+    else a.mod(b)
+
   def div(a: Value, b: Value): Value = {
     val bi = i(b)
     if (bi.equals(BigInteger.ZERO)) VOption.none

--- a/core/src/main/scala/org/bykn/bosatsu/Predef.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/Predef.scala
@@ -112,19 +112,35 @@ object PredefImpl {
   def add(a: Value, b: Value): Value =
     VInt(i(a).add(i(b)))
 
-  def divBigInteger(a: BigInteger, b: BigInteger): BigInteger =
+  def divBigInteger(a: BigInteger, b: BigInteger): BigInteger = {
     if (b == BigInteger.ZERO) BigInteger.ZERO
-    else a.divide(b)
-
-  def modBigInteger(a: BigInteger, b: BigInteger): BigInteger =
-    if (b == BigInteger.ZERO) a
-    else a.mod(b)
-
-  def div(a: Value, b: Value): Value = {
-    val bi = i(b)
-    if (bi.equals(BigInteger.ZERO)) VOption.none
-    else VOption.some(VInt(i(a).divide(bi)))
+    else if (b == BigInteger.ONE) a
+    else {
+      val mod = modBigInteger(a, b)
+      a.subtract(mod).divide(b)
+    }
   }
+
+  def modBigInteger(a: BigInteger, b: BigInteger): BigInteger = {
+    val s = b.signum
+    if (s == 0) a
+    else if (s > 0) a.mod(b)
+    else {
+      // java does not support negative modulus
+      // d = a / b
+      // we want a = d * b + (a % b)
+      // and sign of (a % b).signum == b.signum
+      // so (a % b) = a - d * b
+      val res0 = a.remainder(b)
+      val sr = res0.signum
+      if (sr == 0) res0
+      else if (res0.signum == s) res0
+      else res0.add(b)
+    }
+  }
+
+  def div(a: Value, b: Value): Value =
+    VInt(divBigInteger(i(a), i(b)))
 
   def sub(a: Value, b: Value): Value =
     VInt(i(a).subtract(i(b)))
@@ -140,10 +156,22 @@ object PredefImpl {
     Comparison.fromInt(i(a).compareTo(i(b)))
 
   def mod_Int(a: Value, b: Value): Value =
-    VInt(i(a).mod(i(b).abs()))
+    VInt(modBigInteger(i(a), i(b)))
+
+  def gcdBigInteger(a: BigInteger, b: BigInteger): BigInteger = {
+    @annotation.tailrec
+    def gcd(a: BigInteger, b: BigInteger): BigInteger =
+      if (b == BigInteger.ZERO) a
+      else {
+        gcd(b, modBigInteger(a, b))
+      }
+
+    if (b.signum > 0) a.gcd(b)
+    else gcd(a, b)
+  }
 
   def gcd_Int(a: Value, b: Value): Value =
-    VInt(i(a).gcd(i(b)))
+    VInt(gcdBigInteger(i(a), i(b)))
 
   //def intLoop(intValue: Int, state: a, fn: Int -> a -> TupleCons[Int, TupleCons[a, Unit]]) -> a
   final def intLoop(intValue: Value, state: Value, fn: Value): Value = {

--- a/core/src/test/scala/org/bykn/bosatsu/EvaluationTest.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/EvaluationTest.scala
@@ -350,10 +350,9 @@ main = 6.mod_Int(4)
 package Foo
 
 main = match 6.div(4):
-  Some(0): 42
-  Some(1): 100
-  Some(x): x
-  None: -1
+  0: 42
+  1: 100
+  x: x
 """), "Foo", VInt(100))
 
     evalTest(

--- a/core/src/test/scala/org/bykn/bosatsu/IntLaws.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/IntLaws.scala
@@ -1,0 +1,24 @@
+package org.bykn.bosatsu.pattern
+
+import cats.Eq
+import org.scalacheck.Gen
+import org.scalatest.prop.PropertyChecks.{ forAll, PropertyCheckConfiguration }
+import org.scalatest.FunSuite
+
+class IntLaws extends FunSuite {
+  implicit val generatorDrivenConfig =
+    //PropertyCheckConfiguration(minSuccessful = 50000)
+    PropertyCheckConfiguration(minSuccessful = 5000)
+    //PropertyCheckConfiguration(minSuccessful = 500)
+
+  val genBI: Gen[BigInteger] =
+    Gen.choose(-128, 128)
+      .map(new BigInteger(_))
+
+  test("a = div(a, b) * b + mod(a, b)") {
+    forAll(genBI, genBI) { (a, b) =>
+      val a1 = PredefImpl.divBigInteger(a, b).times(b) + PredefImpl.modBigInteger(a, b)
+      assert(a1 == a)
+    }
+  }
+}

--- a/core/src/test/scala/org/bykn/bosatsu/IntLaws.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/IntLaws.scala
@@ -1,24 +1,164 @@
-package org.bykn.bosatsu.pattern
+package org.bykn.bosatsu
 
-import cats.Eq
+import java.math.BigInteger
 import org.scalacheck.Gen
 import org.scalatest.prop.PropertyChecks.{ forAll, PropertyCheckConfiguration }
 import org.scalatest.FunSuite
 
+object IntLaws {
+  implicit class BIMethods(val self: BigInteger) extends AnyVal {
+    def *(that: BigInteger) = self.multiply(that)
+    def /(that: BigInteger) = PredefImpl.divBigInteger(self, that)
+    def %(that: BigInteger) = PredefImpl.modBigInteger(self, that)
+    def +(that: BigInteger) = self.add(that)
+    def -(that: BigInteger) = self.subtract(that)
+  }
+}
+
 class IntLaws extends FunSuite {
+  import IntLaws.BIMethods
+
   implicit val generatorDrivenConfig =
-    //PropertyCheckConfiguration(minSuccessful = 50000)
-    PropertyCheckConfiguration(minSuccessful = 5000)
+    PropertyCheckConfiguration(minSuccessful = 50000)
+    //PropertyCheckConfiguration(minSuccessful = 5000)
     //PropertyCheckConfiguration(minSuccessful = 500)
 
   val genBI: Gen[BigInteger] =
-    Gen.choose(-128, 128)
-      .map(new BigInteger(_))
+    Gen.choose(-128L, 128L)
+      .map(BigInteger.valueOf(_))
 
-  test("a = div(a, b) * b + mod(a, b)") {
+  test("match python on some examples") {
+    assert(BigInteger.valueOf(4L) % BigInteger.valueOf(-3L) == BigInteger.valueOf(-2L))
+
+    assert(BigInteger.valueOf(-8L) % BigInteger.valueOf(-2L) == BigInteger.valueOf(0L))
+    assert(BigInteger.valueOf(-8L) / BigInteger.valueOf(-2L) == BigInteger.valueOf(4L))
+
+    assert(BigInteger.valueOf(-4L) % BigInteger.valueOf(-3L) == BigInteger.valueOf(-1L))
+    assert(BigInteger.valueOf(13L) % BigInteger.valueOf(3L) == BigInteger.valueOf(1L))
+    assert(BigInteger.valueOf(-113L) / BigInteger.valueOf(16L) == BigInteger.valueOf(-8L))
+
+
+    assert(BigInteger.valueOf(54L) % BigInteger.valueOf(-3L) == BigInteger.valueOf(0L))
+    assert(BigInteger.valueOf(54L) / BigInteger.valueOf(-3L) == BigInteger.valueOf(-18L))
+  }
+
+  test("a = (a / b) * b + (a % b)") {
     forAll(genBI, genBI) { (a, b) =>
-      val a1 = PredefImpl.divBigInteger(a, b).times(b) + PredefImpl.modBigInteger(a, b)
-      assert(a1 == a)
+      val div = a / b
+      val mod = a % b
+      val a1 = (div * b) + mod
+      assert(a1 == a, s"div = $div, mod = $mod")
+    }
+  }
+
+  test("a = (a / b) * b <= a if (b > 0)") {
+    forAll(genBI, genBI) { (a, b) =>
+      if (b.compareTo(BigInteger.ZERO) > 0) {
+        val div = a / b
+        val a1 = div * b
+        assert(a1.compareTo(a) <= 0, s"div = $div")
+      }
+    }
+  }
+
+  test("a = (a / b) * b >= a if (b < 0)") {
+    forAll(genBI, genBI) { (a, b) =>
+      if (b.compareTo(BigInteger.ZERO) < 0) {
+        val div = a / b
+        val a1 = div * b
+        assert(a1.compareTo(a) >= 0, s"div = $div")
+      }
+    }
+  }
+
+  test("(a - (a % b)) % b == 0") {
+    forAll(genBI, genBI) { (a, b) =>
+      assert((a - (a % b)) % b == BigInteger.ZERO)
+    }
+  }
+
+  test("if (a * k) % b ==  (c * k) % b if a ~= c") {
+    forAll(genBI, genBI, genBI, genBI) { (a, b, c0, k) =>
+      // make something with the same mod as a
+      val c = a + (c0 * b)
+
+      assert((a * k) % b == (c * k) % b)
+    }
+  }
+
+  test("if (a + k) % b ==  (c + k) % b if a ~= c") {
+    forAll(genBI, genBI, genBI, genBI) { (a, b, c0, k) =>
+      // make something with the same mod as a
+      val c = a + (c0 * b)
+
+      assert((a + k) % b == (c + k) % b)
+    }
+  }
+
+  test("0 <= a % b <= b if b > 0") {
+    forAll(genBI, genBI) { (a, b) =>
+      if (b.compareTo(BigInteger.ZERO) > 0) {
+        val mod = a % b
+        assert(BigInteger.ZERO.compareTo(mod) <= 0)
+        assert(mod.compareTo(b) < 0)
+      }
+    }
+  }
+
+  test("a / b <= a if b >= 0 and a >= 0") {
+    forAll(genBI, genBI) { (a, b) =>
+      if (b.compareTo(BigInteger.ZERO) >= 0 && a.compareTo(BigInteger.ZERO) >= 0) {
+        val div = a / b
+        assert(div.compareTo(a) <= 0, div)
+      }
+    }
+  }
+
+  test("(-a) / (-b) == a / b") {
+    forAll(genBI, genBI) { (a, b) =>
+      assert((a.negate) / (b.negate) == a / b)
+    }
+  }
+
+  test("a.mod(b) != 0 then has the same sign as b for b != 0") {
+    forAll(genBI, genBI) { (a, b) =>
+      val mod = a % b
+      if ((b != BigInteger.ZERO) && (mod != BigInteger.ZERO)) {
+        assert(mod.signum == b.signum)
+      }
+    }
+  }
+
+  test("a.mod(b) == 0 then (a/b)*b == a") {
+    forAll(genBI, genBI) { (a, b) =>
+      val mod = a % b
+      if (mod == BigInteger.ZERO) {
+        assert((a/b)*b == a)
+      }
+    }
+  }
+
+  test("a.mod(0) == a") {
+    forAll(genBI) { a =>
+      assert(a % BigInteger.ZERO == a)
+    }
+  }
+  test("a / 0 == 0") {
+    forAll(genBI) { a =>
+      assert(a / BigInteger.ZERO == BigInteger.ZERO)
+    }
+  }
+
+  test("gcd matches a simple implementation") {
+    forAll(genBI, genBI) { (a, b) =>
+      @annotation.tailrec
+      def gcd(a: BigInteger, b: BigInteger): BigInteger =
+        if (b == BigInteger.ZERO) a
+        else {
+          gcd(b, a % b)
+        }
+
+      assert(gcd(a, b) == PredefImpl.gcdBigInteger(a, b))
     }
   }
 }

--- a/test_workspace/AvlTree.bosatsu
+++ b/test_workspace/AvlTree.bosatsu
@@ -231,9 +231,7 @@ def size_tests:
 
 def log2(i):
      int_loop(i, 0, \n, cnt ->
-        rr = match n.div(2):
-             None: 0
-             Some(n): n
+        rr = n.div(2)
         (rr, cnt.add(1)))
 
 def all_n(n): range(n).foldLeft(Empty)(add_i)

--- a/test_workspace/BinNat.bosatsu
+++ b/test_workspace/BinNat.bosatsu
@@ -33,10 +33,7 @@ def toBinNat(n: Int) -> BinNat:
     is_even = mod_Int(n, 2).eq_Int(0)
     (hfn, dec) = (\n -> Even(n), \n -> n.sub(1)) if is_even else (\n -> Odd(n), \n -> n)
     fns = [hfn, *fns]
-    # the None case can't really happen
-    n = match n.div(2):
-      None: 0
-      Some(n): n
+    n = n.div(2)
     (dec(n), fns)
   )
   # Now apply all the transformations

--- a/test_workspace/euler3.bosatsu
+++ b/test_workspace/euler3.bosatsu
@@ -27,8 +27,8 @@ def all_factors(n):
     next_factor = smallest_factor(i)
     next_facs = [next_factor, *facs]
     match i.div(next_factor):
-      None | Some(1): (0, next_facs)
-      Some(smaller): (smaller, next_facs))
+      1: (0, next_facs)
+      smaller: (smaller, next_facs))
 
 def largest_factor(n):
   match all_factors(n):

--- a/test_workspace/euler4.bosatsu
+++ b/test_workspace/euler4.bosatsu
@@ -53,11 +53,7 @@ def digit_list(n):
   rev_list = int_loop(n, [], \n, acc ->
     this_digit = n.mod_Int(10)
     next_acc = [this_digit, *acc]
-    next_n = match n.div(10):
-      None:
-        # can't really happen because 10 is not zero
-        n
-      Some(next): next
+    next_n = n.div(10)
     (next_n, next_acc))
   reverse(rev_list)
 


### PR DESCRIPTION
close #153 

see: https://www.hillelwayne.com/post/divide-by-zero/

for more discussion on this.

The main objection to this is that it hides errors. This is true. But without this (or a dependent type system) it becomes painful to deal with the optionality that is inherent in the `PositiveInt` or `Option[Int]` (which are kind of the same thing since PositiveInt is not closed under division, so you'd often wind up back at optionality).

