### PR TITLE
Fix match error in MatchlessTests due to fuzzing

### DIFF
--- a/core/src/main/scala/org/bykn/bosatsu/Matchless.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/Matchless.scala
@@ -192,8 +192,9 @@ object Matchless {
                 val argstail = args.tail
                 val captures = TypedExpr.freeVars(body :: Nil).filterNot(args.toSet)
                 loop(body).map(LoopFn(captures, name, argshead, argstail, _))
-              case None =>
-                // TODO: I don't think this case should ever happen
+              case _ =>
+                // TODO: I don't think this case should ever happen in real code
+                // but it definitely does in fuzz tests
                 e0.map { value => Let(Right((name, RecursionKind.Recursive)), value, Local(name)) }
             }
           }

--- a/core/src/test/scala/org/bykn/bosatsu/MatchlessTests.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/MatchlessTests.scala
@@ -58,6 +58,15 @@ class MatchlessTest extends FunSuite {
     }
   }
 
+  test("regressions") {
+    // this is illegal code, but it shouldn't throw a match error:
+    val name = Identifier.Name("foo")
+    val te = TypedExpr.Local(name, rankn.Type.IntType, ())
+    // this should not throw
+    val me = Matchless.fromLet(name, RecursionKind.Recursive, te)(fnFromTypeEnv(rankn.TypeEnv.empty))
+    assert(me != null)
+  }
+
   def genNE[A](max: Int, ga: Gen[A]): Gen[NonEmptyList[A]] =
     for {
       h <- ga


### PR DESCRIPTION
close #509 

The Matchless scalacheck tests include something that is basically a fuzz test: send in totally random data and running twice on that should not throw and produce the same results.

The match error should not happen on typechecked code, but we are not fuzzing with typechecked code.