### PR TITLE
Add PyBool remove Code.Literal

### DIFF
--- a/cli/src/test/scala/org/bykn/bosatsu/codegen/python/CodeTest.scala
+++ b/cli/src/test/scala/org/bykn/bosatsu/codegen/python/CodeTest.scala
@@ -147,7 +147,7 @@ class CodeTest extends FunSuite {
   test("test bug with IfElse") {
     import Code._
 
-    val ifElse = IfElse(NonEmptyList.of((Literal("a"), Literal("b"))), Literal("c"))
+    val ifElse = IfElse(NonEmptyList.of((Ident("a"), Ident("b"))), Ident("c"))
     val stmt = addAssign(Ident("bar"), ifElse)
 
     assert(toDoc(stmt).renderTrim(80) == """if a:
@@ -159,19 +159,19 @@ else:
   test("test some Operator examples") {
     import Code._
 
-    val apbpc = Op(Literal("a"), Const.Plus, Op(Literal("b"), Const.Plus, Literal("c")))
+    val apbpc = Op(Ident("a"), Const.Plus, Op(Ident("b"), Const.Plus, Ident("c")))
 
     assert(toDoc(apbpc).renderTrim(80) == """a + b + c""")
 
-    val apbmc = Op(Literal("a"), Const.Plus, Op(Literal("b"), Const.Minus, Literal("c")))
+    val apbmc = Op(Ident("a"), Const.Plus, Op(Ident("b"), Const.Minus, Ident("c")))
 
     assert(toDoc(apbmc).renderTrim(80) == """a + b - c""")
 
-    val ambmc = Op(Literal("a"), Const.Minus, Op(Literal("b"), Const.Minus, Literal("c")))
+    val ambmc = Op(Ident("a"), Const.Minus, Op(Ident("b"), Const.Minus, Ident("c")))
 
     assert(toDoc(ambmc).renderTrim(80) == """a - (b - c)""")
 
-    val amzmbmc = Op(Op(Literal("a"), Const.Minus, Literal("z")), Const.Minus, Op(Literal("b"), Const.Minus, Literal("c")))
+    val amzmbmc = Op(Op(Ident("a"), Const.Minus, Ident("z")), Const.Minus, Op(Ident("b"), Const.Minus, Ident("c")))
 
     assert(toDoc(amzmbmc).renderTrim(80) == """(a - z) - (b - c)""")
   }

--- a/core/src/main/scala/org/bykn/bosatsu/codegen/python/Code.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/codegen/python/Code.scala
@@ -93,7 +93,9 @@ object Code {
     c match {
       case PyInt(bi) => Doc.text(bi.toString)
       case PyString(s) => Doc.char('"') + Doc.text(StringUtil.escape('"', s)) + Doc.char('"')
-      case PyBool(b) => Doc.text(b.toString)
+      case PyBool(b) =>
+        if (b) Doc.text("True")
+        else Doc.text("False")
       case Ident(i) => Doc.text(i)
       case o@Op(_, _, _) => o.toDoc
       case Parens(inner@Parens(_)) => toDoc(inner)

--- a/core/src/main/scala/org/bykn/bosatsu/codegen/python/Code.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/codegen/python/Code.scala
@@ -84,8 +84,6 @@ object Code {
     c match {
       case Lambda(_, _) => par(toDoc(c))
       case _ => toDoc(c)
-      //case Apply(_, _) | DotSelect(_, _) | Literal(_) | PyInt(_) | PyString(_) | Ident(_) | Parens(_) | MakeTuple(_) => toDoc(c)
-      //case _ => par(toDoc(c))
     }
 
   private def iflike(name: String, cond: Doc, body: Doc): Doc =
@@ -93,9 +91,9 @@ object Code {
 
   def toDoc(c: Code): Doc =
     c match {
-      case Literal(s) => Doc.text(s)
       case PyInt(bi) => Doc.text(bi.toString)
       case PyString(s) => Doc.char('"') + Doc.text(StringUtil.escape('"', s)) + Doc.char('"')
+      case PyBool(b) => Doc.text(b.toString)
       case Ident(i) => Doc.text(i)
       case o@Op(_, _, _) => o.toDoc
       case Parens(inner@Parens(_)) => toDoc(inner)
@@ -148,10 +146,9 @@ object Code {
   // Here are all the expressions
   /////////////////////////
 
-  // True, False, None, numbers
-  case class Literal(asString: String) extends Expression
   case class PyInt(toBigInteger: BigInteger) extends Expression
   case class PyString(content: String) extends Expression
+  case class PyBool(toBoolean: Boolean) extends Expression
   case class Ident(name: String) extends Dotable { // a kind of expression
     def :=(vl: ValueLike): Statement =
       addAssign(this, vl)
@@ -472,8 +469,8 @@ object Code {
     case object Gt extends Operator(">")
     case object Lt extends Operator("<")
 
-    val True = Literal("True")
-    val False = Literal("False")
+    val True = PyBool(true)
+    val False = PyBool(false)
 
     val Zero = PyInt(BigInteger.ZERO)
     val One = PyInt(BigInteger.ONE)

--- a/core/src/main/scala/org/bykn/bosatsu/codegen/python/PythonGen.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/codegen/python/PythonGen.scala
@@ -303,7 +303,7 @@ object PythonGen {
           case WithValue(stmt, v) =>
             loop(v).map(WithValue(stmt, _))
           // the rest cannot have a call in the tail position
-          case DotSelect(_, _) | Op(_, _, _) | Lambda(_, _) | MakeTuple(_) | SelectItem(_, _) | Ident(_) | Literal(_) | PyString(_) | PyInt(_) => Monad[Env].pure(body)
+          case DotSelect(_, _) | Op(_, _, _) | Lambda(_, _) | MakeTuple(_) | SelectItem(_, _) | Ident(_) | PyBool(_) | PyString(_) | PyInt(_) => Monad[Env].pure(body)
         }
 
       loop(initBody)


### PR DESCRIPTION
we were only using Literal for True/False, but it was easily confused with Ident.

This add PyBool to make the AST more precise.