### PR TITLE
Add python support for complex string patterns

### DIFF
--- a/cli/src/test/scala/org/bykn/bosatsu/PathModuleTest.scala
+++ b/cli/src/test/scala/org/bykn/bosatsu/PathModuleTest.scala
@@ -110,6 +110,7 @@ class PathModuleTest extends FunSuite {
       List("Nat.bosatsu",
         "Bool.bosatsu",
         "List.bosatsu",
+        "StrConcatExample.bosatsu",
         "euler1.bosatsu",
         "euler2.bosatsu",
         "euler3.bosatsu",

--- a/cli/src/test/scala/org/bykn/bosatsu/PathModuleTest.scala
+++ b/cli/src/test/scala/org/bykn/bosatsu/PathModuleTest.scala
@@ -108,8 +108,12 @@ class PathModuleTest extends FunSuite {
   test("test transpile on a few files") {
     val files =
       List("Nat.bosatsu",
+        "AvlTree.bosatsu",
+        "BinNat.bosatsu",
         "Bool.bosatsu",
         "List.bosatsu",
+        "PatternExamples.bosatsu",
+        "Queue.bosatsu",
         "StrConcatExample.bosatsu",
         "euler1.bosatsu",
         "euler2.bosatsu",

--- a/cli/src/test/scala/org/bykn/bosatsu/codegen/python/PythonGenTest.scala
+++ b/cli/src/test/scala/org/bykn/bosatsu/codegen/python/PythonGenTest.scala
@@ -74,4 +74,30 @@ class PythonGenTest extends FunSuite {
     }
   }
 
+  intr.close()
+
+  val strConcat = new PythonInterpreter()
+
+  test("we can compile StrConcatExample") {
+    val path: String = "test_workspace/StrConcatExample.bosatsu"
+
+    val bosatsuPM = compileFile(path)
+    val matchless = MatchlessFromTypedExpr.compile(bosatsuPM)
+
+    val packMap = PythonGen.renderAll(matchless, Map.empty)
+    val doc = packMap(PackageName.parts("StrConcatExample"))._2
+
+    strConcat.execfile(isfromString(doc.renderTrim(80)), "StrConcatExample.py")
+
+  }
+
+  test("res0 .. res4 are all 1 (True)") {
+
+    val one = new PyInteger(1)
+    (0 to 4).foreach { i =>
+      val res = s"res$i"
+
+      assert(strConcat.get(res) == one)
+    }
+  }
 }

--- a/core/src/main/scala/org/bykn/bosatsu/codegen/python/Code.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/codegen/python/Code.scala
@@ -448,9 +448,11 @@ object Code {
 
   def block(stmt: Statement, rest: Statement*): Statement = {
     val all = (stmt :: rest.toList).flatMap(flatten)
-    NonEmptyList.fromList(all) match {
-      case None => Pass
-      case Some(nel) => Block(nel)
+    all match {
+      case Nil => Pass
+      case one :: Nil => one
+      case head :: tail =>
+        Block(NonEmptyList(head, tail))
     }
   }
 

--- a/core/src/main/scala/org/bykn/bosatsu/codegen/python/PythonGen.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/codegen/python/PythonGen.scala
@@ -185,17 +185,18 @@ object PythonGen {
     def topLevelName(n: Bindable): Env[Code.Ident] =
       Impl.env(_.topLevel(n))
 
-    def onLasts(cs: List[ValueLike])(fn: List[Expression] => ValueLike): Env[ValueLike] = {
+    def onLastsM(cs: List[ValueLike])(fn: List[Expression] => Env[ValueLike]): Env[ValueLike] = {
       def loop(cs: List[ValueLike], setup: List[Statement], args: List[Expression]): Env[ValueLike] =
         cs match {
-          case Nil => Monad[Env].pure {
+          case Nil =>
             val res = fn(args.reverse)
             NonEmptyList.fromList(setup) match {
               case None => res
               case Some(nel) =>
-                WithValue(Block(nel.reverse), res)
+                val stmts = nel.reverse
+                val stmt = Code.block(stmts.head, stmts.tail :_*)
+                res.map(stmt.withValue(_))
             }
-          }
           case (e: Expression) :: t => loop(t, setup, e :: args)
           case (ifelse@IfElse(_, _)) :: tail =>
             // we allocate a result and assign
@@ -210,14 +211,20 @@ object PythonGen {
       loop(cs, Nil, Nil)
     }
 
-    def onLast(c: ValueLike)(fn: Expression => ValueLike): Env[ValueLike] =
-      onLasts(c :: Nil) {
+    def onLasts(cs: List[ValueLike])(fn: List[Expression] => ValueLike): Env[ValueLike] =
+      onLastsM(cs)(fn.andThen(Monad[Env].pure(_)))
+
+    def onLastM(c: ValueLike)(fn: Expression => Env[ValueLike]): Env[ValueLike] =
+      onLastsM(c :: Nil) {
         case x :: Nil => fn(x)
         case other =>
           // $COVERAGE-OFF$
           throw new IllegalStateException(s"expected list to have size 1: $other")
           // $COVERAGE-ON$
       }
+
+    def onLast(c: ValueLike)(fn: Expression => ValueLike): Env[ValueLike] =
+      onLastM(c)(fn.andThen(Monad[Env].pure(_)))
 
     def onLast2(c1: ValueLike, c2: ValueLike)(fn: (Expression, Expression)=> ValueLike): Env[ValueLike] =
       onLasts(c1 :: c2 :: Nil) {
@@ -249,12 +256,50 @@ object PythonGen {
             cv <- Env.newAssignableVar
             assigned = cv := cx
             res <- ifElse(NonEmptyList((cv, t), rest), elseV)
-          } yield WithValue(assigned, res)
+          } yield assigned.withValue(res)
       }
     }
 
+    def ifElseS(cond: ValueLike, thenS: Statement, elseS: Statement): Env[Statement] =
+      cond match {
+        case x: Expression => Monad[Env].pure(ifStatement(NonEmptyList((x, thenS), Nil), Some(elseS)))
+        case WithValue(stmt, vl) =>
+          ifElseS(vl, thenS, elseS).map(stmt +: _)
+        case v =>
+          // this is a branch, don't multiply code by writing on each
+          // branch, that could give an exponential blowup
+          Env.newAssignableVar
+            .map { tmp =>
+              Code.block(
+                tmp := v,
+                ifStatement(NonEmptyList((tmp, thenS), Nil), Some(elseS))
+              )
+            }
+      }
+
     def andCode(c1: ValueLike, c2: ValueLike): Env[ValueLike] =
-      onLast2(c1, c2)(_.evalAnd(_))
+      (c1, c2) match {
+        case (_, x2: Expression) =>
+          onLast(c1)(_.evalAnd(x2))
+        case (Code.Const.True, c2) => Monad[Env].pure(c2)
+        case _ =>
+          // we know that c2 is not a simple expression
+          // res = False
+          // if c1:
+          //   res = c2
+          Env.onLastM(c1) { x1 =>
+            for {
+              res <- Env.newAssignableVar
+              ifstmt <- ifElseS(x1, res := c2, Code.Pass)
+            } yield {
+                Code.block(
+                  res := Code.Const.False,
+                  ifstmt
+                )
+                .withValue(res)
+            }
+          }
+      }
 
     def makeDef(defName: Code.Ident, arg: Code.Ident, v: ValueLike): Code.Def =
       Code.Def(defName, arg :: Nil, toReturn(v))
@@ -284,7 +329,7 @@ object PythonGen {
               if (flatArgs.length == argSize) {
                 val all = onArgs(flatArgs)
                 // set all the values and return the empty tuple
-                Monad[Env].pure(WithValue(all, MakeTuple(Nil)))
+                Monad[Env].pure(all.withValue(MakeTuple(Nil)))
               }
               else {
                 // $COVERAGE-OFF$
@@ -301,9 +346,9 @@ object PythonGen {
             val ifs = ifCases.traverse { case (cond, res) => loop(res).map((cond, _)) }
             (ifs, loop(elseCase)).mapN(IfElse(_, _))
           case WithValue(stmt, v) =>
-            loop(v).map(WithValue(stmt, _))
+            loop(v).map(stmt.withValue(_))
           // the rest cannot have a call in the tail position
-          case DotSelect(_, _) | Op(_, _, _) | Lambda(_, _) | MakeTuple(_) | SelectItem(_, _) | Ident(_) | PyBool(_) | PyString(_) | PyInt(_) => Monad[Env].pure(body)
+          case DotSelect(_, _) | Op(_, _, _) | Lambda(_, _) | MakeTuple(_) | MakeList(_) | SelectItem(_, _) | SelectRange(_, _, _) | Ident(_) | PyBool(_) | PyString(_) | PyInt(_) => Monad[Env].pure(body)
         }
 
       loop(initBody)
@@ -341,7 +386,7 @@ object PythonGen {
         body1 <- replaceTailCallWithAssign(selfName, mutArgs.length, body)(assignMut(cont))
         setRes = res := body1
         loop = While(cont, Assign(cont, Const.False) +: setRes)
-        newBody = WithValue(ac +: ar +: loop, res)
+        newBody = (ac +: ar +: loop).withValue(res)
         curried <- makeCurriedDef(selfName, fnArgs, newBody)
       } yield curried
     }
@@ -636,33 +681,70 @@ object PythonGen {
                   .flatMap { case (cont, res, _i, _a, tmp_i) =>
                     Env.onLasts(input) {
                       case i :: a :: fn :: Nil =>
-                        Code.WithValue(
-                          Code.block(
-                            cont := Code.Op(Code.fromInt(0), Code.Const.Lt, i),
-                            res := a,
-                            _i := i,
-                            _a := a,
-                            Code.While(cont,
-                              Code.block(
-                                res := fn(_i)(_a),
-                                tmp_i := res.get(0),
-                                _a := res.get(1).get(0),
-                                cont := Code.Op(Code.Op(Code.fromInt(0), Code.Const.Lt, tmp_i),
-                                  Code.Const.And,
-                                  Code.Op(tmp_i, Code.Const.Lt, _i)),
-                                _i := tmp_i
-                                )
-                             )
-                          ),
-                          _a)
+                        Code.block(
+                          cont := Code.Op(Code.fromInt(0), Code.Const.Lt, i),
+                          res := a,
+                          _i := i,
+                          _a := a,
+                          Code.While(cont,
+                            Code.block(
+                              res := fn(_i)(_a),
+                              tmp_i := res.get(0),
+                              _a := res.get(1).get(0),
+                              cont := Code.Op(Code.Op(Code.fromInt(0), Code.Const.Lt, tmp_i),
+                                Code.Const.And,
+                                Code.Op(tmp_i, Code.Const.Lt, _i)),
+                              _i := tmp_i
+                              )
+                           )
+                        )
+                        .withValue(_a)
                       case other =>
                         // $COVERAGE-OFF$
                         throw new IllegalStateException(s"expected arity 3 got: $other")
                         // $COVERAGE-ON$
                     }
                   }
-            }, 3))
-          )
+            }, 3)),
+        (Identifier.unsafeBindable("concat_String"),
+          ({ input =>
+            Env.onLastM(input.head) { listOfStrings =>
+              // convert to python list, then call "".join(seq)
+              Env.newAssignableVar
+                .flatMap { pyList =>
+                  bosatsuListToPython(pyList, listOfStrings)
+                    .map { loop =>
+                      Code.block(
+                        pyList := Code.MakeList(Nil),
+                        loop
+                      )
+                      .withValue {
+                        Code.PyString("").dot(Code.Ident("join"))(pyList)
+                      }
+                    }
+                }
+            }
+          }, 1))
+      )
+
+      def bosatsuListToPython(pyList: Code.Ident, bList: Expression): Env[Statement] =
+        Env.newAssignableVar
+          .map { tmp =>
+            // tmp = bList
+            // while tmp != 0:
+            //   //(_, h, tail) = tmp
+            //   pyList.append(tmp[1])
+            //   tmp = tmp[2]
+            Code.block(
+              tmp := bList,
+              Code.While(Code.Op(tmp, Code.Const.Neq, Code.fromInt(0)),
+                Code.block(
+                  Code.Call(pyList.dot(Code.Ident("append"))(tmp.get(1))),
+                  tmp := tmp.get(2)
+                )
+              )
+            )
+          }
 
       def unapply(expr: Expr): Option[(List[ValueLike] => Env[ValueLike], Int)] =
         expr match {
@@ -768,21 +850,178 @@ object PythonGen {
                   Code.Op(t, Code.Const.Eq, idxExpr)
                 }
                 else
-                  Code.Op(Code.SelectItem(t, 0), Code.Const.Eq, idxExpr)
+                  Code.Op(t.get(0), Code.Const.Eq, idxExpr)
               }
             }
           case SetMut(LocalAnonMut(mut), expr) =>
             (Env.nameForAnon(mut), loop(expr))
               .mapN { (ident, result) =>
                 Env.onLast(result) { resx =>
-                  val a = Code.Assign(ident, resx)
-                  Code.WithValue(a, Code.Const.True)
+                  (ident := resx).withValue(Code.Const.True)
                 }
               }
               .flatten
-          case MatchString(str, pat, binds) => ???
+          case MatchString(str, pat, binds) =>
+            (loop(str), binds.traverse { case LocalAnonMut(m) => Env.nameForAnon(m) })
+              .mapN { (strVL, binds) =>
+                Env.onLastM(strVL)(matchString(_, pat, binds))
+              }
+              .flatten
           case SearchList(LocalAnonMut(mutV), init, check, optLeft) => ???
         }
+
+      def matchString(strEx: Expression, pat: List[StrPart], binds: List[Code.Ident]): Env[ValueLike] = {
+        import StrPart.{LitStr, Glob}
+        val bindArray = binds.toArray
+        // return a value like expression that contains the boolean result
+        // and assigns all the bindings along the way
+        def loop(offsetIdent: Code.Ident, pat: List[StrPart], next: Int): Env[ValueLike] =
+          pat match {
+            case Nil =>
+              //offset == str.length
+              Monad[Env].pure(Code.Op(offsetIdent, Code.Const.Eq, strEx.dot(Code.Ident("__len__"))()))
+            case LitStr(expect) :: tail =>
+              //val len = expect.length
+              //str.regionMatches(offset, expect, 0, len) && loop(offset + len, tail, next)
+              //
+              // strEx.startswith(expect, offsetIdent)
+              loop(offsetIdent, tail, next)
+                .flatMap { loopRes =>
+                  val regionMatches = strEx.dot(Code.Ident("startswith"))(Code.PyString(expect), offsetIdent)
+                  val rest =
+                    (
+                      offsetIdent := (offsetIdent.evalPlus(Code.fromInt(expect.length)))
+                    ).withValue(loopRes)
+
+                  Env.andCode(regionMatches, rest)
+                }
+            case (h: Glob) :: tail =>
+              tail match {
+                case Nil =>
+                  // we capture all the rest
+                  Monad[Env].pure(
+                    if (h.capture) {
+                      // b = str[offset:]
+                      (bindArray(next) := Code.SelectRange(strEx, Some(offsetIdent), None))
+                        .withValue(Code.Const.True)
+                    }
+                    else Code.Const.True
+                  )
+                case LitStr(expect) :: tail2 =>
+                  // here we have to make a loop
+                  // searching for expect, and then see if we
+                  // can match the rest of the pattern
+                  val next1 = if (h.capture) next + 1 else next
+
+                  /*
+                   * this is the scala code for the below
+                   * it is in MatchlessToValue but left here
+                   * as an aid to read the code below
+                   *
+                  var start = offset
+                  var result = false
+                  while (start >= 0) {
+                    val candidate = str.indexOf(expect, start)
+                    if (candidate >= 0) {
+                      // we have to skip the current expect string
+                      val candidateOffset = candidate + expect.lenth
+                      val check1 = loop(candidateOffset, tail2, next1)
+                      if (check1) {
+                        // this was a match, write into next if needed
+                        if (h.capture) {
+                          results(next) = str.substring(offset, candidate)
+                        }
+                        result = true
+                        start = -1
+                      }
+                      else {
+                        // we couldn't match here, try just after candidate
+                        start = candidate + 1
+                      }
+                    }
+                    else {
+                      // no more candidates
+                      start = -1
+                    }
+                  }
+                  result
+                  */
+                  (Env.newAssignableVar, Env.newAssignableVar, Env.newAssignableVar, Env.newAssignableVar)
+                    .mapN { (start, result, candidate, candOffset) =>
+                      val searchEnv = loop(candOffset, tail2, next1)
+
+                      def onSearch(search: ValueLike): Env[Statement] =
+                        Env.ifElseS(search,
+                          {
+                            // we have matched
+                            val capture = if (h.capture) (bindArray(next) := Code.SelectRange(strEx, Some(offsetIdent), Some(candidate))) else Code.Pass
+                            Code.block(
+                              capture,
+                              result := Code.Const.True,
+                              start := Code.fromInt(-1)
+                            )
+                          },
+                          {
+                            // we couldn't match at start, advance just after the
+                            // candidate
+                            start := candidate.evalPlus(Code.fromInt(1))
+                          })
+
+                      def findBranch(search: ValueLike): Env[Statement] =
+                        onSearch(search)
+                          .flatMap { onS =>
+                            Env.ifElseS(
+                              Code.Op(candidate, Code.Const.Gt, Code.fromInt(-1)),
+                              {
+                                // update candidate and search
+                                Code.block(
+                                  candOffset := Code.Op(candidate, Code.Const.Plus, Code.fromInt(expect.length)),
+                                  onS)
+                              },
+                              {
+                                // else no more candidates
+                                start := Code.fromInt(-1)
+                              }
+                            )
+                          }
+
+                      for {
+                        search <- searchEnv
+                        find <- findBranch(search)
+                      } yield
+                        (Code.block(
+                          start := offsetIdent,
+                          result := Code.Const.False,
+                          Code.While(Code.Op(start, Code.Const.Gt, Code.fromInt(-1)),
+                            Code.block(
+                              candidate := strEx.dot(Code.Ident("find"))(Code.PyString(expect), start),
+                              find
+                            )
+                          )
+                        )
+                        .withValue(result))
+                    }
+                    .flatten
+                case (_: Glob) :: _ =>
+                  val (cap, n1) =
+                    if (h.capture) {
+                      // we match the right side first, so this wild gets nothing
+                      (bindArray(next) := Code.PyString(""), next + 1)
+                    }
+                    else (Code.Pass, next)
+
+                  loop(offsetIdent, tail, n1).map { vl =>
+                    cap.withValue(vl)
+                  }
+              }
+          }
+
+        Env.newAssignableVar
+          .flatMap { offsetIdent =>
+            loop(offsetIdent, pat, 0)
+              .map { res => (offsetIdent := Code.fromInt(0)).withValue(res) }
+          }
+      }
 
       def topLet(name: Code.Ident, expr: Expr, v: ValueLike): Env[Statement] = {
 
@@ -855,7 +1094,7 @@ object PythonGen {
                   for {
                     defName <- Env.newAssignableVar
                     defn = Env.makeDef(defName, arg, v)
-                  } yield Code.WithValue(defn, defName)
+                  } yield defn.withValue(defName)
               }
             }
             .flatMap(_ <* Env.unbind(arg))
@@ -885,7 +1124,7 @@ object PythonGen {
               // we have bound the args twice: once as args, once as interal muts
               _ <- subs.traverse_ { case (a, _) => Env.unbind(a) }
               _ <- unbindA
-            } yield Code.WithValue(loopRes, nameI)
+            } yield loopRes.withValue(nameI)
 
           case PredefExternal((fn, arity)) =>
             // make a lambda
@@ -942,7 +1181,7 @@ object PythonGen {
                     ve <- loop(value)
                     tl <- topLet(bi, value, ve)
                     ine <- inF
-                    wv = Code.WithValue(tl, ine)
+                    wv = tl.withValue(ine)
                     _ <- Env.unbind(b)
                   } yield wv
                 }
@@ -953,7 +1192,7 @@ object PythonGen {
                     bi <- Env.bind(b)
                     tl <- topLet(bi, value, ve)
                     ine <- inF
-                    wv = Code.WithValue(tl, ine)
+                    wv = tl.withValue(ine)
                     _ <- Env.unbind(b)
                   } yield wv
                 }
@@ -962,7 +1201,7 @@ object PythonGen {
                 (Env.nameForAnon(l), loop(value))
                   .mapN { (bi, vE) =>
                     (topLet(bi, value, vE), inF)
-                      .mapN(Code.WithValue(_, _))
+                      .mapN(_.withValue(_))
                   }
                   .flatten
             }
@@ -996,20 +1235,14 @@ object PythonGen {
 
           case Always(cond, expr) =>
             (boolExpr(cond).map(Code.always), loop(expr))
-              .mapN {
-                case (Code.Pass, v) => v
-                case (notPass, v) =>
-                  Code.WithValue(notPass, v)
-              }
+              .mapN(_.withValue(_))
 
           case GetEnumElement(expr, _, idx, sz) =>
             // nonempty enums are just structs with the first element being the variant
             // we could assert the v matches when debugging, but typechecking
             // should assure this
             loop(expr).flatMap { tup =>
-              Env.onLast(tup) { t =>
-                Code.SelectItem(t, idx + 1)
-              }
+              Env.onLast(tup)(_.get(idx + 1))
             }
           case GetStructElement(expr, idx, sz) =>
             val exprR = loop(expr)
@@ -1020,9 +1253,7 @@ object PythonGen {
             else {
               // structs are just tuples
               exprR.flatMap { tup =>
-                Env.onLast(tup) { t =>
-                  Code.SelectItem(t, idx)
-                }
+                Env.onLast(tup)(_.get(idx))
               }
             }
           case PrevNat(expr) =>

--- a/test_workspace/StrConcatExample.bosatsu
+++ b/test_workspace/StrConcatExample.bosatsu
@@ -11,21 +11,26 @@ def m2s(m):
         "mahina": "sarah"
         _: m
 
-res0 = match "${x} ${y} and ${z}":
-        "hello atticus and mahina": True
-        _: False
+res0 = "${x} ${y} and ${z}" matches "hello atticus and mahina"
 
-res1 = match "${ident(x)} ${y} and ${m2s(z)}":
-        "hello atticus and sarah": True
-        _: False
+res1 = "${ident(x)} ${y} and ${m2s(z)}" matches "hello atticus and sarah"
 
-res2 = match "${x}":
-    "hello": True
+res2 = "${x}" matches "hello"
+
+res3 = match "${x} ${y} and ${z}":
+    "hello ${rest}": rest matches "atticus${_}mahina"
+    _: False
+
+res4 = match "${x} ${y} and ${z}":
+    "${left}atticus${right}":
+        (left, right) matches ("hello ", " and mahina")
     _: False
 
 test = TestSuite("interpolation", [
     Assertion(res0, "res0"),
     Assertion(res1, "res1"),
     Assertion(res2, "res2"),
+    Assertion(res3, "res3"),
+    Assertion(res4, "res4"),
 ])
 


### PR DESCRIPTION
This supports string patterns with substring matching.

There are some more improvements to the code used to generate python code including some utility functions that attempt to avoid branches where we statically know which one we are taking.

There is still a significant issue of over-use of bindings. Often bindings are made and used exactly once, or are only used by other bindings to initialize from. This is not a priority now as completeness and result correctness are the current focus.