### PR TITLE
Implement SearchList for python

### DIFF
--- a/cli/src/test/scala/org/bykn/bosatsu/PathModuleTest.scala
+++ b/cli/src/test/scala/org/bykn/bosatsu/PathModuleTest.scala
@@ -112,6 +112,7 @@ class PathModuleTest extends FunSuite {
         "BinNat.bosatsu",
         "Bool.bosatsu",
         "List.bosatsu",
+        "ListPat.bosatsu",
         "PatternExamples.bosatsu",
         "Queue.bosatsu",
         "StrConcatExample.bosatsu",

--- a/cli/src/test/scala/org/bykn/bosatsu/codegen/python/PythonGenTest.scala
+++ b/cli/src/test/scala/org/bykn/bosatsu/codegen/python/PythonGenTest.scala
@@ -9,7 +9,7 @@ import org.scalacheck.Gen
 import org.scalatest.FunSuite
 import org.scalatest.prop.PropertyChecks.{ forAll, PropertyCheckConfiguration }
 import org.python.util.PythonInterpreter
-import org.python.core.{PyInteger, PyFunction}
+import org.python.core.{PyInteger, PyFunction, PyObject, PyTuple}
 
 import org.bykn.bosatsu.DirectEC.directEC
 
@@ -21,18 +21,60 @@ class PythonGenTest extends FunSuite {
 
   implicit val showStr: Show[String] = Show.show[String](identity)
 
-  def compileFile(path: String): PackageMap.Typed[Any] = {
-    val str = new String(Files.readAllBytes(Paths.get(path)), "UTF-8")
+  val zero = new PyInteger(0)
+  val one = new PyInteger(1)
 
-    val pack = Parser.unsafeParse(Package.parser(None), str)
-    val packNEL = NonEmptyList((("", LocationMap(str)), pack), Nil)
+  @annotation.tailrec
+  final def foreachList(lst: PyObject)(fn: PyObject => Unit): Unit = {
+    if (lst == zero) ()
+    else {
+      val tup = lst.asInstanceOf[PyTuple]
+      val head = tup.getArray()(1)
+      val tail = tup.getArray()(2)
+      fn(head)
+      foreachList(tail)(fn)
+    }
+  }
+
+  // enum Test:
+  //   Assertion(value: Bool, message: String)
+  //   TestSuite(name: String, tests: List[Test])
+  def checkTest(testValue: PyObject, prefix: String): Unit = {
+    val tup = testValue.asInstanceOf[PyTuple]
+    tup.getArray()(0) match {
+      case x if x == zero =>
+        // True == one in our encoding
+        assert(tup.getArray()(1) == one, prefix + "/" + tup.getArray()(2).toString)
+        ()
+      case x if x == one =>
+        val suite = tup.getArray()(1).toString
+        foreachList(tup.getArray()(2)) { t => checkTest(t, prefix + "/" + suite); () }
+      case other =>
+        assert(false, s"expected a Test to have 0 or 1 in first tuple entry: $tup")
+        ()
+    }
+  }
+
+  def compileFile(path: String, rest: String*): PackageMap.Typed[Any] = {
+    def toS(s: String): String =
+      new String(Files.readAllBytes(Paths.get(path)), "UTF-8")
+
+
+    val packNEL =
+      NonEmptyList(path, rest.toList)
+        .map { s =>
+          val str = toS(s)
+          val pack = Parser.unsafeParse(Package.parser(None), str)
+          (("", LocationMap(str)), pack)
+        }
+
     PackageMap.typeCheckParsed(packNEL, Nil, "").right.get
   }
 
   def isfromString(s: String): InputStream =
     new ByteArrayInputStream(s.getBytes("UTF-8"))
 
-  val intr = new PythonInterpreter()
+  def intr = new PythonInterpreter()
 
   test("we can compile Nat.bosatsu") {
     val natPathBosatu: String = "test_workspace/Nat.bosatsu"
@@ -74,7 +116,7 @@ class PythonGenTest extends FunSuite {
     }
   }
 
-  intr.close()
+  //intr.close()
 
   val strConcat = new PythonInterpreter()
 
@@ -100,4 +142,24 @@ class PythonGenTest extends FunSuite {
       assert(strConcat.get(res) == one)
     }
   }
+  //strConcat.close()
+
+  val listPy = new PythonInterpreter()
+
+  /*
+  test("test some list pattern matches") {
+    val bosatsuPM = compileFile(
+      "test_workspace/ListPats.bosatsu",
+    )
+
+    val matchless = MatchlessFromTypedExpr.compile(bosatsuPM)
+
+    val packMap = PythonGen.renderAll(matchless, Map.empty)
+    val doc = packMap(PackageName.parts("ListPats"))._2
+
+    listPy.execfile(isfromString(doc.renderTrim(80)), "ListPats.py")
+
+    checkTest(listPy.get("tests"), "")
+  }
+  */
 }

--- a/cli/src/test/scala/org/bykn/bosatsu/codegen/python/PythonGenTest.scala
+++ b/cli/src/test/scala/org/bykn/bosatsu/codegen/python/PythonGenTest.scala
@@ -87,7 +87,7 @@ class PythonGenTest extends FunSuite {
     val natDoc = packMap(PackageName.parts("Bosatsu", "Nat"))._2
 
     intr.execfile(isfromString(natDoc.renderTrim(80)), "nat.py")
-
+    checkTest(intr.get("tests"), "Nat.bosatsu")
   }
 
   test("to_Nat works like identity") {
@@ -117,11 +117,11 @@ class PythonGenTest extends FunSuite {
     }
   }
 
-  //intr.close()
+  intr.close()
 
-  val strConcat = new PythonInterpreter()
 
   test("we can compile StrConcatExample") {
+    val strConcat = new PythonInterpreter()
     val path: String = "test_workspace/StrConcatExample.bosatsu"
 
     val bosatsuPM = compileFile(path)
@@ -131,23 +131,14 @@ class PythonGenTest extends FunSuite {
     val doc = packMap(PackageName.parts("StrConcatExample"))._2
 
     strConcat.execfile(isfromString(doc.renderTrim(80)), "StrConcatExample.py")
+    checkTest(strConcat.get("test"), "StrConcatExample")
 
+    strConcat.close()
   }
 
-  test("res0 .. res4 are all 1 (True)") {
-
-    val one = new PyInteger(1)
-    (0 to 4).foreach { i =>
-      val res = s"res$i"
-
-      assert(strConcat.get(res) == one)
-    }
-  }
-  strConcat.close()
-
-  val listPy = new PythonInterpreter()
 
   test("test some list pattern matches") {
+    val listPy = new PythonInterpreter()
     val bosatsuPM = compileFile(
       "test_workspace/ListPat.bosatsu",
     )
@@ -160,5 +151,6 @@ class PythonGenTest extends FunSuite {
     listPy.execfile(isfromString(doc.renderTrim(80)), "ListPat.py")
 
     checkTest(listPy.get("tests"), "")
+    listPy.close()
   }
 }

--- a/cli/src/test/scala/org/bykn/bosatsu/codegen/python/PythonGenTest.scala
+++ b/cli/src/test/scala/org/bykn/bosatsu/codegen/python/PythonGenTest.scala
@@ -21,8 +21,9 @@ class PythonGenTest extends FunSuite {
 
   implicit val showStr: Show[String] = Show.show[String](identity)
 
-  val zero = new PyInteger(0)
-  val one = new PyInteger(1)
+  // for some reason, these need to be defs or Jython will NPE
+  def zero = new PyInteger(0)
+  def one = new PyInteger(1)
 
   @annotation.tailrec
   final def foreachList(lst: PyObject)(fn: PyObject => Unit): Unit = {
@@ -74,7 +75,7 @@ class PythonGenTest extends FunSuite {
   def isfromString(s: String): InputStream =
     new ByteArrayInputStream(s.getBytes("UTF-8"))
 
-  def intr = new PythonInterpreter()
+  val intr = new PythonInterpreter()
 
   test("we can compile Nat.bosatsu") {
     val natPathBosatu: String = "test_workspace/Nat.bosatsu"
@@ -142,24 +143,22 @@ class PythonGenTest extends FunSuite {
       assert(strConcat.get(res) == one)
     }
   }
-  //strConcat.close()
+  strConcat.close()
 
   val listPy = new PythonInterpreter()
 
-  /*
   test("test some list pattern matches") {
     val bosatsuPM = compileFile(
-      "test_workspace/ListPats.bosatsu",
+      "test_workspace/ListPat.bosatsu",
     )
 
     val matchless = MatchlessFromTypedExpr.compile(bosatsuPM)
 
     val packMap = PythonGen.renderAll(matchless, Map.empty)
-    val doc = packMap(PackageName.parts("ListPats"))._2
+    val doc = packMap(PackageName.parts("ListPat"))._2
 
-    listPy.execfile(isfromString(doc.renderTrim(80)), "ListPats.py")
+    listPy.execfile(isfromString(doc.renderTrim(80)), "ListPat.py")
 
     checkTest(listPy.get("tests"), "")
   }
-  */
 }

--- a/cli/src/test/scala/org/bykn/bosatsu/codegen/python/PythonGenTest.scala
+++ b/cli/src/test/scala/org/bykn/bosatsu/codegen/python/PythonGenTest.scala
@@ -140,7 +140,7 @@ class PythonGenTest extends FunSuite {
   test("test some list pattern matches") {
     val listPy = new PythonInterpreter()
     val bosatsuPM = compileFile(
-      "test_workspace/ListPat.bosatsu",
+      "test_workspace/ListPat.bosatsu"
     )
 
     val matchless = MatchlessFromTypedExpr.compile(bosatsuPM)

--- a/core/src/main/scala/org/bykn/bosatsu/codegen/python/Code.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/codegen/python/Code.scala
@@ -456,6 +456,9 @@ object Code {
     }
   }
 
+  // just for better type inference
+  def pass: Statement = Pass
+
   def toReturn(v: ValueLike): Statement =
     v match {
       case x: Expression => Code.Return(x)

--- a/core/src/main/scala/org/bykn/bosatsu/codegen/python/PythonGen.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/codegen/python/PythonGen.scala
@@ -1064,7 +1064,7 @@ object PythonGen {
                           Nil),
                         Some {
                           Code.block(
-                            tmpList := tmpList.get(3), // tail of the list
+                            tmpList := tmpList.get(2), // tail of the list
                             optLeft.fold(Code.pass) { left =>
                               val head = currentList.get(1)
                               val cons = Code.MakeTuple(List(Code.fromInt(1), head, left))

--- a/core/src/main/scala/org/bykn/bosatsu/codegen/python/PythonGen.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/codegen/python/PythonGen.scala
@@ -375,7 +375,7 @@ object PythonGen {
       def assignMut(cont: Code.Ident)(args: List[Expression]): Statement = {
         // do the replacement
         val vs = mutArgs.toList.zip(args).map { case (v, x) => Assign(v, x) }
-        vs.foldLeft(Assign(cont, Const.True): Statement)(_ +: _)
+        vs.foldLeft(cont := Const.True)(_ +: _)
       }
 
       for {
@@ -860,7 +860,14 @@ object PythonGen {
                 Env.onLastM(strVL)(matchString(_, pat, binds))
               }
               .flatten
-          case SearchList(LocalAnonMut(mutV), init, check, optLeft) => ???
+          case SearchList(locMut, init, check, optLeft) =>
+            // check to see if we can find a non-empty
+            // list that matches check
+            (loop(init), boolExpr(check))
+              .mapN { (initVL, checkVL) =>
+                searchList(locMut, initVL, checkVL, optLeft)
+              }
+              .flatten
         }
 
       def matchString(strEx: Expression, pat: List[StrPart], binds: List[Code.Ident]): Env[ValueLike] = {
@@ -1007,6 +1014,68 @@ object PythonGen {
             loop(offsetIdent, pat, 0)
               .map { res => (offsetIdent := Code.fromInt(0)).withValue(res) }
           }
+      }
+
+      def searchList(locMut: LocalAnonMut, initVL: ValueLike, checkVL: ValueLike, optLeft: Option[LocalAnonMut]): Env[ValueLike] = {
+        /*
+         * here is the implementation from MatchlessToValue
+         *
+            Dynamic { scope: Scope =>
+              var res = false
+              var currentList = initF(scope)
+              var leftList = VList.VNil
+              while (currentList ne null) {
+                currentList match {
+                  case nonempty@VList.Cons(head, tail) =>
+                    scope.updateMut(mutV, nonempty)
+                    scope.updateMut(left, leftList)
+                    res = checkF(scope)
+                    if (res) { currentList = null }
+                    else {
+                      currentList = tail
+                      leftList = VList.Cons(head, leftList)
+                    }
+                  case _ =>
+                    currentList = null
+                    // we don't match empty lists
+                }
+              }
+              res
+            }
+        */
+       // note, lists are encoded as:
+       // EmptyList = 0
+       // NonEmptyList(a, b) = (1, a, b)
+       (Env.nameForAnon(locMut.ident), optLeft.traverse { lm => Env.nameForAnon(lm.ident) }, Env.newAssignableVar, Env.newAssignableVar)
+         .mapN { (currentList, optLeft, res, tmpList) =>
+            Code
+              .block(
+                res := Code.Const.False,
+                tmpList := initVL,
+                optLeft.fold(Code.pass)(_ := Code.fromInt(0)), // left := EmptyList
+                // we don't match empty lists, so if currentList reaches Empty we are done
+                Code.While(Code.Op(tmpList, Code.Const.Neq, Code.fromInt(0)),
+                  Code.block(
+                      currentList := tmpList,
+                      res := checkVL,
+                      Code.ifStatement(
+                        NonEmptyList(
+                          (res, (tmpList := Code.fromInt(0))),
+                          Nil),
+                        Some {
+                          Code.block(
+                            tmpList := tmpList.get(3), // tail of the list
+                            optLeft.fold(Code.pass) { left =>
+                              val head = currentList.get(1)
+                              val cons = Code.MakeTuple(List(Code.fromInt(1), head, left))
+                              left := cons
+                            }
+                          )
+                        })
+                    )
+                  ),
+              ).withValue(res)
+         }
       }
 
       def topLet(name: Code.Ident, expr: Expr, v: ValueLike): Env[Statement] =

--- a/core/src/main/scala/org/bykn/bosatsu/codegen/python/PythonGen.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/codegen/python/PythonGen.scala
@@ -1073,7 +1073,7 @@ object PythonGen {
                           )
                         })
                     )
-                  ),
+                  )
               ).withValue(res)
          }
       }

--- a/test_workspace/BUILD
+++ b/test_workspace/BUILD
@@ -94,6 +94,12 @@ bosatsu_test(
     packages = ["Queue"],
    )
 
+bosatsu_test(
+    name = "list_pat",
+    srcs = ["ListPat.bosatsu"],
+    packages = ["ListPat"],
+   )
+
 bosatsu_library(
     name = "treelist",
     deps = [":list"],

--- a/test_workspace/List.bosatsu
+++ b/test_workspace/List.bosatsu
@@ -2,7 +2,10 @@ package Bosatsu/List
 
 import Bosatsu/Bool [ not ]
 import Bosatsu/Nat [ Nat, Zero, Succ ]
-export [ eq_List, exists, head, for_all, size, sum, sort, uncons, zip ]
+export [ any, eq_List, exists, head, for_all, size, sum, sort, uncons, zip ]
+
+def any(as: List[Bool]) -> Bool:
+    as matches [*_, True, *_]
 
 def for_all(xs: List[a], fn: a -> Bool) -> Bool:
   recur xs:
@@ -129,5 +132,12 @@ tests = TestSuite("List tests", [
   unconsTest,
   zipTest,
   sortTest,
+  Assertion(any([]) matches False, "any([])"),
+  Assertion(any([True]) matches True, "any([True])"),
+  Assertion(any([False]) matches False, "any([False])"),
+  Assertion(any([False, False]) matches False, "any([False, False])"),
+  Assertion(any([False, True]) matches True, "any([False, True])"),
+  Assertion(any([True, False]) matches True, "any([True, False])"),
+  Assertion(any([True, True]) matches True, "any([True, True])"),
   ])
 

--- a/test_workspace/ListPat.bosatsu
+++ b/test_workspace/ListPat.bosatsu
@@ -1,0 +1,20 @@
+package ListPat
+
+def any(as: List[Bool]) -> Bool:
+    as matches [*_, True, *_]
+
+def one_count(is, acc):
+    recur is:
+        [*_, 1, *rest]: one_count(rest, acc.add(1))
+        _: acc
+
+tests = TestSuite("ListPat tests", [
+  Assertion(any([]) matches False, "any([])"),
+  Assertion(any([True]) matches True, "any([True])"),
+  Assertion(any([False]) matches False, "any([False])"),
+  Assertion(any([False, False]) matches False, "any([False, False])"),
+  Assertion(any([False, True]) matches True, "any([False, True])"),
+  Assertion(any([True, False]) matches True, "any([True, False])"),
+  Assertion(any([True, True]) matches True, "any([True, True])"),
+  Assertion(one_count([0, 0, 1, 0, 1], 0) matches 2, "one_count 1"),
+])


### PR DESCRIPTION
this is the last missing "instruction" from matchless to be able to compile to python.

This also adds code to run the bosatsu tests from Jython so we don't need to write tests twice.

There are still some todos with python however (the file names don't have .py, we aren't creating `__init__.py` files, and not all the external methods in Predef are implemented).