### PR TITLE
Add a basic Parser example and partition to Predef

### DIFF
--- a/cli/src/test/scala/org/bykn/bosatsu/codegen/python/CodeTest.scala
+++ b/cli/src/test/scala/org/bykn/bosatsu/codegen/python/CodeTest.scala
@@ -449,4 +449,13 @@ else:
       }
     }
   }
+
+  test("(a == b) and (b == c) renders correctly") {
+    val left = Code.Op(Code.Ident("a"), Code.Const.Eq, Code.Ident("b"))
+    val right = Code.Op(Code.Ident("b"), Code.Const.Eq, Code.Ident("c"))
+    val and = left.evalAnd(right)
+
+    assert(Code.toDoc(and).renderTrim(80) == "(a == b) and (b == c)")
+    assert(Code.toDoc(Code.Ident("z").evalAnd(and)).renderTrim(80) == "z and (a == b) and (b == c)")
+  }
 }

--- a/cli/src/test/scala/org/bykn/bosatsu/codegen/python/PythonGenTest.scala
+++ b/cli/src/test/scala/org/bykn/bosatsu/codegen/python/PythonGenTest.scala
@@ -162,10 +162,10 @@ class PythonGenTest extends FunSuite {
       "tests")
   }
 
-  test("test IntTests") {
+  test("test PredefTests") {
     runBoTests(
-      "test_workspace/IntTests.bosatsu",
-      PackageName.parts("IntTests"),
+      "test_workspace/PredefTests.bosatsu",
+      PackageName.parts("PredefTests"),
       "test")
   }
 }

--- a/core/src/main/resources/bosatsu/predef.bosatsu
+++ b/core/src/main/resources/bosatsu/predef.bosatsu
@@ -30,6 +30,8 @@ export [
   items,
   map_List,
   mod_Int,
+  partition_String,
+  rpartition_String,
   range,
   range_fold,
   remove_key,
@@ -140,6 +142,15 @@ external struct String
 external def string_Order_fn(str0: String, str1: String) -> Comparison
 string_Order = Order(string_Order_fn)
 external def concat_String(items: List[String]) -> String
+
+# if this returns Some((a, b)) then arg == concat_String([a, sep, b])
+# a and b are always proper substrings, so partition_String(a, "") == None
+# this matches from the left, so partition_String(a, sep) == None
+external def partition_String(arg: String, sep: String) -> Option[(String, String)]
+# if this returns Some((a, b)) then arg == concat_String([a, sep, b])
+# a and b are always proper substrings, so rpartition_String(a, "") == None
+# this matches from the right, so partition_String(b, sep) == None
+external def rpartition_String(arg: String, sep: String) -> Option[(String, String)]
 
 external def int_to_String(i: Int) -> String
 

--- a/core/src/main/scala/org/bykn/bosatsu/Predef.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/Predef.scala
@@ -81,6 +81,8 @@ object Predef {
       .add(packageName, "trace", FfiCall.Fn2(PredefImpl.trace(_, _)))
       .add(packageName, "string_Order_fn", FfiCall.Fn2(PredefImpl.string_Order_Fn(_, _)))
       .add(packageName, "concat_String", FfiCall.Fn1(PredefImpl.concat_String(_)))
+      .add(packageName, "partition_String", FfiCall.Fn2(PredefImpl.partitionString(_, _)))
+      .add(packageName, "rpartition_String", FfiCall.Fn2(PredefImpl.rightPartitionString(_, _)))
 
   def withPredef(ps: List[Package.Parsed]): List[Package.Parsed] =
     predefPackage :: ps.map(_.withImport(predefImports))
@@ -223,5 +225,39 @@ object PredefImpl {
         sys.error(s"type error: $other")
         //$COVERAGE-ON$
     }
+
+  // return an Option[(String, String)]
+  def partitionString(arg: Value, sep: Value): Value = {
+    val sepS = sep.asExternal.toAny.asInstanceOf[String]
+
+    if (sepS.isEmpty) Value.VOption.none
+    else {
+      val argS = arg.asExternal.toAny.asInstanceOf[String]
+
+      val idx = argS.indexOf(sepS)
+      if (idx < 0) Value.VOption.none
+      else Value.VOption.some {
+        val left = argS.substring(0, idx)
+        val right = argS.substring(idx + sepS.length)
+        Value.Tuple(Value.ExternalValue(left), Value.ExternalValue(right))
+      }
+    }
+  }
+
+  def rightPartitionString(arg: Value, sep: Value): Value = {
+    val sepS = sep.asExternal.toAny.asInstanceOf[String]
+
+    if (sepS.isEmpty) Value.VOption.none
+    else {
+      val argS = arg.asExternal.toAny.asInstanceOf[String]
+      val idx = argS.lastIndexOf(sepS)
+      if (idx < 0) Value.VOption.none
+      else Value.VOption.some {
+        val left = argS.substring(0, idx)
+        val right = argS.substring(idx + sepS.length)
+        Value.Tuple(Value.ExternalValue(left), Value.ExternalValue(right))
+      }
+    }
+  }
 }
 

--- a/core/src/main/scala/org/bykn/bosatsu/Value.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/Value.scala
@@ -190,6 +190,9 @@ object Value {
         case Nil => UnitValue
         case h :: tail => TupleCons(h, fromList(tail))
       }
+
+    def apply(vs: Value*): ProductValue =
+      fromList(vs.toList)
   }
 
   object Comparison {

--- a/test_python.sh
+++ b/test_python.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+tmp_dir=$(mktemp -d -t bosatsupy-XXXXXXXXXX)
+./bosatsuj transpile --input_dir test_workspace/ --package_root test_workspace/ --lang python --outdir $tmp_dir
+#./bosatsu transpile --input_dir test_workspace/ --package_root test_workspace/ --lang python --outdir $tmp_dir
+python3 -m unittest discover $tmp_dir -v --pattern "*.py"
+rm -rf $tmp_dir
+#echo $tmp_dir

--- a/test_workspace/Nat.bosatsu
+++ b/test_workspace/Nat.bosatsu
@@ -4,8 +4,7 @@ import Bosatsu/Predef [ add as operator +, times as operator * ]
 export [ Nat(), times2, add, mult, to_Int, to_Nat ]
 
 # This is the traditional encoding of natural numbers
-# it is useful when you are iterating on all values, but
-# not space efficient
+# it is useful when you are iterating on all values
 enum Nat: Zero, Succ(prev: Nat)
 
 # This is an O(n) operation

--- a/test_workspace/Parser.bosatsu
+++ b/test_workspace/Parser.bosatsu
@@ -1,0 +1,117 @@
+package Parser
+
+struct Parser[a](parse: String -> Option[(String, a)])
+
+empty = Parser(\_ -> None)
+
+def parse(p: Parser[a], str: String) -> Option[a]:
+    Parser(fn) = p
+    match fn(str):
+        Some((_, a)): Some(a)
+        None: None
+
+def pure(item: a) -> Parser[a]: Parser(\s -> Some((s, item)))
+
+def expect(str: String) -> Parser[Unit]:
+    def p(s): match s.partition_String(str):
+        Some(("", rest)): Some((rest, ()))
+        Some(_) | None: None
+
+    Parser(p)
+
+def map(p, fn):
+    Parser(pfn) = p
+    Parser(\s -> match pfn(s):
+        Some((rest, a)): Some((rest, fn(a)))
+        None: None)
+
+def flat_map(p: Parser[a], fn: a -> Parser[b]) -> Parser[b]:
+    Parser(fa) = p
+    def parse(s0):
+        match fa(s0):
+            Some((s1, a)):
+                Parser(fb) = fn(a)
+                fb(s1)
+            None: None
+
+    Parser(parse)
+
+def one_of(ps: List[Parser[a]]) -> Parser[a]:
+    recur ps:
+        []: empty
+        [p1]: p1
+        [Parser(headFn), *prest]:
+            Parser(tailFn) = one_of(prest)
+            def parse(s):
+                match headFn(s):
+                    None: tailFn(s)
+                    notEmpty: notEmpty
+
+            Parser(parse)
+
+def then_parse(pa: Parser[a], pb: Parser[b]) -> Parser[(a, b)]:
+    Parser(fa) = pa
+    Parser(fb) = pb
+    def parse(s0):
+        match fa(s0):
+            Some((s1, a)):
+                match fb(s1):
+                    Some((s2, b)): Some((s2, (a, b)))
+                    None: None
+            None: None
+
+    Parser(parse)
+
+def expect_int(i: Int) -> Parser[Int]:
+  expect(int_to_String(i)).map(\_ -> i)
+
+digit = one_of([expect_int(i) for i in range(10)])
+
+enum Nat: Z, S(n: Nat)
+
+def to_Nat(i: Int) -> Nat:
+  int_loop(i, Z, \i, nat -> (i.sub(1), S(nat)))
+
+enum Rec[a, b]: Cont(next_input: a), Done(output: b)
+
+def recur_max(n: Nat, fn: a -> Rec[a, b], in: a) -> Option[b]:
+    recur n:
+        Z: None
+        S(prev):
+            match fn(in):
+              Cont(in1): recur_max(prev, fn, in1)
+              Done(out): Some(out)
+
+def digits_n(at_most: Int) -> Parser[Int]:
+    Parser(fn) = digit
+
+    def loop(in: (String, Int)) -> Rec[(String, Int), Option[(String, Int)]]:
+        (s0, acc0) = in
+        first = acc0 matches -1
+        match fn(s0):
+            Some((s1, d)):
+                acc = 0 if first else acc0
+                Cont((s1, acc.times(10).add(d)))
+            None:
+                if first: Done(None)
+                else: Done(Some((s0, acc0)))
+
+    # We add 1 because we want to go beyond the digit
+    # and see that we have fully parsed
+    parseFn = recur_max(S(to_Nat(at_most)), loop)
+    Parser(\s ->
+        match parseFn((s, -1)):
+            Some(Some(a)): Some(a)
+            Some(None) | None: None)
+
+tests = TestSuite("Parser tests", [
+    Assertion(pure(1).parse("foo") matches Some(1), "pure"),
+    Assertion(expect("fo").parse("foo") matches Some(()), "expect(fo)"),
+    Assertion(expect("fo").then_parse(expect("o")).parse("foo") matches Some(_), "expect(fo)"),
+    Assertion(digit.parse("2") matches Some(2), "digit.parse(2)"),
+    Assertion(digit.parse("9") matches Some(9), "digit.parse(2)"),
+    Assertion(digits_n(10).parse("4242") matches Some(4242), "digits_n(10).parse(4242)"),
+    Assertion(digits_n(10).parse("4242") matches Some(4242), "digits_n(10).parse(4242)"),
+    Assertion(digits_n(3).parse("4242") matches None, "digits_n(3).parse(4242)"),
+    Assertion(digits_n(4).parse("4242") matches Some(4242), "digits_n(4).parse(4242)"),
+  ])

--- a/test_workspace/PredefTests.bosatsu
+++ b/test_workspace/PredefTests.bosatsu
@@ -1,9 +1,9 @@
-package IntTests
+package PredefTests
 
 operator / = div
 operator % = mod_Int
 
-test = TestSuite("IntTests", [
+test_int = TestSuite("Int tests", [
       Assertion((4 % -3) matches -2, "(4 % -3) == -2"),
       Assertion((-8 % -2) matches 0, "(-8 % -2) == 0"),
       Assertion((-8 / -2) matches 4, "(-8 / -2) == 4"),
@@ -25,3 +25,17 @@ test = TestSuite("IntTests", [
       Assertion(int_to_String(123) matches "123", "123 str"),
       Assertion(int_to_String(-123) matches "-123", "-123 str"),
     ])
+
+test_string = TestSuite("String tests", [
+  Assertion("foo".partition_String("f") matches Some(("", "oo")), "foo partition_String f"),
+  Assertion("foo".partition_String("") matches None, "foo partition_String \"\""),
+  Assertion("foo".partition_String("x") matches None, "foo partition_String x"),
+  Assertion("foo".rpartition_String("o") matches Some(("fo", "")), "foo rpartition_String o"),
+  Assertion("foo".rpartition_String("") matches None, "foo rpartition_String \"\""),
+  Assertion("foo".rpartition_String("x") matches None, "foo rpartition_String x"),
+])
+
+test = TestSuite("Predef tests", [
+    test_int,
+    test_string,
+])


### PR DESCRIPTION
1. add an example of a basic parser combinator library with bosatsu
2. add partition_String and rpartition_String to predef
3. fix a bug this uncovered in python.Code.Op rendering