### PR TITLE
Support python-like import/from syntax for imports and prefer it

### DIFF
--- a/cli/src/test/scala/org/bykn/bosatsu/TestProtoType.scala
+++ b/cli/src/test/scala/org/bykn/bosatsu/TestProtoType.scala
@@ -159,7 +159,7 @@ class TestProtoType extends FunSuite {
     TestUtils.testInferred(List(
 """package Foo
 
-export [bar]
+export bar
 
 bar = 1
 """

--- a/core/src/main/resources/bosatsu/predef.bosatsu
+++ b/core/src/main/resources/bosatsu/predef.bosatsu
@@ -1,6 +1,6 @@
 package Bosatsu/Predef
 
-export [
+export (
   Bool(),
   Comparison(),
   Int,
@@ -44,7 +44,7 @@ export [
   trace,
   uncurry2,
   uncurry3,
-]
+)
 
 struct Unit
 struct TupleCons(first, second)

--- a/core/src/main/scala/org/bykn/bosatsu/Declaration.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/Declaration.scala
@@ -873,7 +873,7 @@ object Declaration {
    * that cannot be used by identifiers
    */
   val keywords: Set[String] =
-    Set("if", "else", "elif", "match", "matches", "def", "recur", "struct", "enum")
+    Set("from", "import", "if", "else", "elif", "match", "matches", "def", "recur", "struct", "enum")
 
   /**
    * A Parser that matches keywords

--- a/core/src/main/scala/org/bykn/bosatsu/Import.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/Import.scala
@@ -6,7 +6,7 @@ import cats.implicits._
 import fastparse.all._
 import org.typelevel.paiges.{Doc, Document}
 
-import Parser.{spaces, maybeSpace, Combinators}
+import Parser.{spaces, Combinators}
 
 sealed abstract class ImportedName[+T] {
   def originalName: Identifier
@@ -74,22 +74,13 @@ object Import {
     }
 
   val parser: P[Import[PackageName, Unit]] = {
-    val original = P("import" ~ spaces ~/ PackageName.parser ~ maybeSpace ~
-      ImportedName.parser.nonEmptyListSyntax).map { case (pname, imported) =>
-        Import(pname, imported)
-      }
+    val pyimps = ImportedName.parser.itemsMaybeParens
 
-    val pyimps =
-      (ImportedName.parser.parensLines1Cut |
-        ImportedName.parser.nonEmptyListOfWs(maybeSpace))
-
-    val pythonStyle = P("from" ~ spaces ~/ PackageName.parser ~ spaces ~
+    P("from" ~ spaces ~/ PackageName.parser ~ spaces ~
       "import" ~ spaces ~ pyimps)
-      .map { case (pname, imported) =>
+      .map { case (pname, (_, imported)) =>
         Import(pname, imported)
       }
-
-    original | pythonStyle
   }
 
   /**

--- a/core/src/main/scala/org/bykn/bosatsu/Package.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/Package.scala
@@ -8,7 +8,7 @@ import org.typelevel.paiges.{Doc, Document}
 import scala.util.hashing.MurmurHash3
 
 import rankn._
-import Parser.{spaces, maybeSpace, Combinators}
+import Parser.{spaces, Combinators}
 
 import FixType.Fix
 import LocationMap.Colorize
@@ -126,9 +126,7 @@ object Package {
         case nonEmptyExports =>
           Doc.line +
             Doc.text("export ") +
-            Doc.text("[ ") +
             Doc.intercalate(Doc.text(", "), nonEmptyExports.map(Document[ExportedName[Unit]].document _)) +
-            Doc.text(" ]") +
             Doc.line
       }
       val b = statments.map(Document[Statement].document(_))
@@ -143,7 +141,7 @@ object Package {
       case Some(p) => parsePack.?.map(_.getOrElse(p))
     }
     val im = Padding.parser(Import.parser ~ Parser.toEOL).map(_.padded).rep().map(_.toList)
-    val ex = Padding.parser(P("export" ~ maybeSpace ~ ExportedName.parser.nonEmptyListSyntax ~ Parser.toEOL)).map(_.padded)
+    val ex = Padding.parser(P("export" ~ spaces ~/ ExportedName.parser.itemsMaybeParens.map(_._2) ~ Parser.toEOL)).map(_.padded)
     val body = Statement.parser
     (pname ~ im ~ Parser.nonEmptyListToList(ex) ~ body).map { case (p, i, e, b) =>
       Package(p, i, e, b)

--- a/core/src/main/scala/org/bykn/bosatsu/Parser.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/Parser.scala
@@ -338,6 +338,17 @@ object Parser {
     }
 
     /**
+     * either: a, b, c, ..
+     * or (a, b, c, ) where we allow newlines:
+     * return true if we do have parens
+     */
+    def itemsMaybeParens: P[(Boolean, NonEmptyList[T])] = {
+      val withP = item.parensLines1Cut.map((true, _))
+      val noP = item.nonEmptyListOfWs(maybeSpace).map((false, _))
+      withP | noP
+    }
+
+    /**
      * Parse a python-like tuple or a parens
      */
     def tupleOrParens: P[Either[T, List[T]]] = {

--- a/core/src/test/scala/org/bykn/bosatsu/EvaluationTest.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/EvaluationTest.scala
@@ -1571,7 +1571,7 @@ main = fn(0, 1, 2)
       List("""
 package A
 
-export [ foo ]
+export foo
 
 foo = 3
 """, """
@@ -1588,7 +1588,7 @@ baz = fooz
       List("""
 package A
 
-export [ foo ]
+export foo
 
 foo = 3
 bar = 3

--- a/core/src/test/scala/org/bykn/bosatsu/EvaluationTest.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/EvaluationTest.scala
@@ -1386,7 +1386,7 @@ a = 1
 """, """
 package B
 
-import A [ a ]
+from A import a
 
 main = a"""), "B") { case PackageError.UnknownImportName(_, _, _, _) => () }
 
@@ -1394,7 +1394,7 @@ main = a"""), "B") { case PackageError.UnknownImportName(_, _, _, _) => () }
       List("""
 package B
 
-import A [ a ]
+from A import a
 
 main = a"""), "B") { case PackageError.UnknownImportPackage(_, _) => () }
 
@@ -1576,7 +1576,7 @@ export [ foo ]
 foo = 3
 """, """
 package B
-import A [ fooz ]
+from A import fooz
 
 baz = fooz
 """), "B") { case te@PackageError.UnknownImportName(_, _, _, _) =>
@@ -1594,7 +1594,7 @@ foo = 3
 bar = 3
 """, """
 package B
-import A [ bar ]
+from A import bar
 
 baz = bar
 """), "B") { case te@PackageError.UnknownImportName(_, _, _, _) =>
@@ -2239,7 +2239,7 @@ main = Foo(1, "2")
       List("""
 package Err
 
-import Bosatsu/Predef [ foldLeft ]
+from Bosatsu/Predef import foldLeft
 
 main = 1
 """), "Err") { case sce@PackageError.DuplicatedImport(_) =>
@@ -2253,7 +2253,7 @@ main = 1
       """
         |package Err
         |
-        |import Bosatsu/Predef [ foldLeft ]
+        |from Bosatsu/Predef import foldLeft
         |
         |main = 1
         |""".stripMargin

--- a/core/src/test/scala/org/bykn/bosatsu/LetFreeTest.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/LetFreeTest.scala
@@ -356,7 +356,7 @@ out = match Buzz:
     normalExpressionTest(
       List("""
 package Imp/First
-export [fizz]
+export fizz
 
 def fizz(f, s):
   (s, f)
@@ -379,7 +379,7 @@ out=fizz(1,2)
 """,
 """
 package Imp/Second
-export [fizz]
+export fizz
 
 def fizz(f, s):
   (s, f)

--- a/core/src/test/scala/org/bykn/bosatsu/LetFreeTest.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/LetFreeTest.scala
@@ -363,7 +363,7 @@ def fizz(f, s):
 """,
 """
 package Imp/Second
-import Imp/First [fizz]
+from Imp/First import fizz
 
 out=fizz(1,2)
 """
@@ -373,7 +373,7 @@ out=fizz(1,2)
     normalExpressionTest(
       List("""
 package Imp/First
-import Imp/Second [fizz]
+from Imp/Second import fizz
 
 out=fizz(1,2)
 """,

--- a/core/src/test/scala/org/bykn/bosatsu/OperatorTest.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/OperatorTest.scala
@@ -109,7 +109,7 @@ operator == = eq_Int
   """
 package T2
 
-import T1 [ operator + as operator ++, `*`, `==` ]
+from T1 import operator + as operator ++, `*`, `==`
 
 `.+` = `++`
 `+.` = `++`

--- a/core/src/test/scala/org/bykn/bosatsu/OperatorTest.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/OperatorTest.scala
@@ -100,7 +100,7 @@ test = TestSuite("precedence",
     runBosatsuTest(List("""
 package T1
 
-export [ operator +, operator *, operator == ]
+export operator +, operator *, operator ==
 
 operator + = add
 operator * = times

--- a/core/src/test/scala/org/bykn/bosatsu/PackageTest.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/PackageTest.scala
@@ -46,7 +46,7 @@ class PackageTest extends FunSuite {
     val p1 = parse(
 """
 package Foo
-export [ main ]
+export main
 
 main = 1
 """)
@@ -54,7 +54,7 @@ main = 1
 """
 package Foo2
 from Foo import main as mainFoo
-export [ main, ]
+export main,
 
 main = mainFoo
 """)
@@ -86,7 +86,7 @@ main = add(one, 42)
 """
 package P5
 
-export [ Option(), List(), head, tail ]
+export Option(), List(), head, tail
 
 enum Option:
   None
@@ -113,7 +113,7 @@ def tail(list):
 """
 package P6
 from P5 import Option, List, NonEmpty, Empty, head,  tail
-export [ data ]
+export data
 
 data = NonEmpty(1, NonEmpty(2, Empty))
 
@@ -160,7 +160,7 @@ main = maybeOne(42)
 """
 package R1
 
-export [ Foo(), mkFoo, takeFoo ]
+export Foo(), mkFoo, takeFoo
 
 struct Foo
 

--- a/core/src/test/scala/org/bykn/bosatsu/PackageTest.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/PackageTest.scala
@@ -53,7 +53,7 @@ main = 1
     val p2 = parse(
 """
 package Foo2
-import Foo [ main as mainFoo ]
+from Foo import main as mainFoo
 export [ main, ]
 
 main = mainFoo
@@ -62,7 +62,7 @@ main = mainFoo
     val p3 = parse(
 """
 package Foo
-import Foo2 [ main as mainFoo ]
+from Foo2 import main as mainFoo
 
 main = 1
 """)
@@ -74,7 +74,7 @@ main = 1
     val p4 = parse(
 """
 package P4
-import Foo2 [ main as one ]
+from Foo2 import main as one
 
 external def add(a: a, b: a) -> a
 
@@ -112,7 +112,7 @@ def tail(list):
     val p6 = parse(
 """
 package P6
-import P5 [ Option, List, NonEmpty, Empty, head,  tail ]
+from P5 import Option, List, NonEmpty, Empty, head,  tail
 export [ data ]
 
 data = NonEmpty(1, NonEmpty(2, Empty))
@@ -124,8 +124,8 @@ main = head(data)
     val p7 = parse(
 """
 package P7
-import P6 [ data as p6_data ]
-import P5 [ Option, List, NonEmpty as Cons, Empty as Nil, head,  tail ]
+from P6 import data as p6_data
+from P5 import Option, List, NonEmpty as Cons, Empty as Nil, head,  tail
 
 data = Cons(1, Cons(2, Nil))
 data1 = Cons(0, p6_data)
@@ -174,7 +174,7 @@ def takeFoo(foo):
   val p2 = parse(
 """
 package R2
-import R1 [ Foo as Bar, mkFoo, takeFoo ]
+from R1 import Foo as Bar, mkFoo, takeFoo
 
 # note Bar is the same as foo
 struct Baz(b: Bar)

--- a/core/src/test/scala/org/bykn/bosatsu/ParserTest.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/ParserTest.scala
@@ -460,6 +460,14 @@ class ParserTest extends ParserTestBase {
 
     expectFail(Operators.operatorToken, "=", 0)
   }
+
+  test("test import statements") {
+    roundTrip(Import.parser, "import Foo [bar, baz]")
+    roundTrip(Import.parser, "import Foo [bar as quux, baz]")
+    roundTrip(Import.parser, "from Foo import bar, baz")
+    roundTrip(Import.parser, "from Foo import bar as quux, baz")
+    roundTrip(Import.parser, "from Foo import (\nbar as quux,\nbaz)")
+  }
 }
 
 /**

--- a/core/src/test/scala/org/bykn/bosatsu/ParserTest.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/ParserTest.scala
@@ -462,9 +462,8 @@ class ParserTest extends ParserTestBase {
   }
 
   test("test import statements") {
-    roundTrip(Import.parser, "import Foo [bar, baz]")
-    roundTrip(Import.parser, "import Foo [bar as quux, baz]")
     roundTrip(Import.parser, "from Foo import bar, baz")
+    roundTrip(Import.parser, "from Foo import bar as quux, baz")
     roundTrip(Import.parser, "from Foo import bar as quux, baz")
     roundTrip(Import.parser, "from Foo import (\nbar as quux,\nbaz)")
   }
@@ -1148,8 +1147,8 @@ external def foo2(i: Integer, b: a) -> String
     roundTrip(Package.parser(None),
 """
 package Foo/Bar
-import Baz [Bippy]
-export [foo]
+from Baz import Bippy
+export foo
 
 foo = 1
 """)
@@ -1203,24 +1202,24 @@ def z:
 
     expectFail(Package.parser(None),
       """package Foo
-import Baz [ a, , b]
+from Baz import a, , b
 
 x = 1
-""", 28)
+""", 31)
 
     expectFail(Package.parser(None),
       """package Foo
-export [ x, , y ]
+export x, , y
 
 x = 1
-""", 24)
+""", 22)
 
     expectFail(Package.parser(None),
       """package Foo
-export [ x, , ]
+export x, ,
 
 x = 1
-""", 24)
+""", 22)
     expectFail(Package.parser(None),
       """package Foo
 

--- a/docs/language_guide.md
+++ b/docs/language_guide.md
@@ -446,7 +446,7 @@ In some other package:
 ```
 package Animals/Report
 
-import Animals/Favorites [ mammals ]
+from Animals/Favorites import mammals
 export [ most_fav ]
 
 most_fav = match mammals:

--- a/docs/language_guide.md
+++ b/docs/language_guide.md
@@ -435,7 +435,7 @@ All names are private unless exported. All names from external packages must be 
 
 ```
 package Animals/Favorites
-export [ mammals, birds ]
+export mammals, birds
 
 mammals = ["elephant", "whale", "dog"]
 
@@ -447,7 +447,7 @@ In some other package:
 package Animals/Report
 
 from Animals/Favorites import mammals
-export [ most_fav ]
+export most_fav
 
 most_fav = match mammals:
   [head, *tail]: head
@@ -461,7 +461,7 @@ We export types slightly differently. We can export just the type, or the type a
 
 package Great/Types
 
-export [ ClearOption(), OpaqueOption, foldO, noneO, someO ]
+export ClearOption(), OpaqueOption, foldO, noneO, someO
 
 enum ClearOption:
   CNone, CSome(get)

--- a/test_workspace/ApplicativeTraverse.bosatsu
+++ b/test_workspace/ApplicativeTraverse.bosatsu
@@ -2,7 +2,7 @@ package Bosatsu/Example/ApplicativeTraverse
 
 from Bosatsu/List import eq_List
 from Bosatsu/Option import eq_Option
-export [Applicative(), Traverse(), traverse_List, applicative_Option]
+export Applicative(), Traverse(), traverse_List, applicative_Option
 
 # Represents the Applicative typeclass
 struct Applicative(

--- a/test_workspace/ApplicativeTraverse.bosatsu
+++ b/test_workspace/ApplicativeTraverse.bosatsu
@@ -1,7 +1,7 @@
 package Bosatsu/Example/ApplicativeTraverse
 
-import Bosatsu/List [ eq_List ]
-import Bosatsu/Option [ eq_Option ]
+from Bosatsu/List import eq_List
+from Bosatsu/Option import eq_Option
 export [Applicative(), Traverse(), traverse_List, applicative_Option]
 
 # Represents the Applicative typeclass

--- a/test_workspace/AvlTree.bosatsu
+++ b/test_workspace/AvlTree.bosatsu
@@ -1,6 +1,6 @@
 package AvlTree
 
-export [ Tree, Module, module ]
+export Tree, Module, module
 
 enum Tree[a]:
     Empty, Branch(size: Int, height: Int, key: a, left: Tree[a], right: Tree[a])

--- a/test_workspace/Bar.bosatsu
+++ b/test_workspace/Bar.bosatsu
@@ -1,4 +1,4 @@
-import Foo [ x ]
+from Foo import x
 
 test = Assertion(
   string_Order_fn(x, "this is Foo") matches EQ, "got the right string")

--- a/test_workspace/BinNat.bosatsu
+++ b/test_workspace/BinNat.bosatsu
@@ -1,6 +1,6 @@
 package Bosatsu/BinNat
 
-import Bosatsu/Nat [ Nat, Zero as NatZero, Succ as NatSucc, times2 as times2_Nat ]
+from Bosatsu/Nat import Nat, Zero as NatZero, Succ as NatSucc, times2 as times2_Nat
 
 export [ BinNat(), toInt, toNat, toBinNat, next, add_BinNat, times2 ]
 # a natural number with three variants:

--- a/test_workspace/BinNat.bosatsu
+++ b/test_workspace/BinNat.bosatsu
@@ -2,7 +2,7 @@ package Bosatsu/BinNat
 
 from Bosatsu/Nat import Nat, Zero as NatZero, Succ as NatSucc, times2 as times2_Nat
 
-export [ BinNat(), toInt, toNat, toBinNat, next, add_BinNat, times2 ]
+export BinNat(), toInt, toNat, toBinNat, next, add_BinNat, times2
 # a natural number with three variants:
 # Zero = 0
 # Odd(n) = 2n + 1

--- a/test_workspace/Bool.bosatsu
+++ b/test_workspace/Bool.bosatsu
@@ -1,6 +1,6 @@
 package Bosatsu/Bool
 
-export [ not ]
+export not
 
 def not(b: Bool) -> Bool:
   False if b else True

--- a/test_workspace/BuildExample.bosatsu
+++ b/test_workspace/BuildExample.bosatsu
@@ -1,6 +1,6 @@
 package BuildExample
 
-import BuildLibrary [ build, files, library, empty, LibArgs, build_all ]
+from BuildLibrary import build, files, library, empty, LibArgs, build_all
 
 lib1 = library(
   files(["file1.bosatsu", "file2.bosatsu"]),

--- a/test_workspace/BuildLibrary.bosatsu
+++ b/test_workspace/BuildLibrary.bosatsu
@@ -1,6 +1,6 @@
 package BuildLibrary
 
-export [File(), Library(), LibArgs(), build, Build, file, files, build_all, library, empty]
+export File(), Library(), LibArgs(), build, Build, file, files, build_all, library, empty
 
 struct Leibniz[a, b](cast: forall f. f[a] -> f[b])
 (refl: forall a. Leibniz[a, a]) = Leibniz(\x -> x)

--- a/test_workspace/Dict.bosatsu
+++ b/test_workspace/Dict.bosatsu
@@ -2,7 +2,7 @@ package Bosatsu/Dict
 
 from Bosatsu/List import eq_List
 
-export [ eq_Dict, eq_Pair ]
+export eq_Dict, eq_Pair
 
 
 def eq_Pair(eq_a, eq_b, (l1, l2), (r1, r2)) -> Bool:

--- a/test_workspace/Dict.bosatsu
+++ b/test_workspace/Dict.bosatsu
@@ -1,6 +1,6 @@
 package Bosatsu/Dict
 
-import Bosatsu/List [ eq_List ]
+from Bosatsu/List import eq_List
 
 export [ eq_Dict, eq_Pair ]
 

--- a/test_workspace/Foo.bosatsu
+++ b/test_workspace/Foo.bosatsu
@@ -1,4 +1,4 @@
-export [ x, ]
+export x,
 
 # testing an implicit package name
 

--- a/test_workspace/List.bosatsu
+++ b/test_workspace/List.bosatsu
@@ -1,7 +1,7 @@
 package Bosatsu/List
 
-import Bosatsu/Bool [ not ]
-import Bosatsu/Nat [ Nat, Zero, Succ ]
+from Bosatsu/Bool import not
+from Bosatsu/Nat import Nat, Zero, Succ
 export [ any, eq_List, exists, head, for_all, size, sum, sort, uncons, zip ]
 
 def any(as: List[Bool]) -> Bool:

--- a/test_workspace/List.bosatsu
+++ b/test_workspace/List.bosatsu
@@ -2,7 +2,7 @@ package Bosatsu/List
 
 from Bosatsu/Bool import not
 from Bosatsu/Nat import Nat, Zero, Succ
-export [ any, eq_List, exists, head, for_all, size, sum, sort, uncons, zip ]
+export any, eq_List, exists, head, for_all, size, sum, sort, uncons, zip
 
 def any(as: List[Bool]) -> Bool:
     as matches [*_, True, *_]

--- a/test_workspace/Nat.bosatsu
+++ b/test_workspace/Nat.bosatsu
@@ -1,6 +1,6 @@
 package Bosatsu/Nat
 
-import Bosatsu/Predef [ add as operator +, times as operator * ]
+from Bosatsu/Predef import add as operator +, times as operator *
 export [ Nat(), times2, add, mult, to_Int, to_Nat ]
 
 # This is the traditional encoding of natural numbers

--- a/test_workspace/Nat.bosatsu
+++ b/test_workspace/Nat.bosatsu
@@ -1,7 +1,7 @@
 package Bosatsu/Nat
 
 from Bosatsu/Predef import add as operator +, times as operator *
-export [ Nat(), times2, add, mult, to_Int, to_Nat ]
+export Nat(), times2, add, mult, to_Int, to_Nat
 
 # This is the traditional encoding of natural numbers
 # it is useful when you are iterating on all values

--- a/test_workspace/Nothing.bosatsu
+++ b/test_workspace/Nothing.bosatsu
@@ -1,6 +1,6 @@
 package Bosatsu/Nothing
 
-export [ Nothing, impossible ]
+export Nothing, impossible
 
 # In a total language, it is not possible
 # to create a value with the type of magic

--- a/test_workspace/Option.bosatsu
+++ b/test_workspace/Option.bosatsu
@@ -1,6 +1,6 @@
 package Bosatsu/Option
 
-export [ eq_Option ]
+export eq_Option
 
 def eq_Option(eq: a -> a -> Bool, left: Option[a], right: Option[a]) -> Bool:
   match (left, right):

--- a/test_workspace/Queue.bosatsu
+++ b/test_workspace/Queue.bosatsu
@@ -1,6 +1,6 @@
 package Queue
 
-import Bosatsu/List [ eq_List ]
+from Bosatsu/List import eq_List
 export [ Queue,
   empty_Queue, fold_Queue, push, unpush, pop_value, pop, reverse_Queue, eq_Queue,
   to_List, from_List

--- a/test_workspace/Queue.bosatsu
+++ b/test_workspace/Queue.bosatsu
@@ -1,10 +1,10 @@
 package Queue
 
 from Bosatsu/List import eq_List
-export [ Queue,
+export (Queue,
   empty_Queue, fold_Queue, push, unpush, pop_value, pop, reverse_Queue, eq_Queue,
   to_List, from_List
-]
+)
 
 struct Queue(front: List[a], back: List[a])
 

--- a/test_workspace/TreeList.bosatsu
+++ b/test_workspace/TreeList.bosatsu
@@ -1,7 +1,7 @@
 package TreeList
 
 from Bosatsu/List import eq_List
-export [ TreeList, empty, cons, decons, head, get, fold, eq_TreeList ]
+export TreeList, empty, cons, decons, head, get, fold, eq_TreeList
 
 # implementation of O(1) cons/uncons O(log N) list-like data structure
 

--- a/test_workspace/TreeList.bosatsu
+++ b/test_workspace/TreeList.bosatsu
@@ -1,6 +1,6 @@
 package TreeList
 
-import Bosatsu/List [ eq_List ]
+from Bosatsu/List import eq_List
 export [ TreeList, empty, cons, decons, head, get, fold, eq_TreeList ]
 
 # implementation of O(1) cons/uncons O(log N) list-like data structure

--- a/test_workspace/bazel_deps_api.bosatsu
+++ b/test_workspace/bazel_deps_api.bosatsu
@@ -1,6 +1,6 @@
 package BazelDepsApi
 
-import DictTools [ merge as merge_Dict ]
+from DictTools import merge as merge_Dict
 
 export [
   Artifact(), Config(), Resolver(), Replacement(), maven_central,

--- a/test_workspace/bazel_deps_api.bosatsu
+++ b/test_workspace/bazel_deps_api.bosatsu
@@ -2,10 +2,10 @@ package BazelDepsApi
 
 from DictTools import merge as merge_Dict
 
-export [
+export (
   Artifact(), Config(), Resolver(), Replacement(), maven_central,
   default_options_with_scala, scala_dep, scala_dep_modules,
-  merge_deps, merge_dep_List, standard_scala_replacements ]
+  merge_deps, merge_dep_List, standard_scala_replacements )
 
 struct Resolver(id: String, type: String, url: String)
 

--- a/test_workspace/dicttools.bosatsu
+++ b/test_workspace/dicttools.bosatsu
@@ -1,6 +1,6 @@
 package DictTools
 
-export [ merge ]
+export merge
 
 def merge(left: Dict[k, v], right: Dict[k, v], fn: v -> v -> v) -> Dict[k, v]:
   right.items.foldLeft(left, \d, (k, v) ->

--- a/test_workspace/euler2.bosatsu
+++ b/test_workspace/euler2.bosatsu
@@ -1,6 +1,6 @@
 package Euler/Two
 
-import Bosatsu/List [ sum ]
+from Bosatsu/List import sum
 
 # see:
 # https://projecteuler.net/problem=2

--- a/test_workspace/euler4.bosatsu
+++ b/test_workspace/euler4.bosatsu
@@ -1,7 +1,7 @@
 package Euler/Four
 
-import Bosatsu/List [ eq_List ]
-import Bosatsu/Nat [ Nat, Succ, Zero, to_Nat ]
+from Bosatsu/List import eq_List
+from Bosatsu/Nat import Nat, Succ, Zero, to_Nat
 
 # see:
 # https://projecteuler.net/problem=4

--- a/test_workspace/euler5.bosatsu
+++ b/test_workspace/euler5.bosatsu
@@ -1,6 +1,6 @@
 package Euler/P5
 
-import Bosatsu/List [ for_all ]
+from Bosatsu/List import for_all
 
 # 2520 is the smallest number that can be divided by each of the numbers from 1 to 10 without any remainder.
 #

--- a/test_workspace/euler7.bosatsu
+++ b/test_workspace/euler7.bosatsu
@@ -1,7 +1,7 @@
 package Euler/P7
 
-import Bosatsu/Bool [ not ]
-import Bosatsu/List [ for_all ]
+from Bosatsu/Bool import not
+from Bosatsu/List import for_all
 
 # By listing the first six prime numbers: 2, 3, 5, 7, 11, and 13, we can see that the 6th prime is 13.
 # What is the 10 001st prime number?

--- a/test_workspace/gen_deps.bosatsu
+++ b/test_workspace/gen_deps.bosatsu
@@ -1,8 +1,9 @@
 package GenDeps
 
-import BazelDepsApi [
+from BazelDepsApi import (
   Config, Artifact, Replacement, default_options_with_scala, merge_dep_List, scala_dep,
-  scala_dep_modules, standard_scala_replacements ]
+  scala_dep_modules, standard_scala_replacements
+  )
 
 cats_version = '2.0.0'
 cats_effect_version = '2.0.0'


### PR DESCRIPTION
change the import syntax to:

```
from package import foo
```

The export syntax becomes just 
```
export foo, bar
```
If you need multiline, you can use parens:
```
from package import (
    foo,
    bar,
    baz as quux,
)
```

Similarly with exports.