### PR TITLE
Improve the parsing library a bit more

### DIFF
--- a/parser/.js/src/main/scala/org/bykn/bosatsu/parser/BitSet.scala
+++ b/parser/.js/src/main/scala/org/bykn/bosatsu/parser/BitSet.scala
@@ -9,17 +9,25 @@ object BitSetUtil {
   @inline final val isScalaJvm = false
 
   @inline def isSet(b: BitSet, idx: Int): Boolean =
-    (idx == 0) || ((idx > 0) && b(idx))
+    (idx >= 0) && b(idx)
 
   def bitSetFor(charArray: Array[Char]): BitSet = {
     val min = charArray(0).toInt
     val bs = new BitSet(charArray(charArray.length - 1).toInt + 1 - min)
-    var idx = 1
+    var idx = 0
     while (idx < charArray.length) {
       bs += charArray(idx).toInt - min
       idx += 1
     }
 
     bs
+  }
+
+  // what are all the Chars in these bitsets
+  def union(bs: List[(Int, BitSet)]): Iterable[Char] = {
+    def toIter(m: Int, bs: BitSet): Iterator[Char] =
+      bs.iterator.map { i => (i + m).toChar } ++ Iterator.single(m.toChar)
+
+    bs.flatMap { case (m, bs) => toIter(m, bs) }
   }
 }

--- a/parser/.jvm/src/main/scala/org/bykn/bosatsu/parser/BitSet.scala
+++ b/parser/.jvm/src/main/scala/org/bykn/bosatsu/parser/BitSet.scala
@@ -9,17 +9,28 @@ object BitSetUtil {
   @inline final val isScalaJvm = true
 
   @inline def isSet(b: BitSet, idx: Int): Boolean =
-    (idx == 0) || ((idx > 0) && b.get(idx))
+    // BitSet can't deal with negatives, so mask those out
+    b.get(idx & Int.MaxValue)
 
   def bitSetFor(charArray: Array[Char]): BitSet = {
     val min = charArray(0).toInt
     val bs = new BitSet(charArray(charArray.length - 1).toInt + 1 - min)
-    var idx = 1
+    var idx = 0
     while (idx < charArray.length) {
       bs.set(charArray(idx).toInt - min)
       idx += 1
     }
 
     bs
+  }
+
+  // what are all the Chars in these bitsets
+  def union(bs: List[(Int, BitSet)]): Iterable[Char] = {
+    def toIter(m: Int, bs: BitSet): Iterator[Char] =
+      Iterator.iterate(0) { m => bs.nextSetBit(m + 1) }
+        .takeWhile(_ >= 0)
+        .map { i => (m + i).toChar }
+
+    bs.flatMap { case (m, bs) => toIter(m, bs) }
   }
 }

--- a/parser/src/test/scala/org/bykn/bosatsu/parser/ParserTest.scala
+++ b/parser/src/test/scala/org/bykn/bosatsu/parser/ParserTest.scala
@@ -2,6 +2,7 @@ package org.bykn.bosatsu.parser
 
 import cats.{Eq, Id, FlatMap, Functor, Defer, MonoidK, Monad, Eval}
 import cats.arrow.FunctionK
+import cats.data.NonEmptyList
 import org.scalacheck.Prop.forAll
 import org.scalacheck.{Arbitrary, Gen, Cogen}
 
@@ -313,6 +314,7 @@ object ParserGen {
      (1, rec.map(string(_))),
      (1, rec.map(backtrack(_))),
      (1, rec.map(defer(_))),
+     (1, rec.map { gen => GenT(!gen.fa) }),
      (1, Gen.lzy(gen1.map(rep(_)))),
      (1, rec.flatMap(mapped(_))),
      (1, tailRecM(Gen.lzy(gen1))),
@@ -392,7 +394,9 @@ class ParserTest extends munit.ScalaCheckSuite {
     parseTest(Parser.product(fooP, barP), "foobar", ((), ()))
   }
 
-  val digit = Parser.charIn('0' to '9')
+  // we can use String => Iterable[Char]
+  val digit = Parser.charIn("0123456789")
+  // or use a range which reads a bit nicer:
   val digit1 = Parser.charIn('1' to '9')
   def maybeNeg[A](p1: Parser1[A]): Parser1[String] =
      (Parser.expect("-").?.with1 ~ p1).string
@@ -453,7 +457,7 @@ class ParserTest extends munit.ScalaCheckSuite {
               assertEquals(s.drop(len), rest)
             }
             else fail(s"expected to not parse: $rest, $first")
-          case Left(Parser.Error.MissedExpectation(Parser.Expectation.Length(off, l, a))) =>
+          case Left(Parser.Error(NonEmptyList(Parser.Expectation.Length(off, l, a), Nil))) =>
             assertEquals(off, 0)
             assertEquals(l, len)
             assertEquals(a, s.length)
@@ -625,7 +629,7 @@ class ParserTest extends munit.ScalaCheckSuite {
 
   test("range messages seem to work") {
     val pa = Parser.charIn('0' to '9')
-    assertEquals(pa.parse("z").toString, "Left(MissedExpectation(InRange(0,0,9)))")
+    assertEquals(pa.parse("z").toString, "Left(Error(NonEmptyList(InRange(0,0,9))))")
   }
 
   test("partial parse fails in rep") {
@@ -692,7 +696,7 @@ class ParserTest extends munit.ScalaCheckSuite {
         case Right((rest, _)) =>
           assertEquals(str, "")
           assertEquals(rest, "")
-        case Left(Parser.Error.MissedExpectation(Parser.Expectation.EndOfString(off, len))) =>
+        case Left(Parser.Error(NonEmptyList(Parser.Expectation.EndOfString(off, len), Nil))) =>
           assertEquals(off, 0)
           assertEquals(len, str.length)
         case other =>
@@ -777,6 +781,52 @@ class ParserTest extends munit.ScalaCheckSuite {
         case (Left(_), l) => assert(l.isLeft)
         case (ra, rb) => assertEquals(ra, rb)
       }
+    }
+  }
+
+  test("charWhere(_ => true) == anyChar") {
+    assertEquals(Parser.charWhere(_ => true), Parser.anyChar)
+  }
+
+  property("with1 *> and with1 <* work as expected") {
+    forAll(ParserGen.gen, ParserGen.gen1, Arbitrary.arbitrary[String]) { (p1, p2, str) =>
+      val rp1 = p1.fa.with1 *> p2.fa
+      val rp2 = (p1.fa.with1 ~ p2.fa).map(_._2)
+      assertEquals(rp1.parse(str), rp2.parse(str))
+
+      val rp3 = p1.fa.with1 <* p2.fa
+      val rp4 = (p1.fa.with1 ~ p2.fa).map(_._1)
+      assertEquals(rp3.parse(str), rp4.parse(str))
+    }
+  }
+
+  property("x and !x never both parse") {
+    forAll(ParserGen.gen, Arbitrary.arbitrary[String]) { (p1, str) =>
+      val notx = !p1.fa
+
+      val both = p1.fa.parse(str).isRight && notx.parse(str).isRight
+      assert(!both)
+    }
+  }
+
+  property("if x ~ y matches then x ~ y.peek match") {
+    forAll(ParserGen.gen, ParserGen.gen, Arbitrary.arbitrary[String]) { (x, y, str) =>
+      val m1 = (x.fa ~ y.fa).parse(str)
+      val m2 = ((x.fa ~ y.fa.peek).map(_._1)).parse(str)
+
+      assertEquals(m1.isRight, m2.isRight)
+      if (m1.isRight) {
+        assert(x.fa.parse(str) == m2)
+      }
+    }
+  }
+
+  property("BitSetUtil union works") {
+    forAll { cs: List[List[Char]] =>
+      val arys = cs.filter(_.nonEmpty).map(_.toArray.sorted)
+      val bs = arys.map { ary => (ary(0).toInt, BitSetUtil.bitSetFor(ary)) }
+      val sortedFlat = BitSetUtil.union(bs)
+      assertEquals(sortedFlat.toSet, cs.flatten.toSet)
     }
   }
 }


### PR DESCRIPTION
I think this basically gets us to feature parity with fastparse BUT the semantics are different: opt in backtracking vs opt out.

In my experience, this makes errors much more clear and discourages writing exponentially bad parsers.