### PR TITLE
update to cats 2.2.0, remove alleycats

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -157,7 +157,6 @@ lazy val core = (crossProject(JSPlatform, JVMPlatform).crossType(CrossType.Pure)
     test in assembly := {},
     libraryDependencies ++=
       Seq(
-        alleycats.value,
         cats.value,
         decline.value,
         paiges.value,
@@ -192,7 +191,6 @@ lazy val jsapi = (crossProject(JSPlatform).crossType(CrossType.Pure) in file("js
     test in assembly := {},
     libraryDependencies ++=
       Seq(
-        alleycats.value,
         cats.value,
         decline.value,
         scalaCheck.value % Test,

--- a/core/src/main/scala/org/bykn/bosatsu/LetFree.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/LetFree.scala
@@ -4,6 +4,7 @@ import cats.data.{NonEmptyList, State}
 import cats.implicits._
 import cats.Id
 import rankn._
+import scala.collection.immutable.SortedMap
 
 import Identifier.Constructor
 
@@ -439,7 +440,7 @@ case class LetFreePackageMap(pm: PackageMap.Inferred) {
       letFreeConvertPackage(name, pack)
         .map((name, _))
     }
-    PackageMap(normAll.run(Map()).value._2.toMap)
+    PackageMap(SortedMap(normAll.run(Map()).value._2: _*))
   }
 
   def hashKey[T](fn: LetFreeExpression => T): PackageMap.Typed[(Declaration, ExpressionKeyTag[T])] = {
@@ -455,7 +456,7 @@ case class LetFreePackageMap(pm: PackageMap.Inferred) {
         val newPack = pack.copy(program = newProgram)
         (packName, newPack)
       }
-    PackageMap(lst.toMap)
+    PackageMap(SortedMap(lst: _*))
   }
 
   def letFreeConvertExpr(expr: TypedExpr[Declaration], env: Env, p: Package.Inferred):

--- a/core/src/main/scala/org/bykn/bosatsu/PackageMap.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/PackageMap.scala
@@ -1,18 +1,18 @@
 package org.bykn.bosatsu
 
-import alleycats.std.map._ // TODO use SortedMap everywhere
 import org.bykn.bosatsu.graph.Memoize
 import cats.{Foldable, Show}
 import cats.data.{Ior, IorT, NonEmptyList, Validated, ValidatedNel, ReaderT}
 import cats.Order
 import cats.implicits._
 import scala.concurrent.ExecutionContext
+import scala.collection.immutable.SortedMap
 
 import Identifier.Constructor
 
 import rankn.{DataRepr, TypeEnv}
 
-case class PackageMap[A, B, C, +D](toMap: Map[PackageName, Package[A, B, C, D]]) {
+case class PackageMap[A, B, C, +D](toMap: SortedMap[PackageName, Package[A, B, C, D]]) {
   def +[D1 >: D](pack: Package[A, B, C, D1]): PackageMap[A, B, C, D1] =
     PackageMap(toMap + (pack.name -> pack))
 
@@ -41,7 +41,7 @@ case class PackageMap[A, B, C, +D](toMap: Map[PackageName, Package[A, B, C, D]])
 
 object PackageMap {
   def empty[A, B, C, D]: PackageMap[A, B, C, D] =
-    PackageMap(Map.empty)
+    PackageMap(SortedMap.empty)
 
   def fromIterable[A, B, C, D](ps: Iterable[Package[A, B, C, D]]): PackageMap[A, B, C, D] =
     empty[A, B, C, D] ++ ps
@@ -150,7 +150,7 @@ object PackageMap {
         }
     }
 
-    type M = Map[PackageName, PackageFix]
+    type M = SortedMap[PackageName, PackageFix]
     val r: ReaderT[Either[NonEmptyList[PackageError], ?], List[PackageName], M] =
       map.toMap.traverse(step)
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -2,8 +2,7 @@ import sbt._
 import org.portablescala.sbtplatformdeps.PlatformDepsPlugin.autoImport._
 
 object Dependencies {
-  lazy val alleycats = Def.setting("org.typelevel" %%% "alleycats-core" % "2.1.1")
-  lazy val cats = Def.setting("org.typelevel" %%% "cats-core" % "2.1.1")
+  lazy val cats = Def.setting("org.typelevel" %%% "cats-core" % "2.2.0")
   lazy val catsEffect = Def.setting("org.typelevel" %%% "cats-effect" % "2.2.0")
   lazy val decline = Def.setting("com.monovore" %%% "decline" % "1.3.0")
   lazy val fastparse = Def.setting("com.lihaoyi" %% "fastparse" % "1.0.0")


### PR DESCRIPTION
replaces #590 

fixes an old todo to remove alley cats and use sortedmap (which has deterministic traversal order)