### PR TITLE
Add a test noticed in issue 574

### DIFF
--- a/core/src/test/scala/org/bykn/bosatsu/EvaluationTest.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/EvaluationTest.scala
@@ -2559,4 +2559,17 @@ out = match [(1,2), (1, 0)]:
 test = Assertion(out.eq_Int(1), "")
 """), "Foo", 1)
   }
+
+  test("test some complex list patterns, issue 574") {
+    runBosatsuTest(List("""
+package Foo
+
+out = match [(True, 2), (True, 0)]:
+  [*_, (True, x), *_, (False, _)]: x
+  [*_, (True, _), *_, (_, y)]: y
+  _: -1
+
+test = Assertion(out.eq_Int(0), "")
+"""), "Foo", 1)
+  }
 }


### PR DESCRIPTION
@snoble noticed this:

https://github.com/johnynek/bosatsu/issues/574#issuecomment-704630538

but strangely it does not fail in the evaluation test. When I paste this in the browser it does fail.

So I guess that means the bug is in one of:

1. some difference in how the browser runs the code than how it is tested in CI. There are some null checks in the matchless code, but I don't think that is generally a problem.
2. the bug is somewhere after execution and this test isn't exercising the problem. But I don't see how that can be since the code does seem to fail when there are two globs in the browser.

@snoble if you have time to poke more at this, let me know if you find any more clues. I am not versed in how to use the browser developer tools to try to find infinite loops, etc...
