### PR TITLE
Remove module configuration that broke browser imports

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -70,7 +70,7 @@ lazy val commonJsSettings = Seq(
   parallelExecution := false,
   jsEnv := new org.scalajs.jsenv.nodejs.NodeJSEnv(),
   // batch mode decreases the amount of memory needed to compile scala.js code
-  scalaJSLinkerConfig := scalaJSLinkerConfig.value.withBatchMode(scala.sys.env.get("TRAVIS").isDefined),
+  scalaJSLinkerConfig := scalaJSLinkerConfig.value.withBatchMode(scala.sys.env.get("TRAVIS").isDefined).withModuleKind(ModuleKind.CommonJSModule),
   coverageEnabled := false,
   scalaJSUseMainModuleInitializer := false,
 )

--- a/build.sbt
+++ b/build.sbt
@@ -70,7 +70,7 @@ lazy val commonJsSettings = Seq(
   parallelExecution := false,
   jsEnv := new org.scalajs.jsenv.nodejs.NodeJSEnv(),
   // batch mode decreases the amount of memory needed to compile scala.js code
-  scalaJSLinkerConfig := scalaJSLinkerConfig.value.withBatchMode(scala.sys.env.get("TRAVIS").isDefined).withModuleKind(ModuleKind.CommonJSModule),
+  scalaJSLinkerConfig := scalaJSLinkerConfig.value.withBatchMode(scala.sys.env.get("TRAVIS").isDefined),
   coverageEnabled := false,
   scalaJSUseMainModuleInitializer := false,
 )

--- a/elmui/Makefile
+++ b/elmui/Makefile
@@ -1,4 +1,4 @@
-all: main.js bosatsu.js
+all: main.js bosatsu.js bosatsu-jsapi-opt.js.map
 
 main.js: src/Main.elm
 	elm make src/Main.elm --optimize --output out/main.js
@@ -8,6 +8,9 @@ main.js: src/Main.elm
 
 bosatsu.js: ../jsapi/.js/target/scala-2.12/bosatsu-jsapi-opt.js
 	cp ../jsapi/.js/target/scala-2.12/bosatsu-jsapi-opt.js out/bosatsu.js
+
+bosatsu-jsapi-opt.js.map: ../jsapi/.js/target/scala-2.12/bosatsu-jsapi-opt.js.map
+	cp ../jsapi/.js/target/scala-2.12/bosatsu-jsapi-opt.js.map out/
 
 format: src/*
 	elm-format --yes src/

--- a/elmui/build.sh
+++ b/elmui/build.sh
@@ -20,4 +20,6 @@ mkdir -p compiler/out
 cp elmui/index.html compiler/
 cp elmui/out/main.js compiler/out/
 cp elmui/out/bosatsu.js compiler/out/
+cp elmui/out/bosatsu-jsapi-opt.js.map compiler/out/
+
 cp -a docs/target/paradox/site/main/* ./

--- a/elmui/index.html
+++ b/elmui/index.html
@@ -2,6 +2,9 @@
 <html>
   <head></head>
   <body>
+    <script>
+      let exports = {}
+    </script>
     <script type="text/javascript" src="out/bosatsu.js"></script>
     <script type="text/javascript" src="out/main.js"></script>
     <div id="elm"></div>
@@ -25,7 +28,7 @@
         node: document.getElementById('elm')
       });
       app.ports.toJS.subscribe(function (msg) {
-        let res = Bosatsu.evaluate(null, "/file", {"/file": msg })
+        let res = exports.Bosatsu.evaluate(null, "/file", {"/file": msg })
         app.ports.toElm.send(escapeHtml(res))
       });
     </script>


### PR DESCRIPTION
just add an exports object to index.html so module like code works. webpack would be a more complete solution but seems like overkill.

fixes https://github.com/johnynek/bosatsu/issues/594