### PR TITLE
directly add a Ternary ast node to parsing for better parsing test coverage

### DIFF
--- a/core/src/main/scala/org/bykn/bosatsu/DefRecursionCheck.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/DefRecursionCheck.scala
@@ -293,6 +293,8 @@ object DefRecursionCheck {
           }
           val e = checkDecl(elseCase.get)
           ifs *> e
+        case Ternary(t, c, f) =>
+          checkDecl(t) *> checkDecl(c) *> checkDecl(f)
         case Lambda(args, body) =>
           // these args create new bindings:
           checkForIllegalBindsSt(args.toList.flatMap(_.names), decl) *> checkDecl(body)

--- a/core/src/main/scala/org/bykn/bosatsu/SourceConverter.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/SourceConverter.scala
@@ -163,6 +163,8 @@ final class SourceConverter(
         val else1 = loop(elseCase.get)
 
         (if1, else1).mapN(loop0(_, _))
+      case tern@Ternary(t, c, f) =>
+        loop(IfElse(NonEmptyList((c, OptIndent.same(t)), Nil), OptIndent.same(f))(tern.region))
       case Lambda(args, body) =>
         val argsRes = args.traverse(convertPattern(_, decl.region))
         val bodyRes = withBound(body, args.toList.flatMap(_.names))


### PR DESCRIPTION
Note this only changes the implementation of parsing, it doesn't change the intermediate language or the supported syntax.