### PR TITLE
Upgrade to cats-parse 0.3.0

### DIFF
--- a/core/src/main/scala/org/bykn/bosatsu/CommentStatement.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/CommentStatement.scala
@@ -1,7 +1,7 @@
 package org.bykn.bosatsu
 
 import cats.data.NonEmptyList
-import cats.parse.{Parser => P, Parser1 => P1}
+import cats.parse.{Parser0 => P0, Parser => P}
 import org.typelevel.paiges.{ Doc, Document }
 
 /**
@@ -23,20 +23,20 @@ object CommentStatement {
   /** on should make sure indent is matching
    * this is to allow a P[Unit] that does nothing for testing or other applications
    */
-  def parser[T](onP: String => P[T]): Parser.Indy[CommentStatement[T]] =
+  def parser[T](onP: String => P0[T]): Parser.Indy[CommentStatement[T]] =
     Parser.Indy { indent =>
-      val sep = Parser.newline ~ P.string(indent)
+      val sep = Parser.newline ~ P.string0(indent)
 
-      val commentBlock: P1[NonEmptyList[String]] =
+      val commentBlock: P[NonEmptyList[String]] =
         // if the next line is part of the comment until we see the # or not
-        P.rep1Sep(commentPart, min = 1, sep = sep) <* Parser.newline.orElse(P.end)
+        P.repSep(commentPart, min = 1, sep = sep) <* Parser.newline.orElse(P.end)
 
       (commentBlock ~ onP(indent))
         .map { case (m, on) => CommentStatement(m, on) }
     }
 
-  val commentPart: P1[String] =
-    (P.char('#') ~ P.until(P.char('\n'))).map(_._2)
+  val commentPart: P[String] =
+    (P.char('#') ~ P.until0(P.char('\n'))).map(_._2)
 }
 
 

--- a/core/src/main/scala/org/bykn/bosatsu/DefStatement.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/DefStatement.scala
@@ -4,7 +4,7 @@ import Parser.{ Combinators, maybeSpace }
 import cats.Applicative
 import cats.data.NonEmptyList
 import cats.implicits._
-import cats.parse.{Parser0 => P0, Parser => P}
+import cats.parse.{Parser => P}
 import org.typelevel.paiges.{ Doc, Document }
 
 import Identifier.{Bindable, Constructor}

--- a/core/src/main/scala/org/bykn/bosatsu/DefStatement.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/DefStatement.scala
@@ -4,7 +4,7 @@ import Parser.{ Combinators, maybeSpace }
 import cats.Applicative
 import cats.data.NonEmptyList
 import cats.implicits._
-import cats.parse.{Parser => P, Parser1 => P1}
+import cats.parse.{Parser0 => P0, Parser => P}
 import org.typelevel.paiges.{ Doc, Document }
 
 import Identifier.{Bindable, Constructor}
@@ -57,9 +57,9 @@ object DefStatement {
     /**
      * The resultTParser should parse some indentation any newlines
      */
-    def parser[A, B](argParser: P1[A], resultTParser: P1[B]): P1[DefStatement[A, B]] = {
+    def parser[A, B](argParser: P[A], resultTParser: P[B]): P[DefStatement[A, B]] = {
       val args = argParser.parensLines1Cut
-      val result = (P.string1("->") *> maybeSpace *> TypeRef.parser).?
+      val result = (P.string("->") *> maybeSpace *> TypeRef.parser).?
       (Parser.keySpace("def") *> (Identifier.bindableParser ~ args.?) <* maybeSpace,
         result.with1 <* (maybeSpace.with1 ~ P.char(':')),
         resultTParser)

--- a/core/src/main/scala/org/bykn/bosatsu/ExportedName.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/ExportedName.scala
@@ -2,7 +2,7 @@ package org.bykn.bosatsu
 
 import cats.data.{NonEmptyList, Validated, ValidatedNel}
 import cats.implicits._
-import cats.parse.{Parser0 => P0, Parser => P}
+import cats.parse.{Parser => P}
 import org.typelevel.paiges.{Doc, Document}
 import scala.util.hashing.MurmurHash3
 

--- a/core/src/main/scala/org/bykn/bosatsu/ExportedName.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/ExportedName.scala
@@ -2,7 +2,7 @@ package org.bykn.bosatsu
 
 import cats.data.{NonEmptyList, Validated, ValidatedNel}
 import cats.implicits._
-import cats.parse.{Parser => P, Parser1 => P1}
+import cats.parse.{Parser0 => P0, Parser => P}
 import org.typelevel.paiges.{Doc, Document}
 import scala.util.hashing.MurmurHash3
 
@@ -59,10 +59,10 @@ object ExportedName {
     }
   }
 
-  val parser: P1[ExportedName[Unit]] =
+  val parser: P[ExportedName[Unit]] =
     Identifier.bindableParser.map(Binding(_, ()))
-      .orElse1(
-        (Identifier.consParser ~ P.string1("()").?)
+      .orElse(
+        (Identifier.consParser ~ P.string("()").?)
           .map {
             case (n, None) => TypeName(n, ())
             case (n, Some(_)) => Constructor(n, ())

--- a/core/src/main/scala/org/bykn/bosatsu/Import.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/Import.scala
@@ -3,7 +3,7 @@ package org.bykn.bosatsu
 import cats.{Foldable, Functor}
 import cats.data.NonEmptyList
 import cats.implicits._
-import cats.parse.{Parser0 => P0, Parser => P}
+import cats.parse.{Parser => P}
 import org.typelevel.paiges.{Doc, Document}
 
 import Parser.{spaces, Combinators}

--- a/core/src/main/scala/org/bykn/bosatsu/Import.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/Import.scala
@@ -3,7 +3,7 @@ package org.bykn.bosatsu
 import cats.{Foldable, Functor}
 import cats.data.NonEmptyList
 import cats.implicits._
-import cats.parse.{Parser => P, Parser1 => P1}
+import cats.parse.{Parser0 => P0, Parser => P}
 import org.typelevel.paiges.{Doc, Document}
 
 import Parser.{spaces, Combinators}
@@ -45,16 +45,16 @@ object ImportedName {
           Document[Identifier].document(to)
     }
 
-  val parser: P1[ImportedName[Unit]] = {
-    def basedOn(of: P1[Identifier]): P1[ImportedName[Unit]] =
-      (of ~ ((spaces *> P.string1("as") *> spaces).backtrack *> of).?)
+  val parser: P[ImportedName[Unit]] = {
+    def basedOn(of: P[Identifier]): P[ImportedName[Unit]] =
+      (of ~ ((spaces *> P.string("as") *> spaces).backtrack *> of).?)
         .map {
           case (from, Some(to)) => ImportedName.Renamed(from, to, ())
           case (orig, None) => ImportedName.OriginalName(orig, ())
         }
 
     basedOn(Identifier.bindableParser)
-      .orElse1(basedOn(Identifier.consParser))
+      .orElse(basedOn(Identifier.consParser))
   }
 }
 
@@ -75,11 +75,11 @@ object Import {
         Doc.space + Doc.intercalate(Doc.text(", "), itemDocs)
     }
 
-  val parser: P1[Import[PackageName, Unit]] = {
+  val parser: P[Import[PackageName, Unit]] = {
     val pyimps = ImportedName.parser.itemsMaybeParens.map(_._2)
 
-    ((P.string1("from") ~ spaces).backtrack *> PackageName.parser <* spaces,
-      P.string1("import") *> spaces *> pyimps)
+    ((P.string("from") ~ spaces).backtrack *> PackageName.parser <* spaces,
+      P.string("import") *> spaces *> pyimps)
       .mapN(Import(_, _))
   }
 

--- a/core/src/main/scala/org/bykn/bosatsu/Indented.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/Indented.scala
@@ -2,7 +2,7 @@ package org.bykn.bosatsu
 
 import org.typelevel.paiges.{ Doc, Document }
 
-import cats.parse.{Parser => P}
+import cats.parse.{Parser0 => P0}
 
 import cats.implicits._
 
@@ -34,7 +34,7 @@ object Indented {
   def indy[T](p: Parser.Indy[T]): Parser.Indy[Indented[T]] =
     Parser.Indy { indent =>
       for {
-        thisIndent <- P.string(indent).with1 *> Parser.spaces.string
+        thisIndent <- Parser.string0(indent).with1 *> Parser.spaces.string
         t <- p.run(indent + thisIndent)
       } yield Indented(Indented.spaceCount(thisIndent), t)
     }

--- a/core/src/main/scala/org/bykn/bosatsu/Indented.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/Indented.scala
@@ -2,7 +2,7 @@ package org.bykn.bosatsu
 
 import org.typelevel.paiges.{ Doc, Document }
 
-import cats.parse.{Parser0 => P0}
+import cats.parse.{Parser => P}
 
 import cats.implicits._
 
@@ -34,7 +34,7 @@ object Indented {
   def indy[T](p: Parser.Indy[T]): Parser.Indy[Indented[T]] =
     Parser.Indy { indent =>
       for {
-        thisIndent <- Parser.string0(indent).with1 *> Parser.spaces.string
+        thisIndent <- P.string0(indent).with1 *> Parser.spaces.string
         t <- p.run(indent + thisIndent)
       } yield Indented(Indented.spaceCount(thisIndent), t)
     }

--- a/core/src/main/scala/org/bykn/bosatsu/Json.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/Json.scala
@@ -5,8 +5,6 @@ import org.typelevel.paiges.Doc
 import cats.parse.{Parser0 => P0, Parser => P}
 import cats.Eq
 
-import cats.implicits._
-
 /**
  * A simple JSON ast for output
  */

--- a/core/src/main/scala/org/bykn/bosatsu/ListLang.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/ListLang.scala
@@ -3,7 +3,7 @@ package org.bykn.bosatsu
 import cats.{Apply, Functor}
 import Parser.{maybeSpacesAndLines, spacesAndLines, Combinators}
 import org.typelevel.paiges.{Doc, Document}
-import cats.parse.{Parser => P, Parser1 => P1}
+import cats.parse.{Parser0 => P0, Parser => P}
 
 import cats.implicits._
 
@@ -32,10 +32,10 @@ object ListLang {
         Functor[F].map(fn(value))(Item(_))
     }
 
-    def parser[A](pa: P1[A]): P1[SpliceOrItem[A]] =
+    def parser[A](pa: P[A]): P[SpliceOrItem[A]] =
       (P.char('*') *> pa)
         .map(Splice(_))
-        .orElse1(pa.map(Item(_)))
+        .orElse(pa.map(Item(_)))
 
     implicit def document[A](implicit A: Document[A]): Document[SpliceOrItem[A]] =
       Document.instance[SpliceOrItem[A]] {
@@ -53,7 +53,7 @@ object ListLang {
   object KVPair {
     private[this] val sep: Doc = Doc.text(": ")
 
-    def parser[A](p: P1[A]): P1[KVPair[A]] =
+    def parser[A](p: P[A]): P[KVPair[A]] =
       ((p <* maybeSpacesAndLines <* P.char(':') <* maybeSpacesAndLines) ~ p)
         .map { case (k, v) => KVPair(k, v) }
 
@@ -66,13 +66,13 @@ object ListLang {
   case class Cons[F[_], A](items: List[F[A]]) extends ListLang[F, A, Nothing]
   case class Comprehension[F[_], A, B](expr: F[A], binding: B, in: A, filter: Option[A]) extends ListLang[F, A, B]
 
-  def parser[A, B](pa: P1[A], psrc: P1[A], pbind: P1[B]): P1[ListLang[SpliceOrItem, A, B]] =
+  def parser[A, B](pa: P[A], psrc: P[A], pbind: P[B]): P[ListLang[SpliceOrItem, A, B]] =
     genParser(P.char('['), SpliceOrItem.parser(pa), psrc, pbind, P.char(']'))
 
-  def dictParser[A, B](pa: P1[A], psrc: P1[A], pbind: P1[B]): P1[ListLang[KVPair, A, B]] =
+  def dictParser[A, B](pa: P[A], psrc: P[A], pbind: P[B]): P[ListLang[KVPair, A, B]] =
     genParser(P.char('{'), KVPair.parser(pa), psrc, pbind, P.char('}'))
 
-  def genParser[F[_], A, B](left: P1[Unit], fa: P1[F[A]], pa: P1[A], pbind: P1[B], right: P1[Unit]): P1[ListLang[F, A, B]] = {
+  def genParser[F[_], A, B](left: P[Unit], fa: P[F[A]], pa: P[A], pbind: P[B], right: P[Unit]): P[ListLang[F, A, B]] = {
     // construct the tail of a list, so we will finally have at least one item
     val consTail = fa.nonEmptyListOfWs(maybeSpacesAndLines).?
       .map { tail =>
@@ -84,11 +84,11 @@ object ListLang {
         { a: F[A] => Cons(a :: listTail) }
       }
 
-    val filterExpr = P.string1("if") *> spacesAndLines *> pa
+    val filterExpr = P.string("if") *> spacesAndLines *> pa
 
     val comp =
-      (P.string1("for") *> spacesAndLines *> pbind <* maybeSpacesAndLines,
-        P.string1("in") *> spacesAndLines *> pa  <* maybeSpacesAndLines,
+      (P.string("for") *> spacesAndLines *> pbind <* maybeSpacesAndLines,
+        P.string("in") *> spacesAndLines *> pa  <* maybeSpacesAndLines,
         filterExpr.?)
         .mapN { (b, i, f) =>
           { e: F[A] => Comprehension(e, b, i, f) }

--- a/core/src/main/scala/org/bykn/bosatsu/ListLang.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/ListLang.scala
@@ -3,7 +3,7 @@ package org.bykn.bosatsu
 import cats.{Apply, Functor}
 import Parser.{maybeSpacesAndLines, spacesAndLines, Combinators}
 import org.typelevel.paiges.{Doc, Document}
-import cats.parse.{Parser0 => P0, Parser => P}
+import cats.parse.{Parser => P}
 
 import cats.implicits._
 

--- a/core/src/main/scala/org/bykn/bosatsu/Lit.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/Lit.scala
@@ -2,7 +2,7 @@ package org.bykn.bosatsu
 
 import org.typelevel.paiges.{Document, Doc}
 import java.math.BigInteger
-import cats.parse.{Parser1 => P1}
+import cats.parse.{Parser => P}
 
 import Parser.escape
 
@@ -30,16 +30,16 @@ object Lit {
   def apply(bi: BigInteger): Lit = Integer(bi)
   def apply(str: String): Lit = Str(str)
 
-  val integerParser: P1[Integer] =
+  val integerParser: P[Integer] =
     Parser.integerString.map { str => Integer(new BigInteger(str.filterNot(_ == '_'))) }
 
-  val stringParser: P1[Str] = {
+  val stringParser: P[Str] = {
     val q1 = '\''
     val q2 = '"'
-    def str(q: Char): P1[Str] =
+    def str(q: Char): P[Str] =
       Parser.escapedString(q).map(Str(_))
 
-    str(q1).orElse1(str(q2))
+    str(q1).orElse(str(q2))
   }
 
   implicit val litOrdering: Ordering[Lit] =
@@ -53,7 +53,7 @@ object Lit {
         }
     }
 
-  val parser: P1[Lit] = integerParser.orElse1(stringParser)
+  val parser: P[Lit] = integerParser.orElse(stringParser)
 
   implicit val document: Document[Lit] =
     Document.instance[Lit] {

--- a/core/src/main/scala/org/bykn/bosatsu/MainModule.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/MainModule.scala
@@ -3,7 +3,7 @@ package org.bykn.bosatsu
 import cats.data.{Chain, Validated, ValidatedNel, NonEmptyList}
 import cats.{Eval, MonadError, Traverse}
 import com.monovore.decline.{Argument, Command, Help, Opts}
-import cats.parse.{Parser => P}
+import cats.parse.{Parser0 => P0}
 import org.typelevel.paiges.Doc
 import scala.concurrent.ExecutionContext
 import scala.util.{ Failure, Success, Try }
@@ -195,7 +195,7 @@ abstract class MainModule[IO[_]](implicit val moduleIOMonad: MonadError[IO, Thro
        case class FileError(readPath: Path, error: Throwable) extends ParseError
     }
 
-    def parseString[A](p: P[A], path: Path, str: String): ValidatedNel[ParseError, (LocationMap, A)] =
+    def parseString[A](p: P0[A], path: Path, str: String): ValidatedNel[ParseError, (LocationMap, A)] =
       Parser.parse(p, str).leftMap { nel =>
         nel.map {
           case pp@Parser.Error.PartialParse(_, _, _) => ParseError.PartialParse(pp, path)
@@ -203,7 +203,7 @@ abstract class MainModule[IO[_]](implicit val moduleIOMonad: MonadError[IO, Thro
         }
       }
 
-    def parseFile[A](p: P[A], path: Path): IO[ValidatedNel[ParseError, (LocationMap, A)]] =
+    def parseFile[A](p: P0[A], path: Path): IO[ValidatedNel[ParseError, (LocationMap, A)]] =
       parseFileOrError(p, path)
         .map {
           case Right(v) => v
@@ -213,7 +213,7 @@ abstract class MainModule[IO[_]](implicit val moduleIOMonad: MonadError[IO, Thro
     /**
      * If we cannot read the file, return the throwable, else parse
      */
-    def parseFileOrError[A](p: P[A], path: Path): IO[Either[Throwable, ValidatedNel[ParseError, (LocationMap, A)]]] =
+    def parseFileOrError[A](p: P0[A], path: Path): IO[Either[Throwable, ValidatedNel[ParseError, (LocationMap, A)]]] =
       readPath(path)
         .attempt
         .map(_.map(parseString(p, path, _)))
@@ -825,7 +825,7 @@ abstract class MainModule[IO[_]](implicit val moduleIOMonad: MonadError[IO, Thro
 
     val opts: Opts[MainCommand] = {
 
-      def argFromParser[A](p: P[A], defmeta: String, typeName: String, suggestion: String): Argument[A] =
+      def argFromParser[A](p: P0[A], defmeta: String, typeName: String, suggestion: String): Argument[A] =
         new Argument[A] {
           def defaultMetavar: String = defmeta
           def read(string: String): ValidatedNel[String, A] =
@@ -841,7 +841,7 @@ abstract class MainModule[IO[_]](implicit val moduleIOMonad: MonadError[IO, Thro
         argFromParser(PackageName.parser, "packageName", "package name", "Must be capitalized strings separated by /")
 
       implicit val argValue: Argument[(PackageName, Option[Bindable])] =
-        argFromParser((PackageName.parser ~ (P.string1("::") *> Identifier.bindableParser).?),
+        argFromParser((PackageName.parser ~ (Parser.string("::") *> Identifier.bindableParser).?),
           "valueIdent",
           "package or package::name",
           "Must be a package name with an optional :: value, e.g. Foo/Bar or Foo/Bar::baz.")

--- a/core/src/main/scala/org/bykn/bosatsu/MainModule.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/MainModule.scala
@@ -3,7 +3,7 @@ package org.bykn.bosatsu
 import cats.data.{Chain, Validated, ValidatedNel, NonEmptyList}
 import cats.{Eval, MonadError, Traverse}
 import com.monovore.decline.{Argument, Command, Help, Opts}
-import cats.parse.{Parser0 => P0}
+import cats.parse.{Parser0 => P0, Parser => P}
 import org.typelevel.paiges.Doc
 import scala.concurrent.ExecutionContext
 import scala.util.{ Failure, Success, Try }
@@ -841,7 +841,7 @@ abstract class MainModule[IO[_]](implicit val moduleIOMonad: MonadError[IO, Thro
         argFromParser(PackageName.parser, "packageName", "package name", "Must be capitalized strings separated by /")
 
       implicit val argValue: Argument[(PackageName, Option[Bindable])] =
-        argFromParser((PackageName.parser ~ (Parser.string("::") *> Identifier.bindableParser).?),
+        argFromParser((PackageName.parser ~ (P.string("::") *> Identifier.bindableParser).?),
           "valueIdent",
           "package or package::name",
           "Must be a package name with an optional :: value, e.g. Foo/Bar or Foo/Bar::baz.")

--- a/core/src/main/scala/org/bykn/bosatsu/Operators.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/Operators.scala
@@ -1,7 +1,7 @@
 package org.bykn.bosatsu
 
 import cats.data.NonEmptyList
-import cats.parse.{Parser0 => P0, Parser => P}
+import cats.parse.{Parser => P}
 
 object Operators {
 
@@ -70,7 +70,7 @@ object Operators {
 
     // write this in a way to avoid backtracking
     ((singles ~ multiToksP.rep0).void)
-      .orElse(multiToksP.rep(rep = 2).void)
+      .orElse(multiToksP.rep(min = 2).void)
       .string
       .map(_.intern)
   }

--- a/core/src/main/scala/org/bykn/bosatsu/Operators.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/Operators.scala
@@ -1,7 +1,7 @@
 package org.bykn.bosatsu
 
 import cats.data.NonEmptyList
-import cats.parse.{Parser => P, Parser1 => P1}
+import cats.parse.{Parser0 => P0, Parser => P}
 
 object Operators {
 
@@ -43,8 +43,8 @@ object Operators {
       "&", "^", "|",
       "?", "~").map(_.intern)
 
-  private def from(strs: Iterable[String]): P1[Unit] =
-    P.oneOf1(strs.map(P.string1(_)).toList)
+  private def from(strs: Iterable[String]): P[Unit] =
+    P.oneOf(strs.map(P.string(_)).toList)
 
   /**
    * strings for operators allowed in single character
@@ -53,7 +53,7 @@ object Operators {
   val multiToks: List[String] =
     ".".intern :: singleToks ::: List("=".intern)
 
-  val multiToksP: P1[Unit] =
+  val multiToksP: P[Unit] =
     from(multiToks)
 
   private val priorityMap: Map[String, Int] =
@@ -65,12 +65,12 @@ object Operators {
   /**
    * Here are a list of operators we allow
    */
-  val operatorToken: P1[String] = {
+  val operatorToken: P[String] = {
     val singles = from(singleToks)
 
     // write this in a way to avoid backtracking
-    ((singles ~ multiToksP.rep).void)
-      .orElse1(multiToksP.rep1(min = 2).void)
+    ((singles ~ multiToksP.rep0).void)
+      .orElse(multiToksP.rep(rep = 2).void)
       .string
       .map(_.intern)
   }
@@ -117,10 +117,10 @@ object Operators {
      * Parse a chain of at least 1 operator being applied
      * with the operator precedence handled by the formula
      */
-    def infixOps1[A](p: P1[A]): P1[A => Formula[A]] = {
+    def infixOps1[A](p: P[A]): P[A => Formula[A]] = {
       val opA = operatorToken ~ (Parser.maybeSpacesAndLines.with1 *> p)
-      val chain: P1[NonEmptyList[(String, A)]] =
-        P.rep1Sep(opA, min = 1, sep = Parser.maybeSpace)
+      val chain: P[NonEmptyList[(String, A)]] =
+        P.repSep(opA, min = 1, sep = Parser.maybeSpace)
 
       chain.map { rest =>
 
@@ -131,7 +131,7 @@ object Operators {
      * An a formula is a series of A's separated by spaces, with
      * the correct parenthesis
      */
-    def parser[A](p: P1[A]): P1[Formula[A]] =
+    def parser[A](p: P[A]): P[Formula[A]] =
       (p ~ (Parser.maybeSpace.with1 *> infixOps1(p)).?)
         .map {
           case (a, None) => Sym(a)

--- a/core/src/main/scala/org/bykn/bosatsu/OptIndent.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/OptIndent.scala
@@ -4,7 +4,7 @@ import cats.Functor
 import cats.implicits._
 import org.typelevel.paiges.{Doc, Document}
 
-import cats.parse.{Parser => P, Parser1 => P1}
+import cats.parse.{Parser0 => P0, Parser => P}
 
 import Parser.{maybeSpace, Indy}
 import Indy.IndyMethods
@@ -61,7 +61,7 @@ object OptIndent {
   def indy[A](p: Indy[A]): Indy[OptIndent[A]] = {
     val ind = Indented.indy(p)
     // we need to read at least 1 new line here
-    val not = ind.mapF { p => Padding.parser1(p).map(notSame[A](_)): P1[OptIndent[A]] }
+    val not = ind.mapF { p => Padding.parser1(p).map(notSame[A](_)): P[OptIndent[A]] }
     val sm = p.map(same[A](_))
     not <+> sm
   }
@@ -74,7 +74,7 @@ object OptIndent {
   def block[A, B](first: Indy[A], next: Indy[B]): Indy[(A, OptIndent[B])] =
     blockLike(first, next, maybeSpace ~ P.char(':'))
 
-  def blockLike[A, B, C](first: Indy[A], next: Indy[B], sep: P[C]): Indy[(A, OptIndent[B])] =
+  def blockLike[A, B, C](first: Indy[A], next: Indy[B], sep: P0[C]): Indy[(A, OptIndent[B])] =
     first
       .cutLeftP((sep ~ maybeSpace).void)
       .cutThen(OptIndent.indy(next))

--- a/core/src/main/scala/org/bykn/bosatsu/Package.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/Package.scala
@@ -3,7 +3,7 @@ package org.bykn.bosatsu
 import cats.{Functor, Parallel}
 import cats.data.{Chain, Ior, ValidatedNel, Validated, NonEmptyList, Writer}
 import cats.implicits._
-import cats.parse.{Parser0 => P0}
+import cats.parse.{Parser0 => P0, Parser => P}
 import org.typelevel.paiges.{Doc, Document}
 import scala.util.hashing.MurmurHash3
 
@@ -135,7 +135,7 @@ object Package {
 
   def parser(defaultPack: Option[PackageName]): P0[Package[PackageName, Unit, Unit, List[Statement]]] = {
     // TODO: support comments before the Statement
-    val parsePack = Padding.parser((Parser.string("package").soft ~ spaces) *> PackageName.parser <* Parser.toEOL).map(_.padded)
+    val parsePack = Padding.parser((P.string("package").soft ~ spaces) *> PackageName.parser <* Parser.toEOL).map(_.padded)
     val pname: P0[PackageName] =
       defaultPack match {
         case None => parsePack
@@ -143,7 +143,7 @@ object Package {
       }
 
     val im = Padding.parser(Import.parser <* Parser.toEOL).map(_.padded).rep0
-    val ex = Padding.parser((Parser.string("export").soft ~ spaces) *> ExportedName.parser.itemsMaybeParens.map(_._2) <* Parser.toEOL).map(_.padded)
+    val ex = Padding.parser((P.string("export").soft ~ spaces) *> ExportedName.parser.itemsMaybeParens.map(_._2) <* Parser.toEOL).map(_.padded)
     val body: P0[List[Statement]] = Statement.parser
     (pname, im, Parser.nonEmptyListToList(ex), body)
       .mapN { (p, i, e, b) => Package(p, i, e, b) }

--- a/core/src/main/scala/org/bykn/bosatsu/Package.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/Package.scala
@@ -3,7 +3,7 @@ package org.bykn.bosatsu
 import cats.{Functor, Parallel}
 import cats.data.{Chain, Ior, ValidatedNel, Validated, NonEmptyList, Writer}
 import cats.implicits._
-import cats.parse.{Parser => P}
+import cats.parse.{Parser0 => P0}
 import org.typelevel.paiges.{Doc, Document}
 import scala.util.hashing.MurmurHash3
 
@@ -133,18 +133,18 @@ object Package {
       Doc.intercalate(Doc.empty, p :: i :: e :: b)
     }
 
-  def parser(defaultPack: Option[PackageName]): P[Package[PackageName, Unit, Unit, List[Statement]]] = {
+  def parser(defaultPack: Option[PackageName]): P0[Package[PackageName, Unit, Unit, List[Statement]]] = {
     // TODO: support comments before the Statement
-    val parsePack = Padding.parser((P.string1("package").soft ~ spaces) *> PackageName.parser <* Parser.toEOL).map(_.padded)
-    val pname: P[PackageName] =
+    val parsePack = Padding.parser((Parser.string("package").soft ~ spaces) *> PackageName.parser <* Parser.toEOL).map(_.padded)
+    val pname: P0[PackageName] =
       defaultPack match {
         case None => parsePack
         case Some(p) => parsePack.?.map(_.getOrElse(p))
       }
 
-    val im = Padding.parser(Import.parser <* Parser.toEOL).map(_.padded).rep
-    val ex = Padding.parser((P.string1("export").soft ~ spaces) *> ExportedName.parser.itemsMaybeParens.map(_._2) <* Parser.toEOL).map(_.padded)
-    val body: P[List[Statement]] = Statement.parser
+    val im = Padding.parser(Import.parser <* Parser.toEOL).map(_.padded).rep0
+    val ex = Padding.parser((Parser.string("export").soft ~ spaces) *> ExportedName.parser.itemsMaybeParens.map(_._2) <* Parser.toEOL).map(_.padded)
+    val body: P0[List[Statement]] = Statement.parser
     (pname, im, Parser.nonEmptyListToList(ex), body)
       .mapN { (p, i, e, b) => Package(p, i, e, b) }
   }

--- a/core/src/main/scala/org/bykn/bosatsu/PackageName.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/PackageName.scala
@@ -3,7 +3,7 @@ package org.bykn.bosatsu
 import cats.Order
 import cats.data.NonEmptyList
 import cats.implicits._
-import cats.parse.{Parser0 => P0, Parser => P}
+import cats.parse.{Parser => P}
 import org.typelevel.paiges.{Doc, Document}
 import Parser.upperIdent
 

--- a/core/src/main/scala/org/bykn/bosatsu/PackageName.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/PackageName.scala
@@ -3,7 +3,7 @@ package org.bykn.bosatsu
 import cats.Order
 import cats.data.NonEmptyList
 import cats.implicits._
-import cats.parse.{Parser => P, Parser1 => P1}
+import cats.parse.{Parser0 => P0, Parser => P}
 import org.typelevel.paiges.{Doc, Document}
 import Parser.upperIdent
 
@@ -19,8 +19,8 @@ object PackageName {
   implicit val document: Document[PackageName] =
     Document.instance[PackageName] { pn => Doc.text(pn.asString) }
 
-  implicit val parser: P1[PackageName] =
-    (upperIdent ~ (P.char('/') *> upperIdent).rep)
+  implicit val parser: P[PackageName] =
+    (upperIdent ~ (P.char('/') *> upperIdent).rep0)
       .map { case (head, tail) =>
         PackageName(NonEmptyList(head, tail))
       }

--- a/core/src/main/scala/org/bykn/bosatsu/Padding.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/Padding.scala
@@ -1,7 +1,7 @@
 package org.bykn.bosatsu
 
 import cats.Functor
-import cats.parse.{Parser => P, Parser1 => P1}
+import cats.parse.{Parser0 => P0, Parser => P}
 import org.typelevel.paiges.{ Doc, Document }
 
 import Parser.maybeSpace
@@ -23,8 +23,8 @@ object Padding {
   /**
    * This allows an empty padding
    */
-  def parser[T](p: P1[T]): P1[Padding[T]] = {
-    val spacing = (maybeSpace.with1.soft ~ Parser.newline).void.rep
+  def parser[T](p: P[T]): P[Padding[T]] = {
+    val spacing = (maybeSpace.with1.soft ~ Parser.newline).void.rep0
 
     (spacing.with1.soft ~ p)
       .map { case (vec, t) => Padding(vec.size, t) }
@@ -33,14 +33,14 @@ object Padding {
   /**
    * Parses a padding of length 1 or more, then p
    */
-  def parser1[T](p: P[T]): P1[Padding[T]] =
-    ((maybeSpace.with1.soft ~ Parser.newline).void.rep1 ~ p)
+  def parser1[T](p: P0[T]): P[Padding[T]] =
+    ((maybeSpace.with1.soft ~ Parser.newline).void.rep ~ p)
       .map { case (vec, t) => Padding(vec.size, t) }
 
   /**
    * This is parser1 by itself, with the padded value being ()
    */
-  val nonEmptyParser: P1[Padding[Unit]] =
+  val nonEmptyParser: P[Padding[Unit]] =
     parser1(P.unit)
 }
 

--- a/core/src/main/scala/org/bykn/bosatsu/TypeRef.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/TypeRef.scala
@@ -4,7 +4,7 @@ import Parser.{ Combinators, lowerIdent, maybeSpace, keySpace }
 import cats.Applicative
 import cats.data.{NonEmptyList, State}
 import cats.implicits._
-import cats.parse.{Parser => P, Parser1 => P1}
+import cats.parse.{Parser0 => P0, Parser => P}
 import org.typelevel.paiges.{ Doc, Document }
 import org.bykn.bosatsu.rankn.Type
 
@@ -160,31 +160,31 @@ object TypeRef {
         }
     }
 
-  val parser: P1[TypeRef] = {
+  val parser: P[TypeRef] = {
     val tvar = lowerIdent.map(TypeVar(_))
     val tname = Identifier.consParser.map { cn => TypeName(Name(cn)) }
-    val recurse = P.defer1(parser)
+    val recurse = P.defer(parser)
 
-    val lambda: P1[TypeLambda] =
+    val lambda: P[TypeLambda] =
       (keySpace("forall") *> tvar.nonEmptyList ~ (maybeSpace *> P.char('.') *> maybeSpace *> recurse))
         .map { case (args, e) => TypeLambda(args, e) }
 
-    val maybeArrow: P1[TypeRef => TypeRef] =
-      ((maybeSpace.with1.soft ~ P.string1("->") ~ maybeSpace) *> recurse)
+    val maybeArrow: P[TypeRef => TypeRef] =
+      ((maybeSpace.with1.soft ~ P.string("->") ~ maybeSpace) *> recurse)
         .map { right => TypeArrow(_, right) }
 
-    val maybeApp: P1[TypeRef => TypeRef] =
+    val maybeApp: P[TypeRef => TypeRef] =
       (P.char('[') *> maybeSpace *> recurse.nonEmptyList <* maybeSpace <* P.char(']'))
         .map { args => TypeApply(_, args) }
 
-    val tupleOrParens: P1[TypeRef] =
+    val tupleOrParens: P[TypeRef] =
       recurse.tupleOrParens.map {
         case Left(par) => par
         case Right(tup) => TypeTuple(tup)
       }
 
     val base =
-      P.oneOf1(lambda :: tvar :: tname :: tupleOrParens :: Nil)
+      P.oneOf(lambda :: tvar :: tname :: tupleOrParens :: Nil)
 
     (base ~ maybeApp.? ~ maybeArrow.?)
       .map {

--- a/core/src/main/scala/org/bykn/bosatsu/TypeRef.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/TypeRef.scala
@@ -4,7 +4,7 @@ import Parser.{ Combinators, lowerIdent, maybeSpace, keySpace }
 import cats.Applicative
 import cats.data.{NonEmptyList, State}
 import cats.implicits._
-import cats.parse.{Parser0 => P0, Parser => P}
+import cats.parse.{Parser => P}
 import org.typelevel.paiges.{ Doc, Document }
 import org.bykn.bosatsu.rankn.Type
 

--- a/core/src/main/scala/org/bykn/bosatsu/codegen/python/PythonGen.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/codegen/python/PythonGen.scala
@@ -4,7 +4,7 @@ import org.typelevel.paiges.Doc
 import org.bykn.bosatsu.{PackageName, Identifier, Matchless, Par, Parser}
 import cats.Monad
 import cats.data.{NonEmptyList, State}
-import cats.parse.{Parser => P, Parser1 => P1}
+import cats.parse.{Parser0 => P0, Parser => P}
 import scala.concurrent.ExecutionContext
 
 import Identifier.Bindable
@@ -651,19 +651,19 @@ object PythonGen {
   //
   // { packageName: { bind: foo.bar.baz } }
   //
-  val externalParser: P1[List[(PackageName, Bindable, Module, Code.Ident)]] = {
-    val identParser: P1[Code.Ident] = Parser.py2Ident.map(Code.Ident(_))
-    val modParser: P1[(Module, Code.Ident)] =
-      P.rep1Sep(identParser, min = 2, sep = P.char('.'))
+  val externalParser: P[List[(PackageName, Bindable, Module, Code.Ident)]] = {
+    val identParser: P[Code.Ident] = Parser.py2Ident.map(Code.Ident(_))
+    val modParser: P[(Module, Code.Ident)] =
+      P.repSep(identParser, min = 2, sep = P.char('.'))
         .map { items =>
           // min = 2 ensures this is safe
           (NonEmptyList.fromListUnsafe(items.init.toList), items.last)
         }
 
-    val inner: P1[List[(Bindable, (Module, Code.Ident))]] =
+    val inner: P[List[(Bindable, (Module, Code.Ident))]] =
       Parser.dictLikeParser(Identifier.bindableParser, modParser)
 
-    val outer: P1[List[(PackageName, List[(Bindable, (Module, Code.Ident))])]] =
+    val outer: P[List[(PackageName, List[(Bindable, (Module, Code.Ident))])]] =
       Parser.dictLikeParser(PackageName.parser, inner) <* Parser.maybeSpacesAndLines
 
     outer.map { items =>

--- a/core/src/main/scala/org/bykn/bosatsu/codegen/python/PythonGen.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/codegen/python/PythonGen.scala
@@ -4,7 +4,7 @@ import org.typelevel.paiges.Doc
 import org.bykn.bosatsu.{PackageName, Identifier, Matchless, Par, Parser}
 import cats.Monad
 import cats.data.{NonEmptyList, State}
-import cats.parse.{Parser0 => P0, Parser => P}
+import cats.parse.{Parser => P}
 import scala.concurrent.ExecutionContext
 
 import Identifier.Bindable

--- a/core/src/test/scala/org/bykn/bosatsu/OperatorTest.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/OperatorTest.scala
@@ -1,7 +1,7 @@
 package org.bykn.bosatsu
 
 import org.typelevel.paiges.{ Doc, Document }
-import cats.parse.{Parser => P, Parser1 => P1}
+import cats.parse.{Parser0 => P0, Parser0 => P0}
 
 import Parser.Combinators
 
@@ -24,13 +24,13 @@ class OperatorTest extends ParserTestBase {
     case class Form(toForm: Formula[F]) extends F
   }
 
-  lazy val formP: P1[F] =
+  lazy val formP: Parser[F] =
     Operators.Formula
       .parser(
         Parser
           .integerString
           .map(F.Num(_))
-          .orElse1(P.defer1(formP.parensCut))
+          .orElse(P.defer(formP.parensCut))
       )
       .map(F.Form(_))
 

--- a/core/src/test/scala/org/bykn/bosatsu/OperatorTest.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/OperatorTest.scala
@@ -1,7 +1,8 @@
 package org.bykn.bosatsu
 
 import org.typelevel.paiges.{ Doc, Document }
-import cats.parse.{Parser0 => P0, Parser0 => P0}
+
+import cats.parse.{Parser => P}
 
 import Parser.Combinators
 
@@ -24,7 +25,7 @@ class OperatorTest extends ParserTestBase {
     case class Form(toForm: Formula[F]) extends F
   }
 
-  lazy val formP: Parser[F] =
+  lazy val formP: P[F] =
     Operators.Formula
       .parser(
         Parser

--- a/core/src/test/scala/org/bykn/bosatsu/ParserTest.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/ParserTest.scala
@@ -7,7 +7,7 @@ import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks.{ forAll, PropertyC
 import org.typelevel.paiges.{Doc, Document}
 
 import cats.implicits._
-import cats.parse.{Parser => P, Parser1 => P1}
+import cats.parse.{Parser0 => P0, Parser => P}
 import Parser.{optionParse, unsafeParse, Indy}
 
 import Generators.{shrinkDecl, shrinkStmt}
@@ -41,7 +41,7 @@ abstract class ParserTestBase extends AnyFunSuite with ParseFns {
   // This is so we can make Declarations without the region
   protected implicit val emptyRegion: Region = Region(0, 0)
 
-  def parseTest[T](p: P[T], str: String, expected: T, exidx: Int) =
+  def parseTest[T](p: P0[T], str: String, expected: T, exidx: Int) =
     p.parse(str) match {
       case Right((rest, t)) =>
         val idx = if (rest == "") str.length else str.indexOf(rest)
@@ -53,10 +53,10 @@ abstract class ParserTestBase extends AnyFunSuite with ParseFns {
         fail(s"failed to parse: $str: at $idx in region ${region(str, idx)} with err: ${err}")
     }
 
-  def parseTestAll[T](p: P[T], str: String, expected: T) =
+  def parseTestAll[T](p: P0[T], str: String, expected: T) =
     parseTest(p, str, expected, str.length)
 
-  def roundTrip[T: Document](p: P[T], str: String, lax: Boolean = false) =
+  def roundTrip[T: Document](p: P0[T], str: String, lax: Boolean = false) =
     p.parse(str) match {
       case Right((rest, t)) =>
         val idx = if (rest == "") str.length else str.indexOf(rest)
@@ -77,7 +77,7 @@ abstract class ParserTestBase extends AnyFunSuite with ParseFns {
         fail(s"failed to parse: $str: $idx in region ${region(str, idx)} with err: ${err}")
     }
 
-  def roundTripExact[T: Document](p: P[T], str: String) =
+  def roundTripExact[T: Document](p: P0[T], str: String) =
     p.parse(str) match {
       case Right((rest, t)) =>
         val idx = if (rest == "") str.length else str.indexOf(rest)
@@ -89,12 +89,12 @@ abstract class ParserTestBase extends AnyFunSuite with ParseFns {
         fail(s"failed to parse: $str: $idx in region ${region(str, idx)} with err: ${err}")
     }
 
-  def law[T: Document](p: P[T])(t: T) = {
+  def law[T: Document](p: P0[T])(t: T) = {
     val syntax = Document[T].document(t).render(80)
     parseTestAll(p, syntax, t)
   }
 
-  def expectFail[T](p: P[T], str: String, atIdx: Int) =
+  def expectFail[T](p: P0[T], str: String, atIdx: Int) =
     p.parse(str) match {
       case Right((rest, t)) =>
         val idx = if (rest == "") str.length else str.indexOf(rest)
@@ -209,7 +209,7 @@ class ParserTest extends ParserTestBase {
     def singleq(str1: String, res: List[Either[Json, String]]) =
       parseTestAll(
         StringUtil
-          .interpolatedString('\'', P.string1("${"), Json.parser, P.char('}'))
+          .interpolatedString('\'', P.string("${"), Json.parser, P.char('}'))
           .map(_.map {
             case Right((_, str)) => Right(str)
             case Left(l) => Left(l)
@@ -256,8 +256,8 @@ class ParserTest extends ParserTestBase {
         case c => c.toString
       }
 
-      val listOfStr: P1[List[String]] =
-        P.string1("List(") *>
+      val listOfStr: P[List[String]] =
+        P.string("List(") *>
           Parser.integerString.nonEmptyList.map(_.toList)
             .orElse(P.pure(Nil)) <*
             P.char(')')
@@ -315,7 +315,7 @@ class ParserTest extends ParserTestBase {
 
   test("we can parse RecordConstructors") {
     def check(str: String) =
-      roundTrip[Declaration](Declaration.recordConstructorP("", Declaration.varP, Declaration.varP.orElse1(Declaration.lits)), str)
+      roundTrip[Declaration](Declaration.recordConstructorP("", Declaration.varP, Declaration.varP.orElse(Declaration.lits)), str)
 
     check("Foo { bar }")
     check("Foo{bar}")
@@ -381,7 +381,7 @@ class ParserTest extends ParserTestBase {
   }
 
   test("we can parse blocks") {
-    val indy = OptIndent.block(Indy.lift(P.string1("if foo")), Indy.lift(P.string1("bar")))
+    val indy = OptIndent.block(Indy.lift(P.string("if foo")), Indy.lift(P.string("bar")))
     val p = indy.run("")
     parseTestAll(p, "if foo: bar", ((), OptIndent.same(())))
     parseTestAll(p, "if foo:\n\tbar", ((), OptIndent.paddedIndented(1, 4, ())))
@@ -396,11 +396,11 @@ class ParserTest extends ParserTestBase {
       NonEmptyList.of(single, single))
 
     // we can nest blocks
-    parseTestAll(OptIndent.block(Indy.lift(P.string1("nest")), indy)(""), "nest: if foo: bar",
+    parseTestAll(OptIndent.block(Indy.lift(P.string("nest")), indy)(""), "nest: if foo: bar",
       ((), OptIndent.same(((), OptIndent.same(())))))
-    parseTestAll(OptIndent.block(Indy.lift(P.string1("nest")), indy)(""), "nest:\n  if foo: bar",
+    parseTestAll(OptIndent.block(Indy.lift(P.string("nest")), indy)(""), "nest:\n  if foo: bar",
       ((), OptIndent.paddedIndented(1, 2, ((), OptIndent.same(())))))
-    parseTestAll(OptIndent.block(Indy.lift(P.string1("nest")), indy)(""), "nest:\n  if foo:\n    bar",
+    parseTestAll(OptIndent.block(Indy.lift(P.string("nest")), indy)(""), "nest:\n  if foo:\n    bar",
       ((), OptIndent.paddedIndented(1, 2, ((), OptIndent.paddedIndented(1, 2, ())))))
 
     val simpleBlock = OptIndent.block(Indy.lift(Parser.lowerIdent <* Parser.maybeSpace), Indy.lift(Parser.lowerIdent))
@@ -739,8 +739,8 @@ x""",
   test("we can parse if") {
     import Declaration._
 
-    val liftVar = Parser.Indy.lift(varP: P1[Declaration])
-    val liftVar0 = Parser.Indy.lift(varP: P1[NonBinding])
+    val liftVar = Parser.Indy.lift(varP: P[Declaration])
+    val liftVar0 = Parser.Indy.lift(varP: P[NonBinding])
     val parser0 = ifElseP(liftVar0, liftVar)("")
 
     roundTrip[Declaration](parser0,
@@ -808,8 +808,8 @@ else: y""")
   }
 
   test("we can parse a match") {
-    val liftVar = Parser.Indy.lift(Declaration.varP: P1[Declaration])
-    val liftVar0 = Parser.Indy.lift(Declaration.varP: P1[Declaration.NonBinding])
+    val liftVar = Parser.Indy.lift(Declaration.varP: P[Declaration])
+    val liftVar0 = Parser.Indy.lift(Declaration.varP: P[Declaration.NonBinding])
     roundTrip[Declaration](Declaration.matchP(liftVar0, liftVar)(""),
 """match x:
   y:

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -4,7 +4,7 @@ import org.portablescala.sbtplatformdeps.PlatformDepsPlugin.autoImport._
 object Dependencies {
   lazy val cats = Def.setting("org.typelevel" %%% "cats-core" % "2.3.1")
   lazy val catsEffect = Def.setting("org.typelevel" %%% "cats-effect" % "2.3.1")
-  lazy val catsParse = Def.setting("org.typelevel" %%% "cats-parse" % "0.2.0")
+  lazy val catsParse = Def.setting("org.typelevel" %%% "cats-parse" % "0.3.0")
   lazy val decline = Def.setting("com.monovore" %%% "decline" % "1.3.0")
   lazy val jawnParser = Def.setting("org.typelevel" %%% "jawn-parser" % "1.0.3")
   lazy val jawnAst = Def.setting("org.typelevel" %%% "jawn-ast" % "1.0.3")


### PR DESCRIPTION
replaces #648 

the scalafix got most of the way, but there were a few imports that were unneeded

cc @martijnhoekstra

