### PR TITLE
Improving comments in Declaration

### DIFF
--- a/core/src/main/scala/org/bykn/bosatsu/CommentStatement.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/CommentStatement.scala
@@ -25,18 +25,18 @@ object CommentStatement {
    */
   def parser[T](onP: String => P0[T]): Parser.Indy[CommentStatement[T]] =
     Parser.Indy { indent =>
-      val sep = Parser.newline ~ P.string0(indent)
+      val sep = Parser.newline ~ Parser.maybeSpace
 
       val commentBlock: P[NonEmptyList[String]] =
         // if the next line is part of the comment until we see the # or not
-        P.repSep(commentPart, min = 1, sep = sep) <* Parser.newline.orElse(P.end)
+        commentPart.repSep(sep = sep) <* Parser.newline.orElse(P.end)
 
       (commentBlock ~ onP(indent))
         .map { case (m, on) => CommentStatement(m, on) }
     }
 
   val commentPart: P[String] =
-    (P.char('#') ~ P.until0(P.char('\n'))).map(_._2)
+    P.char('#') *> P.until0(P.char('\n'))
 }
 
 

--- a/core/src/main/scala/org/bykn/bosatsu/DefRecursionCheck.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/DefRecursionCheck.scala
@@ -280,6 +280,8 @@ object DefRecursionCheck {
               checkDecl(next.padded)
         case Comment(cs) =>
           checkDecl(cs.on.padded)
+        case CommentNB(cs) =>
+          checkDecl(cs.on.padded)
         case DefFn(defstmt) =>
           // we can use the name of the def after we have defined it, which is the next part
           getSt.flatMap { state =>

--- a/core/src/main/scala/org/bykn/bosatsu/SourceConverter.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/SourceConverter.scala
@@ -150,6 +150,8 @@ final class SourceConverter(
         solvePat(pat, loop(value))
       case Comment(CommentStatement(_, Padding(_, decl))) =>
         loop(decl).map(_.as(decl))
+      case CommentNB(CommentStatement(_, Padding(_, decl))) =>
+        loop(decl).map(_.as(decl))
       case DefFn(defstmt@DefStatement(_, _, _, _)) =>
         val inExpr = defstmt.result match {
           case (_, Padding(_, in)) => withBound(in, defstmt.name :: Nil)

--- a/core/src/test/scala/org/bykn/bosatsu/ParserTest.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/ParserTest.scala
@@ -1006,6 +1006,15 @@ x""")
     decl("""|(y = 1
             |_ = y
             |2)""".stripMargin)
+
+    decl("""|(y = 1
+            |# just ignore y
+            |_ = y
+            |2)""".stripMargin)
+
+    decl("""|[1,
+            |  (# comment in a list
+            |2)]""".stripMargin)
   }
 
   test("we can parse any Statement") {

--- a/core/src/test/scala/org/bykn/bosatsu/ParserTest.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/ParserTest.scala
@@ -514,7 +514,7 @@ class SyntaxParseTest extends ParserTestBase {
     parseTestAll(
       Declaration.parser(""),
       commentLit,
-      Declaration.Comment(
+      Declaration.CommentNB(
         CommentStatement(NonEmptyList.of("foo", "bar"),
           Padding(1, Declaration.Literal(Lit.fromInt(1))))))
 
@@ -525,7 +525,7 @@ class SyntaxParseTest extends ParserTestBase {
     parseTestAll(
       Declaration.parser(""),
       parensComment,
-      Declaration.Parens(Declaration.Comment(
+      Declaration.Parens(Declaration.CommentNB(
         CommentStatement(NonEmptyList.of("foo", "bar"),
           Padding(1, Declaration.Literal(Lit.fromInt(1)))))))
   }
@@ -554,7 +554,7 @@ foo"""
       Declaration.parser(""),
       defWithComment,
       Declaration.DefFn(DefStatement(Identifier.Name("foo"), List(Pattern.Var(Identifier.Name("a"))), None,
-        (OptIndent.paddedIndented(1, 2, Declaration.Comment(CommentStatement(NonEmptyList.of(" comment here"),
+        (OptIndent.paddedIndented(1, 2, Declaration.CommentNB(CommentStatement(NonEmptyList.of(" comment here"),
           Padding(0, mkVar("a"))))),
          Padding(0, mkVar("foo"))))))
 
@@ -727,7 +727,7 @@ x""",
       """x = foo(4)
 # x is really great
 x""",
-    Binding(BindingStatement(Pattern.Var(Identifier.Name("x")),Apply(mkVar("foo"),NonEmptyList.of(Literal(Lit.fromInt(4))), ApplyKind.Parens),Padding(0,Comment(CommentStatement(NonEmptyList.of(" x is really great"),Padding(0,mkVar("x"))))))))
+    Binding(BindingStatement(Pattern.Var(Identifier.Name("x")),Apply(mkVar("foo"),NonEmptyList.of(Literal(Lit.fromInt(4))), ApplyKind.Parens),Padding(0,CommentNB(CommentStatement(NonEmptyList.of(" x is really great"),Padding(0,mkVar("x"))))))))
 
     // allow indentation after =
     roundTrip(parser(""),
@@ -1015,6 +1015,15 @@ x""")
     decl("""|[1,
             |  (# comment in a list
             |2)]""".stripMargin)
+
+    decl("""|[1,
+            |  # comment in a list
+            | 2]""".stripMargin)
+
+    decl("""|[1,
+            |  # comment in a list
+            |    # 1.5
+            |  2]""".stripMargin)
   }
 
   test("we can parse any Statement") {


### PR DESCRIPTION
Currently, Comment is not a NonBinding Declaration. As a result of that, any place that prohibits binding expressions or defs also prohibits comments.

This is really annoying.

The goal we have had so far, is be able to reconstruct the code from the parsed representation, or at least a formatted version of it.

The challenge is that means we have to store the comment in the AST somehow to do that.

