### PR TITLE
Fix an issue with imports and enums

### DIFF
--- a/bosatsuj
+++ b/bosatsuj
@@ -1,4 +1,4 @@
 #!/bin/sh
 
 # make sure to run sbt cli/assembly first
-java -jar cli/target/scala-2.12/bosatsu-cli-assembly-0.1.0-SNAPSHOT.jar "$@"
+java -jar cli/target/scala-2.12/bosatsu-cli-assembly-0.0.5.jar "$@"

--- a/build_native.sh
+++ b/build_native.sh
@@ -5,5 +5,5 @@ native-image --static \
   --no-fallback \
   --verbose \
   --initialize-at-build-time \
-  -jar cli/target/scala-2.12/bosatsu-cli-assembly-0.1.0-SNAPSHOT.jar \
+  -jar cli/target/scala-2.12/bosatsu-cli-assembly-0.0.5.jar \
   bosatsu

--- a/core/src/main/scala/org/bykn/bosatsu/TotalityCheck.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/TotalityCheck.scala
@@ -92,12 +92,7 @@ case class TotalityCheck(inEnv: TypeEnv[Any]) {
       case PositionalStruct(name, args) =>
         // This is total if the struct has a single constructor AND each of the patterns is total
         val argCheck = args.parTraverse_(validatePattern)
-        val nameCheck = inEnv.definedTypeFor(name) match {
-          case None =>
-            Left(NonEmptyList.of(UnknownConstructor(name, p, inEnv)))
-          case Some(_) =>
-            checkArity(name, args.size, p)
-        }
+        val nameCheck = checkArity(name, args.size, p)
         (nameCheck, argCheck).parMapN { (_, _) => () }
 
       case _ => validUnit

--- a/core/src/test/scala/org/bykn/bosatsu/EvaluationTest.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/EvaluationTest.scala
@@ -2599,4 +2599,24 @@ test = Assertion(True, "")
       ()
     }
   }
+
+  test("Match on constructors from another package") {
+    runBosatsuTest(
+      """
+package Foo
+
+export FooE()
+
+enum FooE: Foo1, Foo2
+""" ::
+"""
+package Bar
+
+from Foo import Foo1, Foo2
+
+x = Foo1
+
+test = Assertion(x matches Foo1, "x matches Foo1")
+""" :: Nil, "Bar", 1)
+  }
 }


### PR DESCRIPTION
There was a bug where if you use and enum, but only import the names of the constructors, you would get a confusing error message. This was due to a bad check in the TotalityChecker.

The check itself was redundant, and removing it seems to be a fix.