### PR TITLE
Follow up to 660 on imported enum totality checks

### DIFF
--- a/core/src/main/scala/org/bykn/bosatsu/Import.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/Import.scala
@@ -87,7 +87,7 @@ object Import {
    * This only keeps the last name if there are duplicate local names
    * checking for duplicate local names should be done at another layer
    */
-  def locals[F[_], A, B, C](imp: Import[A, F[B]])(pn: PartialFunction[B, C])(implicit F: Foldable[F]): Map[Identifier, C] = {
+  def locals[F[_]: Foldable, A, B, C](imp: Import[A, F[B]])(pn: PartialFunction[B, C]): Map[Identifier, C] = {
     val fn = pn.lift
     imp.items.foldLeft(Map.empty[Identifier, C]) { case (m0, impName) =>
       impName.tag.foldLeft(m0) { (m1, b) =>

--- a/core/src/main/scala/org/bykn/bosatsu/rankn/TypeEnv.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/rankn/TypeEnv.scala
@@ -55,7 +55,8 @@ class TypeEnv[+A] private (
       val nec = constructors.updated((pack, cf.name), (cf.args, dt, cf.fnType))
       // add this constructor to the values
       val v1 = values.updated((pack, cf.name), cf.fnType)
-      new TypeEnv(values = v1, constructors = nec, definedTypes = definedTypes)
+      val dt1 = definedTypes.updated((dt.packageName, dt.name), dt)
+      new TypeEnv(values = v1, constructors = nec, definedTypes = dt1)
     }
 
   /**

--- a/core/src/test/scala/org/bykn/bosatsu/EvaluationTest.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/EvaluationTest.scala
@@ -2615,8 +2615,11 @@ package Bar
 from Foo import Foo1, Foo2
 
 x = Foo1
+m = match x:
+      Foo1: True
+      Foo2: False
 
-test = Assertion(x matches Foo1, "x matches Foo1")
+test = Assertion(m, "x matches Foo1")
 """ :: Nil, "Bar", 1)
   }
 }


### PR DESCRIPTION
This is a continuation of #660 

That fix was only partial. I think this is a more complete fix.