### PR TITLE
Allow case in match/recur

### DIFF
--- a/core/src/main/resources/bosatsu/predef.bosatsu
+++ b/core/src/main/resources/bosatsu/predef.bosatsu
@@ -62,8 +62,8 @@ def foldLeft(lst: List[a], item: b, fn: b -> a -> b) -> b:
   # make the loop function as small as possible
   def loop(lst, item):
     recur lst:
-      []: item
-      [head, *tail]: loop(tail, fn(item, head))
+      case []: item
+      case [head, *tail]: loop(tail, fn(item, head))
   loop(lst, item)
 
 def reverse_concat(front: List[a], back: List[a]) -> List[a]:
@@ -74,8 +74,8 @@ def reverse(as: List[a]) -> List[a]:
 
 def concat(front: List[a], back: List[a]) -> List[a]:
   match back:
-    []: front
-    _: reverse_concat(reverse(front), back)
+    case []: front
+    case _: reverse_concat(reverse(front), back)
 
 def map_List(lst: List[a], fn: a -> b) -> List[b]:
   lst.foldLeft([], \t, a -> [fn(a), *t]).reverse
@@ -187,20 +187,20 @@ def rotation(left: Int, right: Int, max_diff: Int) -> Rotation:
 
 def max(i, j):
     match cmp_Int(i, j):
-        LT: j
-        _: i
+        case LT: j
+        case _: i
 
 # properly balanced trees:
 # h < c log_2(n + 2) + b, c ~= 1.44, b ~= -1.33
 def height(t: Tree[a]) -> Int:
     match t:
-        Empty: 0
-        Branch { height: h, ... }: h
+        case Empty: 0
+        case Branch { height: h, ... }: h
 
 def size(t: Tree[a]) -> Int:
     match t:
-        Empty: 0
-        Branch { size: s, ... }: s
+        case Empty: 0
+        case Branch { size: s, ... }: s
 
 def branch(sz, item, left, right):
     h = max(height(left), height(right))
@@ -212,37 +212,37 @@ def branch_s(item, left, right):
 
 def balance(t: Tree[a]) -> Tree[a]:
     match t:
-        Empty: Empty
-        Branch { key: top_item, left, right, ... }:
+        case Empty: Empty
+        case Branch { key: top_item, left, right, ... }:
           match rotation(height(left), height(right), 1):
-              NoRo: t
-              RightRo:
+              case NoRo: t
+              case RightRo:
                   match left:
-                      Empty: t
-                      Branch { key: inner_item, left, right: left_right, ... }:
+                      case Empty: t
+                      case Branch { key: inner_item, left, right: left_right, ... }:
                           match rotation(height(left), height(left_right), 0):
-                              RightRo | NoRo:
+                              case RightRo | NoRo:
                                   res_r = branch_s(top_item, left_right, right)
                                   branch_s(inner_item, left, res_r)
-                              LeftRo:
+                              case LeftRo:
                                   match left_right:
-                                      Empty: trace("unreachable", t)
-                                      Branch { key: lrv, left: left_right_left, right: left_right_right, ...}:
+                                      case Empty: trace("unreachable", t)
+                                      case Branch { key: lrv, left: left_right_left, right: left_right_right, ...}:
                                           res_r = branch_s(top_item, left_right_right, right)
                                           res_l = branch_s(inner_item, left, left_right_left)
                                           branch_s(lrv, res_l, res_r)
-              LeftRo:
+              case LeftRo:
                   match right:
-                      Empty: t
-                      Branch { key: inner_item, left: right_left, right: right_right, ...}:
+                      case Empty: t
+                      case Branch { key: inner_item, left: right_left, right: right_right, ...}:
                           match rotation(height(right_left), height(right_right), 0):
-                              LeftRo | NoRo:
+                              case LeftRo | NoRo:
                                   res_l = branch_s(top_item, left, right_left)
                                   branch_s(inner_item, res_l, right_right)
-                              RightRo:
+                              case RightRo:
                                   match right_left:
-                                      Empty: trace("unreachable", t)
-                                      Branch { key: right_left_key, right: right_left_left, left: right_left_right, ... }:
+                                      case Empty: trace("unreachable", t)
+                                      case Branch { key: right_left_key, right: right_left_left, left: right_left_right, ... }:
                                           branch_s(
                                             right_left_key,
                                             branch_s(top_item, left, right_left_left),
@@ -253,14 +253,14 @@ def add_item(ord: Order[a], tree: Tree[a], item: a) -> Tree[a]:
 
     def loop(tree: Tree[a]) -> Tree[a]:
         recur tree:
-            Empty: Branch(1, 1, item, Empty, Empty)
-            Branch(s, h, item0, left, right):
+            case Empty: Branch(1, 1, item, Empty, Empty)
+            case Branch(s, h, item0, left, right):
                 match fn(item, item0):
-                    EQ: Branch(s, h, item, left, right)
-                    LT:
+                    case EQ: Branch(s, h, item, left, right)
+                    case LT:
                         left = loop(left)
                         branch(s.add(1), item0, left, right).balance
-                    GT:
+                    case GT:
                         right = loop(right)
                         branch(s.add(1), item0, left, right).balance
 
@@ -271,12 +271,12 @@ def contains(ord: Order[a], tree: Tree[a], item: a) -> Option[a]:
 
     def loop(tree: Tree[a]) -> Option[a]:
         recur tree:
-            Empty: None
-            Branch { key, left, right, ... }:
+            case Empty: None
+            case Branch { key, left, right, ... }:
                 match fn(item, key):
-                    EQ: Some(key)
-                    LT: loop(left)
-                    GT: loop(right)
+                    case EQ: Some(key)
+                    case LT: loop(left)
+                    case GT: loop(right)
 
     loop(tree)
 
@@ -285,19 +285,19 @@ def remove_item(ord: Order[a], tree: Tree[a], item: a) -> Tree[a]:
 
     def loop(tree: Tree[a]) -> Tree[a]:
         recur tree:
-            Empty: Empty
-            Branch { size, key, left, right, ... }:
+            case Empty: Empty
+            case Branch { size, key, left, right, ... }:
                 match fn(item, key):
-                    EQ:
+                    case EQ:
                         match right:
-                            Empty: left
-                            _:
+                            case Empty: left
+                            case _:
                                 right = loop(right)
                                 branch(size.sub(1), key, left, right).balance
-                    LT:
+                    case LT:
                         left = loop(left)
                         branch(size.sub(1), key, left, right).balance
-                    GT:
+                    case GT:
                         right = loop(right)
                         branch(size.sub(1), key, left, right).balance
 
@@ -305,8 +305,8 @@ def remove_item(ord: Order[a], tree: Tree[a], item: a) -> Tree[a]:
 
 def fold_right_Tree(t: Tree[a], right_v: b, fn: a -> b -> b) -> b:
     recur t:
-        Empty: right_v
-        Branch { key, left, right, ... }:
+        case Empty: right_v
+        case Branch { key, left, right, ... }:
             v1 = fold_right_Tree(right, right_v, fn)
             v2 = fn(key, v1)
             fold_right_Tree(left, v2, fn)
@@ -331,21 +331,21 @@ def add_key(dict: Dict[k, v], key: k, value: v) -> Dict[k, v]:
 def get_key(dict: Dict[k, v], key: k) -> Option[v]:
     Dict(ord, tree) = dict
     match tree:
-        Branch { key: (_, v), ... }:
+        case Branch { key: (_, v), ... }:
             # fill in a fake v
             match contains(ord, tree, (key, v)):
-                Some((_, v)): Some(v)
-                None: None
-        Empty: None
+                case Some((_, v)): Some(v)
+                case None: None
+        case Empty: None
 
 def remove_key(dict: Dict[k, v], key: k) -> Dict[k, v]:
     Dict(ord, tree) = dict
     match tree:
-        Branch { key: (_, v), ... }:
+        case Branch { key: (_, v), ... }:
             # fill in a fake v
             tree1 = remove_item(ord, tree, (key, v))
             Dict(ord, tree1)
-        Empty: dict
+        case Empty: dict
 
 def items(dict: Dict[k, v]) -> List[(k, v)]:
     Dict(_, tree) = dict

--- a/core/src/test/scala/org/bykn/bosatsu/DefRecursionCheckTest.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/DefRecursionCheckTest.scala
@@ -81,38 +81,38 @@ def foo(foo): foo
     allowed("""#
 def len(lst):
   recur lst:
-    []: 0
-    [_, *tail]: len(tail)
+    case []: 0
+    case [_, *tail]: len(tail)
 """)
     allowed("""#
 def len(lst):
   empty = 0
   recur lst:
-    []: empty
-    [_, *tail]: len(tail).add(1)
+    case []: empty
+    case [_, *tail]: len(tail).add(1)
 """)
     allowed("""#
 def len(lst, acc):
   recur lst:
-    []: acc
-    [_, *tail]: len(tail, acc.add(1))
+    case []: acc
+    case [_, *tail]: len(tail, acc.add(1))
 """)
     disallowed("""#
 def len(lst):
   recur lst:
-    [*list]: len(list)
+    case [*list]: len(list)
 """)
     disallowed("""#
 def len(lst):
   recur lst:
-    [h, *t]: len(lst)
-    []: 0
+    case [h, *t]: len(lst)
+    case []: 0
 """)
     disallowed("""#
 def len(lst):
   recur lst:
-    []: 0
-    [_, *tail]:
+    case []: 0
+    case [_, *tail]:
       # we can't trivially see this is okay
       fn = \arg -> arg(tail)
       fn(len)
@@ -123,32 +123,32 @@ def len(lst):
     disallowed("""#
 def len(lst):
   recur lst:
-    []:
+    case []:
       len = \x -> 0
       len(lst)
-    [_, *tail]: len(tail)
+    case [_, *tail]: len(tail)
 """)
 
     disallowed("""#
 def len(lst):
   len = "shadow"
   recur lst:
-    []: 0
-    [_, *tail]: len(tail)
+    case []: 0
+    case [_, *tail]: len(tail)
 """)
     disallowed("""#
 def len(lst):
   recur lst:
-    []: 0
-    [_, *tail]:
+    case []: 0
+    case [_, *tail]:
       len = "shadow"
       len(tail)
 """)
     disallowed("""#
 def len(lst):
   recur lst:
-    []: 0
-    [_, *tail]:
+    case []: 0
+    case [_, *tail]:
       # shadowing len is not okay
       fn = \len -> len(tail)
       fn(len)
@@ -156,8 +156,8 @@ def len(lst):
     disallowed("""#
 def len(lst):
   recur lst:
-    []: 0
-    [_, *len]:
+    case []: 0
+    case [_, *len]:
       # shadowing len is not okay
       12
 """)
@@ -168,8 +168,8 @@ def len(lst):
   # by this method, and currently inaccessible
   x = len
   recur lst:
-    []: 0
-    [_, *_]:
+    case []: 0
+    case [_, *_]:
       # shadowing len is not okay
       12
 """)
@@ -179,8 +179,8 @@ def len(lst):
     len = l.add(r)
     len
   recur lst:
-    []: 0
-    [_, *t]: len_helper(len(t), 1)
+    case []: 0
+    case [_, *t]: len_helper(len(t), 1)
 """)
   }
 
@@ -195,18 +195,18 @@ def loop(x):
     disallowed("""#
 def len(lst):
   recur lst:
-    []: 0
-    [_, *tail]: 1
+    case []: 0
+    case [_, *tail]: 1
 """)
 
     disallowed("""#
 def len(lst):
   def foo(x):
     recur lst:
-      0: 1
+      case 0: 1
   recur lst:
-    []: 0
-    [_, *tail]: 1
+    case []: 0
+    case [_, *tail]: 1
 """)
   }
 
@@ -215,28 +215,28 @@ def len(lst):
 def len(lst):
   def foo(x): x
   recur lst:
-    []: 0
-    [_, *tail]: 1
+    case []: 0
+    case [_, *tail]: 1
 """)
     disallowed("""#
 def len(lst):
   def bar(x):
     def foo(x):
       recur x:
-        []: 0
-        [_, *t]: foo(t)
+        case []: 0
+        case [_, *t]: foo(t)
     foo(x)
   recur lst:
-    []: 0
-    [_, *tail]: 1
+    case []: 0
+    case [_, *tail]: 1
 """)
 
     allowed("""#
 def len(lst):
   def foo(x): x
   recur lst:
-    []: 0
-    [_, *tail]: len(tail)
+    case []: 0
+    case [_, *tail]: len(tail)
 """)
   }
 
@@ -247,11 +247,11 @@ def len(lst):
     disallowed("""#
 def foo(lstA, lstB):
   x = recur lstA:
-    []: 1
-    [a, *as]: foo(as, [1,*lstB])
+    case []: 1
+    case [a, *as]: foo(as, [1,*lstB])
   y = recur lstB:
-    []: 2
-    [b, *bs]: foo([1, *lstA], bs)
+    case []: 2
+    case [b, *bs]: foo([1, *lstA], bs)
   x.add(y)
 """)
   }
@@ -260,22 +260,22 @@ def foo(lstA, lstB):
     allowed("""#
 def len(lst, a):
   recur lst:
-    []: a
-    [_, *tail]: len(tail, a.plus(1))
+    case []: a
+    case [_, *tail]: len(tail, a.plus(1))
 """)
     allowed("""#
 def len(a, lst):
   recur lst:
-    []: a
-    [_, *tail]: len(a.plus(1), tail)
+    case []: a
+    case [_, *tail]: len(a.plus(1), tail)
 """)
   }
   test("recur is not return") {
     allowed("""#
 def dots(lst):
   a = recur lst:
-    []: ""
-    [head, *tail]: dots(tail).concat(head)
+    case []: ""
+    case [head, *tail]: dots(tail).concat(head)
   a.concat(".")
 """)
   }
@@ -283,12 +283,12 @@ def dots(lst):
     disallowed("""#
 def foo(lst):
   a = recur lst:
-    []: 0
-    [_, *tail]: foo(tail).plus(1)
+    case []: 0
+    case [_, *tail]: foo(tail).plus(1)
 
   b = recur lst:
-    []: 1
-    [_, *tail]: foo(tail).plus(2)
+    case []: 1
+    case [_, *tail]: foo(tail).plus(2)
 
   a.plus(b)
 """)
@@ -296,12 +296,12 @@ def foo(lst):
     disallowed("""#
 def foo(lstA, lstB):
   a = recur lstA:
-    []: 0
-    [_, *tail]: foo(tail, listB).plus(1)
+    case []: 0
+    case [_, *tail]: foo(tail, listB).plus(1)
 
   b = recur lstB:
-    []: 1
-    [_, *tail]: foo(lstA.concat(1), tail).plus(2)
+    case []: 1
+    case [_, *tail]: foo(lstA.concat(1), tail).plus(2)
 
   a.plus(b)
 """)
@@ -310,18 +310,18 @@ def foo(lstA, lstB):
     allowed("""#
 def zip(lstA, lstB):
   match lstA:
-    []: []
-    [headA, *tailA]: recur lstB:
-      []: []
-      [headB, *tailB]: [(headA, headB)].concat(zip(tailA, tailB))
+    case []: []
+    case [headA, *tailA]: recur lstB:
+      case []: []
+      case [headB, *tailB]: [(headA, headB)].concat(zip(tailA, tailB))
 """)
     allowed("""#
 def zip(lstA, lstB):
   recur lstA:
-    []: []
-    [headA, *tailA]: match lstB:
-      []: []
-      [headB, *tailB]: [(headA, headB)].concat(zip(tailA, tailB))
+    case []: []
+    case [headA, *tailA]: match lstB:
+      case []: []
+      case [headB, *tailB]: [(headA, headB)].concat(zip(tailA, tailB))
 """)
   }
 
@@ -330,13 +330,13 @@ def zip(lstA, lstB):
 def foo(x):
   def bar(x):
     recur x:
-      []: 0
-      [_, *t]: bar(t)
+      case []: 0
+      case [_, *t]: bar(t)
 
   def baz(x):
     recur x:
-      []: 0
-      [_, *t]: baz(t)
+      case []: 0
+      case [_, *t]: baz(t)
   baz([bar([1])])
 """)
   }
@@ -345,20 +345,20 @@ def foo(x):
     allowed("""#
 def foo(x):
   recur x:
-    []: 0
-    [_, *t]: foo(t)
+    case []: 0
+    case [_, *t]: foo(t)
 """)
     disallowed("""#
 def foo(x):
   recur bar(x):
-    []: 0
-    [_, *t]: foo(t)
+    case []: 0
+    case [_, *t]: foo(t)
 """)
     disallowed("""#
 def foo(x):
   recur y:
-    []: 0
-    [_, *t]: foo(t)
+    case []: 0
+    case [_, *t]: foo(t)
 """)
   }
 
@@ -366,16 +366,16 @@ def foo(x):
     disallowed("""#
 def len(acc, x):
   recur x:
-    []: acc
-    [_, *t]: len(t)
+    case []: acc
+    case [_, *t]: len(t)
 """)
   }
   test("we can use a list comprehension") {
     allowed("""#
 def nest(lst):
   recur lst:
-    []: []
-    [_, *tail]: [NonEmptyList(h, nest(tail)) for h in lst]
+    case []: []
+    case [_, *tail]: [NonEmptyList(h, nest(tail)) for h in lst]
 """)
   }
 
@@ -394,12 +394,12 @@ def len(lst):
   # this is doing nothing, but is a nested recursion
   def len0(lst):
     recur lst:
-      []: 0
-      [_, *t]: len0(t).add(1)
+      case []: 0
+      case [_, *t]: len0(t).add(1)
 
   recur lst:
-    []: 0
-    [_, *t]: len(t)
+    case []: 0
+    case [_, *t]: len(t)
 """)
   }
 
@@ -409,8 +409,8 @@ def id(x): x
 
 def len(lst):
   recur lst:
-    []: 0
-    [_, *t]: id(len(t))
+    case []: 0
+    case [_, *t]: id(len(t))
 """)
   }
 }

--- a/core/src/test/scala/org/bykn/bosatsu/EvaluationTest.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/EvaluationTest.scala
@@ -22,7 +22,7 @@ x = 1
     evalTest(
       List("""
 # test shadowing
-x = match 1: x: x
+x = match 1: case x: x
 """), "Package0", VInt(1))
 
     evalTest(
@@ -41,8 +41,8 @@ foo = "hello"
 
 def eq_String(a, b):
   match string_Order_fn(a, b):
-    EQ: True
-    _: False
+    case EQ: True
+    case _: False
 
 test = Assertion(eq_String("hello", foo), "checking equality")
 """), "Foo", 1)
@@ -79,9 +79,9 @@ package Foo
 x = 1
 
 z = match x.cmp_Int(1):
-  EQ:
+  case EQ:
     "foo"
-  _:
+  case _:
     "bar"
 """), "Foo", Str("foo"))
 
@@ -104,8 +104,8 @@ package Foo
 x = Some(1)
 
 z = match x:
-  Some(v): add(v, 10)
-  None: 0
+  case Some(v): add(v, 10)
+  case None: 0
 """), "Foo", VInt(11))
 
     // Use a local name collision and see it not have a problem
@@ -118,8 +118,8 @@ enum Option: None, Some(get)
 x = Some(1)
 
 z = match x:
-  Some(v): add(v, 10)
-  None: 0
+  case Some(v): add(v, 10)
+  case None: 0
 """), "Foo", VInt(11))
 
     evalTest(
@@ -132,8 +132,8 @@ enum Option: Some(get), None
 x = Some(1)
 
 z = match x:
-  None: 0
-  Some(v): add(v, 10)
+  case None: 0
+  case Some(v): add(v, 10)
 """), "Foo", VInt(11))
   }
 
@@ -237,8 +237,8 @@ package Foo
 x = 1
 
 main = match x:
-  1: "good"
-  _: "bad"
+  case 1: "good"
+  case _: "bad"
 """), "Foo", Str("good"))
 
     evalTest(
@@ -260,8 +260,8 @@ package Foo
 x = "1"
 
 main = match x:
-  "1": "good"
-  _: "bad"
+  case "1": "good"
+  case _: "bad"
 """), "Foo", Str("good"))
 
     evalTest(
@@ -273,8 +273,8 @@ struct Pair(fst, snd)
 x = Pair(1, "1")
 
 main = match x:
-  Pair(_, "1"): "good"
-  _: "bad"
+  case Pair(_, "1"): "good"
+  case _: "bad"
 """), "Foo", Str("good"))
   }
 
@@ -286,8 +286,8 @@ package Foo
 x = (1, "1")
 
 main = match x:
-  (_, "1"): "good"
-  _: "bad"
+  case (_, "1"): "good"
+  case _: "bad"
 """), "Foo", Str("good"))
 
     evalTest(
@@ -301,8 +301,8 @@ def go(u):
   _ = u
   (_, y) = x
   match y:
-    "1": "good"
-    _: "bad"
+    case "1": "good"
+    case _: "bad"
 
 main = go(())
 """), "Foo", Str("good"))
@@ -362,9 +362,9 @@ main = 6.mod_Int(4)
 package Foo
 
 main = match 6.div(4):
-  0: 42
-  1: 100
-  x: x
+  case 0: 42
+  case 1: 100
+  case x: x
 """), "Foo", VInt(100))
 
     evalTest(
@@ -386,11 +386,11 @@ threer = range(3)
 
 def zip(as, bs):
   recur as:
-    []: []
-    [ah, *atail]:
+    case []: []
+    case [ah, *atail]:
       match bs:
-        []: []
-        [bh, *btail]: [(ah, bh), *zip(atail, btail)]
+        case []: []
+        case [bh, *btail]: [(ah, bh), *zip(atail, btail)]
 
 def and(a, b):
   b if a else False
@@ -414,11 +414,11 @@ package Foo
 
 def zip(as: List[a], bs: List[b]) -> List[(a, b)]:
   recur as:
-    []: []
-    [ah, *atail]:
+    case []: []
+    case [ah, *atail]:
       match bs:
-        []: []
-        [bh, *btail]: [(ah, bh), *zip(atail, btail)]
+        case []: []
+        case [bh, *btail]: [(ah, bh), *zip(atail, btail)]
 
 main = 1
 """), "Foo", VInt(1))
@@ -455,8 +455,8 @@ package Foo
 
 def headOption(as):
   match as:
-    []: None
-    [a, *_]: Some(a)
+    case []: None
+    case [a, *_]: Some(a)
 
 main = headOption([1])
 """), "Foo", SumValue(1, ConsValue(VInt(1), UnitValue)))
@@ -597,16 +597,14 @@ struct W(fn: W[a, b] -> a -> b)
 
 def call(w0, w1):
   match w0:
-    W(fn): trace("fn(w1)", fn(w1))
+    case W(fn): trace("fn(w1)", fn(w1))
 
 def y(f):
   g = \w -> \a -> trace("calling f", f(call(w, w), a))
   g(W(g))
 
 def ltEqZero(i):
-  match i.cmp_Int(0):
-    GT: False
-    _: True
+  i.cmp_Int(0) matches (LT | EQ)
 
 fac = trace("made fac", y(\f, i -> 1 if ltEqZero(i) else f(i).times(i)))
 
@@ -624,8 +622,8 @@ enum GoodOrBad:
 
 def unbox(gb: GoodOrBad[a]):
   match gb:
-    Good(g): g
-    Bad(b): b
+    case Good(g): g
+    case Bad(b): b
 
 (main: Int) = unbox(Good(42))
 """), "A", VInt(42))
@@ -669,9 +667,9 @@ something = Yep(
   1)
 
 one = match something:
-  Yep(a): a
-  Nope: 0
-  _: 42
+  case Yep(a): a
+  case Nope: 0
+  case _: 42
 
 main = one
 """), "Total") { case PackageError.TotalityCheckError(_, _) => () }
@@ -704,8 +702,8 @@ int = IsInt(42, refl)
 # this takes StringOrInt[a] and returns a
 def getValue(v: StringOrInt[a]) -> a:
   match v:
-    IsStr(s, leib): coerce(s, leib)
-    IsInt(i, leib): coerce(i, leib)
+    case IsStr(s, leib): coerce(s, leib)
+    case IsInt(i, leib): coerce(i, leib)
 
 main = getValue(int)
 """), "A", VInt(42))
@@ -730,8 +728,8 @@ int = IsInt(42, refl)
 # this takes StringOrInt[a] and returns a
 def getValue(v):
   match v:
-    IsStr(s, _): s
-    IsInt(i, _): i
+    case IsStr(s, _): s
+    case IsInt(i, _): i
 
 main = getValue(int)
 """), "A"){ case PackageError.TypeErrorIn(_, _) => () }
@@ -929,14 +927,14 @@ package A
 
 def eq_List(lst1, lst2):
   recur lst1:
-    []:
+    case []:
       match lst2:
-        []: True
-        _: False
-    [h1, *t1]:
+        case []: True
+        case _: False
+    case [h1, *t1]:
       match lst2:
-        []: False
-        [h2, *t2]:
+        case []: False
+        case [h2, *t2]:
           eq_List(t1, t2) if eq_Int(h1, h2) else False
 
 lst1 = [0, 0, 1, 1, 2, 2, 3, 3]
@@ -944,8 +942,8 @@ lst2 = [*[x, x] for x in range(4)]
 lst3 = [*[y, y] for (_, y) in [(x, x) for x in range(4)]]
 
 main = match (eq_List(lst1, lst2), eq_List(lst1, lst3)):
-  (True, True): 1
-  _           : 0
+  case (True, True): 1
+  case _           : 0
 """), "A", VInt(1))
   }
 
@@ -1005,8 +1003,8 @@ package A
 
 def bad_len(list):
   recur list:
-    []: 0
-    [*init, _]: bad_len(init).add(1)
+    case []: 0
+    case [*init, _]: bad_len(init).add(1)
 
 main = bad_len([1, 2, 3, 5])
 """), "A", VInt(4))
@@ -1016,8 +1014,8 @@ package A
 
 def last(list):
   match list:
-    []: -1
-    [*_, s]: s
+    case []: -1
+    case [*_, s]: s
 
 main = last([1, 2, 3, 5])
 """), "A", VInt(5))
@@ -1028,14 +1026,14 @@ package A
 
 def bad_len(list):
   recur list:
-    []: 0
-    [2] | [3]: -1
-    [*_, 4 as four]:
+    case []: 0
+    case [2] | [3]: -1
+    case [*_, 4 as four]:
       #ignore_binding,
       _ = four
       -1
-    [100, *_]: -1
-    [*init, (_: Int) as last]:
+    case [100, *_]: -1
+    case [*init, (_: Int) as last]:
       #ignore binding
       _ = last
       bad_len(init).add(1)
@@ -1053,8 +1051,8 @@ tuple = (1, "two")
 constructed = uncurry2(TwoVar, tuple)
 
 main = match constructed:
-  TwoVar(1, "two"): "good"
-  _: "bad"
+  case TwoVar(1, "two"): "good"
+  case _: "bad"
 """), "A", Str("good"))
   }
   test("uncurry3") {
@@ -1067,8 +1065,8 @@ tuple = (1, "two", 3)
 constructed = uncurry3(ThreeVar, tuple)
 
 main = match constructed:
-  ThreeVar(1, "two", 3): "good"
-  _: "bad"
+  case ThreeVar(1, "two", 3): "good"
+  case _: "bad"
 """), "A", Str("good"))
   }
 
@@ -1112,8 +1110,8 @@ e2 = e1.add_key("hello", "world").add_key("hello1", "world1")
 lst = e2.items
 
 main = match lst:
-  [("hello", "world"), ("hello1", "world1")]: "good"
-  _: "bad"
+  case [("hello", "world"), ("hello1", "world1")]: "good"
+  case _: "bad"
 """), "A", Str("good"))
 
     evalTest(List("""
@@ -1124,8 +1122,8 @@ e2 = e1.add_key("hello", "world").add_key("hello1", "world1")
 lst = e2.items
 
 main = match lst:
-  [("hello", "world"), ("hello1", "world1")]: "good"
-  _: "bad"
+  case [("hello", "world"), ("hello1", "world1")]: "good"
+  case _: "bad"
 """), "A", Str("good"))
 
     evalTest(List("""
@@ -1138,8 +1136,8 @@ e = {
 lst = e.items
 
 main = match lst:
-  [("hello", "world"), ("hello1", "world1")]: "good"
-  _: "bad"
+  case [("hello", "world"), ("hello1", "world1")]: "good"
+  case _: "bad"
 """), "A", Str("good"))
 
     evalTest(List("""
@@ -1151,8 +1149,8 @@ e = { k: v for (k, v) in pairs }
 lst = e.items
 
 main = match lst:
-  [("hello", "world"), ("hello1", "world1")]: "good"
-  _: "bad"
+  case [("hello", "world"), ("hello1", "world1")]: "good"
+  case _: "bad"
 """), "A", Str("good"))
 
     evalTest(List("""
@@ -1162,15 +1160,15 @@ pairs = [("hello", 42), ("hello1", 24)]
 
 def is_hello(s):
   match s.string_Order_fn("hello"):
-    EQ: True
-    _: False
+    case EQ: True
+    case _: False
 
 e = { k: v for (k, v) in pairs if is_hello(k) }
 lst = e.items
 
 main = match lst:
-  [("hello", res)]: res
-  _: -1
+  case [("hello", res)]: res
+  case _: -1
 """), "A", VInt(42))
 
     evalTestJson(
@@ -1428,7 +1426,7 @@ package B
 x = 1
 
 main = match x:
-  Foo: 2
+  case Foo: 2
 """), "B") { case te@PackageError.SourceConverterErrorIn(_, _) =>
     val msg = te.message(Map.empty, Colorize.None)
     assert(!msg.contains("Name("))
@@ -1443,9 +1441,9 @@ package B
 struct X
 
 main = match 1:
-  X1: 0
+  case X1: 0
 """), "B") { case te@PackageError.SourceConverterErrorIn(_, _) =>
-      val b = assert(te.message(Map.empty, Colorize.None) == "in file: <unknown source>, package B, unknown constructor X1\nRegion(44,45)")
+      val b = assert(te.message(Map.empty, Colorize.None) == "in file: <unknown source>, package B, unknown constructor X1\nRegion(49,50)")
       ()
     }
 
@@ -1454,10 +1452,10 @@ main = match 1:
 package A
 
 main = match [1, 2, 3]:
-  []: 0
-  [*a, *b, _]: 2
+  case []: 0
+  case [*a, *b, _]: 2
 """), "A") { case te@PackageError.TotalityCheckError(_, _) =>
-      val b = assert(te.message(Map.empty, Colorize.None) == "in file: <unknown source>, package A\nRegion(19,60)\nmultiple splices in pattern, only one per match allowed")
+      val b = assert(te.message(Map.empty, Colorize.None) == "in file: <unknown source>, package A\nRegion(19,70)\nmultiple splices in pattern, only one per match allowed")
       ()
     }
 
@@ -1468,9 +1466,9 @@ package A
 enum Foo: Bar(a), Baz(b)
 
 main = match Bar(a):
-  Baz(b): b
+  case Baz(b): b
 """), "A") { case te@PackageError.TotalityCheckError(_, _) =>
-      val b = assert(te.message(Map.empty, Colorize.None) == "in file: <unknown source>, package A\nRegion(45,70)\nnon-total match, missing: Bar(_)")
+      val b = assert(te.message(Map.empty, Colorize.None) == "in file: <unknown source>, package A\nRegion(45,75)\nnon-total match, missing: Bar(_)")
       ()
     }
 
@@ -1555,12 +1553,12 @@ package A
 
 def fn(x, y):
   match x:
-    0: y
-    x: fn(x - 1, y + 1)
+    case 0: y
+    case x: fn(x - 1, y + 1)
 
 main = fn
 """), "A") { case te@PackageError.RecursionError(_, _) =>
-      val b = assert(te.message(Map.empty, Colorize.None) == "in file: <unknown source>, package A, invalid recursion on fn\nRegion(53,69)\n")
+      val b = assert(te.message(Map.empty, Colorize.None) == "in file: <unknown source>, package A, invalid recursion on fn\nRegion(63,79)\n")
       ()
     }
 
@@ -1570,12 +1568,12 @@ package A
 
 def fn(x, y):
   match x:
-    0: y
-    x: x
+    case 0: y
+    case x: x
 
 main = fn(0, 1, 2)
 """), "A") { case te@PackageError.TypeErrorIn(_, _) =>
-      val b = assert(te.message(Map.empty, Colorize.None) == "in file: <unknown source>, package A, type error: expected type Bosatsu/Predef::Int to be the same as type ?a -> ?b\nhint: this often happens when you apply the wrong number of arguments to a function.\nRegion(63,74)")
+      val b = assert(te.message(Map.empty, Colorize.None) == "in file: <unknown source>, package A, type error: expected type Bosatsu/Predef::Int to be the same as type ?a -> ?b\nhint: this often happens when you apply the wrong number of arguments to a function.\nRegion(73,84)")
       ()
     }
 
@@ -1624,11 +1622,11 @@ struct Pair(f, s)
 struct Trip(f, s, t)
 
 Trip(a, b, c) = match Pair(1, "two"):
-  Pair(f, s): Trip(3, s, f)
+  case Pair(f, s): Trip(3, s, f)
 
 bgood = match b:
-  "two": True
-  _: False
+  case "two": True
+  case _: False
 
 tests = TestSuite("test triple",
   [ Assertion(a.eq_Int(3), "a == 3"),
@@ -1731,31 +1729,29 @@ def and(x, y):
 operator && = and
 
 def equals(compare, x, y):
-  match compare(x,y):
-    EQ: True
-    _: False
+  compare(x,y) matches EQ
 
 def cmp_Bool(x, y):
   match (x, y):
-    (True, False): GT
-    (False, True): LT
-    _: EQ
+    case (True, False): GT
+    case (False, True): LT
+    case _: EQ
 
 def equal_List(is_equal, l1, l2):
   recur l1:
-    []: match l2:
-      []: True
-      _: False
-    [h1, *r1]: match l2:
-      []: False
-      [h2, *r2]: is_equal(h1, h2) && equal_List(is_equal, r1, r2)
+    case []: match l2:
+      case []: True
+      case _: False
+    case [h1, *r1]: match l2:
+      case []: False
+      case [h2, *r2]: is_equal(h1, h2) && equal_List(is_equal, r1, r2)
 
 def equal_RowEntry(re1, re2):
   match (re1, re2):
-    (REBool(RecordValue(x1)), REBool(RecordValue(x2))): cmp_Bool.equals(x1, x2)
-    (REInt(RecordValue(x1)), REInt(RecordValue(x2))): cmp_Int.equals(x1, x2)
-    (REString(RecordValue(x1)), REString(RecordValue(x2))): string_Order_fn.equals(x1, x2)
-    _: False
+    case (REBool(RecordValue(x1)), REBool(RecordValue(x2))): cmp_Bool.equals(x1, x2)
+    case (REInt(RecordValue(x1)), REInt(RecordValue(x2))): cmp_Int.equals(x1, x2)
+    case (REString(RecordValue(x1)), REString(RecordValue(x2))): string_Order_fn.equals(x1, x2)
+    case _: False
 
 equal_rows = equal_List(equal_RowEntry)
 
@@ -1783,7 +1779,7 @@ package A
 struct Pair(first, second)
 
 f2 = match Pair(1, "1"):
-  Pair { first, ... }: first
+  case Pair { first, ... }: first
 
 tests = TestSuite("test record",
   [
@@ -2021,7 +2017,7 @@ struct Foo(x, y)
 
 a = Foo(42, "42")
 x = match a:
-   Foo(y, _): y
+  case Foo(y, _): y
 
 tests = TestSuite("test record",
   [
@@ -2035,7 +2031,7 @@ struct Foo(x, y)
 
 a = Foo(42, "42")
 x = match a:
-   Foo(y, _): y
+  case Foo(y, _): y
 
 def add_x(a):
   # note x has a closure over a, but
@@ -2064,8 +2060,8 @@ two = one.add(1)
 def one: "one"
 
 good = match (one, two):
-  ("one", 2): True
-  _:     False
+  case ("one", 2): True
+  case _:     False
 
 tests = TestSuite("test",
   [
@@ -2087,8 +2083,8 @@ foo = Foo { one }
 def one: "one"
 
 good = match (one, two, foo):
-  ("one", 2, Foo(1)): True
-  _:     False
+  case ("one", 2, Foo(1)): True
+  case _:     False
 
 tests = TestSuite("test",
   [
@@ -2109,8 +2105,8 @@ def incB(one): one.add(1)
 def one: "one"
 
 good = match (one, two, incA(0), incB(1)):
-  ("one", 2, 1, 2): True
-  _:     False
+  case ("one", 2, 1, 2): True
+  case _:     False
 
 tests = TestSuite("test",
   [
@@ -2128,8 +2124,8 @@ def add(x, y):
   x.sub(y)
 
 good = match two:
-  2: True
-  _:     False
+  case 2: True
+  case _:     False
 
 tests = TestSuite("test",
   [
@@ -2284,11 +2280,11 @@ package Err
 x = [1, 2, 3]
 
 main = match x:
-  [*_, *_]: "bad"
-  _: "still bad"
+  case [*_, *_]: "bad"
+  case _: "still bad"
 
 """), "Err") { case sce@PackageError.TotalityCheckError(_, _) =>
-      assert(sce.message(Map.empty, Colorize.None) == "in file: <unknown source>, package Err\nRegion(36,79)\nmultiple splices in pattern, only one per match allowed")
+      assert(sce.message(Map.empty, Colorize.None) == "in file: <unknown source>, package Err\nRegion(36,89)\nmultiple splices in pattern, only one per match allowed")
       ()
     }
   }
@@ -2302,13 +2298,13 @@ package Err
 x = "foo bar"
 
 main = match x:
-  "$dollar{_}$dollar{_}": "bad"
-  _: "still bad"
+  case "$dollar{_}$dollar{_}": "bad"
+  case _: "still bad"
 
 """), "Err") { case sce@PackageError.TotalityCheckError(_, _) =>
       val dollar = '$'
       assert(sce.message(Map.empty, Colorize.None) ==
-        s"in file: <unknown source>, package Err\nRegion(36,81)\ninvalid string pattern: '$dollar{_}$dollar{_}' (adjacent bindings aren't allowed)")
+        s"in file: <unknown source>, package Err\nRegion(36,91)\ninvalid string pattern: '$dollar{_}$dollar{_}' (adjacent bindings aren't allowed)")
       ()
     }
   }
@@ -2345,8 +2341,8 @@ package A
 
 enum MyBool: T, F
 main = match T:
-  T: (\x -> x)(True)
-  F: False
+  case T: (\x -> x)(True)
+  case F: False
 
 tests = Assertion(main, "t1")
 """), "A", 1)
@@ -2385,12 +2381,12 @@ w = 1
 
 def inc(x):
   match w:
-    1:
+    case 1:
       y = x
       z = y
       y = w
       z.add(y)
-    x: x
+    case x: x
 
 tests = Assertion(inc(1).eq_Int(2), "t1")
 """), "A", 1)
@@ -2543,31 +2539,31 @@ test = Assertion(True, "")
 package Foo
 
 out = match (1,2):
-  (a, a): a
+  case (a, a): a
 
 test = Assertion(True, "")
 """), "Foo") { case sce@PackageError.SourceConverterErrorIn(_, _) =>
-      assert(sce.message(Map.empty, Colorize.None) == "in file: <unknown source>, package Foo, repeated bindings in pattern: a\nRegion(43,44)")
+      assert(sce.message(Map.empty, Colorize.None) == "in file: <unknown source>, package Foo, repeated bindings in pattern: a\nRegion(48,49)")
       ()
     }
     evalFail(List("""
 package Foo
 
 out = match [(1,2), (1, 0)]:
-  [(a, a), (1, 0)]: a
-  _: 0
+  case [(a, a), (1, 0)]: a
+  case _: 0
 
 test = Assertion(True, "")
 """), "Foo") { case sce@PackageError.SourceConverterErrorIn(_, _) =>
-      assert(sce.message(Map.empty, Colorize.None) == "in file: <unknown source>, package Foo, repeated bindings in pattern: a\nRegion(63,64)")
+      assert(sce.message(Map.empty, Colorize.None) == "in file: <unknown source>, package Foo, repeated bindings in pattern: a\nRegion(68,69)")
       ()
     }
     runBosatsuTest(List("""
 package Foo
 
 out = match [(1,2), (1, 0)]:
-  [(a, _) | (_, a), (1, 0)]: a
-  _: 0
+  case [(a, _) | (_, a), (1, 0)]: a
+  case _: 0
 
 test = Assertion(out.eq_Int(1), "")
 """), "Foo", 1)
@@ -2578,9 +2574,9 @@ test = Assertion(out.eq_Int(1), "")
 package Foo
 
 out = match [(True, 2), (True, 0)]:
-  [*_, (True, x), *_, (False, _)]: x
-  [*_, (True, _), *_, (_, y)]: y
-  _: -1
+  case [*_, (True, x), *_, (False, _)]: x
+  case [*_, (True, _), *_, (_, y)]: y
+  case _: -1
 
 test = Assertion(out.eq_Int(0), "")
 """), "Foo", 1)
@@ -2616,8 +2612,8 @@ from Foo import Foo1, Foo2
 
 x = Foo1
 m = match x:
-      Foo1: True
-      Foo2: False
+      case Foo1: True
+      case Foo2: False
 
 test = Assertion(m, "x matches Foo1")
 """ :: Nil, "Bar", 1)

--- a/core/src/test/scala/org/bykn/bosatsu/PackageTest.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/PackageTest.scala
@@ -91,15 +91,15 @@ enum List:
 
 def head(list):
   match list:
-    Empty:
+    case Empty:
       None
-    NonEmpty(h, _):
+    case NonEmpty(h, _):
       Some(h)
 
 def tail(list):
   match list:
-    Empty: None
-    NonEmpty(_, t): Some(t)
+    case Empty: None
+    case NonEmpty(_, t): Some(t)
 """)
 
     val p6 = parse(
@@ -160,7 +160,7 @@ struct Foo
 mkFoo = Foo
 def takeFoo(foo):
   match foo:
-    Foo:
+    case Foo:
       0
 """)
 
@@ -177,7 +177,7 @@ baz = Baz(mkFoo)
 main = takeFoo(mkFoo)
 
 main2 = match baz:
-  Baz(fooAsBar):
+  case Baz(fooAsBar):
     # here we pass a fooAsBar which has type Bar =:= Foo to takeFoo
     takeFoo(fooAsBar)
 """)

--- a/core/src/test/scala/org/bykn/bosatsu/ParserTest.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/ParserTest.scala
@@ -815,59 +815,59 @@ else: y""")
     val liftVar0 = Parser.Indy.lift(Declaration.varP: P[Declaration.NonBinding])
     roundTrip[Declaration](Declaration.matchP(liftVar0, liftVar)(""),
 """match x:
-  y:
+  case y:
     z
-  w:
+  case w:
     r""")
     roundTrip(Declaration.parser(""),
 """match 1:
-  Foo(a, b):
+  case Foo(a, b):
     a.plus(b)
-  Bar:
+  case Bar:
     42""")
     roundTrip(Declaration.parser(""),
 
 """match 1:
-  (a, b):
+  case (a, b):
     a.plus(b)
-  ():
+  case ():
     42""")
 
     roundTrip(Declaration.parser(""),
 
 """match 1:
-  (a, (b, c)):
+  case (a, (b, c)):
     a.plus(b).plus(e)
-  (1,):
+  case (1,):
     42""")
 
     roundTrip(Declaration.parser(""),
 """match 1:
-  Foo(a, b):
+  case Foo(a, b):
     a.plus(b)
-  Bar:
+  case Bar:
     match x:
-      True:
+      case True:
         100
-      False:
+      case False:
         99""")
 
     roundTrip(Declaration.parser(""),
 """foo(1, match 2:
-  Foo:
+  case Foo:
 
     foo
-  Bar:
+  case Bar:
 
     # this is the bar case
     bar, 100)""")
 
     roundTrip(Declaration.parser(""),
 """if (match 2:
-  Foo:
+  case Foo:
 
     foo
-  Bar:
+  case Bar:
 
     # this is the bar case
     bar):
@@ -878,33 +878,33 @@ else:
     roundTrip(Declaration.parser(""),
 """if True:
   match 1:
-    Foo(f):
+    case Foo(f):
       1
 else:
   100""")
 
     roundTrip(Declaration.parser(""),
 """match x:
-  Bar(_, _):
+  case Bar(_, _):
     10""")
 
     roundTrip(Declaration.parser(""),
 """match x:
-  Bar(_, _):
+  case Bar(_, _):
       if True: 0
       else: 10""")
 
     roundTrip(Declaration.parser(""),
 """match x:
-  Bar(_, _):
+  case Bar(_, _):
       if True: 0
       else: 10""")
 
     roundTrip(Declaration.parser(""),
 """match x:
-  []: 0
-  [x]: 1
-  _: 2""")
+  case []: 0
+  case [x]: 1
+  case _: 2""")
 
     roundTrip(Declaration.parser(""),
 """Foo(x) = bar
@@ -920,13 +920,13 @@ x""")
 
     roundTrip(Declaration.parser(""),
 """match x:
-  Some(_) | None: 1""")
+  case Some(_) | None: 1""")
 
     roundTrip(Declaration.parser(""),
 """match x:
-  Some(_) | None: 1
-  y: y
-  [x | y, _]: z""")
+  case Some(_) | None: 1
+  case y: y
+  case [x | y, _]: z""")
 
 
     roundTrip(Declaration.parser(""),

--- a/core/src/test/scala/org/bykn/bosatsu/Regressions.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/Regressions.scala
@@ -13,11 +13,11 @@ struct Field(name: String, extract: a -> b)
 
 def applyFields(fields, row):
   recur fields:
-    (f, Some(s)):
+    case (f, Some(s)):
       Field(_, fn) = f
       rec = applyFields(s, row)
       (fn(row), Some(rec))
-    (f, None):
+    case (f, None):
       Field(_, fn) = f
       (fn(row), None)
 

--- a/core/src/test/scala/org/bykn/bosatsu/TypedExprTest.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/TypedExprTest.scala
@@ -40,8 +40,8 @@ class TypedExprTest extends AnyFunSuite {
     checkLast("""
 enum AB: A, B(x)
 x = match B(100):
-  A: 10
-  B(b): b
+  case A: 10
+  case B(b): b
 """)(law)
   }
 
@@ -70,7 +70,7 @@ struct Tup2(a, b)
 x = 23
 x = Tup2(1, 2)
 y = match x:
-  Tup2(a, _): a
+  case Tup2(a, _): a
 """) { te => assert(TypedExpr.freeVars(te :: Nil) == Nil) }
   }
 
@@ -322,14 +322,14 @@ x = \_ -> 1
       """
 x = 10
 y = match x:
-  z: z
+  case z: z
 """) { te => assert(countMatch(te) == 0) }
 
     checkLast(
       """
 x = 10
 y = match x:
-  _: 20
+  case _: 20
 """) { te => assert(countMatch(te) == 0) }
   }
 
@@ -339,7 +339,7 @@ y = match x:
       """
 x = 10
 y = match x:
-  _: 20
+  case _: 20
 """) { te => assert(countLet(te) == 0) }
 
     checkLast(
@@ -368,8 +368,8 @@ enum N: Z, S(prev: N)
 
 def list_len(list, acc):
   recur list:
-    E: acc
-    NE(_, t): list_len(t, S(acc))
+    case E: acc
+    case NE(_, t): list_len(t, S(acc))
 """) { te => assert(TypedExpr.selfCallKind(Name("list_len"), te) == TailCall) }
 
     checkLast(
@@ -379,8 +379,8 @@ enum N: Z, S(prev: N)
 
 def list_len(list):
   recur list:
-    E: Z
-    NE(_, t): S(list_len(t))
+    case E: Z
+    case NE(_, t): S(list_len(t))
 """) { te => assert(TypedExpr.selfCallKind(Name("list_len"), te) == NonTailCall) }
 
     checkLast(
@@ -389,8 +389,8 @@ enum List[a]: E, NE(head: a, tail: List[a])
 
 def list_len(list):
   match list:
-    E: 0
-    NE(_, _): 1
+    case E: 0
+    case NE(_, _): 1
 """) { te => assert(TypedExpr.selfCallKind(Name("list_len"), te) == NoCall) }
 
   }

--- a/core/src/test/scala/org/bykn/bosatsu/rankn/RankNInferTest.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/rankn/RankNInferTest.scala
@@ -413,8 +413,8 @@ struct Pair(fst, snd)
 
 def swap_maybe(x: a, y, swap) -> Pair[a, a]:
   match swap:
-    T: Pair(y, x)
-    F: Pair(x, y)
+    case T: Pair(y, x)
+    case F: Pair(x, y)
 
 def res:
   Pair(r, _) = swap_maybe(1, 2, F)
@@ -479,8 +479,8 @@ enum Option:
 
 x = Some(1)
 main = match x:
-  None: 0
-  Some(y): y
+  case None: 0
+  case Some(y): y
 """, "Int")
 
    parseProgram("""#
@@ -490,8 +490,8 @@ enum List:
 
 x = NonEmpty(1, Empty)
 main = match x:
-  Empty: 0
-  NonEmpty(y, _): y
+  case Empty: 0
+  case NonEmpty(y, _): y
 """, "Int")
 
    parseProgram("""#
@@ -502,8 +502,8 @@ struct Monad(pure: forall a. a -> f[a], bind: forall a, b. f[a] -> (a -> f[b]) -
 
 def optBind(opt, bindFn):
   match opt:
-    None: None
-    Some(a): bindFn(a)
+    case None: None
+    case Some(a): bindFn(a)
 
 main = Monad(Some, optBind)
 """, "Monad[Opt]")
@@ -516,8 +516,8 @@ struct Monad(pure: forall a. a -> f[a], bind: forall a, b. f[a] -> (a -> f[b]) -
 
 def opt_bind(opt, bind_fn):
   match opt:
-    None: None
-    Some(a): bind_fn(a)
+    case None: None
+    case Some(a): bind_fn(a)
 
 option_monad = Monad(Some, opt_bind)
 
@@ -545,8 +545,8 @@ struct Monad(pure: forall a. a -> f[a], bind: forall a, b. f[a] -> (a -> f[b]) -
 
 def opt_bind(opt, bind_fn):
   match opt:
-    None: None
-    Some(a): bind_fn(a)
+    case None: None
+    case Some(a): bind_fn(a)
 
 option_monad = Monad(Some, opt_bind)
 
@@ -816,8 +816,8 @@ main = foo("Not an Int")
 x = "foo"
 
 main = match x:
-  1: "can't really be an int"
-  y: y
+  case 1: "can't really be an int"
+  case y: y
 """)
 
   parseProgramIllTyped("""#
@@ -825,8 +825,8 @@ main = match x:
 x = 1
 
 main = match x:
-  "1": "can't really be a string"
-  y: y
+  case "1": "can't really be a string"
+  case y: y
 """)
   }
 
@@ -857,8 +857,8 @@ enum Nat: Zero, Succ(prev: Nat)
 
 def len(l):
   recur l:
-    Zero: 0
-    Succ(p): len(p)
+    case Zero: 0
+    case Succ(p): len(p)
 
 main = len(Succ(Succ(Zero)))
 """, "Int")
@@ -870,8 +870,8 @@ enum Nat: Zero, Succ(prev: Nat)
 def len(l):
   def len0(l):
     recur l:
-      Zero: 0
-      Succ(p): len0(p)
+      case Zero: 0
+      case Succ(p): len0(p)
   len0(l)
 
 main = len(Succ(Succ(Zero)))
@@ -924,7 +924,7 @@ struct Nil
 #Nil
 def foo(cra_fn: Wrap[(forall ssss. Foo[ssss]) -> Nil]):
   match cra_fn:
-    (_: Wrap[(forall x. Foo[x]) -> Nil]): Nil
+    case (_: Wrap[(forall x. Foo[x]) -> Nil]): Nil
 main = foo
 """, "Wrap[(forall ssss. Foo[ssss]) -> Nil] -> Nil")
   }


### PR DESCRIPTION
allow `case` in match to harmonize with:

https://www.python.org/dev/peps/pep-0622/

this does not require case yet, just because it is a lot of work.

I do think visually this helps parse the parts of the block. Without case, it is parseable by machine, but starts to look like a sea of expressions to a human eye, IMO.

related to #623 #666 