### PR TITLE
Use protocVersion 3.17.3 for M1 compatibility

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -141,6 +141,7 @@ lazy val cli = (project in file("cli"))
     Compile / PB.targets := Seq(
      scalapb.gen() -> (Compile / sourceManaged).value
     ),
+    PB.protocVersion := "3.17.3",
     nativeImageOptions ++= Seq("--static", "--no-fallback", "--verbose", "--initialize-at-build-time"),
     nativeImageVersion := "21.1.0"
    )


### PR DESCRIPTION
use the workaround described here:

https://github.com/scalapb/ScalaPB/issues/1024

Seems to work for me on an M1 laptop.