### PR TITLE
Use mustMatch parameter in Nat-like matching

### DIFF
--- a/core/src/main/scala/org/bykn/bosatsu/Matchless.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/Matchless.scala
@@ -530,12 +530,13 @@ object Matchless {
                       }
                     }
                 case DataRepr.ZeroNat =>
-                  Monad[F].pure(NonEmptyList((Nil, EqualsNat(arg, DataRepr.ZeroNat), Nil), Nil))
+                  val cv: BoolExpr = if (mustMatch) TrueConst else EqualsNat(arg, DataRepr.ZeroNat)
+                  Monad[F].pure(NonEmptyList((Nil, cv, Nil), Nil))
                 case DataRepr.SuccNat =>
                   params match {
                     case single :: Nil =>
                       // if we match, we recur on the inner pattern and prev of current
-                      val check = EqualsNat(arg, DataRepr.SuccNat)
+                      val check = if (mustMatch) TrueConst else EqualsNat(arg, DataRepr.SuccNat)
                       for {
                         nm <- makeAnon
                         loc = LocalAnonMut(nm)


### PR DESCRIPTION
This reduces the `Nat.bosatsu` test file compiling to python from 252 lines to 234 lines. This is because we can avoid some checks on nat-like types (which were overlooked previously).