### PR TITLE
Fix Python staircasing, fix testing deadlock

### DIFF
--- a/cli/src/main/scala/org/bykn/bosatsu/CodeGenWrite.scala
+++ b/cli/src/main/scala/org/bykn/bosatsu/CodeGenWrite.scala
@@ -19,7 +19,7 @@ object CodeGenWrite {
     IO {
       Option(p.getParent).foreach(_.toFile.mkdirs)
       val pw = new PrintWriter(p.toFile, "UTF-8")
-      try d.renderStream(80).foreach(pw.print(_))
+      try d.renderStream(100).foreach(pw.print(_))
       finally {
         pw.close
       }

--- a/cli/src/test/scala/org/bykn/bosatsu/codegen/python/CodeTest.scala
+++ b/cli/src/test/scala/org/bykn/bosatsu/codegen/python/CodeTest.scala
@@ -182,7 +182,7 @@ class CodeTest extends AnyFunSuite {
 
   def assertParse(str: String) = {
     try {
-      val mod = JythonParserFacade.parseExpressionOrModule(new java.io.StringReader(str), "filename.py", new org.python.core.CompilerFlags())
+      val mod = JythonBarrier.run(JythonParserFacade.parseExpressionOrModule(new java.io.StringReader(str), "filename.py", new org.python.core.CompilerFlags()))
       assert(mod != null)
     }
     catch {


### PR DESCRIPTION
close #765 

I also think I fixed the problems with the transient deadlocks in the test code. It seems Jython is not thread-safe and two different tests running concurrently could sometimes cause a deadlock.

I put any code accessing jython first acquiring a semaphore and it seems to fix the issue.