### PR TITLE
Upgrade cats-parse to 0.3.5

### DIFF
--- a/core/src/test/scala/org/bykn/bosatsu/LocationMapTest.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/LocationMapTest.scala
@@ -26,27 +26,6 @@ class LocationMapTest extends AnyFunSuite {
     }
   }
 
-  test("some specific examples") {
-    val lm0 = LocationMap("\n")
-    assert(lm0.toLineCol(0) == Some((0, 0)))
-    assert(lm0.toLineCol(1) == None)
-
-    val lm1 = LocationMap("012\n345\n678")
-    assert(lm1.toLineCol(-1) == None)
-    assert(lm1.toLineCol(0) == Some((0, 0)))
-    assert(lm1.toLineCol(1) == Some((0, 1)))
-    assert(lm1.toLineCol(2) == Some((0, 2)))
-    assert(lm1.toLineCol(3) == Some((0, 3)))
-    assert(lm1.toLineCol(4) == Some((1, 0)))
-    assert(lm1.toLineCol(5) == Some((1, 1)))
-    assert(lm1.toLineCol(6) == Some((1, 2)))
-    assert(lm1.toLineCol(7) == Some((1, 3)))
-    assert(lm1.toLineCol(8) == Some((2, 0)))
-    assert(lm1.toLineCol(9) == Some((2, 1)))
-    assert(lm1.toLineCol(10) == Some((2, 2)))
-    assert(lm1.toLineCol(11) == None)
-  }
-
   test("we can reassemble input with getLine") {
     forAll { str: String =>
       val lm = LocationMap(str)
@@ -68,13 +47,13 @@ class LocationMapTest extends AnyFunSuite {
       def test(offset: Int) =
         lm.toLineCol(offset) match {
           case None =>
-            assert(offset < 0 || offset >= s.length)
+            assert(offset < 0 || offset > s.length)
           case Some((row, col)) =>
             lm.getLine(row) match {
-              case None => fail()
+              case None => assert(offset == s.length)
               case Some(line) =>
                 assert(line.length >= col)
-                if (line.length == col) assert(s(offset) == '\n')
+                if (line.length == col) assert(offset == s.length || s(offset) == '\n')
                 else assert(line(col) == s(offset))
             }
         }
@@ -89,47 +68,6 @@ class LocationMapTest extends AnyFunSuite {
       LocationMap(s).toLineCol(0) match {
         case Some(r) => assert(r == ((0, 0)))
         case None => assert(s.isEmpty)
-      }
-    }
-  }
-
-  test("slow toLineCol matches") {
-
-    def slow(str: String, offset: Int): Option[(Int, Int)] = {
-      val split = str.split("\n", -1)
-      def lineCol(off: Int, row: Int): Option[(Int, Int)] =
-        if (row == split.length) None
-        else {
-          val r = split(row)
-          val extraNewLine = if (row < (split.length - 1)) 1 else 0 // all but the last have an extra newline
-          val chars = r.length + extraNewLine
-
-          if (off >= chars) lineCol(off - chars, row + 1)
-          else Some((row, off))
-        }
-
-      if (offset < 0 || offset >= str.length) None
-      else lineCol(offset, 0)
-    }
-
-    assert(slow("\n", 0) == Some((0, 0)))
-    assert(LocationMap("\n").toLineCol(0) == Some((0, 0)))
-
-    assert(slow(" \n", 1) == Some((0, 1)))
-    assert(LocationMap(" \n").toLineCol(1) == Some((0, 1)))
-
-    assert(slow(" \n ", 1) == Some((0, 1)))
-    assert(LocationMap(" \n ").toLineCol(1) == Some((0, 1)))
-
-    assert(slow("\n ", 1) == Some((1, 0)))
-    assert(LocationMap("\n ").toLineCol(1) == Some((1, 0)))
-
-    forAll { (str: String, offset: Int) =>
-      val lm = LocationMap(str)
-      assert(lm.toLineCol(offset) === slow(str, offset))
-      if (str.length > 0) {
-        val validOffset = math.abs(offset % str.length)
-        assert(lm.toLineCol(validOffset) === slow(str, validOffset))
       }
     }
   }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -4,7 +4,7 @@ import org.portablescala.sbtplatformdeps.PlatformDepsPlugin.autoImport._
 object Dependencies {
   lazy val cats = Def.setting("org.typelevel" %%% "cats-core" % "2.6.1")
   lazy val catsEffect = Def.setting("org.typelevel" %%% "cats-effect" % "3.2.9")
-  lazy val catsParse = Def.setting("org.typelevel" %%% "cats-parse" % "0.3.4")
+  lazy val catsParse = Def.setting("org.typelevel" %%% "cats-parse" % "0.3.5")
   lazy val decline = Def.setting("com.monovore" %%% "decline" % "2.2.0")
   lazy val jawnParser = Def.setting("org.typelevel" %%% "jawn-parser" % "1.2.0")
   lazy val jawnAst = Def.setting("org.typelevel" %%% "jawn-ast" % "1.2.0")


### PR DESCRIPTION
This makes type-check on the test_workspace directory about 10% faster.