### PR TITLE
Remove zero arg defs

### DIFF
--- a/core/src/main/scala/org/bykn/bosatsu/CommentStatement.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/CommentStatement.scala
@@ -25,11 +25,11 @@ object CommentStatement {
    */
   def parser[T](onP: String => P0[T]): Parser.Indy[CommentStatement[T]] =
     Parser.Indy { indent =>
-      val sep = Parser.newline ~ Parser.maybeSpace
+      val sep = Parser.newline
 
       val commentBlock: P[NonEmptyList[String]] =
         // if the next line is part of the comment until we see the # or not
-        commentPart.repSep(sep = sep) <* Parser.newline.orElse(P.end)
+        (Parser.maybeSpace.with1.soft *> commentPart).repSep(sep = sep) <* Parser.newline.orElse(P.end)
 
       (commentBlock ~ onP(indent))
         .map { case (m, on) => CommentStatement(m, on) }

--- a/core/src/main/scala/org/bykn/bosatsu/Declaration.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/Declaration.scala
@@ -552,13 +552,13 @@ object Declaration {
             .map { p1 =>
               Comment(CommentStatement(c.message, p1))(decl.region)
             }
-        case DefFn(ds@DefStatement(nm, args, rtype, (body, rest))) =>
+        case DefFn(DefStatement(nm, args, rtype, (body, rest))) =>
           def go(scope: List[Bindable], d0: Declaration): Option[Declaration] =
             if (scope.exists(masks)) None
             else if (scope.exists(shadows)) Some(d0)
             else loopDec(d0)
 
-          val bodyScope = nm :: ds.args.patternNames
+          val bodyScope = nm :: args.patternNames
           val restScope = nm :: Nil
 
           (body.traverse(go(bodyScope, _)), rest.traverse(go(restScope, _)))

--- a/core/src/main/scala/org/bykn/bosatsu/DefRecursionCheck.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/DefRecursionCheck.scala
@@ -40,7 +40,7 @@ object DefRecursionCheck {
     def region = decl.region
     def message = "unexpected recur: may only appear unnested inside a def"
   }
-  case class RecurNotOnArg(decl: Declaration.Match, fnname: Bindable, args: List[Pattern.Parsed]) extends RecursionError {
+  case class RecurNotOnArg(decl: Declaration.Match, fnname: Bindable, args: NonEmptyList[Pattern.Parsed]) extends RecursionError {
     def region = decl.region
     def message = {
       val argStr = args.iterator.map { pat => Pattern.document.document(pat).render(80) }.mkString(", ")
@@ -110,7 +110,7 @@ object DefRecursionCheck {
           case InRecurBranch(ir, _) => ir.defNamesContain(n)
         }
 
-      def inDef(fnname: Bindable, args: List[Pattern.Parsed]): InDef =
+      def inDef(fnname: Bindable, args: NonEmptyList[Pattern.Parsed]): InDef =
         InDef(this, fnname, args, Set.empty)
     }
     sealed abstract class InDefState extends State {
@@ -122,7 +122,7 @@ object DefRecursionCheck {
         }
     }
     case object TopLevel extends State
-    case class InDef(outer: State, fnname: Bindable, args: List[Pattern.Parsed], localScope: Set[Bindable]) extends InDefState {
+    case class InDef(outer: State, fnname: Bindable, args: NonEmptyList[Pattern.Parsed], localScope: Set[Bindable]) extends InDefState {
 
       def addLocal(b: Bindable): InDef =
         InDef(outer, fnname, args, localScope + b)
@@ -142,7 +142,7 @@ object DefRecursionCheck {
      */
     def getRecurIndex(
       fnname: Bindable,
-      args: List[Pattern.Parsed],
+      args: NonEmptyList[Pattern.Parsed],
       m: Declaration.Match,
       locals: Set[Bindable]): ValidatedNel[RecursionError, Int] = {
       import Declaration._
@@ -152,7 +152,7 @@ object DefRecursionCheck {
             case b: Bindable if locals(b) =>
               Validated.invalidNel(RecurNotOnArg(m, fnname, args))
             case _ =>
-              val idx = args.indexWhere { p => p.topNames.contains(v) }
+              val idx = args.toList.indexWhere { p => p.topNames.contains(v) }
               if (idx < 0) Validated.invalidNel(RecurNotOnArg(m, fnname, args))
               else Validated.valid(idx)
           }
@@ -418,7 +418,7 @@ object DefRecursionCheck {
      */
     def checkDef[A](state: State, defstmt: DefStatement[Pattern.Parsed, (OptIndent[Declaration], A)]): Res = {
       val body = defstmt.result._1.get
-      val nameArgs = defstmt.args.flatMap(_.names)
+      val nameArgs = defstmt.args.toList.flatMap(_.names)
       val state1 = state.inDef(defstmt.name, defstmt.args)
       checkForIllegalBinds(state, defstmt.name :: nameArgs, body) {
         val st = setSt(state1) *> checkDecl(body) *> (getSt.flatMap {

--- a/core/src/main/scala/org/bykn/bosatsu/DefRecursionCheck.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/DefRecursionCheck.scala
@@ -301,7 +301,7 @@ object DefRecursionCheck {
           checkDecl(t) *> checkDecl(c) *> checkDecl(f)
         case Lambda(args, body) =>
           // these args create new bindings:
-          checkForIllegalBindsSt(args.toList.flatMap(_.names), decl) *> checkDecl(body)
+          checkForIllegalBindsSt(args.patternNames, decl) *> checkDecl(body)
         case Literal(_) =>
           unitSt
         case Match(RecursionKind.NonRecursive, arg, cases) =>
@@ -418,7 +418,7 @@ object DefRecursionCheck {
      */
     def checkDef[A](state: State, defstmt: DefStatement[Pattern.Parsed, (OptIndent[Declaration], A)]): Res = {
       val body = defstmt.result._1.get
-      val nameArgs = defstmt.args.toList.flatMap(_.names)
+      val nameArgs = defstmt.args.patternNames
       val state1 = state.inDef(defstmt.name, defstmt.args)
       checkForIllegalBinds(state, defstmt.name :: nameArgs, body) {
         val st = setSt(state1) *> checkDecl(body) *> (getSt.flatMap {

--- a/core/src/main/scala/org/bykn/bosatsu/DefStatement.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/DefStatement.scala
@@ -11,7 +11,7 @@ import Identifier.{Bindable, Constructor}
 
 case class DefStatement[A, B](
   name: Bindable,
-  args: List[A],
+  args: NonEmptyList[A],
   retType: Option[TypeRef], result: B) {
 
   /**
@@ -24,32 +24,27 @@ case class DefStatement[A, B](
       retType.fold(unTypedBody) { t =>
         (unTypedBody, trFn(t), tag).mapN(Expr.Annotation(_, _, _))
       }
-    NonEmptyList.fromList(args) match {
-      case None => bodyExp
-      case Some(neargs) =>
-        (neargs.traverse(argFn), bodyExp, tag).mapN { (as, b, t) =>
-          Expr.buildPatternLambda(as, b, t)
-        }
+
+    (args.traverse(argFn), bodyExp, tag).mapN { (as, b, t) =>
+      Expr.buildPatternLambda(as, b, t)
     }
   }
 }
 
 object DefStatement {
   private[this] val defDoc = Doc.text("def ")
+  private[this] val arrow = Doc.text(" -> ")
+  private[this] val commaSpace = Doc.text(", ")
 
   implicit def document[A: Document, B: Document]: Document[DefStatement[A, B]] =
     Document.instance[DefStatement[A, B]] { defs =>
       import defs._
-      val res = retType.fold(Doc.empty) { t => Doc.text(" -> ") + t.toDoc }
+      val res = retType.fold(Doc.empty) { t => arrow + t.toDoc }
       val argDoc =
-        if (args.isEmpty) Doc.empty
-        else {
-          val docA = Document[A]
-          Doc.char('(') +
-            Doc.intercalate(Doc.text(", "), args.map(docA.document(_))) +
-            Doc.char(')')
-        }
-      val line0 = defDoc + Document[Bindable].document(name) + argDoc + res + Doc.text(":")
+        Doc.char('(') +
+          Doc.intercalate(commaSpace, args.map(Document[A].document(_)).toList) +
+          Doc.char(')')
+      val line0 = defDoc + Document[Bindable].document(name) + argDoc + res + Doc.char(':')
 
       line0 + Document[B].document(result)
     }
@@ -60,15 +55,11 @@ object DefStatement {
     def parser[A, B](argParser: P[A], resultTParser: P[B]): P[DefStatement[A, B]] = {
       val args = argParser.parensLines1Cut
       val result = (P.string("->") *> maybeSpace *> TypeRef.parser).?
-      (Parser.keySpace("def") *> (Identifier.bindableParser ~ args.?) <* maybeSpace,
+      (Parser.keySpace("def") *> (Identifier.bindableParser ~ args) <* maybeSpace,
         result.with1 <* (maybeSpace.with1 ~ P.char(':')),
         resultTParser)
-          .mapN { case ((name, optArgs), resType, res) =>
-            val args = optArgs match {
-              case None => Nil
-              case Some(ne) => ne.toList
-            }
+          .mapN { case ((name, args), resType, res) =>
             DefStatement(name, args, resType, res)
-        }
+          }
     }
 }

--- a/core/src/main/scala/org/bykn/bosatsu/Expr.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/Expr.scala
@@ -261,7 +261,7 @@ object Expr {
       .iterator
       .map(_.name)
       .map(Identifier.Name(_))
-      .filterNot(allNames(body) ++ args.toList.flatMap(_.names))
+      .filterNot(allNames(body) ++ args.patternNames)
 
     def loop(
       args: NonEmptyList[Pattern[(PackageName, Constructor), Type]],

--- a/core/src/main/scala/org/bykn/bosatsu/Indented.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/Indented.scala
@@ -34,7 +34,7 @@ object Indented {
   def indy[T](p: Parser.Indy[T]): Parser.Indy[Indented[T]] =
     Parser.Indy { indent =>
       for {
-        thisIndent <- P.string0(indent).with1 *> Parser.spaces.string
+        thisIndent <- P.string0(indent).with1.soft *> Parser.spaces.string
         t <- p.run(indent + thisIndent)
       } yield Indented(Indented.spaceCount(thisIndent), t)
     }

--- a/core/src/main/scala/org/bykn/bosatsu/OptIndent.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/OptIndent.scala
@@ -76,6 +76,6 @@ object OptIndent {
 
   def blockLike[A, B, C](first: Indy[A], next: Indy[B], sep: P0[C]): Indy[(A, OptIndent[B])] =
     first
-      .cutLeftP((sep ~ maybeSpace).void)
+      .cutLeftP(sep ~ maybeSpace)
       .cutThen(OptIndent.indy(next))
 }

--- a/core/src/main/scala/org/bykn/bosatsu/Pattern.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/Pattern.scala
@@ -1,6 +1,6 @@
 package org.bykn.bosatsu
 
-import cats.Applicative
+import cats.{Applicative, Foldable}
 import cats.data.NonEmptyList
 import cats.parse.{Parser0 => P0, Parser => P}
 import org.typelevel.paiges.{ Doc, Document }
@@ -369,6 +369,10 @@ object Pattern {
 
       go(pat)
     }
+  }
+
+  implicit class FoldablePattern[F[_], N, T](private val pats: F[Pattern[N, T]]) extends AnyVal {
+    def patternNames(implicit F: Foldable[F]): List[Bindable] = F.toList(pats).flatMap(_.names)
   }
 
   case object WildCard extends Pattern[Nothing, Nothing]

--- a/core/src/main/scala/org/bykn/bosatsu/SourceConverter.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/SourceConverter.scala
@@ -156,7 +156,7 @@ final class SourceConverter(
         val inExpr = defstmt.result match {
           case (_, Padding(_, in)) => withBound(in, defstmt.name :: Nil)
         }
-        val newBindings = defstmt.name :: defstmt.args.flatMap(_.names)
+        val newBindings = defstmt.name :: defstmt.args.toList.flatMap(_.names)
         // TODO
         val lambda = defstmt.toLambdaExpr({ res => withBound(res._1.get, newBindings) }, success(decl))(
           convertPattern(_, decl.region), { t => toType(t, decl.region) })

--- a/core/src/main/scala/org/bykn/bosatsu/SourceConverter.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/SourceConverter.scala
@@ -156,7 +156,7 @@ final class SourceConverter(
         val inExpr = defstmt.result match {
           case (_, Padding(_, in)) => withBound(in, defstmt.name :: Nil)
         }
-        val newBindings = defstmt.name :: defstmt.args.toList.flatMap(_.names)
+        val newBindings = defstmt.name :: defstmt.args.patternNames
         // TODO
         val lambda = defstmt.toLambdaExpr({ res => withBound(res._1.get, newBindings) }, success(decl))(
           convertPattern(_, decl.region), { t => toType(t, decl.region) })
@@ -187,7 +187,7 @@ final class SourceConverter(
         loop(IfElse(NonEmptyList((c, OptIndent.same(t)), Nil), OptIndent.same(f))(tern.region))
       case Lambda(args, body) =>
         val argsRes = args.traverse(convertPattern(_, decl.region))
-        val bodyRes = withBound(body, args.toList.flatMap(_.names))
+        val bodyRes = withBound(body, args.patternNames)
         (argsRes, bodyRes).mapN { (args, body) =>
           Expr.buildPatternLambda(args, body, decl)
         }

--- a/core/src/main/scala/org/bykn/bosatsu/Statement.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/Statement.scala
@@ -95,7 +95,7 @@ object Statement {
         case Def(defstatement) =>
           val innerFrees = defstatement.result.get.freeVars
           // but the def name and, args shadow
-          (innerFrees - defstatement.name) -- defstatement.args.toList.flatMap(_.names)
+          (innerFrees - defstatement.name) -- defstatement.args.patternNames
         case ExternalDef(name, _, _) => SortedSet.empty
       }
 
@@ -106,8 +106,7 @@ object Statement {
       this match {
         case Bind(BindingStatement(pat, decl, _)) => decl.allNames ++ pat.names
         case Def(defstatement) =>
-          (defstatement.result.get.allNames + defstatement.name) ++
-            defstatement.args.toList.flatMap(_.names)
+          (defstatement.result.get.allNames + defstatement.name) ++ defstatement.args.patternNames
         case ExternalDef(name, _, _) => SortedSet(name)
       }
     }

--- a/core/src/main/scala/org/bykn/bosatsu/Statement.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/Statement.scala
@@ -95,7 +95,7 @@ object Statement {
         case Def(defstatement) =>
           val innerFrees = defstatement.result.get.freeVars
           // but the def name and, args shadow
-          (innerFrees - defstatement.name) -- defstatement.args.flatMap(_.names)
+          (innerFrees - defstatement.name) -- defstatement.args.toList.flatMap(_.names)
         case ExternalDef(name, _, _) => SortedSet.empty
       }
 
@@ -107,7 +107,7 @@ object Statement {
         case Bind(BindingStatement(pat, decl, _)) => decl.allNames ++ pat.names
         case Def(defstatement) =>
           (defstatement.result.get.allNames + defstatement.name) ++
-            defstatement.args.flatMap(_.names)
+            defstatement.args.toList.flatMap(_.names)
         case ExternalDef(name, _, _) => SortedSet(name)
       }
     }
@@ -183,27 +183,30 @@ object Statement {
              case (region, (name, tva)) => ExternalStruct(name, tva)(region)
            }
 
+       val argParser: P[(Bindable, TypeRef)] = Identifier.bindableParser ~ (
+         maybeSpace *> P.char(':') *> maybeSpace *> TypeRef.parser)
+
        val externalDef = {
-         val argParser: P[(Bindable, TypeRef)] =
-           Identifier.bindableParser ~ (maybeSpace *> P.char(':') *> maybeSpace *> TypeRef.parser)
 
          val args = P.char('(') *> maybeSpace *> argParser.nonEmptyList <* maybeSpace <* P.char(')')
 
          val result = maybeSpace.with1 *> P.string("->") *> maybeSpace *> TypeRef.parser
 
-         (((keySpace("def") *> Identifier.bindableParser ~ args.? ~ result).region) <* toEOL)
+         (((keySpace("def") *> Identifier.bindableParser ~ args ~ result).region) <* toEOL)
            .map {
-             case (region, ((name, optArgs), resType)) =>
-               val alist = optArgs match {
-                 case None => Nil
-                 case Some(ne) => ne.toList
-               }
-
-               ExternalDef(name, alist, resType)(region)
+             case (region, ((name, args), resType)) =>
+               ExternalDef(name, args.toList, resType)(region)
            }
        }
 
-       keySpace("external") *> externalStruct.orElse(externalDef)
+       val externalVal =
+         (argParser <* toEOL)
+           .region
+           .map { case (region, (name, resType)) =>
+             ExternalDef(name, Nil, resType)(region)
+           }
+
+       keySpace("external") *> P.oneOf(externalStruct :: externalDef :: externalVal :: Nil)
      }
 
      val struct =
@@ -318,14 +321,14 @@ object Statement {
         Doc.text("enum ") + Document[Constructor].document(nm) + taDoc + Doc.char(':') +
           colonSep +
           indentedCons + Doc.line
+      case ExternalDef(name, Nil, res) =>
+        Doc.text("external ") + Document[Bindable].document(name) + Doc.text(": ") + res.toDoc + Doc.line
       case ExternalDef(name, args, res) =>
-        val argDoc = args match {
-          case Nil => Doc.empty
-          case nonEmpty =>
-            val da = Doc.intercalate(Doc.text(", "), nonEmpty.map { case (n, tr) =>
-              Document[Bindable].document(n) + Doc.text(": ") + tr.toDoc
-            })
-            Doc.char('(') + da + Doc.char(')')
+        val argDoc = {
+          val da = Doc.intercalate(Doc.text(", "), args.map { case (n, tr) =>
+            Document[Bindable].document(n) + Doc.text(": ") + tr.toDoc
+          })
+          Doc.char('(') + da + Doc.char(')')
         }
         Doc.text("external def ") + Document[Bindable].document(name) + argDoc + Doc.text(" -> ") + res.toDoc + Doc.line
       case ExternalStruct(nm, targs) =>

--- a/core/src/test/scala/org/bykn/bosatsu/DeclarationTest.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/DeclarationTest.scala
@@ -1,5 +1,6 @@
 package org.bykn.bosatsu
 
+import cats.data.NonEmptyList
 import org.scalacheck.Gen
 import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks.{ forAll, PropertyCheckConfiguration }
 
@@ -122,10 +123,10 @@ class DeclarationTest extends AnyFunSuite {
           val b = Identifier.Backticked("")
           val d1 = Literal(Lit.fromInt(0))
           val d0 = DefFn(
-            DefStatement(Name("mfLjwok"),List(),None,
+            DefStatement(Name("mfLjwok"),NonEmptyList.of(Pattern.Var(Name("foo"))),None,
               (NotSameLine(Padding(10,Indented(10,Var(Backticked(""))))),
                 Padding(10,Binding(BindingStatement(
-                  Pattern.Var(Backticked("")),Var(Constructor("Rgt")),Padding(1,DefFn(DefStatement(Backticked(""),List(),None,(NotSameLine(Padding(2,Indented(4,Literal(Lit.fromInt(42))))),Padding(2,DefFn(DefStatement(Name("gkxAckqpatu"),List(),Some(TypeRef.TypeName(TypeName(Constructor("Y")))),(NotSameLine(Padding(6,Indented(8,Literal(Lit("oimsu"))))),Padding(2,Var(Name("j")))))))))))))))))
+                  Pattern.Var(Backticked("")),Var(Constructor("Rgt")),Padding(1,DefFn(DefStatement(Backticked(""),NonEmptyList.of(Pattern.Var(Name("bar"))),None,(NotSameLine(Padding(2,Indented(4,Literal(Lit.fromInt(42))))),Padding(2,DefFn(DefStatement(Name("gkxAckqpatu"),NonEmptyList.of(Pattern.Var(Name("quux"))),Some(TypeRef.TypeName(TypeName(Constructor("Y")))),(NotSameLine(Padding(6,Indented(8,Literal(Lit("oimsu"))))),Padding(2,Var(Name("j")))))))))))))))))
 
           (b, d1, d0)
         }

--- a/core/src/test/scala/org/bykn/bosatsu/DefRecursionCheckTest.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/DefRecursionCheckTest.scala
@@ -37,26 +37,22 @@ x = x.plus(1)
 """)
     // shadowing is okay
     allowed("""#
-def foo:
+foo = (
   x = 1
   x = 1.plus(1)
-  x
-""")
-
-    disallowed("""#
-def foo: foo
+  x)
 """)
 
     // typechecking catches this issue
     allowed("""#
-def foo:
+foo = (
   x = x
-  x
+  x)
 """)
     allowed("""#
-def foo:
+foo = (
   x = 1
-  x
+  x)
 """)
   }
 

--- a/core/src/test/scala/org/bykn/bosatsu/EvaluationTest.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/EvaluationTest.scala
@@ -53,9 +53,10 @@ package Foo
 
 def let(arg, in): in(arg)
 
-def foo:
+foo = (
   x <- let(3)
   x.add(1)
+)
 
 test = Assertion(foo matches 4, "checking equality")
 """), "Foo", 1)
@@ -336,17 +337,6 @@ sum1 = three.foldLeft(0, \x, y -> add(x, y))
 same = sum0.eq_Int(sum1)
 """), "Foo", True)
 
-  }
-
-  test("test zero arg defs") {
-    evalTest(
-      List("""
-package Foo
-
-def foo: 42
-
-main = foo
-"""), "Foo", VInt(42))
   }
 
   test("test Int functions") {
@@ -1793,9 +1783,10 @@ package A
 
 struct Pair(first, second)
 
-def res:
+res = (
   Pair { first, ... } = Pair(1, 2)
   first
+)
 
 tests = TestSuite("test record",
   [
@@ -2053,11 +2044,11 @@ tests = TestSuite("test record",
   test("test ordered shadowing issue #328") {
     runBosatsuTest(List("""package A
 
-def one: 1
+one = 1
 
 two = one.add(1)
 
-def one: "one"
+one = "one"
 
 good = match (one, two):
   case ("one", 2): True
@@ -2074,13 +2065,13 @@ tests = TestSuite("test",
 
 struct Foo(one)
 
-def one: 1
+one = 1
 
 two = one.add(1)
 
 foo = Foo { one }
 
-def one: "one"
+one = "one"
 
 good = match (one, two, foo):
   case ("one", 2, Foo(1)): True
@@ -2095,14 +2086,14 @@ tests = TestSuite("test",
     // test local shadowing of a duplicate
     runBosatsuTest(List("""package A
 
-def one: 1
+one = 1
 
 two = one.add(1)
 
 incA = \one -> one.add(1)
 def incB(one): one.add(1)
 
-def one: "one"
+one = "one"
 
 good = match (one, two, incA(0), incB(1)):
   case ("one", 2, 1, 2): True
@@ -2315,9 +2306,10 @@ package A
 
 x: Int = 1
 
-def y:
+y = (
   z: Int = x
   z
+)
 
 tests = Assertion(y.eq_Int(x), "none")
 """), "A", 1)
@@ -2327,9 +2319,10 @@ package A
 
 x: Int = 1
 
-def y:
+y = (
   z: Int = x
   z: Int
+)
 
 tests = Assertion(y.eq_Int(x), "none")
 """), "A", 1)
@@ -2415,10 +2408,11 @@ test = Assertion(three.eq_Int(3), "let inside apply")
   runBosatsuTest(List("""
 package A
 
-def substitute:
+substitute = (
   x = 40
   y = x.add(1)
   y.add(1)
+)
 
 test = Assertion(substitute.eq_Int(42), "basis substitution")
 """), "A", 1)

--- a/core/src/test/scala/org/bykn/bosatsu/FreeVarTest.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/FreeVarTest.scala
@@ -23,7 +23,7 @@ class FreeVarTest extends AnyFunSuite {
   test("freeVar examples") {
     assertFreeVars("""x = y""", List("y"))
     assertFreeVars("""y = 1""", Nil)
-    assertFreeVars("""external def foo -> Int""", Nil)
+    assertFreeVars("""external foo: Int""", Nil)
     assertFreeVars("""def foo(x): y""", List("y"))
     assertFreeVars("""def foo(x):
   y = x

--- a/core/src/test/scala/org/bykn/bosatsu/Gen.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/Gen.scala
@@ -145,7 +145,7 @@ object Generators {
   def defGen[T](dec: Gen[T]): Gen[DefStatement[Pattern.Parsed, T]] =
     for {
       name <- bindIdentGen
-      args <- Gen.listOf(argGen)
+      args <- nonEmpty(argGen)
       retType <- Gen.option(typeRefGen)
       body <- dec
     } yield DefStatement(name, args.map(argToPat), retType, body)

--- a/core/src/test/scala/org/bykn/bosatsu/TypedExprTest.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/TypedExprTest.scala
@@ -111,12 +111,13 @@ y = 1
     checkLast("""#
 struct Tup2(a, b)
 
-def inner:
+inner = (
   z = 1
   fn = Tup2
   x = fn(z, 2)
   match x:
     case Tup2(a, _): a
+)
 """) {
       case TypedExpr.Literal(lit, _, _) => assert(lit == Lit.fromInt(1))
       case notLit => fail(s"expected Literal got: ${notLit.repr}")
@@ -125,10 +126,11 @@ def inner:
     checkLast("""#
 struct Tup2(a, b)
 
-def inner:
+inner = (
   x = Tup2(1, 2)
   match x:
     case Tup2(a, _): a
+)
 
 y = inner
 """) {
@@ -204,7 +206,7 @@ y = match x:
     checkLast("""#
 enum E: Left(l), Right(r)
 
-def inner:
+inner = (
   x = Left(1)
   z = 1
   match x:
@@ -213,6 +215,7 @@ def inner:
       match z:
         case 1: 1
         case _: r
+)
 """) {
       case TypedExpr.Literal(lit, _, _) => assert(lit == Lit.fromInt(1))
       case notLit => fail(s"expected Literal got: ${notLit.repr}")
@@ -638,10 +641,11 @@ y = match x:
 
     checkLast(
       """
-def foo:
+foo = (
   x = 1
   _ = x
   42
+)
 """) { te => assert(countLet(te) == 0) }
   }
 

--- a/core/src/test/scala/org/bykn/bosatsu/rankn/RankNInferTest.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/rankn/RankNInferTest.scala
@@ -382,7 +382,7 @@ main = y
   test("test inference with partial def annotation") {
     parseProgram("""#
 
-def ident -> forall a. a -> a:
+ident: forall a. a -> a =
   \x -> x
 
 main = ident(1)
@@ -412,9 +412,10 @@ def swap_maybe(x: a, y, swap) -> Pair[a, a]:
     case T: Pair(y, x)
     case F: Pair(x, y)
 
-def res:
+res = (
   Pair(r, _) = swap_maybe(1, 2, F)
   r
+)
 
 main = res
 """, "Int")
@@ -427,9 +428,10 @@ struct Pair(fst: a, snd: a)
 def mkPair(y, x: a):
   Pair(x, y)
 
-def fst:
+fst = (
   Pair(f, _) = mkPair(1, 2)
   f
+)
 
 main = fst
 """, "Int")
@@ -562,7 +564,7 @@ main = use_bind(None, None, None, option_monad)
 
 struct Foo
 
-def fst -> Foo: Foo
+fst: Foo = Foo
 
 main = fst
 """, "Foo")
@@ -572,7 +574,7 @@ main = fst
 enum Foo:
   Bar, Baz(a)
 
-def fst -> Foo[a]: Bar
+fst: Foo[a] = Bar
 
 main = fst
 """, "forall a. Foo[a]")
@@ -961,27 +963,30 @@ d = c
 struct Foo
 struct Bar
 
-def x:
+x = (
   f = Foo
   f: Bar
+)
 """)
 
     parseProgramIllTyped("""#
 struct Foo
 struct Bar
 
-def x:
+x = (
   f: Bar = Foo
   f
+)
 """)
     parseProgramIllTyped("""#
 struct Pair(a, b)
 struct Foo
 struct Bar
 
-def x:
+x = (
   Pair(f: Bar, g) = Pair(Foo, Foo)
   f
+)
 """)
 
     parseProgramIllTyped("""#
@@ -989,9 +994,10 @@ struct Pair(a, b)
 struct Foo
 struct Bar
 
-def x:
+x = (
   Pair(f, g) = Pair(Foo: Bar, Foo)
   f
+)
 """)
 
     parseProgramIllTyped("""#
@@ -1005,18 +1011,20 @@ x: Bar = Foo
 struct Foo
 struct Bar
 
-def x:
+x = (
   f = Foo
   f: Foo
+)
 """, "Foo")
 
     parseProgram("""#
 struct Foo
 struct Bar
 
-def x:
+x = (
   f: Foo = Foo
   f
+)
 """, "Foo")
     parseProgram("""#
 struct Pair(a, b)
@@ -1024,19 +1032,21 @@ struct Foo
 
 def ignore(_): Foo
 
-def x:
+x = (
   Pair(f: Foo, g) = Pair(Foo, Foo)
   _ = ignore(g)
   f
+)
 """, "Foo")
 
     parseProgram("""#
 struct Pair(a, b)
 struct Foo
 
-def x:
+x = (
   Pair(f, _) = Pair(Foo: Foo, Foo)
   f
+)
 """, "Foo")
 
     parseProgram("""#
@@ -1051,12 +1061,13 @@ x: Foo = Foo
 struct Foo
 
 # this should just be: type Foo
-def foo:
+foo = (
   # TODO, we would like this test to pass with
   # the annotations below
   #def ident(x: a) -> a: x
   def ident(x): x
   ident(Foo)
+)
 
 """, "Foo")
   }

--- a/docs/language_guide.md
+++ b/docs/language_guide.md
@@ -172,7 +172,8 @@ every def would be a return. Like Python chooses to omit return in `lambda` expr
 to remove `return` entirely from bosatsu.
 
 All functions internally are functions of a single value returning a single value. We have syntax to
-call multiple variable functions, but that is just syntactic sugar over curried functions.
+call multiple variable functions, but that is just syntactic sugar over curried functions. All def statements
+require at least one argument since they all are functions.
 
 So, we can write:
 ```

--- a/test_workspace/AvlTree.bosatsu
+++ b/test_workspace/AvlTree.bosatsu
@@ -229,7 +229,7 @@ contains_i = \tree, i -> (contains_i_opt(tree, i) matches Some(_))
 
 def not(x): False if x else True
 
-def contains_test:
+contains_test = (
     def add_law(t, i, msg):
         Assertion(t.add_i(i).contains_i(i), msg)
 
@@ -244,6 +244,7 @@ def contains_test:
       missing_law(single_i(2).rem_i(2), 2, "Empty + 2 - 2, !contains(2)"),
       missing_law(single_i(2).rem_i(2).rem_i(2), 2, "Empty + 2 - 2, !contains(2)")
     ])
+)
 
 def eq_i(a, b):
     cmp_Int(a, b) matches EQ
@@ -260,7 +261,7 @@ def rem_decreases_size(t, i, msg):
     diff_one = eq_i(s0.sub(s1), 1)
     Assertion(diff_one, msg)
 
-def size_tests:
+size_tests = (
     TestSuite('size tests', [
       add_increases_size(Empty, 1, "Empty.add(1)"),
       add_increases_size(single_i(1), 2, "single(1).add(2)"),
@@ -268,6 +269,7 @@ def size_tests:
       rem_decreases_size(single_i(1), 1, "single(1) - 1"),
       rem_decreases_size(single_i(2).add_i(3), 2, "single(2) + 3 - 2"),
     ])
+)
 
 def log2(i):
      int_loop(i, 0, \n, cnt ->
@@ -276,7 +278,7 @@ def log2(i):
 
 def all_n(n): range(n).foldLeft(Empty)(add_i)
 
-def height_tests:
+height_tests =(
     # h < c log_2(n + 2) + b, c ~= 1.44, b ~= -1.33
     # we can weaken this to: 3/2 * log_2(n + 2)
     def size_law(n):
@@ -291,8 +293,9 @@ def height_tests:
     TestSuite("height_tests", [
       size_law(n) for n in range(30)
     ])
+)
 
-def fold_left_tests:
+fold_left_tests = (
   TestSuite("fold_left_tests", [
     Assertion(all_n(100).fold_left_Tree(0, \i, _ -> i.add(1)).eq_i(100), "sum 100"),
     Assertion(all_n(100).fold_left_Tree(0, max).eq_i(99), "max 100"),
@@ -301,8 +304,9 @@ def fold_left_tests:
           -1: i
           _: acc).eq_i(0), "first is 0"),
   ])
+)
 
-def fold_right_tests:
+fold_right_tests = (
   TestSuite("fold_right_tests", [
     Assertion(all_n(100).fold_right_Tree(0, \_, i -> i.add(1)).eq_i(100), "sum 100"),
     Assertion(all_n(100).fold_right_Tree(0, max).eq_i(99), "max 100"),
@@ -311,6 +315,7 @@ def fold_right_tests:
           -1: i
           _: acc).eq_i(99), "last is 99"),
   ])
+)
 
 tests = TestSuite("AvlTree tests", [
     contains_test,

--- a/test_workspace/List.bosatsu
+++ b/test_workspace/List.bosatsu
@@ -87,15 +87,17 @@ operator =*= = eq_List(eq_Int)
 
 def not(x): False if x else True
 
-def headTest:
+headTest = (
     res = head([1, 2, 3]) matches Some(1)
     Assertion(res, "head test")
+)
 
-def unconsTest:
+unconsTest = (
     res = uncons([1, 2, 3]) matches Some((1, [2, 3]))
     Assertion(res, "uncons test")
+)
 
-def zipTest:
+zipTest = (
     test1 = zip([1, 2], ["1", "2"]) matches [(1, "1"), (2, "2")]
 
     test2 = zip([1], ["1", "2"]) matches [(1, "1")]
@@ -107,8 +109,9 @@ def zipTest:
       Assertion(test2, "left smaller"),
       Assertion(test3, "right smaller"),
     ])
+)
 
-def sortTest:
+sortTest = (
     sort_Int = sort(Order(cmp_Int))
     test1 = sort_Int([3, 1, 2]) matches [1, 2, 3]
     test2 = sort_Int([1, 2, 3]) matches [1, 2, 3]
@@ -121,6 +124,7 @@ def sortTest:
       Assertion(test3, "2, 3, 1"),
       Assertion(test4, "1, 2, 1"),
     ])
+)
 
 tests = TestSuite("List tests", [
   Assertion([1, 2, 3] =*= [1, 2, 3], "list [1, 2, 3]"),


### PR DESCRIPTION
The idea here is in general there should only be one way to do things.

With blocks like:
```
x = (
  y = 1
  f(y)
)
```

We don't really need `def x:`.

This also has the nice side effect that `def` *always* defines a function now and has a more regular syntax: there is always a `(` after def.

This requires adding `external foo: Int` as a valid syntax for values, but that is more regular anyway, so I think that's fine.