### PR TITLE
Add parsing of Type

### DIFF
--- a/core/src/main/scala/org/bykn/bosatsu/TypeParser.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/TypeParser.scala
@@ -1,0 +1,43 @@
+package org.bykn.bosatsu
+
+import cats.data.NonEmptyList
+import cats.parse.{Parser => P}
+
+import Parser.{ Combinators, lowerIdent, maybeSpace, keySpace }
+
+abstract class TypeParser[A] {
+  def makeVar: String => A
+  def parseName: P[A]
+  def makeFn(in: A, out: A): A
+
+  def applyTypes(cons: A, args: NonEmptyList[A]): A
+  def universal(vars: NonEmptyList[String], in: A): A
+  def makeTuple(items: List[A]): A
+
+  final val parser: P[A] = P.recursive[A] { recurse =>
+    val tvar = lowerIdent.map(makeVar)
+    val tname = parseName
+
+    val lambda =
+      (keySpace("forall") *> lowerIdent.nonEmptyList ~ (maybeSpace *> P.char('.') *> maybeSpace *> recurse))
+        .map { case (args, e) => universal(args, e) }
+
+    val tupleOrParens: P[A] =
+      recurse.tupleOrParens.map {
+        case Left(par) => par
+        case Right(tup) => makeTuple(tup)
+      }
+
+    val appP: P[A => A] =
+      (P.char('[') *> maybeSpace *> recurse.nonEmptyList <* maybeSpace <* P.char(']'))
+        .map { args => applyTypes(_, args) }
+
+    val arrowP: P[A => A] =
+      ((maybeSpace.with1.soft ~ P.string("->") ~ maybeSpace) *> recurse)
+        .map { right => makeFn(_, right) }
+
+    P.oneOf(lambda :: tvar :: tname :: tupleOrParens :: Nil)
+      .maybeAp(appP)
+      .maybeAp(arrowP)
+  }
+}

--- a/core/src/main/scala/org/bykn/bosatsu/TypeRefConverter.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/TypeRefConverter.scala
@@ -3,6 +3,7 @@ package org.bykn.bosatsu
 import cats.Applicative
 import cats.data.NonEmptyList
 import cats.implicits._
+import cats.parse.{Parser => P}
 import org.bykn.bosatsu.rankn.Type
 import org.bykn.bosatsu.Identifier.Constructor
 
@@ -22,17 +23,7 @@ object TypeRefConverter {
       case TypeName(n) => nameToType(n.ident).map(TyConst(_))
       case TypeArrow(a, b) => (toType(a), toType(b)).mapN(Fun(_, _))
       case TypeApply(a, bs) =>
-        @annotation.tailrec
-        def toType1(fn: Type, args: NonEmptyList[Type]): Type =
-          args match {
-            case NonEmptyList(a0, Nil) => TyApply(fn,a0)
-            case NonEmptyList(a0, a1 :: as) =>
-              toType1(TyApply(fn, a0), NonEmptyList(a1, as))
-          }
-        (toType(a), bs.traverse(toType)).mapN(toType1(_, _))
-      case TypeLambda(pars0, TypeLambda(pars1, e)) =>
-        // we normalize to lifting all the foralls to the outside
-        toType(TypeLambda(pars0 ::: pars1, e))
+        (toType(a), bs.toList.traverse(toType)).mapN(Type.applyAll(_, _))
       case TypeLambda(pars, e) =>
         toType(e).map { te =>
           Type.forAll(pars.map { case TypeVar(v) => Type.Var.Bound(v) }.toList, te)

--- a/core/src/test/scala/org/bykn/bosatsu/ParserTest.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/ParserTest.scala
@@ -448,6 +448,24 @@ class ParserTest extends ParserTestBase {
     }
   }
 
+  test("we can parse fully pathed types") {
+    import rankn.Type
+    import Type._
+
+    def check(s: String, t: Type) = parseTestAll(Type.fullyResolvedParser, s, t)
+
+    val varA = TyVar(Var.Bound("a"))
+    val varB = TyVar(Var.Bound("b"))
+    val FooBarBar = TyConst(Const.Defined(PackageName.parts("Foo", "Bar"), TypeName(Identifier.Constructor("Bar"))))
+    check("a", varA)
+    check("Foo/Bar::Bar", FooBarBar)
+    check("a -> Foo/Bar::Bar", Fun(varA, FooBarBar))
+    check("forall a, b. Foo/Bar::Bar[a, b]", Type.forAll(List(Var.Bound("a"), Var.Bound("b")), TyApply(TyApply(FooBarBar, varA), varB)))
+    check("forall a. forall b. Foo/Bar::Bar[a, b]", Type.forAll(List(Var.Bound("a"), Var.Bound("b")), TyApply(TyApply(FooBarBar, varA), varB)))
+    check("(a)", varA)
+    check("(a, b)", Tuple(List(varA, varB)))
+  }
+
   test("we can parse python style list expressions") {
     val pident = Parser.lowerIdent
     implicit val stringDoc: Document[String] = Document.instance[String](Doc.text(_))

--- a/core/src/test/scala/org/bykn/bosatsu/rankn/TypeTest.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/rankn/TypeTest.scala
@@ -11,6 +11,12 @@ class TypeTest extends AnyFunSuite {
     PropertyCheckConfiguration(minSuccessful = 500)
     //PropertyCheckConfiguration(minSuccessful = 5)
 
+  def parse(s: String): Type =
+    Type.fullyResolvedParser.parseAll(s) match {
+      case Right(t) => t
+      case Left(err) => sys.error(err.toString)
+    }
+
   test("free vars are not duplicated") {
     forAll(Gen.listOf(NTypeGen.genDepth03)) { ts =>
       val frees = Type.freeTyVars(ts)
@@ -81,11 +87,10 @@ class TypeTest extends AnyFunSuite {
   }
 
   test("Type.freeTyVars is empty for ForAll fully bound") {
-    val ba = Type.Var.Bound("a")
-    val fa = Type.ForAll(NonEmptyList.of(ba), Type.TyVar(ba))
+    val fa = parse("forall a. a")
     assert(Type.freeTyVars(fa :: Nil).isEmpty)
 
-    val fb = Type.ForAll(NonEmptyList.of(ba), Type.Fun(Type.TyVar(ba), Type.IntType))
+    val fb = parse("forall a. a -> Bosatsu/Predef::Int")
     assert(Type.freeTyVars(fb :: Nil).isEmpty)
   }
 


### PR DESCRIPTION
We previously could not directly parse into `Type` instead we parse into `TypeRef` and then convert in the context of the names imported in the source.

This refactors to share most of the same syntax but parsing a Type requires the fully qualified names (for things other than function or tuples).

