### PR TITLE
Remove TypeRef.fromType, which created invalid TypeRefs

### DIFF
--- a/cli/src/main/scala/org/bykn/bosatsu/PathModule.scala
+++ b/cli/src/main/scala/org/bykn/bosatsu/PathModule.scala
@@ -112,8 +112,7 @@ object PathModule extends MainModule[IO] {
         }
       case Output.EvaluationResult(_, tpe, resDoc) =>
         IO.defer {
-          val tMap = TypeRef.fromTypes(None, tpe :: Nil)
-          val tDoc = tMap(tpe).toDoc
+          val tDoc = rankn.Type.fullyResolvedDocument.document(tpe)
 
           val doc = resDoc.value + (Doc.lineOrEmpty + Doc.text(": ") + tDoc).nested(4)
           print(doc.render(100))

--- a/core/src/main/scala/org/bykn/bosatsu/DefRecursionCheck.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/DefRecursionCheck.scala
@@ -43,7 +43,7 @@ object DefRecursionCheck {
   case class RecurNotOnArg(decl: Declaration.Match, fnname: Bindable, args: NonEmptyList[Pattern.Parsed]) extends RecursionError {
     def region = decl.region
     def message = {
-      val argStr = args.iterator.map { pat => Pattern.document.document(pat).render(80) }.mkString(", ")
+      val argStr = args.iterator.map { pat => Pattern.document[TypeRef].document(pat).render(80) }.mkString(", ")
       s"recur not on an argument to the def of ${fnname.sourceCodeRepr}, args: $argStr"
     }
   }

--- a/core/src/main/scala/org/bykn/bosatsu/Pattern.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/Pattern.scala
@@ -651,8 +651,8 @@ object Pattern {
         }
     }
 
-  implicit lazy val document: Document[Parsed] =
-    Document.instance[Parsed] {
+  implicit def document[T: Document]: Document[Pattern[StructKind, T]] =
+    Document.instance[Pattern[StructKind, T]] {
       case WildCard => Doc.char('_')
       case Literal(lit) => Document[Lit].document(lit)
       case Var(n) => Document[Identifier].document(n)
@@ -688,7 +688,7 @@ object Pattern {
          *   3. at the top level we need parens to distinguish a: Integer from being the rhs of a
          *      case
          */
-        document.document(p) + Doc.text(": ") + Document[TypeRef].document(t)
+        document.document(p) + Doc.text(": ") + Document[T].document(t)
       case PositionalStruct(n, Nil) =>
         n match {
           case StructKind.Tuple =>
@@ -743,7 +743,7 @@ object Pattern {
               Doc.text(" }")
         }
       case Union(head, rest) =>
-        def doc(p: Parsed): Doc =
+        def doc(p: Pattern[StructKind, T]): Doc =
           p match {
             case Annotation(_, _) | Union(_, _) =>
               // if an annotation or union is embedded, we need to put parens for parsing

--- a/core/src/main/scala/org/bykn/bosatsu/TypeRef.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/TypeRef.scala
@@ -1,7 +1,6 @@
 package org.bykn.bosatsu
 
-import cats.Applicative
-import cats.data.{NonEmptyList, State}
+import cats.data.NonEmptyList
 import cats.implicits._
 import cats.parse.{Parser => P}
 import org.bykn.bosatsu.rankn.Type
@@ -60,50 +59,6 @@ object TypeRef {
 
   case class TypeLambda(params: NonEmptyList[TypeVar], in: TypeRef) extends TypeRef
   case class TypeTuple(params: List[TypeRef]) extends TypeRef
-
-  def fromTypeA[F[_]: Applicative](
-    tpe: Type,
-    onSkolem: Type.Var.Skolem => F[TypeRef],
-    onMeta: Long => F[TypeRef],
-    onConst: Type.Const.Defined => F[TypeRef]): F[TypeRef] = {
-    import Type._
-    def loop(tpe: Type) = fromTypeA(tpe, onSkolem, onMeta, onConst)
-
-    tpe match {
-      case ForAll(vs, in) =>
-        val args = vs.map { case Type.Var.Bound(b) => TypeVar(b) }
-        loop(in).map(TypeLambda(args, _))
-      case Type.Tuple(ts) =>
-        // this needs to be above TyConst
-        ts.traverse(loop(_)).map(TypeTuple(_))
-      case TyConst(defined@Type.Const.Defined(_, _)) =>
-        onConst(defined)
-      case Type.Fun(from, to) =>
-        (loop(from), loop(to)).mapN { (ftr, ttr) =>
-          TypeArrow(ftr, ttr)
-        }
-      case ta@TyApply(_, _) =>
-        val (on, args) = unapplyAll(ta)
-        (loop(on), args.traverse(loop)).mapN {
-          (of, arg1) =>
-            TypeApply(of, NonEmptyList.fromListUnsafe(arg1))
-        }
-      case TyVar(tv) =>
-        tv match {
-          case Type.Var.Bound(v) =>
-            Applicative[F].pure(TypeVar(v))
-          case sk@Type.Var.Skolem(_, _) =>
-            onSkolem(sk)
-        }
-      case TyMeta(Type.Meta(id, _)) =>
-        onMeta(id)
-      // $COVERAGE-OFF$
-      case other =>
-        // the extractors mess this up
-        sys.error(s"unreachable: $other")
-        // $COVERAGE-ON$
-    }
-  }
 
   implicit val typeRefOrdering: Ordering[TypeRef] =
     new Ordering[TypeRef] {
@@ -190,55 +145,5 @@ object TypeRef {
 
   val annotationParser: P[TypeRef] =
     maybeSpace.with1.soft *> P.char(':') *> maybeSpace *> parser
-
-  /**
-   * In a given PackageName, convert the
-   * Type back to a TypeRef, which should parse correctly for non-meta
-   * types
-   *
-   * A common use case it to build up all the types you are going to work
-   * with into the map, then consult the map as needed to convert them back
-   * to TypeRef
-   */
-  def fromTypes(pack: Option[PackageName], tpes: List[Type]): Map[Type, TypeRef] = {
-    type S = (Map[Long, TypeRef], LazyList[String])
-    def encodeSkolem(sk: Type.Var.Skolem): State[S, TypeRef] =
-      // Make use a typevar
-      State.pure(TypeRef.TypeVar("$" + s"${sk.name}${sk.id}"))
-
-    def encodeMeta(id: Long): State[S, TypeRef] =
-      State { s: S =>
-        val (idMap, vars) = s
-        idMap.get(id) match {
-          case Some(tr) => (s, tr)
-          case None =>
-            val nextId = vars.head
-            val tr = TypeRef.TypeVar("?" + nextId)
-            val nextMap = idMap.updated(id, tr)
-            ((nextMap, vars.tail), tr)
-        }
-      }
-
-    def onConst(c: Type.Const.Defined): State[S, TypeRef] = {
-      val Type.Const.Defined(pn, n) = c
-      val tn: TypeName =
-        if (Some(pn) == pack) TypeName(n)
-        else TypeName(Name(Identifier.Constructor(s"${pn.asString}::${n.ident.asString}")))
-
-      State.pure(tn)
-    }
-
-    val state0: S = (Map.empty, Type.allBinders.map(_.name))
-    tpes.traverse { tpe =>
-      TypeRef.fromTypeA[State[S, *]](
-        tpe,
-        encodeSkolem _,
-        encodeMeta _,
-        onConst _).map { tr => (tpe, tr) }
-    }
-    .runA(state0)
-    .value
-    .toMap
-  }
 }
 

--- a/core/src/main/scala/org/bykn/bosatsu/TypedExpr.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/TypedExpr.scala
@@ -50,11 +50,7 @@ sealed abstract class TypedExpr[+T] { self: Product =>
   // TODO: we need to make sure this parsable and maybe have a mode that has the compiler
   // emit these
   def repr: String = {
-    val tfn = TypeRef.fromTypes(None, this.allTypes.toList)
-
-    // We need a consistent naming for meta variables,
-    // so build this table once
-    def rept(t: Type): Doc = tfn(t).toDoc
+    def rept(t: Type): Doc = Type.fullyResolvedDocument.document(t)
 
     def loop(te: TypedExpr[T]): Doc = {
       te match {

--- a/core/src/main/scala/org/bykn/bosatsu/rankn/Infer.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/rankn/Infer.scala
@@ -13,7 +13,6 @@ import org.bykn.bosatsu.{
   Pattern => GenPattern,
   Region,
   RecursionKind,
-  TypeRef,
   TypedExpr,
   Variance}
 
@@ -129,8 +128,7 @@ object Infer {
 
     case class NotUnifiable(left: Type, right: Type, leftRegion: Region, rightRegion: Region) extends TypeError {
       def message = {
-        val tStrMap = TypeRef.fromTypes(None, left :: right :: Nil)
-        def tStr(t: Type): String = tStrMap(t).toDoc.render(80)
+        def tStr(t: Type): String = Type.fullyResolvedDocument.document(t).render(80)
         s"${tStr(left)} ($leftRegion) cannot be unified with ${tStr(right)} ($rightRegion)"
       }
     }
@@ -138,8 +136,7 @@ object Infer {
     case class NotPolymorphicEnough(tpe: Type, in: Expr[_], badTvs: NonEmptyList[Type.Var.Skolem], reg: Region) extends TypeError {
       def message = {
         val bads = badTvs.map(Type.TyVar(_))
-        val tStrMap = TypeRef.fromTypes(None, tpe :: bads.toList)
-        def tStr(t: Type): String = tStrMap(t).toDoc.render(80)
+        def tStr(t: Type): String = Type.fullyResolvedDocument.document(t).render(80)
         s"type ${tStr(tpe)} not polymorphic enough in $in, bad type variables: ${bads.map(tStr).toList.mkString(", ")}, at $reg"
       }
     }
@@ -147,8 +144,7 @@ object Infer {
     case class SubsumptionCheckFailure(inferred: Type, declared: Type, infRegion: Region, decRegion: Region, badTvs: NonEmptyList[Type.Var]) extends TypeError {
       def message = {
         val bads = badTvs.map(Type.TyVar(_))
-        val tStrMap = TypeRef.fromTypes(None, inferred :: declared :: bads.toList)
-        def tStr(t: Type): String = tStrMap(t).toDoc.render(80)
+        def tStr(t: Type): String = Type.fullyResolvedDocument.document(t).render(80)
         s"subsumption check failed: ${tStr(inferred)} ${tStr(declared)}, bad types: ${bads.map(tStr).toList.mkString(", ")}"
       }
     }

--- a/core/src/test/scala/org/bykn/bosatsu/EvaluationTest.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/EvaluationTest.scala
@@ -1563,7 +1563,7 @@ def fn(x, y):
 
 main = fn(0, 1, 2)
 """)) { case te@PackageError.TypeErrorIn(_, _) =>
-      assert(te.message(Map.empty, Colorize.None) == "in file: <unknown source>, package A, type error: expected type Bosatsu/Predef::Int to be the same as type ?a -> ?b\nhint: this often happens when you apply the wrong number of arguments to a function.\nRegion(73,84)")
+      assert(te.message(Map.empty, Colorize.None) == "in file: <unknown source>, package A, type error: expected type Bosatsu/Predef::Int to be the same as type ?2 -> ?3\nhint: this often happens when you apply the wrong number of arguments to a function.\nRegion(73,84)")
       ()
     }
 
@@ -2629,7 +2629,7 @@ from Foo import bar
 
 x = bar
 """ :: Nil) { case sce =>
-      assert(sce.message(Map.empty, Colorize.None) == "in <unknown source> export bar of type Bar references private type Bar")
+      assert(sce.message(Map.empty, Colorize.None) == "in <unknown source> export bar of type Foo::Bar references private type Foo::Bar")
       ()
     }
   }

--- a/core/src/test/scala/org/bykn/bosatsu/TestUtils.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/TestUtils.scala
@@ -45,7 +45,7 @@ object TestUtils {
       }
     te.traverseType[cats.Id](checkType)
     val tp = te.getType
-    lazy val teStr = TypeRef.fromTypes(None, tp :: Nil)(tp).toDoc.render(80)
+    lazy val teStr = Type.fullyResolvedDocument.document(tp).render(80)
     scala.Predef.require(Type.freeTyVars(tp :: Nil).isEmpty,
       s"illegal inferred type: $teStr in: ${te.repr}")
 

--- a/core/src/test/scala/org/bykn/bosatsu/TotalityTest.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/TotalityTest.scala
@@ -1,7 +1,7 @@
 package org.bykn.bosatsu
 
 import cats.Eq
-import cats.data.{Chain, NonEmptyList, Writer}
+import cats.data.NonEmptyList
 import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks.{ forAll, PropertyCheckConfiguration }
 import org.scalacheck.Gen
 
@@ -32,14 +32,13 @@ class TotalityTest extends SetOpsLaws[Pattern[(PackageName, Constructor), Type]]
     Generators.genCompiledPattern(5, useUnion = false, useAnnotation = false)
 
   def showPat(pat: Pattern[(PackageName, Constructor), Type]): String = {
-    val allTypes = pat.traverseType { t => Writer(Chain.one(t), ()) }.run._1.toList
-    val toStr = TypeRef.fromTypes(None, allTypes)
     val pat0 = pat.mapName {
       case (_, n) =>
         Pattern.StructKind.Named(n, Pattern.StructKind.Style.TupleLike)
-    }.mapType { t => toStr(t) }
+    }
 
-    Document[Pattern.Parsed].document(pat0).render(80)
+    implicit val tdoc = Type.fullyResolvedDocument
+    Document[Pattern[Pattern.StructKind, Type]].document(pat0).render(80)
   }
 
   def showPats(pats: List[Pattern[(PackageName, Constructor), Type]]): String =

--- a/core/src/test/scala/org/bykn/bosatsu/TypeRefTest.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/TypeRefTest.scala
@@ -22,8 +22,15 @@ class TypeRefTest extends AnyFunSuite {
 
     forAll(typeRefGen) { tr =>
       val tpe = TypeRefConverter[cats.Id](tr) { c => Type.Const.Defined(pn, TypeName(c)) }
-      val tr1 = TypeRef.fromTypes(Some(pn), tpe :: Nil)(tpe)
-      assert(tr1 == tr.normalizeForAll)
+      val tr1 = TypeRefConverter.fromTypeA[Option](tpe,
+        { _ => None },
+        { _ => None },
+        {
+          case Type.Const.Defined(p, t) if p == pn => Some(TypeRef.TypeName(t))
+          case _ => None
+        })
+
+      assert(tr1 == Some(tr.normalizeForAll))
     }
   }
 }

--- a/core/src/test/scala/org/bykn/bosatsu/rankn/RankNInferTest.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/rankn/RankNInferTest.scala
@@ -127,7 +127,7 @@ class RankNInferTest extends AnyFunSuite {
       // make sure we can render repr:
       val rendered = te.repr
       val tp = te.getType
-      lazy val teStr = TypeRef.fromTypes(None, tp :: Nil)(tp).toDoc.render(80)
+      lazy val teStr = Type.fullyResolvedDocument.document(tp).render(80)
       assert(Type.freeTyVars(tp :: Nil).isEmpty, s"illegal inferred type: $teStr, in: $rendered")
 
       assert(Type.metaTvs(tp :: Nil).isEmpty,

--- a/core/src/test/scala/org/bykn/bosatsu/rankn/TypeTest.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/rankn/TypeTest.scala
@@ -60,6 +60,22 @@ class TypeTest extends AnyFunSuite {
     }
 
     forAll(NTypeGen.genDepth03)(law(_))
+
+
+    forAll(NTypeGen.lowerIdent, Gen.choose(Long.MinValue, Long.MaxValue)) { (b, id) =>
+      val str = "$" + b + "$" + id.toString
+      val tpe = parse(str)
+      law(tpe)
+      tpe match {
+        case Type.TyVar(Type.Var.Skolem(b1, i1)) =>
+          assert((b1, i1) == (b, id))
+        case other => fail(other.toString)
+      }
+    }
+
+    forAll { l: Long =>
+      assert(parse("?" + l.toString).asInstanceOf[Type.TyMeta].toMeta.id == l)
+    }
   }
 
   test("test all binders") {

--- a/jsapi/src/main/scala/org/bykn/bosatsu/jsapi/JsApi.scala
+++ b/jsapi/src/main/scala/org/bykn/bosatsu/jsapi/JsApi.scala
@@ -38,9 +38,8 @@ object JsApi {
     module.runWith(files)("eval" :: main ::: makeInputArgs(files.keys)) match {
       case Left(err) =>
         new Error(s"error: ${err.getMessage}")
-      case Right(module.Output.EvaluationResult(res, tpe, resDoc)) =>
-          val tMap = TypeRef.fromTypes(None, tpe :: Nil)
-          val tDoc = tMap(tpe).toDoc
+      case Right(module.Output.EvaluationResult(_, tpe, resDoc)) =>
+          val tDoc = rankn.Type.fullyResolvedDocument.document(tpe)
           val doc = resDoc.value + (Doc.lineOrEmpty + Doc.text(": ") + tDoc).nested(4)
         new EvalSuccess(doc.render(80))
       case Right(other) =>


### PR DESCRIPTION
Since Type has skolems, metas and full package names, and TypeRef has none of these things, TypeRef was abused to get access to Document capabilities of TypeRef.

With #829 and #831 we added this capability to Type.

Here we removed almost all the unsoundness.

There is one wart here: parsing a meta is impossible because it has a mutable cell that is allocated in a monadic context. We can't do that while parsing so we allocate that cell to be null.

In practice this shouldn't be a problem since we only create meta variables during inference, and when inference succeeds, they should all be gone. It would be nice to find a way to statically verify that however.