### PR TITLE
Remove cyclic dependencies, re-enable acyclic

### DIFF
--- a/bench/src/main/scala/org/bykn/bosatsu/TestBench.scala
+++ b/bench/src/main/scala/org/bykn/bosatsu/TestBench.scala
@@ -32,7 +32,7 @@ class TestBench {
     }
 
     implicit val show: Show[(String, LocationMap)] = Show.show { case (s, _) => s }
-    PackageMap.resolveThenInfer(Predef.withPredefA(("predef", LocationMap("")), parsedPaths), Nil).strictToValidated match {
+    PackageMap.resolveThenInfer(PackageMap.withPredefA(("predef", LocationMap("")), parsedPaths), Nil).strictToValidated match {
       case Validated.Valid(packMap) =>
         (packMap, mainPack)
       case other => sys.error(s"expected clean compilation: $other")

--- a/build.sbt
+++ b/build.sbt
@@ -151,17 +151,15 @@ lazy val core = (crossProject(JSPlatform, JVMPlatform).crossType(CrossType.Pure)
         scalaTest.value % Test,
         scalaTestPlusScalacheck.value % Test,
         // needed for acyclic which we run periodically, not all the time
-        //"com.lihaoyi" %% "acyclic" % "0.1.7" % "provided"
+        "com.lihaoyi" % "acyclic_2.13.7" % "0.3.0" % "provided"
       )
-      /*
       // periodically we use acyclic to ban cyclic dependencies and make compilation faster
       ,
       autoCompilerPlugins := true,
 
-      addCompilerPlugin("com.lihaoyi" %% "acyclic" % "0.1.7"),
+      addCompilerPlugin("com.lihaoyi" % "acyclic_2.13.7" % "0.3.0"),
 
       scalacOptions += "-P:acyclic:force"
-      */
   )
   .dependsOn(base)
   .jsSettings(commonJsSettings)

--- a/cli/src/main/scala/org/bykn/bosatsu/TypedExprToProto.scala
+++ b/cli/src/main/scala/org/bykn/bosatsu/TypedExprToProto.scala
@@ -1376,7 +1376,7 @@ object ProtoConverter {
       }
 
       val predefIface = {
-        val iface = Package.interfaceOf(Predef.predefCompiled)
+        val iface = Package.interfaceOf(PackageMap.predefCompiled)
         (iface, ExportedName.typeEnvFromExports(iface.name, iface.exports))
       }
 

--- a/core/src/main/scala/org/bykn/bosatsu/MainModule.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/MainModule.scala
@@ -219,7 +219,7 @@ abstract class MainModule[IO[_]](implicit val moduleIOMonad: MonadError[IO, Thro
             !ifs.exists { p: Package.Interface => p.name == PackageName.PredefName }
 
           if (useInternalPredef) {
-            moduleIOMonad.pure((PackageMap.fromIterable(Predef.predefCompiled :: Nil), Nil))
+            moduleIOMonad.pure((PackageMap.fromIterable(PackageMap.predefCompiled :: Nil), Nil))
           }
           else {
             moduleIOMonad.pure((PackageMap.empty, Nil))

--- a/core/src/main/scala/org/bykn/bosatsu/Package.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/Package.scala
@@ -346,6 +346,18 @@ object Package {
 
     usedTypes.flatMap(errorFor).toList
   }
+
+  /**
+   * The parsed representation of the predef.
+   */
+  val predefPackage: Package.Parsed =
+    parser(None).parse(Predef.predefString) match {
+      case Right((_, pack)) => pack
+      case Left(err) =>
+        val idx = err.failedAtOffset
+        val lm = LocationMap(Predef.predefString)
+        sys.error(s"couldn't parse predef: ${lm.showContext(idx, 2, LocationMap.Colorize.None)} with errs: ${err}")
+    }
 }
 
 

--- a/core/src/test/scala/org/bykn/bosatsu/PackageTest.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/PackageTest.scala
@@ -130,7 +130,7 @@ main = head(data1)
 
   test("test Predef working") {
 
-    assert(Predef.predefPackage != null)
+    assert(Package.predefPackage != null)
 
     val p = parse(
 """
@@ -144,7 +144,7 @@ def maybeOne(x):
 
 main = maybeOne(42)
 """)
-    valid(resolveThenInfer(Predef.withPredef(p :: Nil)))
+    valid(resolveThenInfer(PackageMap.withPredef(p :: Nil)))
   }
 
   test("test using a renamed type") {

--- a/core/src/test/scala/org/bykn/bosatsu/TestUtils.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/TestUtils.scala
@@ -146,7 +146,7 @@ object TestUtils {
     import ExecutionContext.Implicits.global
 
     val fullParsed =
-        Predef.withPredefA(("predef", LocationMap("")), parsedPaths)
+        PackageMap.withPredefA(("predef", LocationMap("")), parsedPaths)
           .map { case ((path, _), p) => (path, p) }
 
     PackageMap
@@ -181,7 +181,7 @@ object TestUtils {
     // use parallelism to typecheck
     import ExecutionContext.Implicits.global
     val withPre =
-      Predef.withPredefA(("predef", LocationMap("")), parsedPaths)
+      PackageMap.withPredefA(("predef", LocationMap("")), parsedPaths)
 
     val withPrePaths = withPre.map { case ((path, _), p) => (path, p) }
     PackageMap.resolveThenInfer(withPrePaths, Nil).left match {


### PR DESCRIPTION
cyclic dependencies can slow down the build and often point to confused design IMO.