### PR TITLE
Add Evaluators to transpiler

### DIFF
--- a/cli/src/test/scala/org/bykn/bosatsu/PathModuleTest.scala
+++ b/cli/src/test/scala/org/bykn/bosatsu/PathModuleTest.scala
@@ -109,7 +109,7 @@ class PathModuleTest extends AnyFunSuite {
   }
 
   test("test python transpile on the entire test_workspace") {
-    val out = run(s"transpile --input_dir test_workspace/ --outdir pyout --lang python --package_root test_workspace".split("\\s+").toSeq: _*)
+    val out = run("transpile --input_dir test_workspace/ --outdir pyout --lang python --package_root test_workspace".split("\\s+").toSeq: _*)
     out match {
       case PathModule.Output.TranspileOut(_, _) =>
         assert(true)

--- a/cli/src/test/scala/org/bykn/bosatsu/codegen/python/PythonGenTest.scala
+++ b/cli/src/test/scala/org/bykn/bosatsu/codegen/python/PythonGenTest.scala
@@ -102,7 +102,7 @@ class PythonGenTest extends AnyFunSuite {
     val bosatsuPM = compileFile(natPathBosatu)
     val matchless = MatchlessFromTypedExpr.compile(bosatsuPM)
 
-    val packMap = PythonGen.renderAll(matchless, Map.empty, Map.empty)
+    val packMap = PythonGen.renderAll(matchless, Map.empty, Map.empty, Map.empty)
     val natDoc = packMap(PackageName.parts("Bosatsu", "Nat"))._2
 
     JythonBarrier.run {
@@ -149,7 +149,7 @@ class PythonGenTest extends AnyFunSuite {
     val bosatsuPM = compileFile(path)
     val matchless = MatchlessFromTypedExpr.compile(bosatsuPM)
 
-    val packMap = PythonGen.renderAll(matchless, Map.empty, Map.empty)
+    val packMap = PythonGen.renderAll(matchless, Map.empty, Map.empty, Map.empty)
     val doc = packMap(pn)._2
 
     intr.execfile(isfromString(doc.renderTrim(80)), "test.py")

--- a/core/src/main/scala/org/bykn/bosatsu/CollectionUtils.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/CollectionUtils.scala
@@ -1,0 +1,40 @@
+package org.bykn.bosatsu
+
+import cats.Order
+import cats.data.NonEmptyList
+import scala.collection.immutable.SortedMap
+import scala.util.{Success, Failure, Try}
+
+import cats.implicits._
+
+object CollectionUtils {
+  /**
+   * Either return a unique mapping from B to A, or return a pair of duplicates
+   * and the unque subset
+   */
+  def uniqueByKey[A, B: Order](as: List[A])(fn: A => B): Either[(SortedMap[B, (A, NonEmptyList[A])], SortedMap[B, A]), SortedMap[B, A]] = {
+    val m: SortedMap[B, NonEmptyList[A]] = as.groupByNel(fn)
+    def check(as: NonEmptyList[A]): Either[(A, NonEmptyList[A]), A] =
+      as match {
+        case NonEmptyList(a, Nil) =>
+          Right(a)
+        case NonEmptyList(a0, a1 :: tail) =>
+          Left((a0, NonEmptyList(a1, tail)))
+      }
+
+    val checked: SortedMap[B, Either[(A, NonEmptyList[A]), A]] = m.map { case (b, as) => (b, check(as)) }
+    val good: SortedMap[B, A] = checked.collect { case (b, Right(a)) => (b, a) }
+    val bad: SortedMap[B, (A, NonEmptyList[A])] = checked.collect { case (b, Left(a)) => (b, a) }
+
+    if (bad.isEmpty) Right(good)
+    else Left((bad, good))
+  }
+
+  def listToUnique[A, K: Order, V](l: List[A])(key: A => K, value: A => V, msg: => String): Try[SortedMap[K, V]] =
+    uniqueByKey(l)(key) match {
+      case Right(b) => Success(b.map { case (k, a) => (k, value(a)) })
+      case Left((errMap, _)) =>
+        Failure(new IllegalArgumentException(s"$msg, $errMap"))
+      }
+
+}

--- a/core/src/main/scala/org/bykn/bosatsu/CollectionUtils.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/CollectionUtils.scala
@@ -32,6 +32,7 @@ object CollectionUtils {
       // $COVERAGE-OFF$
       case _ =>
         sys.error("unreachable due to as being nonempty")
+      // $COVERAGE-ON$
     }
   }
 

--- a/core/src/main/scala/org/bykn/bosatsu/ExportedName.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/ExportedName.scala
@@ -69,13 +69,6 @@ object ExportedName {
           }
       )
 
-  private[bosatsu] def buildExportMap[T](exs: List[ExportedName[T]]): Map[Identifier, NonEmptyList[ExportedName[T]]] =
-    exs match {
-      case Nil => Map.empty
-      case h :: tail => NonEmptyList(h, tail).groupBy(_.name)
-    }
-
-
   /**
    * Build exports into referants given a typeEnv
    * The only error we have have here is if we name an export we didn't define

--- a/core/src/main/scala/org/bykn/bosatsu/Package.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/Package.scala
@@ -209,9 +209,7 @@ object Package {
       (TypeEnv[Variance], Program[TypeEnv[Variance], TypedExpr[Declaration], List[Statement]])] = {
 
     // here we make a pass to get all the local names
-    val localDefs = Statement.definitionsOf(stmts)
-    val optProg = SourceConverter(p, imps.map { i => i.copy(pack = i.pack.name) }, localDefs)
-      .toProgram(stmts)
+    val optProg = SourceConverter.toProgram(p, imps.map { i => i.copy(pack = i.pack.name) }, stmts)
       .leftMap(_.map(PackageError.SourceConverterErrorIn(_, p): PackageError).toNonEmptyList)
 
     optProg.flatMap {

--- a/core/src/main/scala/org/bykn/bosatsu/TotalityCheck.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/TotalityCheck.scala
@@ -490,11 +490,11 @@ case class TotalityCheck(inEnv: TypeEnv[Any]) {
 
           val structs = u
             .collect { case Pattern.PositionalStruct(n, a) => (n, a) }
-            .groupBy { case (n, a) => (n, a.size) }
+            .groupByNel { case (n, a) => (n, a.size) }
             .iterator
             .flatMap { case ((n, arity), as) =>
               getProd(arity)
-                .unifyUnion(as.map(_._2))
+                .unifyUnion(as.toList.map(_._2))
                 .map(Pattern.PositionalStruct(n, _): Pattern[Cons, Type])
             }
             .toList

--- a/core/src/main/scala/org/bykn/bosatsu/TypedExpr.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/TypedExpr.scala
@@ -1,6 +1,6 @@
 package org.bykn.bosatsu
 
-import cats.{Applicative, Eval, Monad, Monoid, Traverse}
+import cats.{Applicative, Eval, Monad, Traverse}
 import cats.arrow.FunctionK
 import cats.data.{NonEmptyList, Writer}
 import cats.implicits._
@@ -133,6 +133,7 @@ sealed abstract class TypedExpr[+T] { self: Product =>
         val branchFreeMax = branchFrees
           .zipWithIndex
           .flatMap { case (names, br) => names.map((_, br)) }
+          // these groupBys are okay because we sort at the end
           .groupBy(identity) // group-by-name x branch
           .map { case ((name, branch), names) => (names.length, branch, name) }
           .groupBy(_._3) // group by just the name now
@@ -333,12 +334,6 @@ object TypedExpr {
           }
         }
       case _ => None
-    }
-
-  private implicit val setM: Monoid[SortedSet[Type]] =
-    new Monoid[SortedSet[Type]] {
-      def empty = SortedSet.empty
-      def combine(a: SortedSet[Type], b: SortedSet[Type]) = a ++ b
     }
 
   implicit class InvariantTypedExpr[A](val self: TypedExpr[A]) extends AnyVal {

--- a/core/src/main/scala/org/bykn/bosatsu/ValueToJson.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/ValueToJson.scala
@@ -77,8 +77,8 @@ case class ValueToJson(getDefinedType: Type.Const => Option[DefinedType[Any]]) {
   private[this] def get[A](e: Either[UnsupportedType, A]): A =
     e match {
       case Right(a) => a
+      // $COVERAGE-OFF$
       case Left(u) =>
-        // $COVERAGE-OFF$
         sys.error(s"should have only called on a supported type: $u")
         // $COVERAGE-ON$
     }
@@ -109,8 +109,8 @@ case class ValueToJson(getDefinedType: Type.Const => Option[DefinedType[Any]]) {
               {
                 case ExternalValue(v: BigInteger) =>
                   Right(Json.JNumberStr(v.toString))
+                // $COVERAGE-OFF$this should be unreachable
                 case other =>
-                  // $COVERAGE-OFF$this should be unreachable
                   Left(IllTyped(revPath.reverse, tpe, other))
                   // $COVERAGE-ON$
               }
@@ -118,8 +118,8 @@ case class ValueToJson(getDefinedType: Type.Const => Option[DefinedType[Any]]) {
               {
                 case ExternalValue(v: String) =>
                   Right(Json.JString(v))
+                // $COVERAGE-OFF$this should be unreachable
                 case other =>
-                  // $COVERAGE-OFF$this should be unreachable
                   Left(IllTyped(revPath.reverse, tpe, other))
                   // $COVERAGE-ON$
               }

--- a/core/src/main/scala/org/bykn/bosatsu/codegen/python/Code.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/codegen/python/Code.scala
@@ -518,6 +518,15 @@ object Code {
     }
   }
 
+  /*
+   * if __name__ == "__main__":
+   *   stmt
+   */
+  def mainStatement(stmt: Statement): Statement = {
+    val cond = Op(Ident("__name__"), Const.Eq, PyString("__main__"))
+    IfStatement(NonEmptyList.of((cond, stmt)), None)
+  }
+
   def addAssign(variable: Expression, code: ValueLike): Statement =
     code match {
       case x: Expression =>

--- a/core/src/main/scala/org/bykn/bosatsu/rankn/Type.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/rankn/Type.scala
@@ -2,7 +2,7 @@ package org.bykn.bosatsu.rankn
 
 import cats.data.NonEmptyList
 import cats.parse.{Parser => P, Numbers}
-import cats.{Applicative, Eq}
+import cats.{Applicative, Eq, Order}
 import org.typelevel.paiges.{Doc, Document}
 import org.bykn.bosatsu.{PackageName, Lit, TypeName, Identifier, Parser, TypeParser}
 import scala.collection.immutable.SortedSet
@@ -24,8 +24,8 @@ object Type {
   case class TyMeta(toMeta: Meta) extends Rho
   case class TyApply(on: Type, arg: Type) extends Rho
 
-  implicit val typeOrdering: Ordering[Type] =
-    new Ordering[Type] {
+  implicit val typeOrder: Order[Type] =
+    new Order[Type] {
       val boundOrd: Ordering[Var.Bound] =
         Ordering[String].on[Var.Bound] { case Var.Bound(v) => v }
 
@@ -56,6 +56,8 @@ object Type {
           case (TyApply(_, _), _) => 1
         }
     }
+
+  implicit val typeOrdering: Ordering[Type] = typeOrder.toOrdering
 
   @annotation.tailrec
   def applyAll(fn: Type, args: List[Type]): Type =

--- a/core/src/test/scala/org/bykn/bosatsu/CollectionUtilsTest.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/CollectionUtilsTest.scala
@@ -1,0 +1,17 @@
+package org.bykn.bosatsu
+
+import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks.{ forAll, PropertyCheckConfiguration }
+import org.scalatest.funsuite.AnyFunSuite
+
+class CollectionUtilsTest extends AnyFunSuite {
+  implicit val generatorDrivenConfig =
+    //PropertyCheckConfiguration(minSuccessful = 5000)
+    PropertyCheckConfiguration(minSuccessful = 500)
+    //PropertyCheckConfiguration(minSuccessful = 5)
+
+  test("listToUnique works for maps converted to lists") {
+    forAll { m: Map[Int, Int] =>
+      assert(CollectionUtils.listToUnique(m.toList)(_._1, _._2, "").get == m)
+    }
+  }
+}

--- a/core/src/test/scala/org/bykn/bosatsu/EvaluationTest.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/EvaluationTest.scala
@@ -2629,7 +2629,7 @@ from Foo import bar
 
 x = bar
 """ :: Nil) { case sce =>
-      assert(sce.message(Map.empty, Colorize.None) == "in <unknown source> export bar of type Foo::Bar references private type Foo::Bar")
+      assert(sce.message(Map.empty, Colorize.None) == "in <unknown source> export bar of type Foo::Bar has an unexported (private) type.")
       ()
     }
   }

--- a/core/src/test/scala/org/bykn/bosatsu/TestUtils.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/TestUtils.scala
@@ -14,12 +14,11 @@ object TestUtils {
   def typeEnvOf(pack: PackageName, str: String): TypeEnv[Unit] = {
 
     val stmt = statementsOf(str)
-    val srcConv = SourceConverter(pack, Nil, Statement.definitionsOf(stmt))
-    val prog = srcConv.toProgram(stmt) match {
-        case Ior.Right(prog) => prog
-        case Ior.Both(_, prog) => prog
-        case Ior.Left(err) => sys.error(err.toString)
-      }
+    val prog = SourceConverter.toProgram(pack, Nil, stmt) match {
+      case Ior.Right(prog) => prog
+      case Ior.Both(_, prog) => prog
+      case Ior.Left(err) => sys.error(err.toString)
+    }
     TypeEnv.fromParsed(prog.types._2)
   }
 

--- a/core/src/test/scala/org/bykn/bosatsu/codegen/python/PythonGenTest.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/codegen/python/PythonGenTest.scala
@@ -55,4 +55,21 @@ class PythonGenTest extends AnyFunSuite {
       }
     }
   }
+
+  test("we can parse an example externals file") {
+    val extstr = """
+      { IO: { foo: bar.baz, quux: quux.quux_impl }, Bop: { foo: collections.queue } }
+    """
+    assert(PythonGen.externalParser.parseAll(extstr).map(_ => ()) == Right(()))
+  }
+
+  test("we can parse an example evals file") {
+    val str = """
+      {
+        IO::IO: IOPy.run_io,
+        Build/Foo::Bar: BuildImpl.run_build,
+      }
+    """
+    assert(PythonGen.evaluatorParser.parseAll(str).map(_ => ()) == Right(()))
+  }
 }


### PR DESCRIPTION
the idea here is to specify different evaluators for pure values so we never have to admit impure or illegal functions into the bosatsu code.

The motivating example is IO. We could put literally no way to run IO directly in Bosatsu, so once you get an IO, you are stuck in IO land.

But when you compile, you can generate an IO evaluator for your program, and if you run that program you could then do impure things, but evaluating pure Bosatsu code is never impure (even though a bosatsu program may be a builder of another impure program).