### PR TITLE
remove use of ExecutionContext.global

### DIFF
--- a/bench/src/main/scala/org/bykn/bosatsu/TestBench.scala
+++ b/bench/src/main/scala/org/bykn/bosatsu/TestBench.scala
@@ -53,7 +53,7 @@ gauss$n = range($n).foldLeft(0, add)
     val c = compiled0
     val ev = Evaluation(c._1, Predef.jvmExternals)
     // run the evaluation
-    val res = ev.evaluateLast(c._2).get._1.value
+    val _ = ev.evaluateLast(c._2).get._1.value
     ()
   }
 
@@ -64,7 +64,7 @@ gauss$n = range($n).foldLeft(0, add)
     val c = compiled1
     val ev = Evaluation(c._1, Predef.jvmExternals)
     // run the evaluation
-    val res = ev.evaluateLast(c._2).get._1.value
+    val _ = ev.evaluateLast(c._2).get._1.value
     ()
   }
 
@@ -138,7 +138,7 @@ max_pal = match max_pal_opt:
     val c = compiled2
     val ev = Evaluation(c._1, Predef.jvmExternals)
     // run the evaluation
-    val res = ev.evaluateLast(c._2).get._1.value
+    val _ = ev.evaluateLast(c._2).get._1.value
     ()
   }
 }

--- a/cli/src/main/scala/org/bykn/bosatsu/PathModule.scala
+++ b/cli/src/main/scala/org/bykn/bosatsu/PathModule.scala
@@ -65,6 +65,8 @@ object PathModule extends MainModule[IO] {
   def print(str: => String): IO[Unit] =
     IO(println(str))
 
+  def delay[A](a: => A): IO[A] = IO(a)
+
   def reportOutput(out: Output): IO[Unit] =
     out match {
       case Output.TestOutput(resMap, color) =>

--- a/cli/src/test/scala/org/bykn/bosatsu/TestProtoType.scala
+++ b/cli/src/test/scala/org/bykn/bosatsu/TestProtoType.scala
@@ -15,7 +15,7 @@ import java.nio.file.Path
 import Identifier.Constructor
 import org.scalatest.funsuite.AnyFunSuite
 
-class TestProtoType extends AnyFunSuite {
+class TestProtoType extends AnyFunSuite with ParTest {
   implicit val generatorDrivenConfig =
     //PropertyCheckConfiguration(minSuccessful = 5000)
     PropertyCheckConfiguration(minSuccessful = 100)

--- a/core/.js/src/main/scala/org/bykn/bosatsu/Par.scala
+++ b/core/.js/src/main/scala/org/bykn/bosatsu/Par.scala
@@ -26,8 +26,6 @@ object Par {
   def shutdownService(es: ExecutionService): Unit = es
   def ecFromService(es: ExecutionService): EC = DummyImplicit.dummyImplicit
 
-  def withEC[A](fn: EC => A): A = fn(DummyImplicit.dummyImplicit)
-
   implicit def orgByknBosatsuParFMonad: Monad[F] =
     cats.catsInstancesForId
 

--- a/core/.js/src/main/scala/org/bykn/bosatsu/Par.scala
+++ b/core/.js/src/main/scala/org/bykn/bosatsu/Par.scala
@@ -1,7 +1,5 @@
 package org.bykn.bosatsu
 
-import cats.{Monad, Id, Parallel}
-
 /**
  * This is an abstraction to handle parallel computation, not effectful
  * computation. It is used in places where we have parallelism in expensive
@@ -17,7 +15,7 @@ object Par {
     def get: A = value
   }
 
-  type F[A] = Id[A]
+  type F[A] = cats.Id[A]
   type P[A] = Box[A]
   type EC = DummyImplicit
   type ExecutionService = Unit
@@ -26,16 +24,7 @@ object Par {
   def shutdownService(es: ExecutionService): Unit = es
   def ecFromService(es: ExecutionService): EC = DummyImplicit.dummyImplicit
 
-  implicit def orgByknBosatsuParFMonad: Monad[F] =
-    cats.catsInstancesForId
-
-  // since Future has already started, standard Parallel.identity is parallel
-  implicit def orgByknBosatsuParParallel: Parallel[F] =
-    Parallel.identity
-
   @inline def start[A](a: => A): F[A] = a
-
-  @inline def now[A](a: A): F[A] = a
 
   @inline def await[A](f: F[A]): A = f
 

--- a/core/.js/src/main/scala/org/bykn/bosatsu/Par.scala
+++ b/core/.js/src/main/scala/org/bykn/bosatsu/Par.scala
@@ -1,7 +1,6 @@
 package org.bykn.bosatsu
 
 import cats.{Monad, Id, Parallel}
-import scala.concurrent.ExecutionContext
 
 /**
  * This is an abstraction to handle parallel computation, not effectful
@@ -20,16 +19,23 @@ object Par {
 
   type F[A] = Id[A]
   type P[A] = Box[A]
+  type EC = DummyImplicit
+  type ExecutionService = Unit
 
-  implicit def orgByknBosatsuParFMonad(implicit ec: ExecutionContext): Monad[F] =
+  def newService(): ExecutionService = ()
+  def shutdownService(es: ExecutionService): Unit = es
+  def ecFromService(es: ExecutionService): EC = DummyImplicit.dummyImplicit
+
+  def withEC[A](fn: EC => A): A = fn(DummyImplicit.dummyImplicit)
+
+  implicit def orgByknBosatsuParFMonad: Monad[F] =
     cats.catsInstancesForId
 
   // since Future has already started, standard Parallel.identity is parallel
-  implicit def orgByknBosatsuParParallel(implicit ec: ExecutionContext): Parallel[F] =
+  implicit def orgByknBosatsuParParallel: Parallel[F] =
     Parallel.identity
 
-  @inline def start[A](a: => A)(implicit ec: ExecutionContext): F[A] =
-    a
+  @inline def start[A](a: => A): F[A] = a
 
   @inline def now[A](a: A): F[A] = a
 

--- a/core/.jvm/src/main/scala/org/bykn/bosatsu/Par.scala
+++ b/core/.jvm/src/main/scala/org/bykn/bosatsu/Par.scala
@@ -1,6 +1,5 @@
 package org.bykn.bosatsu
 
-import cats.{Monad, Parallel}
 import java.util.concurrent.Executors
 import scala.concurrent.{Await, ExecutionContext, Future, Promise}
 import scala.concurrent.duration.Duration
@@ -25,17 +24,8 @@ object Par {
 
   def ecFromService(es: ExecutionService): EC = ExecutionContext.fromExecutor(es)
 
-  implicit def orgByknBosatsuParFMonad(implicit ec: EC): Monad[F] =
-    cats.implicits.catsStdInstancesForFuture
-
-  // since Future has already started, standard Parallel.identity is parallel
-  implicit def orgByknBosatsuParParallel(implicit ec: EC): Parallel[F] =
-    Parallel.identity
-
   @inline def start[A](a: => A)(implicit ec: EC): F[A] =
     Future(a)
-
-  @inline def now[A](a: A): F[A] = Future.successful(a)
 
   @inline def await[A](f: F[A]): A =
     Await.result(f, Duration.Inf)

--- a/core/.jvm/src/main/scala/org/bykn/bosatsu/Par.scala
+++ b/core/.jvm/src/main/scala/org/bykn/bosatsu/Par.scala
@@ -25,14 +25,6 @@ object Par {
 
   def ecFromService(es: ExecutionService): EC = ExecutionContext.fromExecutor(es)
 
-  def withEC[A](fn: EC => A): A = {
-    val pool = newService()
-    try fn(ecFromService(pool))
-    finally {
-      shutdownService(pool)
-    }
-  }
-
   implicit def orgByknBosatsuParFMonad(implicit ec: EC): Monad[F] =
     cats.implicits.catsStdInstancesForFuture
 

--- a/core/src/main/scala/org/bykn/bosatsu/MainModule.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/MainModule.scala
@@ -266,7 +266,7 @@ abstract class MainModule[IO[_]](implicit val moduleIOMonad: MonadError[IO, Thro
                 NonEmptyList.fromList(packs) match {
                   case Some(packs) =>
 
-                  val packsString = packs.map { case ((path, lm), parsed) => ((path.toString, lm), parsed) }
+                    val packsString = packs.map { case ((path, lm), parsed) => ((path.toString, lm), parsed) }
                     PackageMap.typeCheckParsed[String](packsString, ifs, "predef").strictToValidated match {
                       case Validated.Valid(p) =>
                         val pathToName: List[(Path, PackageName)] =

--- a/core/src/main/scala/org/bykn/bosatsu/MatchlessFromTypedExpr.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/MatchlessFromTypedExpr.scala
@@ -1,14 +1,12 @@
 package org.bykn.bosatsu
 
-import scala.concurrent.ExecutionContext
-
 import Identifier.Bindable
 
 import cats.implicits._
 
 object MatchlessFromTypedExpr {
   // compile a set of packages given a set of external remappings
-  def compile[A](pm: PackageMap.Typed[A])(implicit ec: ExecutionContext): Map[PackageName, List[(Bindable, Matchless.Expr)]] = {
+  def compile[A](pm: PackageMap.Typed[A])(implicit ec: Par.EC): Map[PackageName, List[(Bindable, Matchless.Expr)]] = {
 
     val gdr = pm.getDataRepr
 

--- a/core/src/main/scala/org/bykn/bosatsu/MemoryMain.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/MemoryMain.scala
@@ -108,6 +108,9 @@ class MemoryMain[F[_], K: Ordering](split: K => List[String])(
 
     loop(roots)
   }
+
+  def delay[A](a: => A): IO[A] =
+    Kleisli(_ => innerMonad.pure(a))
 }
 
 

--- a/core/src/main/scala/org/bykn/bosatsu/PackageMap.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/PackageMap.scala
@@ -3,7 +3,6 @@ package org.bykn.bosatsu
 import org.bykn.bosatsu.graph.Memoize
 import cats.{Foldable, Monad, Show}
 import cats.data.{Ior, IorT, NonEmptyList, NonEmptyMap, Validated, ValidatedNel, ReaderT}
-import scala.concurrent.ExecutionContext
 import scala.collection.immutable.SortedMap
 
 import Identifier.Constructor
@@ -204,7 +203,7 @@ object PackageMap {
   /**
    * Infer all the types in a resolved PackageMap
    */
-  def inferAll(ps: Resolved)(implicit cpuEC: ExecutionContext): Ior[NonEmptyList[PackageError], Inferred] = {
+  def inferAll(ps: Resolved)(implicit cpuEC: Par.EC): Ior[NonEmptyList[PackageError], Inferred] = {
 
     import Par.F
 
@@ -349,7 +348,7 @@ object PackageMap {
 
   def resolveThenInfer[A: Show](
     ps: List[(A, Package.Parsed)],
-    ifs: List[Package.Interface])(implicit cpuEC: ExecutionContext): Ior[NonEmptyList[PackageError], Inferred] =
+    ifs: List[Package.Interface])(implicit cpuEC: Par.EC): Ior[NonEmptyList[PackageError], Inferred] =
       resolveAll(ps, ifs).flatMap(inferAll)
 
   def buildSourceMap[F[_]: Foldable, A](parsedFiles: F[((A, LocationMap), Package.Parsed)]): Map[PackageName, (LocationMap, String)] =
@@ -365,7 +364,7 @@ object PackageMap {
   def typeCheckParsed[A: Show](
     packs: NonEmptyList[((A, LocationMap), Package.Parsed)],
     ifs: List[Package.Interface],
-    predefKey: A)(implicit cpuEC: ExecutionContext): Ior[NonEmptyList[PackageError], PackageMap.Inferred] = {
+    predefKey: A)(implicit cpuEC: Par.EC): Ior[NonEmptyList[PackageError], PackageMap.Inferred] = {
     // if we have passed in a use supplied predef, don't use the internal one
     val useInternalPredef = !ifs.exists { p: Package.Interface => p.name == PackageName.PredefName }
     // Now we have completed all IO, here we do all the checks we need for correctness

--- a/core/src/main/scala/org/bykn/bosatsu/codegen/python/PythonGen.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/codegen/python/PythonGen.scala
@@ -6,7 +6,6 @@ import cats.parse.{Parser => P}
 import org.bykn.bosatsu.{PackageName, Identifier, Matchless, Par, Parser, RecursionKind}
 import org.bykn.bosatsu.rankn.Type
 import org.typelevel.paiges.Doc
-import scala.concurrent.ExecutionContext
 
 import Identifier.Bindable
 import Matchless._
@@ -706,7 +705,7 @@ object PythonGen {
     pm: Map[PackageName, List[(Bindable, Expr)]],
     externals: Map[(PackageName, Bindable), (Module, Code.Ident)],
     tests: Map[PackageName, Bindable],
-    evaluators: Map[PackageName, (Bindable, Module, Code.Ident)])(implicit ec: ExecutionContext): Map[PackageName, (Module, Doc)] = {
+    evaluators: Map[PackageName, (Bindable, Module, Code.Ident)])(implicit ec: Par.EC): Map[PackageName, (Module, Doc)] = {
 
     val externalRemap: (PackageName, Bindable) => Env[Option[ValueLike]] =
       { (p, b) =>

--- a/core/src/test/scala/org/bykn/bosatsu/EvaluationTest.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/EvaluationTest.scala
@@ -5,7 +5,7 @@ import Value._
 import LocationMap.Colorize
 import org.scalatest.funsuite.AnyFunSuite
 
-class EvaluationTest extends AnyFunSuite {
+class EvalationTest extends AnyFunSuite with ParTest {
 
   import TestUtils._
 

--- a/core/src/test/scala/org/bykn/bosatsu/PackageTest.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/PackageTest.scala
@@ -2,16 +2,13 @@ package org.bykn.bosatsu
 
 import cats.Show
 import cats.data.{Validated, ValidatedNel}
-import scala.concurrent.ExecutionContext
 
 import IorMethods.IorExtension
 import org.scalatest.funsuite.AnyFunSuite
 
-class PackageTest extends AnyFunSuite {
+class PackageTest extends AnyFunSuite with ParTest {
 
   def resolveThenInfer(ps: Iterable[Package.Parsed]): ValidatedNel[PackageError, PackageMap.Inferred] = {
-    // use parallelism to typecheck
-    import ExecutionContext.Implicits.global
     implicit val showInt: Show[Int] = Show.fromToString
     PackageMap.resolveThenInfer(ps.toList.zipWithIndex.map(_.swap), Nil)
       .strictToValidated

--- a/core/src/test/scala/org/bykn/bosatsu/ParTest.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/ParTest.scala
@@ -1,0 +1,19 @@
+package org.bykn.bosatsu
+
+import org.scalatest.{BeforeAndAfterAll, Suite }
+
+trait ParTest extends BeforeAndAfterAll { self: Suite =>
+
+  private var ec: Par.EC = _
+  private var es: Par.ExecutionService = _
+  override protected def beforeAll(): Unit = {
+    es = Par.newService()
+    ec = Par.ecFromService(es)
+  }
+
+  override protected def afterAll(): Unit = {
+    Par.shutdownService(es)
+  }
+
+  implicit def implicitParEC: Par.EC = ec
+}

--- a/core/src/test/scala/org/bykn/bosatsu/Regressions.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/Regressions.scala
@@ -2,7 +2,7 @@ package org.bykn.bosatsu
 
 import org.scalatest.funsuite.AnyFunSuite
 
-class Regressions extends AnyFunSuite {
+class Regressions extends AnyFunSuite with ParTest {
   import TestUtils._
 
   test("test complex recursion case from #196") {

--- a/core/src/test/scala/org/bykn/bosatsu/TestUtils.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/TestUtils.scala
@@ -4,7 +4,6 @@ import cats.data.{Ior, Validated}
 import cats.implicits._
 import org.bykn.bosatsu.rankn._
 import org.scalatest.{Assertion, Assertions}
-import scala.concurrent.ExecutionContext
 
 import Assertions.{succeed, fail}
 import IorMethods.IorExtension
@@ -123,7 +122,7 @@ object TestUtils {
     }
   }
 
-  def testInferred(packages: List[String], mainPackS: String, inferredHandler: (PackageMap.Inferred, PackageName) => Assertion ) = {
+  def testInferred(packages: List[String], mainPackS: String, inferredHandler: (PackageMap.Inferred, PackageName) => Assertion)(implicit ec: Par.EC) = {
     val mainPack = PackageName.parse(mainPackS).get
 
     val parsed = packages.zipWithIndex.traverse { case (pack, i) =>
@@ -140,9 +139,6 @@ object TestUtils {
         }
         sys.error("failed to parse") //errs.toString)
     }
-
-    // use parallelism to typecheck
-    import ExecutionContext.Implicits.global
 
     val fullParsed =
         PackageMap.withPredefA(("predef", LocationMap("")), parsedPaths)
@@ -163,7 +159,7 @@ object TestUtils {
       }
   }
 
-  def evalFail(packages: List[String])(errFn: PartialFunction[PackageError, Unit]) = {
+  def evalFail(packages: List[String])(errFn: PartialFunction[PackageError, Unit])(implicit ec: Par.EC) = {
 
     val parsed = packages.zipWithIndex.traverse { case (pack, i) =>
       Parser.parse(Package.parser(None), pack).map { case (lm, parsed) =>
@@ -178,7 +174,6 @@ object TestUtils {
     }
 
     // use parallelism to typecheck
-    import ExecutionContext.Implicits.global
     val withPre =
       PackageMap.withPredefA(("predef", LocationMap("")), parsedPaths)
 


### PR DESCRIPTION
clean up some TODOs around use of ExecutionContext in a way that is clean for scalajs and jvm.