### PR TITLE
use literal type lambda for scala 3 compatibility

### DIFF
--- a/core/src/main/scala/org/bykn/bosatsu/DefStatement.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/DefStatement.scala
@@ -49,10 +49,10 @@ object DefStatement {
       line0 + Document[B].document(result)
     }
 
-    /**
-     * The resultTParser should parse some indentation any newlines
-     */
-    def parser[A, B](argParser: P[A], resultTParser: P[B]): P[DefStatement[A, B]] = {
+  /**
+   * The resultTParser should parse some indentation any newlines
+   */
+  def parser[A, B](argParser: P[A], resultTParser: P[B]): P[DefStatement[A, B]] = {
       val args = argParser.parensLines1Cut
       val result = (P.string("->") *> maybeSpace *> TypeRef.parser).?
       (Parser.keySpace("def") *> (Identifier.bindableParser ~ args) <* maybeSpace,

--- a/core/src/main/scala/org/bykn/bosatsu/MainModule.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/MainModule.scala
@@ -833,7 +833,7 @@ abstract class MainModule[IO[_]](implicit val moduleIOMonad: MonadError[IO, Thro
                       err.getClass.toString)
               }
           }
-        errors(msgs)
+          errors(msgs)
       }
 
     val opts: Opts[MainCommand] = {

--- a/core/src/main/scala/org/bykn/bosatsu/MemoryMain.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/MemoryMain.scala
@@ -63,7 +63,7 @@ class MemoryMain[F[_], K: Ordering](split: K => List[String])(
   def hasExtension(str: String): (Path => Boolean) =
     Function.const(false)(_)
 
-    def runWith(
+  def runWith(
       files: Iterable[(K, String)],
       packages: Iterable[(K, List[Package.Typed[Unit]])] = Nil,
       interfaces: Iterable[(K, List[Package.Interface])] = Nil)(cmd: List[String]): F[Output] =

--- a/core/src/main/scala/org/bykn/bosatsu/OptIndent.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/OptIndent.scala
@@ -51,12 +51,15 @@ object OptIndent {
     if (padding == 0 && indenting == 0) SameLine(a)
     else NotSameLine(Padding(padding, Indented(indenting, a)))
 
-  implicit def document[A: Document]: Document[OptIndent[A]] =
+  implicit def document[A: Document]: Document[OptIndent[A]] = {
+    val da = Document[A]
+    val dpi = Document[Padding[Indented[A]]]
+
     Document.instance[OptIndent[A]] {
-      case SameLine(a) => Document[A].document(a)
-      case NotSameLine(p) =>
-        Document[Padding[Indented[A]]].document(p)
+      case SameLine(a) => da.document(a)
+      case NotSameLine(p) => dpi.document(p)
     }
+  }
 
   def indy[A](p: Indy[A]): Indy[OptIndent[A]] = {
     val ind = Indented.indy(p)
@@ -72,9 +75,9 @@ object OptIndent {
    *   B
    */
   def block[A, B](first: Indy[A], next: Indy[B]): Indy[(A, OptIndent[B])] =
-    blockLike(first, next, maybeSpace ~ P.char(':'))
+    blockLike(first, next, (maybeSpace ~ P.char(':')).void)
 
-  def blockLike[A, B, C](first: Indy[A], next: Indy[B], sep: P0[C]): Indy[(A, OptIndent[B])] =
+  def blockLike[A, B](first: Indy[A], next: Indy[B], sep: P0[Unit]): Indy[(A, OptIndent[B])] =
     first
       .cutLeftP(sep ~ maybeSpace)
       .cutThen(OptIndent.indy(next))

--- a/core/src/main/scala/org/bykn/bosatsu/Package.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/Package.scala
@@ -61,7 +61,7 @@ object Package {
    * 1 a package of the same kind
    * 2 an interface
    */
-  type FixPackage[B, C, D] = Fix[Lambda[a => Either[Interface, Package[a, B, C, D]]]]
+  type FixPackage[B, C, D] = Fix[λ[a => Either[Interface, Package[a, B, C, D]]]]
   type PackageF[A, B, C] = Either[Interface, Package[FixPackage[A, B, C], A, B, C]]
   type PackageF2[A, B] = PackageF[A, A, B]
   type Parsed = Package[PackageName, Unit, Unit, List[Statement]]
@@ -126,10 +126,10 @@ object Package {
   }
 
   def fix[A, B, C](p: PackageF[A, B, C]): FixPackage[A, B, C] =
-    FixType.fix[Lambda[a => Either[Interface, Package[a, A, B, C]]]](p)
+    FixType.fix[λ[a => Either[Interface, Package[a, A, B, C]]]](p)
 
   def unfix[A, B, C](fp: FixPackage[A, B, C]): PackageF[A, B, C] =
-    FixType.unfix[Lambda[a => Either[Interface, Package[a, A, B, C]]]](fp)
+    FixType.unfix[λ[a => Either[Interface, Package[a, A, B, C]]]](fp)
   /**
    * build a Parsed Package from a Statement. This is useful for testing or
    * library usages.

--- a/core/src/main/scala/org/bykn/bosatsu/PackageMap.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/PackageMap.scala
@@ -146,12 +146,12 @@ object PackageMap {
         case Some(neps) =>
           CollectionUtils.uniqueByKey(neps)(_._2.name)
             .fold(
-              { a => (a.toSortedMap, SortedMap.empty) },
-              { b => (SortedMap.empty, b.toSortedMap) },
+              { a => (a.toSortedMap, SortedMap.empty[PackageName, AP]) },
+              { b => (SortedMap.empty[PackageName, (AP, NonEmptyList[AP])], b.toSortedMap) },
               { (a, b) => (a.toSortedMap, b.toSortedMap) }
             )
         case None =>
-          (SortedMap.empty, SortedMap.empty)
+          (SortedMap.empty[PackageName, (AP, NonEmptyList[AP])], SortedMap.empty[PackageName, AP])
       }
 
     def toProg(p: Package.Parsed):

--- a/core/src/main/scala/org/bykn/bosatsu/Statement.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/Statement.scala
@@ -279,11 +279,12 @@ object Statement {
         // Comments already end with newline
         Document[CommentStatement[Unit]].document(cm)
       case Def(d) =>
-        implicit val pair = Document.instance[OptIndent[Declaration]] {
-          body =>
-            body.sepDoc +
-            Document[OptIndent[Declaration]].document(body)
-        }
+        implicit val pair: Document[OptIndent[Declaration]] =
+          Document.instance[OptIndent[Declaration]] {
+            body =>
+              body.sepDoc +
+              Document[OptIndent[Declaration]].document(body)
+          }
         DefStatement.document[Pattern.Parsed, OptIndent[Declaration]].document(d) + Doc.line
       case PaddingStatement(p) =>
         // this will just be some number of lines

--- a/core/src/main/scala/org/bykn/bosatsu/TotalityCheck.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/TotalityCheck.scala
@@ -217,7 +217,7 @@ case class TotalityCheck(inEnv: TypeEnv[Any]) {
     }
 
   lazy val patternSetOps: SetOps[Pattern[Cons, Type]] =
-    new SetOps[Pattern[Cons, Type]] {
+    new SetOps[Pattern[Cons, Type]] { self =>
       val top = Some(WildCard)
 
       def intersection(
@@ -415,7 +415,7 @@ case class TotalityCheck(inEnv: TypeEnv[Any]) {
           case Pattern.Union(h, t) =>
             val u = h :: t.toList
             u.exists(isTop(_)) || {
-              missingBranches(WildCard :: Nil, u).isEmpty
+              self.missingBranches(WildCard :: Nil, u).isEmpty
             }
         }
 

--- a/core/src/main/scala/org/bykn/bosatsu/TypedExpr.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/TypedExpr.scala
@@ -351,7 +351,7 @@ object TypedExpr {
       }
 
     def allTypes: SortedSet[Type] =
-      traverseType { t => Writer(SortedSet(t), t) }.run._1
+      traverseType { t => Writer[SortedSet[Type], Type](SortedSet(t), t) }.run._1
 
     /**
      * Traverse all the *non-shadowed* types inside the TypedExpr
@@ -559,7 +559,7 @@ object TypedExpr {
           type Branch = (Pattern[(PackageName, Constructor), Type], TypedExpr[A])
 
           def allTypes[X](p: Pattern[X, Type]): SortedSet[Type] =
-            p.traverseType { t => Writer(SortedSet(t), t) }.run._1
+            p.traverseType { t => Writer[SortedSet[Type], Type](SortedSet(t), t) }.run._1
 
           val allMatchMetas: F[SortedSet[Type.Meta]] =
             getMetaTyVars(arg.getType :: branches.foldMap { case (p, _) => allTypes(p) }.toList)

--- a/core/src/main/scala/org/bykn/bosatsu/UnusedLetCheck.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/UnusedLetCheck.scala
@@ -58,7 +58,7 @@ object UnusedLetCheck {
         }
         .map(_.combineAll)
 
-      (argCheck, bcheck).mapN(_ ++ _)
+        (argCheck, bcheck).mapN(_ ++ _)
     }
 
   /**

--- a/core/src/main/scala/org/bykn/bosatsu/ValueToDoc.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/ValueToDoc.scala
@@ -245,9 +245,9 @@ case class ValueToDoc(getDefinedType: Type.Const => Option[DefinedType[Any]]) {
           // so we can recurse
           successCache.put(tpe, res)
           res
-        }
+      }
 
-      loop(tpe, Nil).value
-    }
+    loop(tpe, Nil).value
+  }
 
 }

--- a/core/src/main/scala/org/bykn/bosatsu/ValueToJson.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/ValueToJson.scala
@@ -319,8 +319,8 @@ case class ValueToJson(getDefinedType: Type.Const => Option[DefinedType[Any]]) {
           res
         }
 
-      supported(tpe).map(_ => loop(tpe, Nil).value)
-    }
+    supported(tpe).map(_ => loop(tpe, Nil).value)
+  }
 
   /**
    * Convert a Json to a Value
@@ -549,8 +549,8 @@ case class ValueToJson(getDefinedType: Type.Const => Option[DefinedType[Any]]) {
           res
       }
 
-      supported(tpe).map(_ => loop(tpe, Nil).value)
-    }
+    supported(tpe).map(_ => loop(tpe, Nil).value)
+  }
 
   /**
    * Given a type return the function to convert it a function

--- a/core/src/main/scala/org/bykn/bosatsu/codegen/python/Code.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/codegen/python/Code.scala
@@ -168,8 +168,8 @@ object Code {
           if (ex.isEmpty) Doc.empty
           else par(Doc.intercalate(Doc.comma + Doc.space, ex.map(toDoc)))
 
-          Doc.text("class") + Doc.space + Doc.text(name.name) + exDoc + Doc.char(':') + (Doc.hardLine +
-            toDoc(body)).nested(4)
+        Doc.text("class") + Doc.space + Doc.text(name.name) + exDoc + Doc.char(':') + (Doc.hardLine +
+          toDoc(body)).nested(4)
 
       case IfStatement(conds, Some(Pass)) =>
         toDoc(IfStatement(conds, None))

--- a/core/src/main/scala/org/bykn/bosatsu/codegen/python/PythonGen.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/codegen/python/PythonGen.scala
@@ -583,10 +583,10 @@ object PythonGen {
           } yield (nm, me, ve)
       }
 
-    for {
-      (nm, me, ve) <- nmVeEnv
-      stmt <- ops.topLet(nm, me, ve)
-    } yield stmt
+    nmVeEnv
+      .flatMap { case (nm, me, ve) =>
+        ops.topLet(nm, me, ve)
+      }
   }
 
   private def addUnitTest(name: Bindable): Env[Statement] = {

--- a/core/src/main/scala/org/bykn/bosatsu/rankn/DefinedType.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/rankn/DefinedType.scala
@@ -53,10 +53,10 @@ final case class DefinedType[+A](
           { cons => if (cons == zero) DataRepr.ZeroNat else DataRepr.SuccNat }
         }
         else {
-           val famArities = c0.arity :: c1.arity :: Nil
-           val zero = c0.name
-           val zrep = DataRepr.Enum(0, c0.arity, famArities)
-           val orep = DataRepr.Enum(1, c1.arity, famArities)
+          val famArities = c0.arity :: c1.arity :: Nil
+          val zero = c0.name
+          val zrep = DataRepr.Enum(0, c0.arity, famArities)
+          val orep = DataRepr.Enum(1, c1.arity, famArities)
 
           { cons => if (cons == zero) zrep else orep }
         }

--- a/core/src/main/scala/org/bykn/bosatsu/rankn/Infer.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/rankn/Infer.scala
@@ -874,7 +874,7 @@ object Infer {
                 case l@ListPart.NamedList(splice) =>
                   // this is *a pattern that has list type, and binds that type to the name
                   Infer.pure((l, (splice, lst) :: Nil))
-                  case ListPart.Item(p) =>
+                case ListPart.Item(p) =>
                   // This is a non-splice
                   checkPat(p, inner, reg).map { case (p, l) => (ListPart.Item(p), l) }
               }


### PR DESCRIPTION
(and some other indentation fixes that were confusing the scala 3 parser).