### PR TITLE
Simplify ConstructorFn

### DIFF
--- a/cli/src/main/scala/org/bykn/bosatsu/TypedExprToProto.scala
+++ b/cli/src/main/scala/org/bykn/bosatsu/TypedExprToProto.scala
@@ -768,10 +768,7 @@ object ProtoConverter {
         tpe <- lookupType(p.typeOf, s"invalid type id: $p")
       } yield (bn, tpe)
 
-    def consFromProto(
-      tc: Type.Const.Defined,
-      tp: List[Type.Var.Bound],
-      c: proto.ConstructorFn): DTab[rankn.ConstructorFn] =
+    def consFromProto(c: proto.ConstructorFn): DTab[rankn.ConstructorFn] =
       lookup(c.name, c.toString)
         .flatMap { cname =>
           ReaderT.liftF(toConstructor(cname))
@@ -779,7 +776,7 @@ object ProtoConverter {
               //def
               c.params.toList.traverse(fnParamFromProto)
                 .map { fnParams =>
-                  rankn.ConstructorFn.build(tc.packageName, tc.name, tp, cname, fnParams)
+                  rankn.ConstructorFn(cname, fnParams)
                 }
             }
         }
@@ -790,7 +787,7 @@ object ProtoConverter {
         for {
           tconst <- typeConstFromProto(tc)
           tparams <- pdt.typeParams.toList.traverse(paramFromProto)
-          cons <- pdt.constructors.toList.traverse(consFromProto(tconst, tparams.map(_._1), _))
+          cons <- pdt.constructors.toList.traverse(consFromProto)
         } yield DefinedType(tconst.packageName, tconst.name, tparams, cons)
     }
   }

--- a/core/src/main/scala/org/bykn/bosatsu/ExportedName.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/ExportedName.scala
@@ -80,7 +80,7 @@ object ExportedName {
     nm: PackageName,
     exports: List[ExportedName[E]],
     typeEnv: rankn.TypeEnv[V],
-    lets: List[(Identifier.Bindable, R, TypedExpr[D])]): ValidatedNel[ExportedName[E], List[ExportedName[Referant[V]]]] = {
+    lets: List[(Identifier.Bindable, R, TypedExpr[D])])(implicit ev: V <:< Variance): ValidatedNel[ExportedName[E], List[ExportedName[Referant[V]]]] = {
 
      val letMap = lets.iterator.map { case (n, _, t) => (n, t) }.toMap
 

--- a/core/src/main/scala/org/bykn/bosatsu/NameKind.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/NameKind.scala
@@ -37,8 +37,7 @@ object NameKind {
         prog.types
           .getConstructor(from.name, cn)
           .map { case (dt, cfn) =>
-            val tpe = cfn.fnType(dt.packageName, dt.name, dt.annotatedTypeParams.map(_._1))
-            Constructor(cn, cfn.args, dt, tpe)
+            Constructor(cn, cfn.args, dt, dt.fnTypeOf(cfn))
           }
       }
 

--- a/core/src/main/scala/org/bykn/bosatsu/NameKind.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/NameKind.scala
@@ -19,7 +19,7 @@ object NameKind {
       // The type could be an import, so we need to check for the type
       // in the TypeEnv
       val pn = from.name
-      val tpe = prog.types.getValue(pn, n).get
+      val tpe = prog.types.getExternalValue(pn, n).get
       ExternalDef[T](pn, n, tpe)
     }
   }
@@ -36,8 +36,9 @@ object NameKind {
       item.toConstructor.flatMap { cn =>
         prog.types
           .getConstructor(from.name, cn)
-          .map { case (params, dt, tpe) =>
-            Constructor(cn, params, dt, tpe)
+          .map { case (dt, cfn) =>
+            val tpe = cfn.fnType(dt.packageName, dt.name, dt.annotatedTypeParams.map(_._1))
+            Constructor(cn, cfn.args, dt, tpe)
           }
       }
 

--- a/core/src/main/scala/org/bykn/bosatsu/PackageMap.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/PackageMap.scala
@@ -26,7 +26,7 @@ case class PackageMap[A, B, C, +D](toMap: SortedMap[PackageName, Package[A, B, C
           ev(pack.program)
             .types
             .getConstructor(pname, cons)
-            .map(_._2.dataRepr(cons))
+            .map(_._1.dataRepr(cons))
         }
   }
 

--- a/core/src/main/scala/org/bykn/bosatsu/Referant.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/Referant.scala
@@ -65,7 +65,7 @@ object Referant {
         val key = (pn, orig)
         i.tag.toList.iterator.collect {
           case Referant.Value(t) => (key, t)
-          case Referant.Constructor(_, fn) => (key, fn.fnType)
+          case Referant.Constructor(dt, fn) => (key, fn.fnType(dt.packageName, dt.name, dt.annotatedTypeParams.map(_._1)))
         }
       }
     }

--- a/core/src/main/scala/org/bykn/bosatsu/Referant.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/Referant.scala
@@ -57,7 +57,7 @@ object Referant {
    * Fully qualified original names
    */
   def fullyQualifiedImportedValues[A, B](
-    imps: List[Import[A, NonEmptyList[Referant[B]]]])(nameOf: A => PackageName): Map[(PackageName, Identifier), Type] =
+    imps: List[Import[A, NonEmptyList[Referant[B]]]])(nameOf: A => PackageName)(implicit ev: B <:< Variance): Map[(PackageName, Identifier), Type] =
     imps.iterator.flatMap { item =>
       val pn = nameOf(item.pack)
       item.items.toList.iterator.flatMap { i =>
@@ -65,7 +65,7 @@ object Referant {
         val key = (pn, orig)
         i.tag.toList.iterator.collect {
           case Referant.Value(t) => (key, t)
-          case Referant.Constructor(dt, fn) => (key, fn.fnType(dt.packageName, dt.name, dt.annotatedTypeParams.map(_._1)))
+          case Referant.Constructor(dt, fn) => (key, dt.fnTypeOf(fn))
         }
       }
     }

--- a/core/src/main/scala/org/bykn/bosatsu/SourceConverter.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/SourceConverter.scala
@@ -424,8 +424,8 @@ final class SourceConverter(
       case rc@RecordConstructor(name, args) =>
           val (p, c) = nameToCons(name)
           val cons: Expr[Declaration] = Expr.Global(p, c, rc)
-          localTypeEnv.flatMap(_.getConstructor(p, c) match {
-            case Some((params, _, _)) =>
+          localTypeEnv.flatMap(_.getConstructorParams(p, c) match {
+            case Some(params) =>
               def argExpr(arg: RecordArg): (Bindable, Result[Expr[Declaration]]) =
                 arg match {
                   case RecordArg.Simple(b) =>
@@ -561,7 +561,7 @@ final class SourceConverter(
 
             updateInferedWithDecl(typeArgs, typeParams0).map { typeParams =>
               val tname = TypeName(nm)
-              val consFn = rankn.ConstructorFn.build(pname, tname, typeParams, nm, params)
+              val consFn = rankn.ConstructorFn(nm, params)
 
               rankn.DefinedType(pname,
                 tname,
@@ -594,9 +594,8 @@ final class SourceConverter(
             }
           }
           updateInferedWithDecl(typeArgs, typeParams0).map { typeParams =>
-            val tname = TypeName(nm)
             val finalCons = constructors.toList.map { case (c, params) =>
-              rankn.ConstructorFn.build(pname, tname, typeParams, c, params)
+              rankn.ConstructorFn(c, params)
             }
             rankn.DefinedType(pname, TypeName(nm), typeParams.map((_, ())), finalCons)
           }
@@ -701,8 +700,8 @@ final class SourceConverter(
       case (Pattern.StructKind.Named(nm, Pattern.StructKind.Style.TupleLike), rargs) =>
         rargs.flatMap { args =>
           val pc@(p, c) = nameToCons(nm)
-          localTypeEnv.flatMap(_.getConstructor(p, c) match {
-            case Some((params, _, _)) =>
+          localTypeEnv.flatMap(_.getConstructorParams(p, c) match {
+            case Some(params) =>
               val argLen = args.size
               val paramLen = params.size
               if (argLen == paramLen) {
@@ -722,8 +721,8 @@ final class SourceConverter(
       case (Pattern.StructKind.NamedPartial(nm, Pattern.StructKind.Style.TupleLike), rargs) =>
         rargs.flatMap { args =>
           val pc@(p, c) = nameToCons(nm)
-          localTypeEnv.flatMap(_.getConstructor(p, c) match {
-            case Some((params, _, _)) =>
+          localTypeEnv.flatMap(_.getConstructorParams(p, c) match {
+            case Some(params) =>
               val argLen = args.size
               val paramLen = params.size
               if (argLen <= paramLen) {
@@ -744,8 +743,8 @@ final class SourceConverter(
       case (Pattern.StructKind.Named(nm, Pattern.StructKind.Style.RecordLike(fs)), rargs) =>
         rargs.flatMap { args =>
           val pc@(p, c) = nameToCons(nm)
-          localTypeEnv.flatMap(_.getConstructor(p, c) match {
-            case Some((params, _, _)) =>
+          localTypeEnv.flatMap(_.getConstructorParams(p, c) match {
+            case Some(params) =>
               val mapping = fs.toList.iterator.map(_.field).zip(args.iterator).toMap
               lazy val present = SortedSet(fs.toList.iterator.map(_.field).toList: _*)
               def get(b: Bindable): Result[Pattern[(PackageName, Constructor), rankn.Type]] =
@@ -779,8 +778,8 @@ final class SourceConverter(
       case (Pattern.StructKind.NamedPartial(nm, Pattern.StructKind.Style.RecordLike(fs)), rargs) =>
         rargs.flatMap { args =>
           val pc@(p, c) = nameToCons(nm)
-          localTypeEnv.flatMap(_.getConstructor(p, c) match {
-            case Some((params, _, _)) =>
+          localTypeEnv.flatMap(_.getConstructorParams(p, c) match {
+            case Some(params) =>
               val mapping = fs.toList.iterator.map(_.field).zip(args.iterator).toMap
               def get(b: Bindable): Pattern[(PackageName, Constructor), rankn.Type] =
                 mapping.get(b) match {

--- a/core/src/main/scala/org/bykn/bosatsu/rankn/ConstructorFn.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/rankn/ConstructorFn.scala
@@ -1,11 +1,11 @@
 package org.bykn.bosatsu.rankn
 
-import org.bykn.bosatsu.{TypeName, PackageName}
 import org.bykn.bosatsu.Identifier.{Bindable, Constructor}
 
 final case class ConstructorFn(
-  name: Constructor,
-  args: List[(Bindable, Type)]) {
+    name: Constructor,
+    args: List[(Bindable, Type)]
+) {
 
   def isZeroArg: Boolean = args == Nil
 
@@ -14,25 +14,8 @@ final case class ConstructorFn(
   def hasSingleArgType(t: Type): Boolean =
     args match {
       case (_, t0) :: Nil => t == t0
-      case _ => false
+      case _              => false
     }
 
   def arity: Int = args.length
-
-  def fnType(packageName: PackageName, typeName: TypeName, dtTypeParams: List[Type.Var.Bound]): Type = {
-    val tc: Type = Type.const(packageName, typeName)
-
-    def loop(params: List[Type]): Type =
-       params match {
-         case Nil =>
-           dtTypeParams.foldLeft(tc) { (res, v) =>
-             Type.TyApply(res, Type.TyVar(v))
-           }
-         case h :: tail =>
-           Type.Fun(h, loop(tail))
-       }
-
-    val resT = loop(args.map(_._2))
-    Type.forAll(dtTypeParams, resT)
-  }
 }

--- a/core/src/main/scala/org/bykn/bosatsu/rankn/ConstructorFn.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/rankn/ConstructorFn.scala
@@ -5,8 +5,7 @@ import org.bykn.bosatsu.Identifier.{Bindable, Constructor}
 
 final case class ConstructorFn(
   name: Constructor,
-  args: List[(Bindable, Type)],
-  fnType: Type) {
+  args: List[(Bindable, Type)]) {
 
   def isZeroArg: Boolean = args == Nil
 
@@ -19,26 +18,21 @@ final case class ConstructorFn(
     }
 
   def arity: Int = args.length
-}
 
-object ConstructorFn {
-
-  def build(packageName: PackageName, typeName: TypeName, tparams: List[Type.Var.Bound], name: Constructor, fnParams: List[(Bindable, Type)]): ConstructorFn = {
+  def fnType(packageName: PackageName, typeName: TypeName, dtTypeParams: List[Type.Var.Bound]): Type = {
     val tc: Type = Type.const(packageName, typeName)
 
     def loop(params: List[Type]): Type =
        params match {
          case Nil =>
-           tparams.foldLeft(tc) { (res, v) =>
+           dtTypeParams.foldLeft(tc) { (res, v) =>
              Type.TyApply(res, Type.TyVar(v))
            }
          case h :: tail =>
            Type.Fun(h, loop(tail))
        }
 
-    val resT = loop(fnParams.map(_._2))
-    val fnType = Type.forAll(tparams, resT)
-
-    ConstructorFn(name, fnParams, fnType)
+    val resT = loop(args.map(_._2))
+    Type.forAll(dtTypeParams, resT)
   }
 }

--- a/core/src/main/scala/org/bykn/bosatsu/rankn/DefinedType.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/rankn/DefinedType.scala
@@ -1,7 +1,7 @@
 package org.bykn.bosatsu.rankn
 
 import cats.{Applicative, Eval, Traverse}
-import org.bykn.bosatsu.{TypeName, PackageName, Identifier}
+import org.bykn.bosatsu.{TypeName, PackageName, Identifier, Variance}
 import scala.collection.immutable.SortedMap
 
 import Identifier.Constructor
@@ -79,6 +79,10 @@ final case class DefinedType[+A](
         else DataFamily.Enum
       case _ => DataFamily.Enum
   }
+
+  def fnTypeOf(cf: ConstructorFn)(implicit ev: A <:< Variance): Type =
+    // evidence to prove that we only ask for this after inference
+    cf.fnType(packageName, name, annotatedTypeParams.map(_._1))
 }
 
 object DefinedType {

--- a/core/src/main/scala/org/bykn/bosatsu/rankn/TypeEnv.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/rankn/TypeEnv.scala
@@ -1,14 +1,12 @@
 package org.bykn.bosatsu.rankn
 
-import org.bykn.bosatsu.{TypeName, PackageName}
-import scala.collection.immutable.SortedMap
-
-import org.bykn.bosatsu.Identifier
+import org.bykn.bosatsu.{TypeName, PackageName, Identifier, Variance}
 import org.bykn.bosatsu.Identifier.{Bindable, Constructor}
+import scala.collection.immutable.SortedMap
 
 class TypeEnv[+A] private (
   protected val values: SortedMap[(PackageName, Identifier), Type],
-  protected val constructors: SortedMap[(PackageName, Constructor), (List[(Bindable, Type)], DefinedType[A], Type)],
+  protected val constructors: SortedMap[(PackageName, Constructor), (DefinedType[A], ConstructorFn)],
   val definedTypes: SortedMap[(PackageName, TypeName), DefinedType[A]]) {
 
   override def equals(that: Any): Boolean =
@@ -37,26 +35,50 @@ class TypeEnv[+A] private (
   def allDefinedTypes: List[DefinedType[A]] =
     definedTypes.values.toList.sortBy { dt => (dt.packageName, dt.name) }
 
-  def getConstructor(p: PackageName, c: Constructor): Option[(List[(Bindable, Type)], DefinedType[A], Type)] =
+  def getConstructor(p: PackageName, c: Constructor): Option[(DefinedType[A], ConstructorFn)] =
     constructors.get((p, c))
+
+  def getConstructorParams(p: PackageName, c: Constructor): Option[List[(Bindable, Type)]] =
+    constructors.get((p, c)).map(_._2.args)
 
   def getType(p: PackageName, t: TypeName): Option[DefinedType[A]] =
     definedTypes.get((p, t))
 
-  def getValue(p: PackageName, n: Identifier): Option[Type] =
+  def getExternalValue(p: PackageName, n: Identifier): Option[Type] =
     values.get((p, n))
 
-  def localValuesOf(p: PackageName): SortedMap[Identifier, Type] =
-    (SortedMap.newBuilder[Identifier, Type] ++= values.iterator.collect { case ((pn, n), v) if pn == p => (n, v) }).result()
+  private def getConsType[A1](dt: DefinedType[A1], cf: ConstructorFn)(implicit ev: A1 <:< Variance): Type =
+    cf.fnType(dt.packageName, dt.name, dt.annotatedTypeParams.map(_._1))  
+
+  // when we have resolved, we can get the types of constructors out
+  def getValue(p: PackageName, n: Identifier)(implicit ev: A <:< Variance): Option[Type] =
+    n match {
+      case c @ Constructor(_) =>
+        // constructors are never external defs
+        constructors.get((p, c)).map { case (dt, cfn) => getConsType(dt, cfn) }
+      case notCons => getExternalValue(p, notCons)
+    }
+
+  // when we have resolved, we can get the types of constructors out
+  def localValuesOf(p: PackageName)(implicit ev: A <:< Variance): SortedMap[Identifier, Type] = {
+    val bldr = SortedMap.newBuilder[Identifier, Type]
+    // add externals
+    bldr ++= values.iterator.collect { case ((pn, n), v) if pn == p => (n, v) }
+    // add constructors
+    bldr ++= constructors.iterator.collect { case ((pn, n), (dt, cf)) if pn == p => (n, getConsType(dt, cf)) }
+
+    bldr.result()
+  }
 
   def addConstructor[A1 >: A](pack: PackageName,
     dt: DefinedType[A1],
     cf: ConstructorFn): TypeEnv[A1] = {
-      val nec = constructors.updated((pack, cf.name), (cf.args, dt, cf.fnType))
+      val nec = constructors.updated((pack, cf.name), (dt, cf))
       // add this constructor to the values
-      val v1 = values.updated((pack, cf.name), cf.fnType)
+      // TODO: we have to get these back out later
+      //val v1 = values.updated((pack, cf.name), cf.fnType)
       val dt1 = definedTypes.updated((dt.packageName, dt.name), dt)
-      new TypeEnv(values = v1, constructors = nec, definedTypes = dt1)
+      new TypeEnv(values = values, constructors = nec, definedTypes = dt1)
     }
 
   /**
@@ -76,16 +98,12 @@ class TypeEnv[+A] private (
     val dt1 = definedTypes.updated((dt.packageName, dt.name), dt)
     val cons1 =
       dt.constructors
-        .foldLeft(constructors: SortedMap[(PackageName, Constructor), (List[(Bindable, Type)], DefinedType[A1], Type)]) {
+        .foldLeft(constructors: SortedMap[(PackageName, Constructor), (DefinedType[A1], ConstructorFn)]) {
           case (cons0, cf) =>
-            cons0.updated((dt.packageName, cf.name), (cf.args, dt, cf.fnType))
+            cons0.updated((dt.packageName, cf.name), (dt, cf))
         }
-    // here we have to actually add the constructor values:
-    val v1 = dt.constructors.foldLeft(values) { case (v0, cf) =>
-      v0.updated((dt.packageName, cf.name), cf.fnType)
-    }
 
-    new TypeEnv(constructors = cons1, definedTypes = dt1, values = v1)
+    new TypeEnv(constructors = cons1, definedTypes = dt1, values = values)
   }
 
   /**
@@ -99,10 +117,10 @@ class TypeEnv[+A] private (
       values = values.updated((pack, name), t))
 
   lazy val typeConstructors: SortedMap[(PackageName, Constructor), (List[(Type.Var, A)], List[Type], Type.Const.Defined)] =
-    constructors.map { case (pc, (params, dt, _)) =>
+    constructors.map { case (pc, (dt, cf)) =>
       (pc,
         (dt.annotatedTypeParams,
-          params.map(_._2),
+          cf.args.map(_._2),
           dt.toTypeConst))
     }
 
@@ -124,7 +142,7 @@ object TypeEnv {
   val empty: TypeEnv[Nothing] =
     new TypeEnv(
       SortedMap.empty[(PackageName, Identifier), Type],
-      SortedMap.empty[(PackageName, Constructor), (List[(Bindable, Type)], DefinedType[Nothing], Type)],
+      SortedMap.empty[(PackageName, Constructor), (DefinedType[Nothing], ConstructorFn)],
       SortedMap.empty[(PackageName, TypeName), DefinedType[Nothing]])
 
   /**

--- a/core/src/test/scala/org/bykn/bosatsu/Gen.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/Gen.scala
@@ -923,7 +923,7 @@ object Generators {
         for {
           cons <- consIdentGen
           ps <- smallList(Gen.zip(bindIdentGen, genType))
-        } yield rankn.ConstructorFn.build(p, t, params.map(_._1), cons, ps)
+        } yield rankn.ConstructorFn(cons, ps)
       cons0 <- smallList(genCons)
       cons = cons0.map { cf => (cf.name, cf) }.toMap.values.toList
     } yield rankn.DefinedType(p, t, params, cons)

--- a/core/src/test/scala/org/bykn/bosatsu/MatchlessTests.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/MatchlessTests.scala
@@ -25,7 +25,7 @@ class MatchlessTest extends AnyFunSuite {
         Some(DataRepr.Enum(1, 2, List(0, 1)))
       case (pn, cons) =>
         te.getConstructor(pn, cons)
-          .map(_._2.dataRepr(cons))
+          .map(_._1.dataRepr(cons))
           .orElse(Some(DataRepr.Struct(0)))
     }
 


### PR DESCRIPTION
ConstructorFn has some codesmell that so far was ignored. For instance, it carries its full type, but that type is actually ignored by serialization.

Secondly, we require to know the full type of the constructor for all `TypeEnv[A]` but we actually only query that type once we have fully inferred types (currently that means A =:= Variance in practice).

In the work to check (or infer) Kinds, we wouldn't know the full Kind of generic type parameters at SourceConverter time, and only later at Infer time. This currently presents a problem, but it is only a problem due to how the code is factored, not an actual problem with the algorithms.

relates to #121 