### PR TITLE
Simplify Expr by removing annotated Lambda

### DIFF
--- a/core/src/main/scala/org/bykn/bosatsu/SourceConverter.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/SourceConverter.scala
@@ -413,6 +413,7 @@ final class SourceConverter(
             val newPattern = convertPattern(binding, decl.region)
             (newPattern, resExpr, loop(in)).mapN { (pat, res, in) =>
               val foldFn = Expr.Lambda(dictSymbol,
+                None,
                 Expr.buildPatternLambda(
                   NonEmptyList(pat, Nil),
                   res,

--- a/core/src/main/scala/org/bykn/bosatsu/TotalityCheck.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/TotalityCheck.scala
@@ -106,8 +106,7 @@ case class TotalityCheck(inEnv: TypeEnv[Any]) {
     import Expr._
     expr match {
       case Annotation(e, _, _) => checkExpr(e)
-      case AnnotatedLambda(_, _, e, _) => checkExpr(e)
-      case Lambda(_, e, _) => checkExpr(e)
+      case Lambda(_, _, e, _) => checkExpr(e)
       case Global(_, _, _) | Local(_, _) | Literal(_, _) => Validated.valid(())
       case App(fn, arg, _) => checkExpr(fn) *> checkExpr(arg)
       case Let(_, e1, e2, _, _) => checkExpr(e1) *> checkExpr(e2)

--- a/core/src/main/scala/org/bykn/bosatsu/UnusedLetCheck.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/UnusedLetCheck.scala
@@ -25,9 +25,7 @@ object UnusedLetCheck {
     e match {
       case Annotation(expr, _, _) =>
         loop(expr)
-      case AnnotatedLambda(arg, _, expr, _) =>
-        checkArg(arg, HasRegion.region(e), loop(expr))
-      case Lambda(arg, expr, _) =>
+      case Lambda(arg, _, expr, _) =>
         checkArg(arg, HasRegion.region(e), loop(expr))
       case Let(arg, expr, in, rec, _) =>
         val exprCheck = loop(expr)

--- a/core/src/main/scala/org/bykn/bosatsu/rankn/Infer.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/rankn/Infer.scala
@@ -651,7 +651,7 @@ object Infer {
              typedArg <- checkSigma(arg, argT)
              coerce <- instSigma(resT, expect, region(term))
            } yield coerce(TypedExpr.App(typedFn, typedArg, resT, tag))
-        case Lambda(name, result, tag) =>
+        case Lambda(name, None, result, tag) =>
           expect match {
             case Expected.Check((expTy, rr)) =>
               for {
@@ -672,7 +672,7 @@ object Infer {
                 _ <- infer.set((Type.Fun(varT, bodyT), region(term)))
               } yield TypedExpr.AnnotatedLambda(name, varT, typedBody, tag)
           }
-        case AnnotatedLambda(name, tpe, result, tag) =>
+        case Lambda(name, Some(tpe), result, tag) =>
           expect match {
             case Expected.Check((expTy, rr)) =>
               for {

--- a/core/src/test/scala/org/bykn/bosatsu/rankn/RankNInferTest.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/rankn/RankNInferTest.scala
@@ -86,7 +86,7 @@ class RankNInferTest extends AnyFunSuite {
   def let(n: String, expr: Expr[Unit], in: Expr[Unit]): Expr[Unit] =
     Let(Identifier.Name(n), expr, in, RecursionKind.NonRecursive, ())
   def lambda(arg: String, result: Expr[Unit]): Expr[Unit] =
-    Lambda(Identifier.Name(arg), result, ())
+    Lambda(Identifier.Name(arg), None, result, ())
   def v(name: String): Expr[Unit] =
     Identifier.unsafe(name) match {
       case c@Identifier.Constructor(_) => Global(testPackage, c, ())
@@ -96,7 +96,7 @@ class RankNInferTest extends AnyFunSuite {
 
   def app(fn: Expr[Unit], arg: Expr[Unit]): Expr[Unit] = App(fn, arg, ())
   def alam(arg: String, tpe: Type, res: Expr[Unit]): Expr[Unit] =
-    AnnotatedLambda(Identifier.Name(arg), tpe, res, ())
+    Lambda(Identifier.Name(arg), Some(tpe), res, ())
 
   def ife(cond: Expr[Unit], ift: Expr[Unit], iff: Expr[Unit]): Expr[Unit] = Expr.ifExpr(cond, ift, iff, ())
   def matche(arg: Expr[Unit], branches: NonEmptyList[(Pattern[String, Type], Expr[Unit])]): Expr[Unit] =


### PR DESCRIPTION
This just unifies Lambda and AnnotatedLambda by making the type Option. This nets less code.

I'm about to make another change to Expr so I thought I'd do this first.