### PR TITLE
Add syntax for def type annotation

### DIFF
--- a/core/src/main/scala/org/bykn/bosatsu/Declaration.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/Declaration.scala
@@ -552,7 +552,7 @@ object Declaration {
             .map { p1 =>
               Comment(CommentStatement(c.message, p1))(decl.region)
             }
-        case DefFn(DefStatement(nm, args, rtype, (body, rest))) =>
+        case DefFn(DefStatement(nm, ta, args, rtype, (body, rest))) =>
           def go(scope: List[Bindable], d0: Declaration): Option[Declaration] =
             if (scope.exists(masks)) None
             else if (scope.exists(shadows)) Some(d0)
@@ -563,7 +563,7 @@ object Declaration {
 
           (body.traverse(go(bodyScope, _)), rest.traverse(go(restScope, _)))
             .mapN { (b, r) =>
-              DefFn(DefStatement(nm, args, rtype, (b, r)))(decl.region)
+              DefFn(DefStatement(nm, ta, args, rtype, (b, r)))(decl.region)
             }
         case LeftApply(n, r, v, in) =>
           val thisNames = n.names

--- a/core/src/main/scala/org/bykn/bosatsu/DefStatement.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/DefStatement.scala
@@ -1,76 +1,67 @@
 package org.bykn.bosatsu
 
-import Parser.{ Combinators, maybeSpace }
-import cats.Applicative
+import Parser.{Combinators, maybeSpace}
 import cats.data.NonEmptyList
-import cats.implicits._
 import cats.parse.{Parser => P}
-import org.typelevel.paiges.{ Doc, Document }
+import org.typelevel.paiges.{Doc, Document}
 
-import Identifier.{Bindable, Constructor}
+import Identifier.Bindable
+
+import cats.syntax.all._
 
 case class DefStatement[A, B](
-  name: Bindable,
-  typeArgs: Option[NonEmptyList[TypeRef.TypeVar]],
-  args: NonEmptyList[A],
-  retType: Option[TypeRef], result: B) {
-
-  /**
-   * This ignores the name completely and just returns the lambda expression here
-   */
-  def toLambdaExpr[F[_]: Applicative, C](resultExpr: B => F[Expr[C]],
-    tag: F[C])(argFn: A => F[Pattern[(PackageName, Constructor), rankn.Type]], trFn: TypeRef => F[rankn.Type]): F[Expr[C]] = {
-    val unTypedBody = resultExpr(result)
-    val bodyExp =
-      retType.fold(unTypedBody) { t =>
-        (unTypedBody, trFn(t), tag).mapN(Expr.Annotation(_, _, _))
-      }
-
-    (args.traverse(argFn), bodyExp, tag).mapN { (as, b, t) =>
-      val lambda = Expr.buildPatternLambda(as, b, t)
-      typeArgs match {
-        case None => lambda
-        case Some(args) =>
-          val bs = args.map { case TypeRef.TypeVar(b) => rankn.Type.Var.Bound(b) }
-          Expr.Generic(bs, lambda)
-      }
-    }
-  }
-}
+    name: Bindable,
+    typeArgs: Option[NonEmptyList[TypeRef.TypeVar]],
+    args: NonEmptyList[A],
+    retType: Option[TypeRef],
+    result: B
+)
 
 object DefStatement {
   private[this] val defDoc = Doc.text("def ")
   private[this] val arrow = Doc.text(" -> ")
   private[this] val commaSpace = Doc.text(", ")
 
-  implicit def document[A: Document, B: Document]: Document[DefStatement[A, B]] =
+  implicit def document[A: Document, B: Document]
+      : Document[DefStatement[A, B]] =
     Document.instance[DefStatement[A, B]] { defs =>
       import defs._
       val res = retType.fold(Doc.empty) { t => arrow + t.toDoc }
       val taDoc = typeArgs match {
-        case None => Doc.empty
+        case None     => Doc.empty
         case Some(ta) => TypeRef.docTypeArgs(ta.toList)
       }
       val argDoc =
         Doc.char('(') +
-          Doc.intercalate(commaSpace, args.map(Document[A].document(_)).toList) +
+          Doc.intercalate(
+            commaSpace,
+            args.map(Document[A].document(_)).toList
+          ) +
           Doc.char(')')
-      val line0 = defDoc + Document[Bindable].document(name) + taDoc + argDoc + res + Doc.char(':')
+      val line0 =
+        defDoc + Document[Bindable].document(name) + taDoc + argDoc + res + Doc
+          .char(':')
 
       line0 + Document[B].document(result)
     }
 
-  /**
-   * The resultTParser should parse some indentation any newlines
-   */
-  def parser[A, B](argParser: P[A], resultTParser: P[B]): P[DefStatement[A, B]] = {
-      val args = argParser.parensLines1Cut
-      val result = (P.string("->") *> maybeSpace *> TypeRef.parser).?
-      (Parser.keySpace("def") *> (Identifier.bindableParser ~ TypeRef.typeParams.? ~ args) <* maybeSpace,
-        result.with1 <* (maybeSpace.with1 ~ P.char(':')),
-        resultTParser)
-          .mapN { case (((name, tps), args), resType, res) =>
-            DefStatement(name, tps, args, resType, res)
-          }
-    }
+  /** The resultTParser should parse some indentation any newlines
+    */
+  def parser[A, B](
+      argParser: P[A],
+      resultTParser: P[B]
+  ): P[DefStatement[A, B]] = {
+    val args = argParser.parensLines1Cut
+    val result = (P.string("->") *> maybeSpace *> TypeRef.parser).?
+    (
+      Parser.keySpace(
+        "def"
+      ) *> (Identifier.bindableParser ~ TypeRef.typeParams.? ~ args) <* maybeSpace,
+      result.with1 <* (maybeSpace.with1 ~ P.char(':')),
+      resultTParser
+    )
+      .mapN { case (((name, tps), args), resType, res) =>
+        DefStatement(name, tps, args, resType, res)
+      }
+  }
 }

--- a/core/src/main/scala/org/bykn/bosatsu/SourceConverter.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/SourceConverter.scala
@@ -152,7 +152,7 @@ final class SourceConverter(
         loop(decl).map(_.as(decl))
       case CommentNB(CommentStatement(_, Padding(_, decl))) =>
         loop(decl).map(_.as(decl))
-      case DefFn(defstmt@DefStatement(_, _, _, _)) =>
+      case DefFn(defstmt@DefStatement(_, _, _, _, _)) =>
         val inExpr = defstmt.result match {
           case (_, Padding(_, in)) => withBound(in, defstmt.name :: Nil)
         }
@@ -1094,7 +1094,7 @@ final class SourceConverter(
           val r = apply(decl, Set.empty, topBound).map((nm, RecursionKind.NonRecursive, _) :: Nil)
           (topBound + nm, r)
 
-        case Right(Left(d @ Def(defstmt@DefStatement(_, pat, _, _)))) =>
+        case Right(Left(d @ Def(defstmt@DefStatement(_, _, pat, _, _)))) =>
           // using body for the outer here is a bummer, but not really a good outer otherwise
 
           val boundName = defstmt.name

--- a/core/src/main/scala/org/bykn/bosatsu/TotalityCheck.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/TotalityCheck.scala
@@ -106,6 +106,7 @@ case class TotalityCheck(inEnv: TypeEnv[Any]) {
     import Expr._
     expr match {
       case Annotation(e, _, _) => checkExpr(e)
+      case Generic(_, e) => checkExpr(e)
       case Lambda(_, _, e, _) => checkExpr(e)
       case Global(_, _, _) | Local(_, _) | Literal(_, _) => Validated.valid(())
       case App(fn, arg, _) => checkExpr(fn) *> checkExpr(arg)

--- a/core/src/main/scala/org/bykn/bosatsu/TypeRef.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/TypeRef.scala
@@ -7,7 +7,7 @@ import org.bykn.bosatsu.rankn.Type
 import org.bykn.bosatsu.{TypeName => Name}
 import org.typelevel.paiges.{ Doc, Document }
 
-import Parser.maybeSpace
+import Parser.{lowerIdent, maybeSpace, Combinators}
 
 /**
  * This AST is the syntactic version of Type
@@ -145,5 +145,16 @@ object TypeRef {
 
   val annotationParser: P[TypeRef] =
     maybeSpace.with1.soft *> P.char(':') *> maybeSpace *> parser
+
+  def docTypeArgs(targs: List[TypeRef.TypeVar]): Doc =
+    targs match {
+      case Nil => Doc.empty
+      case nonEmpty =>
+        val params = nonEmpty.map { case TypeRef.TypeVar(v) => Doc.text(v) }
+        Doc.char('[') + Doc.intercalate(Doc.text(", "), params) + Doc.char(']')
+    }
+
+  val typeParams: P[NonEmptyList[TypeRef.TypeVar]] =
+    lowerIdent.nonEmptyListSyntax.map { nel => nel.map { s => TypeRef.TypeVar(s.intern) } }
 }
 

--- a/core/src/main/scala/org/bykn/bosatsu/UnusedLetCheck.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/UnusedLetCheck.scala
@@ -25,6 +25,7 @@ object UnusedLetCheck {
     e match {
       case Annotation(expr, _, _) =>
         loop(expr)
+      case Generic(_, in) => loop(in)
       case Lambda(arg, _, expr, _) =>
         checkArg(arg, HasRegion.region(e), loop(expr))
       case Let(arg, expr, in, rec, _) =>

--- a/core/src/test/scala/org/bykn/bosatsu/DeclarationTest.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/DeclarationTest.scala
@@ -123,10 +123,10 @@ class DeclarationTest extends AnyFunSuite {
           val b = Identifier.Backticked("")
           val d1 = Literal(Lit.fromInt(0))
           val d0 = DefFn(
-            DefStatement(Name("mfLjwok"),NonEmptyList.of(Pattern.Var(Name("foo"))),None,
+            DefStatement(Name("mfLjwok"),None, NonEmptyList.of(Pattern.Var(Name("foo"))),None,
               (NotSameLine(Padding(10,Indented(10,Var(Backticked(""))))),
                 Padding(10,Binding(BindingStatement(
-                  Pattern.Var(Backticked("")),Var(Constructor("Rgt")),Padding(1,DefFn(DefStatement(Backticked(""),NonEmptyList.of(Pattern.Var(Name("bar"))),None,(NotSameLine(Padding(2,Indented(4,Literal(Lit.fromInt(42))))),Padding(2,DefFn(DefStatement(Name("gkxAckqpatu"),NonEmptyList.of(Pattern.Var(Name("quux"))),Some(TypeRef.TypeName(TypeName(Constructor("Y")))),(NotSameLine(Padding(6,Indented(8,Literal(Lit("oimsu"))))),Padding(2,Var(Name("j")))))))))))))))))
+                  Pattern.Var(Backticked("")),Var(Constructor("Rgt")),Padding(1,DefFn(DefStatement(Backticked(""),None,NonEmptyList.of(Pattern.Var(Name("bar"))),None,(NotSameLine(Padding(2,Indented(4,Literal(Lit.fromInt(42))))),Padding(2,DefFn(DefStatement(Name("gkxAckqpatu"),None, NonEmptyList.of(Pattern.Var(Name("quux"))),Some(TypeRef.TypeName(TypeName(Constructor("Y")))),(NotSameLine(Padding(6,Indented(8,Literal(Lit("oimsu"))))),Padding(2,Var(Name("j")))))))))))))))))
 
           (b, d1, d0)
         }

--- a/core/src/test/scala/org/bykn/bosatsu/EvaluationTest.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/EvaluationTest.scala
@@ -2646,5 +2646,19 @@ def foo[a](a: a) -> a:
   
 test = Assertion(foo(True), "")
 """), "Foo", 1)
+
+    evalFail(List("""
+package Foo
+
+def foo[a](a: a) -> a:
+  x: a = a
+  def again(x: a): x
+  def and_again[b](x: a): x
+  and_again(again(x))
+
+""")) { case sce@PackageError.SourceConverterErrorIn(_, _) =>
+      assert(sce.message(Map.empty, Colorize.None) == "in file: <unknown source>, package Foo, and_again found declared types: [b], not a subset of [a]\nRegion(71,118)")
+      ()
+    }
   }
 }

--- a/core/src/test/scala/org/bykn/bosatsu/EvaluationTest.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/EvaluationTest.scala
@@ -2633,4 +2633,18 @@ x = bar
       ()
     }
   }
+
+  test("test def with type params") {
+    runBosatsuTest(List("""
+package Foo
+
+def foo[a](a: a) -> a:
+  x: a = a
+  def again(x: a): x
+  def and_again[b](x: b): x
+  and_again(again(x))
+  
+test = Assertion(foo(True), "")
+"""), "Foo", 1)
+  }
 }

--- a/core/src/test/scala/org/bykn/bosatsu/Gen.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/Gen.scala
@@ -147,9 +147,10 @@ object Generators {
     for {
       name <- bindIdentGen
       args <- nonEmpty(argGen)
+      tpes <- smallList(typeRefVarGen)
       retType <- Gen.option(typeRefGen)
       body <- dec
-    } yield DefStatement(name, args.map(argToPat), retType, body)
+    } yield DefStatement(name, NonEmptyList.fromList(tpes), args.map(argToPat), retType, body)
 
   def genSpliceOrItem[A](spliceGen: Gen[A], itemGen: Gen[A]): Gen[ListLang.SpliceOrItem[A]] =
     Gen.oneOf(spliceGen.map(ListLang.SpliceOrItem.Splice(_)),

--- a/core/src/test/scala/org/bykn/bosatsu/ParserTest.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/ParserTest.scala
@@ -576,7 +576,7 @@ foo"""
     parseTestAll(
       Declaration.parser(""),
       defWithComment,
-      Declaration.DefFn(DefStatement(Identifier.Name("foo"), NonEmptyList.of(Pattern.Var(Identifier.Name("a"))), None,
+      Declaration.DefFn(DefStatement(Identifier.Name("foo"), None, NonEmptyList.of(Pattern.Var(Identifier.Name("a"))), None,
         (OptIndent.paddedIndented(1, 2, Declaration.CommentNB(CommentStatement(NonEmptyList.of(" comment here"),
           Padding(0, mkVar("a"))))),
          Padding(0, mkVar("foo"))))))

--- a/core/src/test/scala/org/bykn/bosatsu/TestUtils.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/TestUtils.scala
@@ -118,6 +118,7 @@ object TestUtils {
       case Right(other) =>
         fail(s"got an unexpected success: $other")
       case Left(err) =>
+        err.printStackTrace
         fail(s"got an exception: $err")
     }
   }


### PR DESCRIPTION
close #938 

This turns out to be needed to make kinds work with many of our current examples (which do have types mentioned which are not of kind `*`).

The change is pretty mechanical and minor.

We cannot use any kind of strict checking that all free vars are mentioned like we do with structs/enums because unlike structs and enums `defs` are recursive. We assume any param not mentioned is free in the higher level until we reach the top and then it is a top level free param.