### PR TITLE
Add quick look tests

### DIFF
--- a/core/src/test/scala/org/bykn/bosatsu/EvaluationTest.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/EvaluationTest.scala
@@ -2685,7 +2685,44 @@ struct RecordGetter[shape, t](
 def get[shape](sh: shape[RecordValue], RecordGetter(getter): RecordGetter[shape, t]) -> t:
   RecordValue(result) = sh.getter
   result
-""")) { case tpe@PackageError.TypeErrorIn(_, _) => () //rankn.Infer.Error.KindNotUnifiable(_, _, _, _, _, _), _) => ()
+""")) { case PackageError.TypeErrorIn(_, _) => () //rankn.Infer.Error.KindNotUnifiable(_, _, _, _, _, _), _) => ()
     }
+  }
+
+  test("test quicklook example") {
+    runBosatsuTest(List("""
+package Foo
+
+def f(fn: forall a. List[a] -> List[a]) -> Int:
+  fn([1]).foldLeft(0)(\x, _ -> x.add(1))
+
+def g(b: Bool) -> (forall a. List[a] -> List[a]):
+  match b:
+    case True: \x -> x
+    case False: \_ -> []
+
+def id(a): a
+def single(a): [a]    
+
+def foo1(fn) -> Int:
+  fn.foldLeft(0)(\x, _ -> x.add(1))
+
+def foo2(fn: List[forall a. a -> a]) -> Int:
+  fn.foldLeft(0)(\x, _ -> x.add(1))
+
+count = foo1(single(id))
+count = foo2(single(id))
+
+single_id1: forall a. List[a -> a] = single(id)
+single_id2: List[forall a. a -> a] = single(id)
+
+struct Pair1(fst: a, snd: a)
+
+pair = Pair1(single_id1, single_id2)
+
+comp = \x -> f(g(x))
+  
+test = Assertion(True, "")
+"""), "Foo", 1)
   }
 }


### PR DESCRIPTION
I was looking at #650 

but I can't seem to get any of the examples to fail.

I don't know why. I have a few theories:

1. since I track the variance of all types, I can see that `List[forall a. a -> a]` and `forall a. List[a -> a]` are the same type, but maybe without variance you can't?
2. the type system is unsound so we are accepting invalid programs
3. there are bugs in the current implementation, but not exactly soundness problems

I couldn't get any real programs to fail with #267 either. All the examples I tried either involved uninhabited types that I couldn't write with programs that didn't ignore bindings, or they just worked.
