### PR TITLE
Improve inference of types containing forall and matching.

### DIFF
--- a/core/src/main/scala/org/bykn/bosatsu/Referant.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/Referant.scala
@@ -73,7 +73,7 @@ object Referant {
 
   def typeConstructors[A, B](
     imps: List[Import[A, NonEmptyList[Referant[B]]]]):
-      Map[(PackageName, ConstructorName), (List[(Type.Var, B)], List[Type], Type.Const.Defined)] = {
+      Map[(PackageName, ConstructorName), (List[(Type.Var.Bound, B)], List[Type], Type.Const.Defined)] = {
     val refs: Iterator[Referant[B]] = imps.iterator.flatMap(_.items.toList.iterator.flatMap(_.tag.toList))
     refs.collect { case Constructor(dt, fn) =>
       ((dt.packageName, fn.name), (dt.annotatedTypeParams, fn.args.map(_._2), dt.toTypeConst))

--- a/core/src/main/scala/org/bykn/bosatsu/TypeParser.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/TypeParser.scala
@@ -115,6 +115,8 @@ abstract class TypeParser[A] {
     Doc.text(s"<nothing matched: $a>")
   }
 
+  def render(a: A): String = toDoc(a).renderTrim(80)
+
   final val document: Document[A] = Document.instance(toDoc(_))
 }
 

--- a/core/src/main/scala/org/bykn/bosatsu/TypedExpr.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/TypedExpr.scala
@@ -30,7 +30,7 @@ sealed abstract class TypedExpr[+T] { self: Product =>
   lazy val getType: Type =
     this match {
       case Generic(params, expr) =>
-        Type.forAll(params.toList, expr.getType)
+        Type.forAll(params, expr.getType)
       case Annotation(_, tpe, _) =>
         tpe
       case AnnotatedLambda(_, tpe, res, _) =>

--- a/core/src/main/scala/org/bykn/bosatsu/rankn/Infer.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/rankn/Infer.scala
@@ -457,6 +457,12 @@ object Infer {
     def instantiate(t: Type): Infer[Type.Rho] =
       t match {
         case Type.ForAll(vars, ty) =>
+          // TODO: by following the pushdownCovariant
+          // we can probably typecheck more code by
+          // pushing down as much as possible so we don't
+          // need to allocate metas for everything.
+          // we want to defer metas as long as possible
+          // since they can only hold tau types
           vars.traverse { case (_, k) => newMetaType(k) }
             .map { vars1T =>
               substTyRho(vars.map(_._1), vars1T)(ty)

--- a/core/src/main/scala/org/bykn/bosatsu/rankn/Infer.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/rankn/Infer.scala
@@ -885,18 +885,10 @@ object Infer {
           //
           // It feels like there should be another inference rule, which we
           // are missing here.
-          def debug(any: Any) = {
-            term match {
-              case Local(b: Bindable, _) if b.asString == "maybeFn" =>
-                println(s"$b == $any")
-              case _ => ()
-            }
-          }
           expect match {
             case Expected.Check((resT, _)) =>
               for {
                 tsigma <- inferSigma(term)
-                _ = debug(Type.typeParser.render(tsigma.getType))
                 tbranches <- branches.traverse { case (p, r) =>
                   // note, resT is in weak-prenex form, so this call is permitted
                   checkBranch(p, Expected.Check((tsigma.getType, region(term))), r, resT)
@@ -905,7 +897,6 @@ object Infer {
             case infer@Expected.Inf(_) =>
               for {
                 tsigma <- inferSigma(term)
-                _ = debug(Type.typeParser.render(tsigma.getType))
                 tbranches <- branches.traverse { case (p, r) =>
                   inferBranch(p, Expected.Check((tsigma.getType, region(term))), r)
                 }

--- a/core/src/main/scala/org/bykn/bosatsu/rankn/Ref.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/rankn/Ref.scala
@@ -22,9 +22,9 @@ sealed trait Ref[A] {
 
 sealed abstract class RefSpace[+A] {
   final def run: Eval[A] =
-    runState(new AtomicLong(0L), new MutableMap)
+    runState(new AtomicLong(0L), RefSpace.State.newEmpty())
 
-  protected def runState(al: AtomicLong, state: MutableMap[Any]): Eval[A]
+  protected def runState(al: AtomicLong, state: RefSpace.State): Eval[A]
 
   def map[B](fn: A => B): RefSpace[B] =
     RefSpace.Map(this, fn)
@@ -38,7 +38,7 @@ sealed abstract class RefSpace[+A] {
 
 object RefSpace {
   private case class Pure[A](value: Eval[A]) extends RefSpace[A] {
-    protected def runState(al: AtomicLong, state: MutableMap[Any]) =
+    protected def runState(al: AtomicLong, state: State) =
       value
   }
   private case class AllocRef[A](handle: Long, init: A) extends RefSpace[A] with Ref[A] {
@@ -46,7 +46,7 @@ object RefSpace {
     def set(a: A) = SetRef(handle, a)
     val reset = Reset(handle)
 
-    protected def runState(al: AtomicLong, state: MutableMap[Any]): Eval[A] =
+    protected def runState(al: AtomicLong, state: State): Eval[A] =
       Eval.now {
         state.get(handle) match {
           case Some(res) =>
@@ -57,47 +57,85 @@ object RefSpace {
       }
   }
   private case class SetRef(handle: Long, value: Any) extends RefSpace[Unit] {
-    protected def runState(al: AtomicLong, state: MutableMap[Any]): Eval[Unit] =
+    protected def runState(al: AtomicLong, state: State): Eval[Unit] =
       { state.put(handle, value); Eval.Unit }
   }
   private case class Reset(handle: Long) extends RefSpace[Unit] {
-    protected def runState(al: AtomicLong, state: MutableMap[Any]): Eval[Unit] =
+    protected def runState(al: AtomicLong, state: State): Eval[Unit] =
       { state.remove(handle); Eval.Unit }
   }
   private case class Alloc[A](init: A) extends RefSpace[Ref[A]] {
-    protected def runState(al: AtomicLong, state: MutableMap[Any]) =
+    protected def runState(al: AtomicLong, state: State) =
       Eval.now(AllocRef(al.getAndIncrement, init))
   }
 
   private case class Map[A, B](init: RefSpace[A], fn: A => B) extends RefSpace[B] {
-    protected def runState(al: AtomicLong, state: MutableMap[Any]) =
+    protected def runState(al: AtomicLong, state: State) =
       Eval.defer(init.runState(al, state)).map(fn)
   }
 
   private case class FlatMap[A, B](init: RefSpace[A], fn: A => RefSpace[B]) extends RefSpace[B] {
-    protected def runState(al: AtomicLong, state: MutableMap[Any]): Eval[B] =
+    protected def runState(al: AtomicLong, state: State): Eval[B] =
       Eval.defer(init.runState(al, state))
         .flatMap { a =>
           fn(a).runState(al, state)
         }
   }
 
+  sealed abstract class State {
+    def put(key: Long, value: Any): Unit
+    def get(key: Long): Option[Any]
+    def remove(key: Long): Unit
+  }
+  object State {
+    // just to bypass discard warning. I assume this is inlined
+    @inline private[this] def discard[A](a: A): Unit = ()
+
+    private[RefSpace] class FromMMap(map: MutableMap[Any]) extends State {
+      def put(key: Long, value: Any): Unit =
+        discard(map.put(key, value))
+      def get(key: Long): Option[Any] = map.get(key)
+      def remove(key: Long): Unit = 
+        discard(map.remove(key))
+    }
+
+    private[RefSpace] class Fork(under: State, over: MutableMap[Option[Any]]) extends State {
+      def put(key: Long, value: Any): Unit = discard(over.put(key, Some(value)))
+      def get(key: Long): Option[Any] =
+        over.get(key) match {
+          case Some(s) => s
+          case None => under.get(key)
+        }
+      def remove(key: Long): Unit = discard(over.put(key, None))
+
+      def flush(): Unit = {
+        over.foreach {
+          case (k, Some(v)) => under.put(k, v)
+          case (k, None) => under.remove(k)
+        }
+      }
+
+      def reset: State = under
+    }
+
+    def newEmpty(): State = new FromMMap(MutableMap.empty[Any])
+    def fork(state: State): Fork = new Fork(state, MutableMap.empty)
+  }
+
   private case class ResetOnLeft[A, B, C](init: RefSpace[A], fn: A => Either[B, C]) extends RefSpace[Either[B, C]] {
-    protected def runState(al: AtomicLong, state: MutableMap[Any]): Eval[Either[B, C]] = {
-      val state0 = state.iterator.toMap
-      init.runState(al, state)
+    protected def runState(al: AtomicLong, state: State): Eval[Either[B, C]] = {
+      val forked = State.fork(state)
+      init.runState(al, forked)
         .map { a =>
           fn(a) match {
-            case r@Right(_) => r
+            case r@Right(_) =>
+              forked.flush()
+              r
             case l@Left(_) =>
-              // restore the state    
-              state.clear()
-              state ++= state0.iterator
+              // just let the forked state disappear
               l
           }
         }
-        .memoize
-      
     }
   }
 

--- a/core/src/main/scala/org/bykn/bosatsu/rankn/Type.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/rankn/Type.scala
@@ -145,7 +145,7 @@ object Type {
   /**
    * This form is often useful in Infer
    */
-  def substTy(keys: NonEmptyList[Var], vals: NonEmptyList[Rho]): Type => Type = {
+  def substTy(keys: NonEmptyList[Var], vals: NonEmptyList[Type]): Type => Type = {
     val env = keys.toList.iterator.zip(vals.toList.iterator).toMap
 
     { t => substituteVar(t, env) }

--- a/core/src/main/scala/org/bykn/bosatsu/rankn/Type.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/rankn/Type.scala
@@ -558,4 +558,5 @@ object Type {
    */
   def fullyResolvedParser: P[Type] = FullResolved.parser
   def fullyResolvedDocument: Document[Type] = FullResolved.document
+  def typeParser: TypeParser[Type] = FullResolved
 }

--- a/core/src/main/scala/org/bykn/bosatsu/rankn/Type.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/rankn/Type.scala
@@ -99,11 +99,13 @@ object Type {
   final def forAll(vars: List[(Var.Bound, Kind)], in: Type): Type =
     NonEmptyList.fromList(vars) match {
       case None => in
-      case Some(ne) =>
-        in match {
-          case rho: Rho => Type.ForAll(ne, rho)
-          case Type.ForAll(ne1, rho) => Type.ForAll(ne ::: ne1, rho)
-        }
+      case Some(ne) => forAll(ne, in)
+    }
+
+  final def forAll(vars: NonEmptyList[(Var.Bound, Kind)], in: Type): Type =
+    in match {
+      case rho: Rho => Type.ForAll(vars, rho)
+      case Type.ForAll(ne1, rho) => Type.ForAll(vars ::: ne1, rho)
     }
 
   implicit val typeEq: Eq[Type] =
@@ -500,7 +502,7 @@ object Type {
     def applyTypes(left: Type, args: NonEmptyList[Type]) = applyAll(left, args.toList)
 
     def universal(vs: NonEmptyList[(String, Option[Kind])], on: Type) =
-      Type.forAll(vs.toList.map {
+      Type.forAll(vs.map {
         case (s, None) => (Type.Var.Bound(s), Kind.Type)
         case (s, Some(k)) => (Type.Var.Bound(s), k)
       }, on) 

--- a/core/src/main/scala/org/bykn/bosatsu/rankn/TypeEnv.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/rankn/TypeEnv.scala
@@ -110,7 +110,7 @@ class TypeEnv[+A] private (
       definedTypes = definedTypes,
       values = values.updated((pack, name), t))
 
-  lazy val typeConstructors: SortedMap[(PackageName, Constructor), (List[(Type.Var, A)], List[Type], Type.Const.Defined)] =
+  lazy val typeConstructors: SortedMap[(PackageName, Constructor), (List[(Type.Var.Bound, A)], List[Type], Type.Const.Defined)] =
     constructors.map { case (pc, (dt, cf)) =>
       (pc,
         (dt.annotatedTypeParams,

--- a/core/src/test/scala/org/bykn/bosatsu/EvaluationTest.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/EvaluationTest.scala
@@ -2010,6 +2010,17 @@ ListWrapper2(_, _, r) = w
 
 tests = Assertion(r, "match with total list pattern")
 """), "A", 1)
+
+    runBosatsuTest(List("""package A
+
+struct ListWrapper(items: List[(a, b)], b: Bool)
+
+w = ListWrapper([], True)
+
+ListWrapper(_, r) = w
+
+tests = Assertion(r, "match with total list pattern")
+"""), "A", 1)
   }
 
   test("test scoping bug (issue #311)") {
@@ -2772,6 +2783,11 @@ Region(14,41)""")
 package SubsumeTest
 
 def lengths(l1: List[Int], l2: List[String], maybeFn: Option[forall tt. List[tt] -> Int]):
+  match maybeFn:
+    Some(fn): fn(l1).add(fn(l2))
+    None: 0
+
+def lengths2(l1: List[Int], l2: List[String], maybeFn: forall tt. Option[List[tt] -> Int]):
   match maybeFn:
     Some(fn): fn(l1).add(fn(l2))
     None: 0

--- a/core/src/test/scala/org/bykn/bosatsu/EvaluationTest.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/EvaluationTest.scala
@@ -1995,6 +1995,17 @@ ListWrapper([*_], r) = w
 
 tests = Assertion(r, "match with total list pattern")
 """), "A", 1)
+
+    runBosatsuTest(List("""package A
+
+struct ListWrapper2(items: List[a], others: List[b], b: Bool)
+
+w = ListWrapper2([], [], True)
+
+ListWrapper2(_, _, r) = w
+
+tests = Assertion(r, "match with total list pattern")
+"""), "A", 1)
   }
 
   test("test scoping bug (issue #311)") {
@@ -2750,5 +2761,19 @@ struct Foo[a: *](a: a[Int])
 Region(14,41)""")
       ()
     }
+  }
+
+  test("example from issue #264") {
+    runBosatsuTest("""
+package SubsumeTest
+
+def lengths(l1: List[Int], l2: List[String], maybeFn: Option[forall tt. List[tt] -> Int]):
+  match maybeFn:
+    Some(fn: forall t. List[t] -> Int):
+      fn(l1).add(fn(l2))
+    None: 0
+
+test = Assertion(lengths([], [], None) matches 0, "test")
+    """ :: Nil, "SubsumeTest", 1)
   }
 }

--- a/core/src/test/scala/org/bykn/bosatsu/EvaluationTest.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/EvaluationTest.scala
@@ -2769,8 +2769,7 @@ package SubsumeTest
 
 def lengths(l1: List[Int], l2: List[String], maybeFn: Option[forall tt. List[tt] -> Int]):
   match maybeFn:
-    Some(fn: forall t. List[t] -> Int):
-      fn(l1).add(fn(l2))
+    Some(fn): fn(l1).add(fn(l2))
     None: 0
 
 test = Assertion(lengths([], [], None) matches 0, "test")

--- a/core/src/test/scala/org/bykn/bosatsu/EvaluationTest.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/EvaluationTest.scala
@@ -1756,7 +1756,11 @@ equal_rows = equal_List(equal_RowEntry)
 
 ##################################################
 
-rs_empty = new_record_set.restructure(\_ -> ps("String field".string_field(\_ -> ""), ps("Int field".int_field(\_ -> 0), ps("Bool field".bool_field(\_ -> True), ps_end))))
+rs_empty = new_record_set.restructure(
+  \_ -> ps("String field".string_field(\_ -> ""),
+  ps("Int field".int_field(\_ -> 0),
+  ps("Bool field".bool_field(\_ -> True),
+  ps_end))))
 
 rs = rs_empty.concat_records([PS(RecordValue("a"), PS(RecordValue(1), PS(RecordValue(False), NilShape)))])
 

--- a/core/src/test/scala/org/bykn/bosatsu/EvaluationTest.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/EvaluationTest.scala
@@ -2776,6 +2776,11 @@ def lengths(l1: List[Int], l2: List[String], maybeFn: Option[forall tt. List[tt]
     Some(fn): fn(l1).add(fn(l2))
     None: 0
 
+# this is a test that doesn't forget that we have the empty list:
+x = match []:
+      case []: 0
+      case [h, *_]: (h: forall a. a)
+
 test = Assertion(lengths([], [], None) matches 0, "test")
     """ :: Nil, "SubsumeTest", 1)
   }


### PR DESCRIPTION
close #264 and #267

I think this and the other variance related changes address all of the issues in #264  we can reopen later if not.

The pushdownCovariant idea can be taken further I think. The current algorithm is only catching easy, not all cases. And we can possibly use it in more than just inferring types on matches.

cc @snoble 