### PR TITLE
Improve UnexpectedMeta error

### DIFF
--- a/core/src/main/scala/org/bykn/bosatsu/PackageError.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/PackageError.scala
@@ -282,6 +282,30 @@ object PackageError {
             Doc.text("because the first kind does not subsume the second.")
 
           doc.render(80)
+        case Infer.Error.UnexpectedMeta(meta, in, metaR, rightR) =>
+          val tymeta = Type.TyMeta(meta)
+          val tmap = showTypes(pack, tymeta :: in :: Nil)
+          val context0 =
+              lm.showRegion(metaR, 2, errColor).getOrElse(Doc.str(metaR)) // we should highlight the whole region
+          val context1 = {
+            if (metaR != rightR) {
+              Doc.text(" at: ") + Doc.hardLine +
+              lm.showRegion(rightR, 2, errColor).getOrElse(Doc.str(rightR)) + // we should highlight the whole region
+              Doc.hardLine
+            }
+            else {
+              Doc.empty
+            }
+          }
+
+          val doc = Doc.text("Unexpected unknown: the type: ") + tmap(tymeta) +
+            Doc.text(" of kind: ") + Kind.toDoc(meta.kind) + Doc.text(" at: ") + Doc.hardLine +
+            context0 + Doc.hardLine + Doc.hardLine +
+            Doc.text("inside the type ") + tmap(in) + context1 +
+            Doc.hardLine +
+            Doc.text("this sometimes happens when a function arg has been omitted, or an illegal recursive type or function.")
+
+          doc.render(80)
         case err => err.message
       }
       // TODO use the sourceMap/regiouns in Infer.Error

--- a/core/src/test/scala/org/bykn/bosatsu/EvaluationTest.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/EvaluationTest.scala
@@ -2842,4 +2842,32 @@ Region(195,205)"""
     }
  
   }
+  test("print a decent message when there is an unknown meta") {
+   evalFail(List("""
+package QS
+
+def quick_sort0(cmp, left, right):
+  recur left:
+    case []: right
+    case [pivot, *tail]:
+      if right matches ([] | [_]): right
+      else:
+        smaller = [x for x in right if cmp(x, pivot) matches (LT | EQ)]
+        bigger = [x for x in right if cmp(x, pivot) matches GT]
+        smalls = quick_sort0(cmp, tail, smaller)
+        # we accidentally omit bigger below
+        bigs = quick_sort0(cmp, tail)
+        [*smalls, *bigs]
+""")) { case kie@PackageError.TypeErrorIn(_, _) =>
+      assert(kie.message(Map.empty, Colorize.None) ==
+      """in file: <unknown source>, package QS, Unexpected unknown: the type: ?50 of kind: * at: 
+Region(396,450)
+
+inside the type ?51[?52]
+this sometimes happens when a function arg has been omitted, or an illegal recursive type or function."""
+      )
+      ()
+    }
+ 
+  }
 }


### PR DESCRIPTION
that error was wrongly labeled as an InternalError. It's not. It can happen from user code.

Still the message isn't very diagnostic, but at least it isn't toString on an AST.