### PR TITLE
Improve the source embedding macro

### DIFF
--- a/base/src/main/scala/org/bykn/bosatsu/Macro.scala
+++ b/base/src/main/scala/org/bykn/bosatsu/Macro.scala
@@ -1,20 +1,43 @@
 package org.bykn.bosatsu
 
 import reflect.macros.blackbox.Context
-import scala.io._
-
-import scala.util.{Try => STry}
+import java.io.File
+import scala.io.Source
+import scala.util.control.NonFatal
 
 class Macro(val c: Context) {
   import c._, universe._
-  def smac(file: c.Expr[String]) = file.tree match {
-    case Literal(Constant(s: String)) =>
-      val res = STry(
-        Source.fromFile(s, "UTF-8").getLines().mkString("\n")
-      ).getOrElse(
-        Source.fromFile(s"external/org_bykn_bosatsu/$s", "UTF-8").getLines().mkString("\n")
-      )
-      q"$res"
+  def loadFileInCompileImpl(file: c.Expr[String]): c.Expr[String] = {
+
+    def loadPath(s: String): c.Expr[String] =
+      try {
+        val res = Source.fromFile(s, "UTF-8").getLines().mkString("\n")
+        c.Expr[String](q"$res")
+      }
+      catch {
+        case NonFatal(err) =>
+          c.abort(c.enclosingPosition, s"could not read existing file: $s. Exception: $err")
+      }
+
+    file.tree match {
+      case Literal(Constant(s: String)) =>
+        val normal = new File(s)
+        if (normal.exists()) {
+          loadPath(s)
+        }
+        else {
+          val bazelPath = s"external/org_bykn_bosatsu/$s"
+          val bazelFile = new File(bazelPath)
+          if (bazelFile.exists()) {
+            loadPath(bazelPath)
+          }
+          else {
+            c.abort(c.enclosingPosition, s"no file found at: $s. working directory is ${System.getProperty("user.dir")}")
+          }
+        }
+      case otherTree =>
+        c.abort(c.enclosingPosition, s"expected string literal, found: $otherTree")
+    }
   }
 }
 

--- a/core/src/main/scala/org/bykn/bosatsu/Predef.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/Predef.scala
@@ -9,7 +9,7 @@ object Predef {
    * external files into strings. This lets us avoid resources
    * which compilicate matters for scalajs.
    */
-  private[bosatsu] def loadFileInCompile(file: String): String = macro Macro.smac
+  private[bosatsu] def loadFileInCompile(file: String): String = macro Macro.loadFileInCompileImpl
 
   /**
    * String representation of the predef


### PR DESCRIPTION
I tried to get this to not show up as an error in metals, but it seems the problem is metals shares state across different starts, so starting metals in one project will set the working directory for metals in other projects.