### PR TITLE
Support Existential Recursion

### DIFF
--- a/core/src/main/scala/org/bykn/bosatsu/DefRecursionCheck.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/DefRecursionCheck.scala
@@ -53,7 +53,7 @@ object DefRecursionCheck {
   }
   case class RecursionNotSubstructural(fnname: Bindable, recurPat: Pattern.Parsed, arg: Declaration.Var) extends RecursionError {
     def region = arg.region
-    def message = s"recursion is ${fnname.sourceCodeRepr} not substructual"
+    def message = s"recursion in ${fnname.sourceCodeRepr} not substructual"
   }
   case class RecursiveDefNoRecur(defstmt: DefStatement[Pattern.Parsed, Declaration], recur: Declaration.Match) extends RecursionError {
     def region = recur.region

--- a/core/src/main/scala/org/bykn/bosatsu/Pattern.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/Pattern.scala
@@ -37,10 +37,10 @@ sealed abstract class Pattern[+N, +T] {
           if (seen(v)) loop(p :: tail, seen, acc)
           else loop(p :: tail, seen + v, v :: acc)
         case Pattern.StrPat(items) :: tail =>
-          val names = items.collect { case Pattern.StrPart.NamedStr(n) => n }.filterNot(seen)
+          val names = items.collect { case Pattern.StrPart.NamedStr(n) if !seen(n) => n }
           loop(tail, seen ++ names, names reverse_::: acc)
         case Pattern.ListPat(items) :: tail =>
-          val globs = items.collect { case Pattern.ListPart.NamedList(glob) => glob }.filterNot(seen)
+          val globs = items.collect { case Pattern.ListPart.NamedList(glob) if !seen(glob) => glob }
           val next = items.collect { case Pattern.ListPart.Item(inner) => inner }
           loop(next ::: tail, seen ++ globs, globs reverse_::: acc)
         case Pattern.Annotation(p, _) :: tail => loop(p :: tail, seen, acc)

--- a/core/src/test/scala/org/bykn/bosatsu/EvaluationTest.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/EvaluationTest.scala
@@ -902,8 +902,26 @@ loopgen: forall a. Cont[a] -> a = loop
 b: Cont[Int] = Item(1).map(x -> x.add(1))
 main: Int = loop(b)
 """), "A", VInt(2))
-  }
 
+/*
+ It would be great for this to be allowed, but
+ we would have to see that foldLeft doesn't increase
+ the size
+    evalTest(
+      List("""
+package A
+
+struct Tree[a](item: a, children: List[Tree[a]])
+
+def reduce(t: Tree[a], fn: a -> a -> a) -> a:
+  recur t:
+    case Tree(item, many):
+      many.foldLeft(item)((acc, tree) -> fn(acc, reduce(tree, fn)))
+
+main = Tree(0, [Tree(1, []), Tree(1, [])]).reduce((a, b) -> a.add(b))
+"""), "A", VInt(2))
+*/
+  }
 
   test("we can mix literal and enum forms of List") {
   evalTest(

--- a/core/src/test/scala/org/bykn/bosatsu/EvaluationTest.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/EvaluationTest.scala
@@ -882,14 +882,17 @@ enum Box[a: +*]:
   Next(fn: forall res. (forall b. (Box[b], b -> a) -> res) -> res)
 
 def map[a, b](box: Box[a], fn: a -> b) -> Box[b]:
-  Next(cont -> cont((b, fn)))
+  Next(cont -> cont((box, fn)))
 
 b = Item(1)
 
 def loop[a](box: Box[a]) -> a:
   recur box:
     case Item(a): a
-    case Next(cont): cont(((inner, fn)) -> fn(loop(inner)))
+    case Next(cont):
+      # this is polymorphic recursion, since we need to recur on `loop[b](inner)`
+      # but we only have monomorphic recursion currently.
+      cont(((inner, fn)) -> (fn(loop(inner))))
 
 v = loop(b)
 

--- a/core/src/test/scala/org/bykn/bosatsu/EvaluationTest.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/EvaluationTest.scala
@@ -889,7 +889,7 @@ b = Item(1)
 def loop[a](box: Box[a]) -> a:
   recur box:
     case Item(a): a
-    case Next(cont): cont((box, fn) -> fn(loop(box)))
+    case Next(cont): cont(((inner, fn)) -> fn(loop(inner)))
 
 v = loop(b)
 

--- a/core/src/test/scala/org/bykn/bosatsu/TestUtils.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/TestUtils.scala
@@ -95,6 +95,10 @@ object TestUtils {
         assert(gv == expected, s"${gotDoc.value.render(80)}\n\n$gv != $expected")
       case Right(other) =>
         fail(s"got an unexpected success: $other")
+      case Left(err: module.MainException.ParseErrors) =>
+        fail(s"parse errors: ${err.messages.mkString("\n")}")
+      case Left(err: module.MainException.PackageErrors) =>
+        fail(s"package errors: ${err.errors.toList.map(_.message(Map.empty, LocationMap.Colorize.None)).mkString("\n")}")
       case Left(err) =>
         fail(s"got an exception: $err")
     }


### PR DESCRIPTION
the encoding of existential types `forall a. (forall b. (P[b] -> a) -> a)` inside a recursive data type currently isn't supported.

It should be safe for covariant paths to the same time inside the `P[b]` in the above.

