### PR TITLE
Require parens on dot apply

### DIFF
--- a/core/src/main/resources/bosatsu/predef.bosatsu
+++ b/core/src/main/resources/bosatsu/predef.bosatsu
@@ -93,10 +93,10 @@ def concat(front: List[a], back: List[a]) -> List[a]:
     case _: reverse_concat(reverse(front), back)
 
 def map_List(lst: List[a], fn: a -> b) -> List[b]:
-  lst.foldLeft([], \t, a -> [fn(a), *t]).reverse
+  lst.foldLeft([], \t, a -> [fn(a), *t]).reverse()
 
 def flat_map_List(lst: List[a], fn: a -> List[b]) -> List[b]:
-  lst.foldLeft([], \t, a -> fn(a).reverse_concat(t)).reverse
+  lst.foldLeft([], \t, a -> fn(a).reverse_concat(t)).reverse()
 
 #############
 # Some utilities for dealing with functions
@@ -274,10 +274,10 @@ def add_item(ord: Order[a], tree: Tree[a], item: a) -> Tree[a]:
                     case EQ: Branch(s, h, item, left, right)
                     case LT:
                         left = loop(left)
-                        branch(s.add(1), item0, left, right).balance
+                        branch(s.add(1), item0, left, right).balance()
                     case GT:
                         right = loop(right)
-                        branch(s.add(1), item0, left, right).balance
+                        branch(s.add(1), item0, left, right).balance()
 
     loop(tree)
 
@@ -308,13 +308,13 @@ def remove_item(ord: Order[a], tree: Tree[a], item: a) -> Tree[a]:
                             case Empty: left
                             case _:
                                 right = loop(right)
-                                branch(size.sub(1), key, left, right).balance
+                                branch(size.sub(1), key, left, right).balance()
                     case LT:
                         left = loop(left)
-                        branch(size.sub(1), key, left, right).balance
+                        branch(size.sub(1), key, left, right).balance()
                     case GT:
                         right = loop(right)
-                        branch(size.sub(1), key, left, right).balance
+                        branch(size.sub(1), key, left, right).balance()
 
     loop(tree)
 

--- a/core/src/main/scala/org/bykn/bosatsu/MainModule.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/MainModule.scala
@@ -116,7 +116,7 @@ abstract class MainModule[IO[_]](implicit
             val (r, c) = pf.locations.toLineCol(pf.position).get
             val ctx = pf.showContext(color)
             List(
-              s"failed to parse $path at line ${r + 1}, column ${c + 1}",
+              s"failed to parse $path:${r + 1}:${c + 1}",
               ctx.render(80)
             )
           case MainCommand.ParseError.FileError(path, err) =>

--- a/core/src/main/scala/org/bykn/bosatsu/PackageError.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/PackageError.scala
@@ -70,7 +70,7 @@ object PackageError {
       val candidates =
         nearest(ex.name, candidateMap, 3)
           .map { case (n, r) =>
-            val pos = lm.toLineCol(r.start).map { case (l, c) => s" at line: ${l + 1}, column: ${c + 1}" }.getOrElse("")
+            val pos = lm.toLineCol(r.start).map { case (l, c) => s":${l + 1}:${c + 1}" }.getOrElse("")
             s"${n.asString}$pos"
           }
       val candstr = candidates.mkString("\n\t", "\n\t", "\n")

--- a/core/src/main/scala/org/bykn/bosatsu/Parser.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/Parser.scala
@@ -335,6 +335,8 @@ object Parser {
       item.nonEmptyListOfWs(maybeSpacesAndLines)
         .parensCut
 
+    def parensLines0Cut: P[List[T]] =
+      parens(nonEmptyListToList(item.nonEmptyListOfWs(maybeSpacesAndLines)))
     /**
      * either: a, b, c, ..
      * or (a, b, c, ) where we allow newlines:

--- a/core/src/test/scala/org/bykn/bosatsu/EvaluationTest.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/EvaluationTest.scala
@@ -5,7 +5,7 @@ import Value._
 import LocationMap.Colorize
 import org.scalatest.funsuite.AnyFunSuite
 
-class EvalationTest extends AnyFunSuite with ParTest {
+class EvaluationTest extends AnyFunSuite with ParTest {
 
   import TestUtils._
 
@@ -1078,7 +1078,7 @@ package A
 
 e = empty_Dict(string_Order)
 
-e1 = e.clear_Dict.add_key("hello2", "world2")
+e1 = e.clear_Dict().add_key("hello2", "world2")
 
 main = e1.get_key("hello")
 """), "A", VOption.none)
@@ -1099,7 +1099,7 @@ package A
 
 e1 = empty_Dict(string_Order)
 e2 = e1.add_key("hello", "world").add_key("hello1", "world1")
-lst = e2.items
+lst = e2.items()
 
 main = match lst:
   case [("hello", "world"), ("hello1", "world1")]: "good"
@@ -1111,7 +1111,7 @@ package A
 
 e1 = {}
 e2 = e1.add_key("hello", "world").add_key("hello1", "world1")
-lst = e2.items
+lst = e2.items()
 
 main = match lst:
   case [("hello", "world"), ("hello1", "world1")]: "good"
@@ -1125,7 +1125,7 @@ e = {
       "hello": "world",
       "hello1":
         "world1" }
-lst = e.items
+lst = e.items()
 
 main = match lst:
   case [("hello", "world"), ("hello1", "world1")]: "good"
@@ -1138,7 +1138,7 @@ package A
 pairs = [("hello", "world"), ("hello1", "world1")]
 
 e = { k: v for (k, v) in pairs }
-lst = e.items
+lst = e.items()
 
 main = match lst:
   case [("hello", "world"), ("hello1", "world1")]: "good"
@@ -1156,7 +1156,7 @@ def is_hello(s):
     case _: False
 
 e = { k: v for (k, v) in pairs if is_hello(k) }
-lst = e.items
+lst = e.items()
 
 main = match lst:
   case [("hello", res)]: res
@@ -1655,7 +1655,7 @@ struct RecordSet[shape](
 )
 
 def get[shape: (* -> *) -> *, t](sh: shape[RecordValue], RecordGetter(_, getter): RecordGetter[shape, t]) -> t:
-  RecordValue(result) = sh.getter
+  RecordValue(result) = sh.getter()
   result
 
 def create_field[shape: (* -> *) -> *, t](rf: RecordField[t], fn: shape[RecordValue] -> t):
@@ -1769,7 +1769,7 @@ rs0 = rs.restructure(\PS(a, PS(b, PS(c, _))) -> ps(c, ps(b, ps(a, ps("Plus 2".in
 
 tests = TestSuite("reordering",
   [
-    Assertion(equal_rows.equal_List(rs0.list_of_rows, [[REBool(RecordValue(False)), REInt(RecordValue(1)), REString(RecordValue("a")), REInt(RecordValue(3))]]), "swap")
+    Assertion(equal_rows.equal_List(rs0.list_of_rows(), [[REBool(RecordValue(False)), REInt(RecordValue(1)), REString(RecordValue("a")), REInt(RecordValue(3))]]), "swap")
   ]
 )
 """), "RecordSet/Library", 1)
@@ -2427,7 +2427,7 @@ struct Queue[a](front: List[a], back: List[a])
 
 def fold_Queue(Queue(f, b): Queue[a], binit: b, fold_fn: b -> a -> b) -> b:
   front = f.foldLeft(binit, fold_fn)
-  b.reverse.foldLeft(front, fold_fn)
+  b.reverse().foldLeft(front, fold_fn)
 
 test = Assertion(Queue([1], [2]).fold_Queue(0, add).eq_Int(3), "foldQueue")
 """), "QueueTest", 1)
@@ -2458,7 +2458,7 @@ test = Assertion(substitute.eq_Int(42), "basis substitution")
   runBosatsuTest(List("""
 package A
 
-three = 2.(x -> add(x, 1))
+three = 2.(x -> add(x, 1))()
 
 test = Assertion(three.eq_Int(3), "let inside apply")
 """), "A", 1)
@@ -2709,7 +2709,7 @@ struct RecordGetter[shape, t](
 
 # shape is (* -> *) -> *
 def get[shape](sh: shape[RecordValue], RecordGetter(getter): RecordGetter[shape, t]) -> t:
-  RecordValue(result) = sh.getter
+  RecordValue(result) = sh.getter()
   result
 """)) { case PackageError.TypeErrorIn(_, _) => ()
     }

--- a/core/src/test/scala/org/bykn/bosatsu/ParserTest.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/ParserTest.scala
@@ -619,11 +619,11 @@ x""")
       Apply(mkVar("x"), NonEmptyList.of(mkVar("f")), AParens))
 
     parseTestAll(parser(""),
-      "f.x",
+      "f.x()",
       Apply(mkVar("x"), NonEmptyList.of(mkVar("f")), ADot))
 
     parseTestAll(parser(""),
-      "f(foo).x",
+      "f(foo).x()",
       Apply(mkVar("x"), NonEmptyList.of(Apply(mkVar("f"), NonEmptyList.of(mkVar("foo")), AParens)), ADot))
 
     parseTestAll(parser(""),

--- a/test_workspace/AvlTree.bosatsu
+++ b/test_workspace/AvlTree.bosatsu
@@ -92,10 +92,10 @@ def add_item(ord: Order[a], tree: Tree[a], item: a) -> Tree[a]:
                     EQ: Branch(s, h, item, left, right)
                     LT:
                         left = loop(left)
-                        branch(s.add(1), item0, left, right).balance
+                        branch(s.add(1), item0, left, right).balance()
                     GT:
                         right = loop(right)
-                        branch(s.add(1), item0, left, right).balance
+                        branch(s.add(1), item0, left, right).balance()
 
     loop(tree)
 
@@ -133,13 +133,13 @@ def remove_item(ord: Order[a], tree: Tree[a], item: a) -> Tree[a]:
                             Empty: left
                             _:
                                 right = loop(right)
-                                branch(size.sub(1), key, left, right).balance
+                                branch(size.sub(1), key, left, right).balance()
                     LT:
                         left = loop(left)
-                        branch(size.sub(1), key, left, right).balance
+                        branch(size.sub(1), key, left, right).balance()
                     GT:
                         right = loop(right)
-                        branch(size.sub(1), key, left, right).balance
+                        branch(size.sub(1), key, left, right).balance()
 
     loop(tree)
 
@@ -265,7 +265,7 @@ size_tests = (
     TestSuite('size tests', [
       add_increases_size(Empty, 1, "Empty.add(1)"),
       add_increases_size(single_i(1), 2, "single(1).add(2)"),
-      Assertion(single_i(1).size.eq_i(single_i(1).add_i(1).size), "single(1) + 1 has same size"),
+      Assertion(single_i(1).size().eq_i(single_i(1).add_i(1).size()), "single(1) + 1 has same size"),
       rem_decreases_size(single_i(1), 1, "single(1) - 1"),
       rem_decreases_size(single_i(2).add_i(3), 2, "single(2) + 3 - 2"),
     ])

--- a/test_workspace/BinNat.bosatsu
+++ b/test_workspace/BinNat.bosatsu
@@ -23,8 +23,8 @@ def toInt(b: BinNat) -> Int:
 def toNat(b: BinNat) -> Nat:
   recur b:
     Zero: NatZero
-    Odd(n): NatSucc(toNat(n).times2_Nat)
-    Even(n): NatSucc(NatSucc(toNat(n).times2_Nat))
+    Odd(n): NatSucc(toNat(n).times2_Nat())
+    Even(n): NatSucc(NatSucc(toNat(n).times2_Nat()))
 
 # Convert a built in integer to a BinNat. <= 0 is converted to 0
 def toBinNat(n: Int) -> BinNat:
@@ -75,16 +75,16 @@ def add_BinNat(left: BinNat, right: BinNat) -> BinNat:
           Even(add_BinNat(left, right))
         Even(right):
           # 2left + 1 + 2(right + 1) = 2((left + right) + 1) + 1
-          Odd(add_BinNat(left, right.next))
+          Odd(add_BinNat(left, right.next()))
     Even(left) as even:
       match right:
         Zero: even
         Odd(right):
           # 2(left + 1) + 2right + 1 = 2((left + right) + 1) + 1
-          Odd(add_BinNat(left, right.next))
+          Odd(add_BinNat(left, right.next()))
         Even(right):
           # 2(left + 1) + 2(right + 1) = 2((left + right + 1) + 1)
-          Even(add_BinNat(left, right.next))
+          Even(add_BinNat(left, right.next()))
 
 # multiply by 2
 def times2(b: BinNat) -> BinNat:
@@ -144,27 +144,27 @@ def fib(b: BinNat) -> BinNat:
     loop(toNat(b), one, one)
 
 def round_trip_law(i, msg):
-  Assertion(i.toBinNat.toInt.eq_Int(i), msg)
+  Assertion(i.toBinNat().toInt().eq_Int(i), msg)
 
 def next_law(i, msg):
-  Assertion(i.toBinNat.next.toInt.eq_Int(i.add(1)), msg)
+  Assertion(i.toBinNat().next().toInt().eq_Int(i.add(1)), msg)
 
 def times2_law(i, msg):
-  Assertion(i.toBinNat.times2.toInt.eq_Int(i.times(2)), msg)
+  Assertion(i.toBinNat().times2().toInt().eq_Int(i.times(2)), msg)
 
 one = Odd(Zero)
-two = one.next
-three = two.next
-four = three.next
+two = one.next()
+three = two.next()
+four = three.next()
 
 
 test = TestSuite(
   "BinNat tests", [
-    Assertion(Zero.toInt.eq_Int(0), "0.toBinNat"),
-    Assertion(Odd(Zero).toInt.eq_Int(1), "1.toBinNat"),
-    Assertion(Even(Zero).toInt.eq_Int(2), "2.toBinNat"),
-    Assertion(Odd(Odd(Zero)).toInt.eq_Int(3), "3.toBinNat"),
-    Assertion(Even(Odd(Zero)).toInt.eq_Int(4), "4.toBinNat"),
+    Assertion(Zero.toInt().eq_Int(0), "0.toBinNat"),
+    Assertion(Odd(Zero).toInt().eq_Int(1), "1.toBinNat"),
+    Assertion(Even(Zero).toInt().eq_Int(2), "2.toBinNat"),
+    Assertion(Odd(Odd(Zero)).toInt().eq_Int(3), "3.toBinNat"),
+    Assertion(Even(Odd(Zero)).toInt().eq_Int(4), "4.toBinNat"),
     TestSuite("round trip laws", [ round_trip_law(i, m) for (i, m) in [
       (0, "roundtrip 0"),
       (1, "roundtrip 1"),
@@ -184,10 +184,10 @@ test = TestSuite(
       (10, "10.next"),
       (113, "113.next"),
     ]]),
-    Assertion(0.toBinNat.next.prev.toInt.eq_Int(0), "0.next.prev == 0"),
-    Assertion(5.toBinNat.next.prev.toInt.eq_Int(5), "5.next.prev == 5"),
-    Assertion(10.toBinNat.next.prev.toInt.eq_Int(10), "10.next.prev == 10"),
-    Assertion(10.toBinNat.add_BinNat(11.toBinNat).toInt.eq_Int(21), "add_BinNat(10, 11) == 21"),
+    Assertion(0.toBinNat().next().prev().toInt().eq_Int(0), "0.next().prev == 0"),
+    Assertion(5.toBinNat().next().prev().toInt().eq_Int(5), "5.next().prev == 5"),
+    Assertion(10.toBinNat().next().prev().toInt().eq_Int(10), "10.next().prev == 10"),
+    Assertion(10.toBinNat().add_BinNat(11.toBinNat()).toInt().eq_Int(21), "add_BinNat(10, 11) == 21"),
     TestSuite("times2 law", [times2_law(i, msg) for (i, msg) in [
       (0, "0 * 2"),
       (1, "1 * 2"),
@@ -195,13 +195,13 @@ test = TestSuite(
       (5, "5 * 2"),
       (10, "10 * 2"),
     ]]),
-    Assertion(10.toBinNat.times_BinNat(11.toBinNat).toInt.eq_Int(110), "10*11 = 110"),
-    Assertion(0.toBinNat.times_BinNat(11.toBinNat).toInt.eq_Int(0), "0*11 = 0"),
-    Assertion(fold_left_BinNat(\n, _ -> n.next, Zero, 10.toBinNat).toInt.eq_Int(10), "1 + ... + 1 = 10"),
-    Assertion(fold_left_BinNat(\n1, n2 -> n1.add_BinNat(n2), Zero, 4.toBinNat).toInt.eq_Int(6), "1+2+3=6"),
-    Assertion(fib(Zero).toInt.eq_Int(1), "fib(0) == 1"),
-    Assertion(fib(one).toInt.eq_Int(1), "fib(1) == 1"),
-    Assertion(fib(two).toInt.eq_Int(2), "fib(2) == 2"),
-    Assertion(fib(three).toInt.eq_Int(3), "fib(3) == 3"),
-    Assertion(fib(four).toInt.eq_Int(5), "fib(4) == 5"),
+    Assertion(10.toBinNat().times_BinNat(11.toBinNat()).toInt().eq_Int(110), "10*11 = 110"),
+    Assertion(0.toBinNat().times_BinNat(11.toBinNat()).toInt().eq_Int(0), "0*11 = 0"),
+    Assertion(fold_left_BinNat(\n, _ -> n.next(), Zero, 10.toBinNat()).toInt().eq_Int(10), "1 + ... + 1 = 10"),
+    Assertion(fold_left_BinNat(\n1, n2 -> n1.add_BinNat(n2), Zero, 4.toBinNat()).toInt().eq_Int(6), "1+2+3=6"),
+    Assertion(fib(Zero).toInt().eq_Int(1), "fib(0) == 1"),
+    Assertion(fib(one).toInt().eq_Int(1), "fib(1) == 1"),
+    Assertion(fib(two).toInt().eq_Int(2), "fib(2) == 2"),
+    Assertion(fib(three).toInt().eq_Int(3), "fib(3) == 3"),
+    Assertion(fib(four).toInt().eq_Int(5), "fib(4) == 5"),
   ])

--- a/test_workspace/List.bosatsu
+++ b/test_workspace/List.bosatsu
@@ -129,7 +129,7 @@ sortTest = (
 tests = TestSuite("List tests", [
   Assertion([1, 2, 3] =*= [1, 2, 3], "list [1, 2, 3]"),
   Assertion(not([1, 2, 3] =*= [1, 2]), "list [1, 2, 3] != [1, 2]"),
-  Assertion(range(6).sum.eq_Int(15), "range(6).sum == 1 + 2 + 3 + 4 + 5 = 15"),
+  Assertion(range(6).sum().eq_Int(15), "range(6).sum == 1 + 2 + 3 + 4 + 5 = 15"),
   Assertion(range(6).exists(v -> v.eq_Int(5)), "range(6) does have 5"),
   Assertion(not(range(6).exists(v -> v.eq_Int(6))), "range(6) does not have 6"),
   headTest,

--- a/test_workspace/Nat.bosatsu
+++ b/test_workspace/Nat.bosatsu
@@ -58,17 +58,17 @@ def operator ==(i0: Int, i1: Int):
     cmp_Int(i0, i1) matches EQ
 
 def addLaw(n1: Nat, n2: Nat, label: String) -> Test:
-  Assertion(add(n1, n2).to_Int == (n1.to_Int + n2.to_Int), label)
+  Assertion(add(n1, n2).to_Int() == (n1.to_Int() + n2.to_Int()), label)
 
 def multLaw(n1: Nat, n2: Nat, label: String) -> Test:
-  Assertion(mult(n1, n2).to_Int == (n1.to_Int * n2.to_Int), label)
+  Assertion(mult(n1, n2).to_Int() == (n1.to_Int() * n2.to_Int()), label)
 
 def from_to_law(i: Int, message: String) -> Test:
-    Assertion(i.to_Nat.to_Int == i, message)
+    Assertion(i.to_Nat().to_Int() == i, message)
 
 from_to_suite = TestSuite("to_Nat/to_Int tests", [
-        Assertion(-1.to_Nat.to_Int == 0, "-1 -> 0"),
-        Assertion(-42.to_Nat.to_Int == 0, "-42 -> 0"),
+        Assertion(-1.to_Nat().to_Int() == 0, "-1 -> 0"),
+        Assertion(-42.to_Nat().to_Int() == 0, "-42 -> 0"),
         from_to_law(0, "0"),
         from_to_law(1, "1"),
         from_to_law(10, "10"),

--- a/test_workspace/Queue.bosatsu
+++ b/test_workspace/Queue.bosatsu
@@ -23,7 +23,7 @@ def unpush(queue: Queue[a]) -> Option[(a, Queue[a])]:
   match queue:
     Queue([h, *t], b): Some((h, Queue(t, b)))
     Queue([], b):
-      match b.reverse:
+      match b.reverse():
         []: None
         [h, *t]: Some((h, Queue(t, [])))
 
@@ -40,10 +40,10 @@ def pop(queue: Queue[a]) -> Queue[a]:
 
 def fold_Queue(Queue(f, b): Queue[a], init: b, fold_fn: b -> a -> b) -> b:
   front = f.foldLeft(init, fold_fn)
-  b.reverse.foldLeft(front, fold_fn)
+  b.reverse().foldLeft(front, fold_fn)
 
 def reverse_Queue(Queue(f, b): Queue[a]) -> Queue[a]:
-  Queue(b.reverse, f.reverse)
+  Queue(b.reverse(), f.reverse())
 
 def eq_Queue(eq_fn: a -> a -> Bool, left: Queue[a], right: Queue[a]) -> Bool:
   res = left.fold_Queue((True, right), \(g, right), al ->
@@ -60,7 +60,7 @@ def eq_Queue(eq_fn: a -> a -> Bool, left: Queue[a], right: Queue[a]) -> Bool:
     _: False
 
 def to_List(Queue(f, b): Queue[a]) -> List[a]:
-  f.concat(b.reverse)
+  f.concat(b.reverse())
 
 ########
 ## TestSuites below
@@ -79,16 +79,16 @@ eq_li = eq_List(eq_Int)
 q12 = empty.push(1).push(2)
 
 tests = TestSuite("queue tests", [
-  Assertion(eq_oi(q12.pop_value, Some(1)), "1"),
+  Assertion(eq_oi(q12.pop_value(), Some(1)), "1"),
   Assertion(q12.fold_Queue(0,add).eq_Int(3), "fold_Queue add"),
   Assertion(q12.fold_Queue(0,\_, x -> x).eq_Int(2), "take the second"),
   Assertion(q12.fold_Queue(0,\x, _ -> x).eq_Int(0), "take the first"),
-  Assertion(q12.reverse_Queue.reverse_Queue.eq_qi(q12), "reverse is idempotent"),
+  Assertion(q12.reverse_Queue().reverse_Queue().eq_qi(q12), "reverse is idempotent"),
   Assertion(q12.eq_qi(from_List([1, 2])), "from list [1, 2]"),
   Assertion(q12.push(3).eq_qi(from_List([1, 2, 3])), "from list [1, 2, 3]"),
   Assertion(empty_Queue.eq_qi(from_List([])), "empty_Queue == from_List([])"),
   Assertion(q12.eq_qi(from_List([1, 2])), "from list [1, 2]"),
-  Assertion(from_List([1, 2, 3]).pop.pop.pop.eq_qi(empty), "pop to empty"),
-  Assertion(empty.pop.eq_qi(empty), "pop empty is okay"),
+  Assertion(from_List([1, 2, 3]).pop().pop().pop().eq_qi(empty), "pop to empty"),
+  Assertion(empty.pop().eq_qi(empty), "pop empty is okay"),
   Assertion(to_List(from_List([1, 1, 2, 2, 3, 3])).eq_li([1, 1, 2, 2, 3, 3]), "to/from List"),
 ])

--- a/test_workspace/Quicksort.bosatsu
+++ b/test_workspace/Quicksort.bosatsu
@@ -28,5 +28,5 @@ test = TestSuite("quicksort", [
     Assertion(quick_sort([2, 3, 1], cmp_Int) matches [1, 2, 3], "2, 3, 1"),
     Assertion(quick_sort([2, 2, 1], cmp_Int) matches [1, 2, 2], "2, 2, 1"),
     Assertion(quick_sort([2, 2, 1], cmp_Int) matches [1, 2, 2], "2, 2, 1"),
-    Assertion(quick_sort(range(100).reverse, cmp_Int).eq_List(range(100)), "range(100).reverse"),
+    Assertion(quick_sort(range(100).reverse(), cmp_Int).eq_List(range(100)), "range(100).reverse"),
 ])

--- a/test_workspace/TreeList.bosatsu
+++ b/test_workspace/TreeList.bosatsu
@@ -80,7 +80,7 @@ def get(TreeList(trees): TreeList[a], idx: Int) -> Option[a]:
   item
 
 def from_List(list: List[a]) -> TreeList[a]:
-  list.reverse.foldLeft(empty, \lst, h -> cons(h, lst))
+  list.reverse().foldLeft(empty, \lst, h -> cons(h, lst))
 
 def fold(TreeList(trees): TreeList[a], init: b, fn: b -> a -> b) -> b:
   def loop(trees, init):
@@ -91,12 +91,12 @@ def fold(TreeList(trees): TreeList[a], init: b, fn: b -> a -> b) -> b:
   loop(trees, init)
 
 def to_List(list: TreeList[a]) -> List[a]:
-  fold(list, [], \l, h -> [h, *l]).reverse
+  fold(list, [], \l, h -> [h, *l]).reverse()
 
 def eq_TreeList(fn, a, b):
   (res, _) = a.fold((True, b), \(current, b), h ->
     if current:
-      match b.decons:
+      match decons(b):
         None: (False, empty)
         Some((hb, tb)):
           if fn(h, hb): (True, tb)

--- a/test_workspace/dicttools.bosatsu
+++ b/test_workspace/dicttools.bosatsu
@@ -3,7 +3,7 @@ package DictTools
 export merge
 
 def merge(left: Dict[k, v], right: Dict[k, v], fn: v -> v -> v) -> Dict[k, v]:
-  right.items.foldLeft(left, \d, (k, v) ->
+  right.items().foldLeft(left, \d, (k, v) ->
     match d.get_key(k):
       None:     d.add_key(k, v)
       Some(v0): d.add_key(k, fn(v0, v))

--- a/test_workspace/euler7.bosatsu
+++ b/test_workspace/euler7.bosatsu
@@ -25,7 +25,7 @@ def is_prime(x):
     candidate = i + 2
     match cmp_Int(candidate, x):
       LT: (x, True) if div else (nexti, candidate.divides(x))
-      _: (x, False)).not
+      _: (x, False)).not()
 
 def none_divide(primes, x):
   for_all(primes, p -> not(p.divides(x)))

--- a/test_workspace/recordset.bosatsu
+++ b/test_workspace/recordset.bosatsu
@@ -22,7 +22,7 @@ struct RecordSet[shape](
 )
 
 def get[shape: (* -> *) -> *, t](sh: shape[RecordValue], RecordGetter(_, getter): RecordGetter[shape, t]) -> t:
-  RecordValue(result) = sh.getter
+  RecordValue(result) = sh.getter()
   result
 
 def create_field[shape: (* -> *) -> *, t](rf: RecordField[t], fn: shape[RecordValue] -> t):
@@ -132,6 +132,6 @@ rs0 = rs.restructure(\PS(a, PS(b, PS(c, _))) -> ps(c, ps(b, ps(a, ps("Plus 2".in
 
 tests = TestSuite("reordering",
   [
-    Assertion(equal_rows.equal_List(rs0.list_of_rows, [[REBool(RecordValue(False)), REInt(RecordValue(1)), REString(RecordValue("a")), REInt(RecordValue(3))]]), "swap")
+    Assertion(equal_rows.equal_List(rs0.list_of_rows(), [[REBool(RecordValue(False)), REInt(RecordValue(1)), REString(RecordValue("a")), REInt(RecordValue(3))]]), "swap")
   ]
 )


### PR DESCRIPTION
this is the main syntax change in #1026. We can do this before changing the type-system to have FunctionN types.