### PR TITLE
Support recursion in continuations

### DIFF
--- a/core/src/main/scala/org/bykn/bosatsu/DefRecursionCheck.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/DefRecursionCheck.scala
@@ -420,7 +420,9 @@ object DefRecursionCheck {
           checkDecl(t) *> checkDecl(c) *> checkDecl(f)
         case Lambda(args, body) =>
           // these args create new bindings:
-          checkForIllegalBindsSt(args.patternNames, decl) *> filterNames(args.patternNames)(checkDecl(body))
+          val newBinds = args.patternNames
+          checkForIllegalBindsSt(newBinds, decl) *>
+            filterNames(newBinds)(checkDecl(body))
         case Literal(_) =>
           unitSt
         case Match(RecursionKind.NonRecursive, arg, cases) =>

--- a/core/src/main/scala/org/bykn/bosatsu/DefRecursionCheck.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/DefRecursionCheck.scala
@@ -303,11 +303,13 @@ object DefRecursionCheck {
             .flatMapN {
               case (a, InRecurBranch(ir1, b1, _)) =>
                 setSt(InRecurBranch(ir1, b1, names)).as(a)
+        // $COVERAGE-OFF$ this should be unreachable
               case (_, unexpected) =>
                 sys.error(s"invariant violation expected InRecurBranch: start = $start, end = $unexpected")
             }
         case notRecur =>
           sys.error(s"called setNames on $notRecur with names: $newNames")
+        // $COVERAGE-ON$ this should be unreachable
       }
 
     private def filterNames[A](newNames: Iterable[Bindable])(in: St[A]): St[A] =
@@ -317,8 +319,10 @@ object DefRecursionCheck {
             .flatMapN {
               case (a, InRecurBranch(ir1, b1, _)) =>
                 setSt(InRecurBranch(ir1, b1, names)).as(a)
+              // $COVERAGE-OFF$ this should be unreachable
               case (_, unexpected) =>
                 sys.error(s"invariant violation expected InRecurBranch: start = $start, end = $unexpected")
+              // $COVERAGE-ON$ this should be unreachable
             }
         case _ => in
       }

--- a/core/src/test/scala/org/bykn/bosatsu/DefRecursionCheckTest.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/DefRecursionCheckTest.scala
@@ -433,5 +433,17 @@ def loop(box: Cont) -> Int:
     case Next(cont_fn):
       cont_fn(cont -> loop(cont))
     """)
+
+    allowed("""#
+enum Cont:
+  Item(a: Int)
+  Next(use: (Cont -> Int) -> Int)
+
+def loop(box: Cont) -> Int:
+  recur box:
+    case Item(a): a
+    case Next(cont_fn):
+      cont_fn(loop)
+    """)
   }
 }

--- a/core/src/test/scala/org/bykn/bosatsu/DefRecursionCheckTest.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/DefRecursionCheckTest.scala
@@ -477,6 +477,20 @@ def anything0[a, b](box: Box[a]) -> b:
 bottom: forall a. a = anything0(Box(1)) 
 
 """)
+
+    disallowed("""#
+struct Box(a)
+
+def anything0[a, b](box: Box[a]) -> b:
+  recur box:
+    case Box(b):
+      # shadow to trick
+      recur Box(b):
+        b: anything0(b)
+
+bottom: forall a. a = anything0(Box(1)) 
+
+""")
   }
 
   test("we can't trick the checker with a lambda-let shadow") {
@@ -488,6 +502,23 @@ def anything0[a, b](box: Box[a]) -> b:
     case Box(b):
       # shadow to trick
       (b -> anything0(b))(Box(b))
+
+bottom: forall a. a = anything0(Box(1)) 
+
+""")
+  }
+
+  test("we can't trick the checker with a def-let shadow") {
+    disallowed("""#
+struct Box(a)
+
+def anything0[a, b](box: Box[a]) -> b:
+  recur box:
+    case Box(b):
+      # shadow to trick
+      def trick(b): anything0(b)
+
+      trick(Box(b))
 
 bottom: forall a. a = anything0(Box(1)) 
 

--- a/core/src/test/scala/org/bykn/bosatsu/DefRecursionCheckTest.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/DefRecursionCheckTest.scala
@@ -409,4 +409,29 @@ def len(lst):
     case [_, *t]: id(len(t))
 """)
   }
+
+  test("tree example") {
+    allowed("""#
+struct Tree(x: Int, items: List[Tree])
+
+def sum_all(t):
+  recur t:
+    case []: 0
+    case [Tree(x, children), *tail]: x + sum_all(children) + sum_all(tail)
+""")
+  }
+
+  test("we can recur on cont") {
+    allowed("""#
+enum Cont:
+  Item(a: Int)
+  Next(use: (Cont -> Int) -> Int)
+
+def loop(box: Cont) -> Int:
+  recur box:
+    case Item(a): a
+    case Next(cont_fn):
+      cont_fn(cont -> loop(cont))
+    """)
+  }
 }

--- a/core/src/test/scala/org/bykn/bosatsu/DefRecursionCheckTest.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/DefRecursionCheckTest.scala
@@ -446,4 +446,51 @@ def loop(box: Cont) -> Int:
       cont_fn(loop)
     """)
   }
+
+  test("we can't trick the checker with a let shadow") {
+    disallowed("""#
+struct Box(a)
+
+def anything0[a, b](box: Box[a]) -> b:
+  recur box:
+    case Box(b):
+      # shadow to trick
+      b = Box(b)
+      anything0(b)
+
+bottom: forall a. a = anything0(Box(1)) 
+
+""")
+  }
+
+  test("we can't trick the checker with a match shadow") {
+    disallowed("""#
+struct Box(a)
+
+def anything0[a, b](box: Box[a]) -> b:
+  recur box:
+    case Box(b):
+      # shadow to trick
+      match Box(b):
+        b: anything0(b)
+
+bottom: forall a. a = anything0(Box(1)) 
+
+""")
+  }
+
+  test("we can't trick the checker with a lambda-let shadow") {
+    disallowed("""#
+struct Box(a)
+
+def anything0[a, b](box: Box[a]) -> b:
+  recur box:
+    case Box(b):
+      # shadow to trick
+      (b -> anything0(b))(Box(b))
+
+bottom: forall a. a = anything0(Box(1)) 
+
+""")
+  }
 }

--- a/core/src/test/scala/org/bykn/bosatsu/EvaluationTest.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/EvaluationTest.scala
@@ -3054,8 +3054,7 @@ def map[a](ca: Cont[a], fn: a -> a) -> Cont[a]:
 def loop[a](box: Cont[a]) -> a:
   recur box:
     case Item(a): a
-    case Next(cont_fn):
-      cont_fn(cont -> loop(cont))
+    case Next(cont_fn): cont_fn(loop)
 
 loopgen: forall a. Cont[a] -> a = loop
 b: Cont[Int] = Item(1).map(x -> x.add(1))


### PR DESCRIPTION
replaces #1022 

The idea here is that we can recurse on arguments to functions which are themselves allows (substructures).

This allows us to implement functor type things (because to encode those we need existential types, which are encoded as continuations).