### PR TITLE
Improve error messages in DefRecursionCheck, Eval example

### DIFF
--- a/core/src/main/scala/org/bykn/bosatsu/ParallelViaProduct.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/ParallelViaProduct.scala
@@ -1,0 +1,31 @@
+package org.bykn.bosatsu
+
+import cats.arrow.FunctionK
+import cats.{Parallel, Applicative}
+
+// Implement Parallel by implementing just Product
+abstract class ParallelViaProduct[G[_]] extends Parallel[G] { self =>
+
+  type F[A] = G[A]
+  val parallel = new FunctionK[G, F] {
+    def apply[A](ga: G[A]) = ga
+  }
+
+  val sequential = new FunctionK[F, G] {
+    def apply[A](fa: F[A]) = fa
+  }
+
+  def parallelProduct[A, B](fa: F[A], fb: F[B]): F[(A, B)]
+
+  val applicative: Applicative[F] =
+    new Applicative[F] { self =>
+      def pure[A](a: A) = monad.pure(a)
+
+      final def ap[A, B](ff: F[A => B])(fa: F[A]): F[B] =
+        monad.map(parallelProduct(ff, fa)) { case (fn, a) => fn(a) }
+
+      override def map[A, B](fa: F[A])(fn: A => B) = monad.map(fa)(fn)
+
+      override def product[A, B](fa: F[A], fb: F[B]) = parallelProduct(fa, fb)
+    }
+}

--- a/test_workspace/Eval.bosatsu
+++ b/test_workspace/Eval.bosatsu
@@ -1,0 +1,51 @@
+package Eval
+
+from Bosatsu/Nat import Nat, Zero, Succ, to_Nat
+
+export Eval, done, map, flat_map, bind, eval
+# port of cats.Eval to bosatsu
+
+enum Eval[a]:
+    Pure(a: a)
+    FlatMap(use: forall x. (forall y. (Eval[y], y -> Eval[a]) -> x) -> x)
+
+def done(a: a) -> Eval[a]: Pure(a)
+
+def flat_map[a, b](e: Eval[a], fn: a -> Eval[b]) -> Eval[b]:
+    FlatMap(cb -> cb(e, fn))
+
+def bind(e)(fn): flat_map(e, fn)
+
+def map[a, b](e: Eval[a], fn: a -> b) -> Eval[b]:
+    x <- e.bind()
+    Pure(fn(x))
+
+enum Stack[a, b]:
+    Done(fn: a -> b)
+    More(use: forall x. (forall y. (a -> Eval[y], Stack[y, b]) -> x) -> x)
+
+def push_stack[a, b, c](fn: a -> Eval[b], stack: Stack[b, c]) -> Stack[a, c]:
+   More(use -> use(fn, stack))  
+
+enum Loop[a, b]:
+    RunStack(a: a, stack: Stack[a, b])
+    RunEval(e: Eval[a], stack: Stack[a, b])
+
+def run[a, b](budget: Nat, arg: Loop[a, b]) -> Option[b]:
+  recur budget:
+      case Zero: None
+      case Succ(balance):
+          match arg:
+              case RunStack(a, Done(fn)): Some(fn(a))
+              case RunEval(Pure(a), stack):
+                  run(balance, RunStack(a, stack))
+              case RunEval(FlatMap(use), stack):
+                  use((prev, fn) -> run(balance, RunEval(prev, push_stack(fn, stack)))) 
+              case RunStack(a, More(use)):
+                use((fn, stack) -> (
+                  evalb = fn(a)
+                  run(balance, RunEval(evalb, stack))
+                ))
+
+def eval[a](budget: Int, ea: Eval[a]) -> Option[a]:
+    run(to_Nat(budget), RunEval(ea, Done(a -> a)))


### PR DESCRIPTION
I wanted to try implementing cats.Eval now that we have polymorphic recursion #1041 .

I couldn't see a way to do it without a poor version of the fuel pattern: promise up front how many recursions you would do at most.

But along the way, I noticed that we are only returning one error message from any branch in the code in DefRecursionCheck, so I implemented a version of the idea in #1044 which allowed me to see all the error messages at once (when they are on parts of the code I was already traversing).

