### PR TITLE
Fix long bug in error regions

### DIFF
--- a/core/src/main/scala/org/bykn/bosatsu/Expr.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/Expr.scala
@@ -7,7 +7,7 @@ package org.bykn.bosatsu
 
 import cats.implicits._
 import cats.data.{Chain, Writer, NonEmptyList}
-import cats.{Applicative, Eval, Traverse}
+import cats.Applicative
 import scala.collection.immutable.SortedSet
 import org.bykn.bosatsu.rankn.Type
 
@@ -15,6 +15,108 @@ import Identifier.{Bindable, Constructor}
 
 sealed abstract class Expr[T] {
   def tag: T
+
+  /**
+   * All the free variables in this expression in order
+   * encountered and with duplicates (to see how often
+   * they appear)
+   */
+  lazy val freeVarsDup: List[Bindable] = {
+    import Expr._
+    // nearly identical code to TypedExpr.freeVarsDup, bugs should be fixed in both places
+    this match {
+      case Generic(_, expr) =>
+        expr.freeVarsDup
+      case Annotation(t, _, _) =>
+        t.freeVarsDup
+      case Local(ident, _) =>
+        ident :: Nil
+      case Global(_, _, _) =>
+        Nil
+      case Lambda(args, res, _) =>
+        val nameSet = args.toList.iterator.map(_._1).toSet
+        ListUtil.filterNot(res.freeVarsDup)(nameSet)
+      case App(fn, args, _) =>
+        fn.freeVarsDup ::: args.reduceMap(_.freeVarsDup)
+      case Let(arg, argE, in, rec, _) =>
+        val argFree0 = argE.freeVarsDup
+        val argFree =
+          if (rec.isRecursive) {
+            ListUtil.filterNot(argFree0)(_ === arg)
+          }
+          else argFree0
+
+        argFree ::: (ListUtil.filterNot(in.freeVarsDup)(_ === arg))
+      case Literal(_, _) =>
+        Nil
+      case Match(arg, branches, _) =>
+        val argFree = arg.freeVarsDup
+
+        val branchFrees = branches.toList.map { case (p, b) =>
+          // these are not free variables in this branch
+          val newBinds = p.names.toSet
+          val bfree = b.freeVarsDup
+          if (newBinds.isEmpty) bfree
+          else ListUtil.filterNot(bfree)(newBinds)
+        }
+        // we can only take one branch, so count the max on each branch:
+        val branchFreeMax = branchFrees
+          .zipWithIndex
+          .flatMap { case (names, br) => names.map((_, br)) }
+          // these groupBys are okay because we sort at the end
+          .groupBy(identity) // group-by-name x branch
+          .map { case ((name, branch), names) => (names.length, branch, name) }
+          .groupBy(_._3) // group by just the name now
+          .toList
+          .flatMap { case (_, vs) =>
+            val (cnt, branch, name) = vs.maxBy(_._1)
+            List.fill(cnt)((branch, name))
+          }
+          .sorted
+          .map(_._2)
+
+        argFree ::: branchFreeMax
+    }
+  }
+
+  lazy val globals: Set[Expr.Global[T]] = {
+    import Expr._
+    // nearly identical code to TypedExpr.freeVarsDup, bugs should be fixed in both places
+    this match {
+      case Generic(_, expr) =>
+        expr.globals
+      case Annotation(t, _, _) =>
+        t.globals
+      case Local(_, _) => Set.empty
+      case g @ Global(_, _, _) => Set.empty + g
+      case Lambda(_, res, _) => res.globals
+      case App(fn, args, _) =>
+        fn.globals | args.reduceMap(_.globals)
+      case Let(_, argE, in, _, _) =>
+        argE.globals | in.globals
+      case Literal(_, _) => Set.empty
+      case Match(arg, branches, _) =>
+        arg.globals | branches.reduceMap { case (_, b) => b.globals }
+    }
+  }
+
+  def replaceTag(t: T): Expr[T] = {
+    import Expr._
+    this match {
+      case Generic(_, _) => this
+      case a@Annotation(_, _, _) => a.copy(tag = t)
+      case l@Local(_, _) => l.copy(tag = t)
+      case g @ Global(_, _, _) => g.copy(tag = t)
+      case l@Lambda(_, _, _) => l.copy(tag = t)
+      case a@App(_, _, _) => a.copy(tag = t)
+      case l@Let(_, _, _, _, _) => l.copy(tag = t)
+      case l@Literal(_, _) => l.copy(tag = t)
+      case m@Match(_, _, _) => m.copy(tag = t)
+    }
+  }
+
+  def notFree(b: Bindable): Boolean =
+    !freeVarsDup.contains(b)
 }
 
 object Expr {
@@ -187,106 +289,6 @@ object Expr {
         (skVs, expr1)
       }
   }
-
-  /*
-   * We have seen some intermitten CI failures if this isn't lazy
-   * presumably due to initialiazation order
-   */
-  implicit lazy val exprTraverse: Traverse[Expr] =
-    new Traverse[Expr] {
-
-      // Traverse on NonEmptyList[(Pattern[_], Expr[?])]
-      private lazy val tne = {
-        type Tup[T] = (Pattern[(PackageName, Constructor), Type], T)
-        type TupExpr[T] = (Pattern[(PackageName, Constructor), Type], Expr[T])
-        val tup: Traverse[TupExpr] = Traverse[Tup].compose(exprTraverse)
-        Traverse[NonEmptyList].compose(tup)
-      }
-
-      def traverse[G[_]: Applicative, A, B](fa: Expr[A])(f: A => G[B]): G[Expr[B]] =
-        fa match {
-          case Annotation(e, tpe, a) =>
-            (e.traverse(f), f(a)).mapN(Annotation(_, tpe, _))
-          case Local(s, t) =>
-            f(t).map(Local(s, _))
-          case Global(p, s, t) =>
-            f(t).map(Global(p, s, _))
-          case Generic(bs, e) =>
-            traverse(e)(f).map(Generic(bs, _))
-          case App(fn, args, t) =>
-            (fn.traverse(f), args.traverse(_.traverse(f)), f(t)).mapN { (fn1, a1, b) =>
-              App(fn1, a1, b)
-            }
-          case Lambda(args, expr, t) =>
-            (expr.traverse(f), f(t)).mapN { (e1, t1) =>
-              Lambda(args, e1, t1)
-            }
-          case Let(arg, exp, in, rec, tag) =>
-            (exp.traverse(f), in.traverse(f), f(tag)).mapN { (e1, i1, t1) =>
-              Let(arg, e1, i1, rec, t1)
-            }
-          case Literal(lit, tag) =>
-            f(tag).map(Literal(lit, _))
-          case Match(arg, branches, tag) =>
-            val argB = arg.traverse(f)
-            val branchB = tne.traverse(branches)(f)
-            (argB, branchB, f(tag)).mapN { (a, bs, t) =>
-              Match(a, bs, t)
-            }
-        }
-
-      def foldLeft[A, B](fa: Expr[A], b: B)(f: (B, A) => B): B =
-        fa match {
-          case Annotation(e, _, tag) =>
-            val b1 = foldLeft(e, b)(f)
-            f(b1, tag)
-          case n: Name[A] => f(b, n.tag)
-          case App(fn, args, tag) =>
-            val b1 = foldLeft(fn, b)(f)
-            val b2 = args.foldLeft(b1) { (b1, x) => foldLeft(x, b1)(f) }
-            f(b2, tag)
-          case Generic(_, in) => foldLeft(in, b)(f)
-          case Lambda(_, expr, tag) =>
-            val b1 = foldLeft(expr, b)(f)
-            f(b1, tag)
-          case Let(_, exp, in, _, tag) =>
-            val b1 = foldLeft(exp, b)(f)
-            val b2 = foldLeft(in, b1)(f)
-            f(b2, tag)
-          case Literal(_, tag) =>
-            f(b, tag)
-          case Match(arg, branches, tag) =>
-            val b1 = foldLeft(arg, b)(f)
-            val b2 = tne.foldLeft(branches, b1)(f)
-            f(b2, tag)
-        }
-
-      def foldRight[A, B](fa: Expr[A], lb: Eval[B])(f: (A, Eval[B]) => Eval[B]): Eval[B] =
-        fa match {
-          case Annotation(e, _, tag) =>
-            val lb1 = foldRight(e, lb)(f)
-            f(tag, lb1)
-          case n: Name[A] => f(n.tag, lb)
-          case App(fn, args, tag) =>
-            val b1 = f(tag, lb)
-            val b2 = args.foldRight(b1)((a, b1) => foldRight(a, b1)(f))
-            foldRight(fn, b2)(f)
-          case Generic(_, in) => foldRight(in, lb)(f)
-          case Lambda(_, expr, tag) =>
-            val b1 = f(tag, lb)
-            foldRight(expr, b1)(f)
-          case Let(_, exp, in, _, tag) =>
-            val b1 = f(tag, lb)
-            val b2 = foldRight(in, b1)(f)
-            foldRight(exp, b2)(f)
-          case Literal(_, tag) =>
-            f(tag, lb)
-          case Match(arg, branches, tag) =>
-            val b1 = f(tag, lb)
-            val b2 = tne.foldRight(branches, b1)(f)
-            foldRight(arg, b2)(f)
-        }
-    }
 
   def buildPatternLambda[A](
     args: NonEmptyList[Pattern[(PackageName, Constructor), Type]],

--- a/core/src/main/scala/org/bykn/bosatsu/ListUtil.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/ListUtil.scala
@@ -1,0 +1,41 @@
+package org.bykn.bosatsu
+
+import cats.data.NonEmptyList
+
+private[bosatsu] object ListUtil {
+  // filter b from a pretty short lst but try to conserve lst if possible
+  def filterNot[A](lst: List[A])(b: A => Boolean): List[A] =
+    lst match {
+      case Nil => lst
+      case h :: tail =>
+        val t1 = filterNot(tail)(b)
+        if (b(h)) t1
+        else if (t1 eq tail) lst
+        else (h :: t1) // we only allocate here
+    }
+
+  def greedyGroup[A, G](list: NonEmptyList[A])(one: A => G)(combine: (G, A) => Option[G]): NonEmptyList[G] = {
+    def loop(g: G, tail: List[A]): NonEmptyList[G] =
+      tail match {
+        case Nil => NonEmptyList.one(g)
+        case tailh :: tailt =>
+          combine(g, tailh) match {
+            case None =>
+              // can't combine into the head group, start a new group
+              g :: loop(one(tailh), tailt)
+            case Some(g1) =>
+              // we can combine into a new group
+              loop(g1, tailt)
+          }
+      }
+
+    loop(one(list.head), list.tail)
+  }
+
+  def greedyGroup[A, G](list: List[A])(one: A => G)(combine: (G, A) => Option[G]): List[G] =
+    NonEmptyList.fromList(list) match {
+      case None => Nil
+      case Some(nel) => greedyGroup(nel)(one)(combine).toList
+    }
+
+}

--- a/core/src/main/scala/org/bykn/bosatsu/rankn/Infer.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/rankn/Infer.scala
@@ -887,9 +887,9 @@ object Infer {
             // compilers/evaluation can possibly optimize non-recursive
             // cases differently
             val rhsBody = rhs match {
-              case Annotation(expr, tpe, _) => 
+              case Expr.Annotated(tpe) =>
                   extendEnv(name, tpe) {
-                    checkSigma(expr, tpe).parProduct(typeCheckRho(body, expect))
+                    checkSigma(rhs, tpe).parProduct(typeCheckRho(body, expect))
                   }
               case _ =>
                 newMetaType(Kind.Type) // the kind of a let value is a Type
@@ -921,9 +921,9 @@ object Infer {
             // so any recursion in this case won't typecheck, and shadowing rules are
             // in place
             val rhsBody = rhs match {
-              case Annotation(expr, tpe, _) => 
+              case Expr.Annotated(tpe) => 
                   // check in parallel so we collect more errors
-                  checkSigma(expr, tpe)
+                  checkSigma(rhs, tpe)
                     .parProduct(
                       extendEnv(name, tpe) { typeCheckRho(body, expect) }
                     )
@@ -1400,8 +1400,8 @@ object Infer {
   private def recursiveTypeCheck[A: HasRegion](name: Bindable, expr: Expr[A]): Infer[TypedExpr[A]] =
     // values are of kind Type
     expr match {
-      case Expr.Annotation(e, tpe, _) =>
-        extendEnv(name, tpe)(checkSigma(e, tpe))
+      case Expr.Annotated(tpe) =>
+        extendEnv(name, tpe)(checkSigma(expr, tpe))
       case _ =>
         newMetaType(Kind.Type).flatMap { tpe =>
           extendEnv(name, tpe)(typeCheckMeta(expr, Some((name, tpe, region(expr)))))

--- a/core/src/test/scala/org/bykn/bosatsu/EvaluationTest.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/EvaluationTest.scala
@@ -2881,11 +2881,12 @@ def quick_sort0(cmp, left, right):
         bigs = quick_sort0(cmp, tail)
         [*smalls, *bigs]
 """)) { case kie@PackageError.TypeErrorIn(_, _) =>
-      assert(kie.message(Map.empty, Colorize.None) ==
-      """in file: <unknown source>, package QS
-type error: expected type Bosatsu/Predef::Fn3[(?43, ?41) -> Bosatsu/Predef::Comparison] to be the same as type Bosatsu/Predef::Fn2
+      assert(kie.message(Map.empty, Colorize.None) == """in file: <unknown source>, package QS
+type error: expected type Bosatsu/Predef::Fn3[(?43, ?41) -> Bosatsu/Predef::Comparison]
+Region(403,414)
+to be the same as type Bosatsu/Predef::Fn2
 hint: the first type is a function with 3 arguments and the second is a function with 2 arguments.
-Region(396,450)""")
+Region(415,424)""")
       ()
     }
  
@@ -3082,5 +3083,44 @@ def loop[a](box: Box[a]) -> a:
 v = loop(b)
 main = v
 """), "A", VInt(1))
+  }
+
+  test("we get error messages from multiple type errors top level") {
+    val testCode = """
+package ErrorCheck
+
+x: Int = "1"
+y: String = 1
+
+"""
+   evalFail(List(testCode)) { case kie@PackageError.TypeErrorIn(_, _) =>
+      val message = kie.message(Map.empty, Colorize.None)
+      assert(message.contains("Region(30,33)"))
+      assert(testCode.substring(30, 33) == "\"1\"")
+      assert(message.contains("Region(46,47)"))
+      assert(testCode.substring(46, 47) == "1")
+      ()
+    }
+  }
+
+  test("we get error messages from multiple type errors top nested") {
+    val testCode = """
+package ErrorCheck
+
+z = (
+  x: Int = "1"
+  y: String = 1
+  (x, y)
+)
+
+"""
+   evalFail(List(testCode)) { case kie@PackageError.TypeErrorIn(_, _) =>
+      val message = kie.message(Map.empty, Colorize.None)
+      assert(message.contains("Region(38,41)"))
+      assert(testCode.substring(38, 41) == "\"1\"")
+      assert(message.contains("Region(56,57)"))
+      assert(testCode.substring(56, 57) == "1")
+      ()
+    }
   }
 }

--- a/core/src/test/scala/org/bykn/bosatsu/ExprTest.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/ExprTest.scala
@@ -1,0 +1,85 @@
+package org.bykn.bosatsu
+
+import cats.data.NonEmptyList
+import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks.{
+  forAll,
+  PropertyCheckConfiguration
+}
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalacheck.{Arbitrary, Gen}
+
+class ExprTest extends AnyFunSuite {
+  implicit val generatorDrivenConfig: PropertyCheckConfiguration =
+    PropertyCheckConfiguration(minSuccessful = 5000)
+
+  val genExpr: Gen[Expr[Int]] = Generators.Exprs.gen(Gen.choose(0, 99), 4)
+
+  implicit val arbExpr: Arbitrary[Expr[Int]] = Arbitrary(genExpr)
+
+  test("replaceTag replaces") {
+    forAll { (s: Expr[Int], i: Int) =>
+      assert(s.replaceTag(i).tag == i)
+    }
+  }
+
+  test("e.notFree(n) is true if n is not free in e") {
+    forAll(genExpr, Generators.bindIdentGen) { (expr, n) =>
+      assert(expr.notFree(n) == !expr.freeVarsDup.contains(n))
+    }
+  }
+
+  test("if we bind a free variable, it's no longer free") {
+    forAll(
+      genExpr,
+      Generators.bindIdentGen,
+      Generators.genCompiledPattern(4),
+      genExpr
+    ) { (expr, n, pat, bind) =>
+      if (expr.notFree(n)) ()
+      else {
+        // n is free in expr
+        assert(Expr.Lambda(NonEmptyList.one((n, None)), expr, 0).notFree(n))
+        if (bind.notFree(n)) {
+          assert(
+            Expr.Let(n, bind, expr, RecursionKind.NonRecursive, 0).notFree(n)
+          )
+          assert(
+            Expr
+              .Match(bind, NonEmptyList.one((Pattern.Named(n, pat), expr)), 0)
+              .notFree(n)
+          )
+        }
+      }
+    }
+  }
+
+  test("allNames is a superset of freeVars") {
+    forAll(genExpr) { e =>
+      val allNames = Expr.allNames(e)
+      assert(e.freeVarsDup.forall(allNames))
+    }
+  }
+
+  test("let flattening makes sense") {
+    forAll(genExpr) {
+      case let @ Expr.Let(n, b, i, r, tag) =>
+        val (lets, res) = let.flatten
+        assert(Expr.lets(lets.toList, res) == let)
+
+        if (i == res) {
+          assert(lets.length == 1)
+          assert(lets.head == (n, r, b, tag))
+        } else {
+          i match {
+            case l1 @ Expr.Let(_, _, _, _, _) =>
+              val (lets1, res1) = l1.flatten
+              assert(res == res1)
+              assert((n, r, b, tag) :: lets1 == lets)
+            case other =>
+              fail(s"expected Let: $other")
+          }
+        }
+      case _ => ()
+    }
+  }
+}

--- a/core/src/test/scala/org/bykn/bosatsu/ListUtilTest.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/ListUtilTest.scala
@@ -1,0 +1,82 @@
+package org.bykn.bosatsu
+
+import cats.data.NonEmptyList
+import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks.{ forAll, PropertyCheckConfiguration }
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalacheck.{Arbitrary, Gen}
+
+class ListUtilTest extends AnyFunSuite {
+
+  implicit val generatorDrivenConfig: PropertyCheckConfiguration =
+    PropertyCheckConfiguration(minSuccessful = 5000)
+
+  def genNEL[A](ga: Gen[A]): Gen[NonEmptyList[A]] =
+    Gen.sized { sz =>
+      if (sz <= 1) ga.map(NonEmptyList.one)    
+      else Gen.zip(ga, Gen.listOfN(sz - 1, ga)).map { case (h, t) => NonEmptyList(h, t) }
+    } 
+
+  implicit def arbNEL[A: Arbitrary]: Arbitrary[NonEmptyList[A]] =
+    Arbitrary(genNEL(Arbitrary.arbitrary[A]))
+
+  test("unit group has 1 item") {
+    forAll { (nel: NonEmptyList[Int]) =>
+      val unit = ListUtil.greedyGroup(nel)(_ => ())((_, _) => Some(()))    
+      assert(unit == NonEmptyList.one(()))
+    }
+  }
+
+  test("groups satisfy edge property") {
+    forAll { (nel: NonEmptyList[Int], accept: (Int, Int) => Boolean) =>
+      val groups = ListUtil.greedyGroup(nel)(a => Set(a))((s, i) => if (s.forall(accept(_, i))) Some(s + i) else None)    
+      groups.toList.foreach { g =>
+        val items = g.toList.zipWithIndex  
+        for {
+          (i1, idx1) <- items
+          (i2, idx2) <- items
+        } assert((idx1 == idx2) || accept(i1, i2) || accept(i2, i1))
+      }
+    }
+  }
+
+  test("there are as most as many groups as inputs") {
+    forAll { (nel: NonEmptyList[Int], one: Int => Int, accept: (Int, Int) => Option[Int]) =>
+      val groups = ListUtil.greedyGroup(nel)(one)(accept)
+      assert(groups.length <= nel.length)
+    }
+  }
+
+  test("if we always accept there is one group") {
+    forAll { (nel: NonEmptyList[Int], one: Int => Int) =>
+      val groups = ListUtil.greedyGroup(nel)(one)((x, y) => Some(x + y))
+      assert(groups.length == 1)
+    }
+  }
+
+  test("if we never accept there are as many groups as came in") {
+    forAll { (nel: NonEmptyList[Int], one: Int => Int) =>
+      val groups = ListUtil.greedyGroup(nel)(one)((_, _) => None)
+      assert(groups.length == nel.length)
+    }
+  }
+
+  test("groups direct property") {
+    forAll { (nel: NonEmptyList[Int], accept: (List[Int], Int) => Boolean) =>
+      val groups = ListUtil.greedyGroup(nel)(a => a :: Nil)((s, i) => if (accept(s, i)) Some(i :: s) else None)    
+      groups.toList.foreach { g =>
+        def check(g: List[Int]): Unit =
+          g match {
+            case Nil => fail("expected at least one item")
+            case _ :: Nil =>
+                // this can always happen
+                ()
+            case head :: tail =>
+                assert(accept(tail, head))
+                check(tail)
+          }
+
+        check(g)
+      }
+    }
+  }
+}


### PR DESCRIPTION
I wanted to merely improve error reporting by showing more than one type error when it was possible (#1044 )

Along the way, I found a long standing bug with locations incorrectly being set to be their outermost scope. I had noticed this before, but hadn't run it down. I had assumed it was part of typechecking and just due to inference being a bit non-specific when unifying across many types.

But in my example, I wound up printing out the Expr and seeing that the Declarations and Regions were set wrong.

The bug turned out to be the `.as` from `Functor`. The Expr traverse instance is doing what you say, but .as isn't what we meant. We wanted to only replace the outermost tag, not every tag transitively.

I have removed that code since we were only using it for this one bug. :)

This also should do more parallel checking of errors: if two adjacent lets don't depend on each other, we check in parallel.

We can do a bit better by only skipping lets that depend on a previous failed let, but I will punt that to a later PR.