### PR TITLE
Fix coerce in Infer.subsCheck

### DIFF
--- a/core/src/test/scala/org/bykn/bosatsu/EvaluationTest.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/EvaluationTest.scala
@@ -3167,4 +3167,19 @@ test3 = Assertion(last("foo") matches Some(.'o'), "last test")
 all = TestSuite("chars", [test1, test2, test3])
 """), "Foo", 3)
   }
+
+  test("test universal quantified list match") {
+    runBosatsuTest(List("""
+package Foo
+
+empty: (forall a. List[a]) = []
+
+res = match empty:
+  case []: 0
+  case [_, *_]: 1
+
+test = Assertion(res matches 0, "one")
+"""), "Foo", 1)
+
+  }
 }

--- a/core/src/test/scala/org/bykn/bosatsu/rankn/RankNInferTest.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/rankn/RankNInferTest.scala
@@ -1155,5 +1155,21 @@ def branch(x):
 
 res = branch(True)(True)
 """, "B")
+
+    parseProgramIllTyped("""#
+enum B: True, False
+
+def not(b):
+  match b:
+    case True: False
+    case False: True
+
+def branch[a](x: B) -> (a -> a):
+  match x:
+    case True: (x -> x): forall a. a -> a    
+    case False: i -> not(i)
+
+res = branch(True)(True)
+""")
   }
 }

--- a/core/src/test/scala/org/bykn/bosatsu/rankn/RankNInferTest.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/rankn/RankNInferTest.scala
@@ -1138,4 +1138,22 @@ foo = (
 
 """, "Foo")
   }
+
+  test("widening inside a match") {
+    parseProgram("""#
+enum B: True, False
+
+def not(b):
+  match b:
+    case True: False
+    case False: True
+
+def branch(x):
+  match x:
+    case True: (x -> x): forall a. a -> a    
+    case False: i -> not(i)
+
+res = branch(True)(True)
+""", "B")
+  }
 }

--- a/core/src/test/scala/org/bykn/bosatsu/rankn/RankNInferTest.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/rankn/RankNInferTest.scala
@@ -216,6 +216,10 @@ class RankNInferTest extends AnyFunSuite {
     assertTypesDisjoint("Int -> Unit", "String")
     assertTypesDisjoint("Int -> Unit", "String -> a")
     assertTypesUnify("forall a. Int", "Int")
+    
+    // Test unbound vars
+    assertTypesDisjoint("a", "Int")
+    assertTypesDisjoint("Int", "a")
   }
 
   test("Basic inferences") {
@@ -1172,4 +1176,5 @@ def branch[a](x: B) -> (a -> a):
 res = branch(True)(True)
 """)
   }
+
 }


### PR DESCRIPTION
it is *very* concerning that changing these directions (widening instead of narrowing) doesn't require changing any tests.

I should probably try to find some example that fails in the previous direction... I guess it is actually very rare for subsCheck to not be just unifying the code into a single type rather than instantiating.

Or it could be that we just don't have any way of failing after coerce since we just assume the types are right after that so changing them can't change the tests... but it seems like we should be able to find some code that didn't type before that does now?