### PR TITLE
Ensure no meta loops in Infer

### DIFF
--- a/core/src/test/scala/org/bykn/bosatsu/EvaluationTest.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/EvaluationTest.scala
@@ -2897,7 +2897,7 @@ def quick_sort0(cmp, left, right):
         [*smalls, *bigs]
 """)) { case kie@PackageError.TypeErrorIn(_, _) =>
       assert(kie.message(Map.empty, Colorize.None) == """in file: <unknown source>, package QS
-type error: expected type Bosatsu/Predef::Fn3[(?43, ?41) -> Bosatsu/Predef::Comparison]
+type error: expected type Bosatsu/Predef::Fn3[(?13, ?9) -> Bosatsu/Predef::Comparison]
 Region(403,414)
 to be the same as type Bosatsu/Predef::Fn2
 hint: the first type is a function with 3 arguments and the second is a function with 2 arguments.


### PR DESCRIPTION
I don't think loops in the TyMeta graph actually cause a problem, but avoiding them isn't difficult, and makes things a bit simpler to reason about.