### PR TITLE
Fix bug in kind checking of patterns

### DIFF
--- a/core/src/main/scala/org/bykn/bosatsu/PackageError.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/PackageError.scala
@@ -332,27 +332,6 @@ object PackageError {
               Doc.text("this sometimes happens when a function arg has been omitted, or an illegal recursive type or function.")
 
             (doc, Some(metaR))
-          case Infer.Error.KindNotUnifiable(leftK, leftT, rightK, rightT, leftR, rightR) =>
-            val tStr = showTypes(pack, leftT :: rightT :: Nil)
-
-            val context0 =
-                lm.showRegion(leftR, 2, errColor).getOrElse(Doc.str(leftR))
-            val context1 = {
-              if (leftR != rightR) {
-                Doc.text(" at: ") + Doc.hardLine +
-                lm.showRegion(rightR, 2, errColor).getOrElse(Doc.str(rightR))
-              }
-              else {
-                Doc.empty
-              }
-            }
-
-            val doc = Doc.text("kind mismatch error: ") +
-              tStr(leftT) + Doc.text(": ") + Kind.toDoc(leftK) + Doc.text(" at:") + Doc.hardLine + context0 +
-              Doc.text(" cannot be unified with kind: ") +
-              tStr(rightT) + Doc.text(": ") + Kind.toDoc(rightK) + context1
-
-            (doc, Some(leftR))
           case Infer.Error.NotPolymorphicEnough(tpe, _, _, region) => 
             val tmap = showTypes(pack, tpe :: Nil)
             val context =

--- a/core/src/test/scala/org/bykn/bosatsu/EvaluationTest.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/EvaluationTest.scala
@@ -1722,9 +1722,9 @@ def concat_records(RecordSet(fields, rows, getters, traverse, record_to_list), m
   RecordSet(fields, rows.concat(more_rows), getters, traverse, record_to_list)
 
 struct NilShape[w: * -> *]
-struct PS[t, rest, w: * -> *](left: w[t], right: rest[w])
+struct PS[t, rest, w](left: w[t], right: rest[w])
 
-new_record_set = RecordSet(NilShape, [], NilShape, NilShape -> _ -> NilShape, _ -> [])
+new_record_set = RecordSet(NilShape, [], NilShape, NilShape -> _ -> NilShape, NilShape -> [])
 
 (ps_end: forall t: (* -> *) -> *. RestructureOutput[t, NilShape]) = RestructureOutput(
   _ -> NilShape,
@@ -2736,7 +2736,7 @@ def foo[a](a: a) -> a:
 package Foo
 
 struct RecordValue[t](value: t)
-struct RecordGetter[shape: (* -> *) -> *, t](
+struct RecordGetter[shape, t](
   value: shape[RecordValue] -> RecordValue[t]
 )
 

--- a/core/src/test/scala/org/bykn/bosatsu/EvaluationTest.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/EvaluationTest.scala
@@ -1672,12 +1672,12 @@ enum RowEntry[w]:
   REString(value: w[String])
 
 struct RecordField[t](name: String, to_entry: forall w: * -> *. w[t] -> RowEntry[w])
-struct RecordValue[t](value: t)
-struct RecordGetter[shape, t](
+struct RecordValue[t: *](value: t)
+struct RecordGetter[shape: (* -> *) -> *, t](
   field: shape[RecordField] -> RecordField[t],
   value: shape[RecordValue] -> RecordValue[t]
 )
-struct RecordRowEntry[w, t](row_entry: RowEntry[w])
+struct RecordRowEntry[w, t: *](row_entry: RowEntry[w])
 
 struct RecordSet[shape](
   fields: shape[RecordField],
@@ -1722,9 +1722,9 @@ def concat_records(RecordSet(fields, rows, getters, traverse, record_to_list), m
   RecordSet(fields, rows.concat(more_rows), getters, traverse, record_to_list)
 
 struct NilShape[w: * -> *]
-struct PS[t,rest,w](left: w[t], right: rest[w])
+struct PS[t, rest, w: * -> *](left: w[t], right: rest[w])
 
-new_record_set = RecordSet(NilShape, [], NilShape, NilShape -> _ -> NilShape, NilShape -> [])
+new_record_set = RecordSet(NilShape, [], NilShape, NilShape -> _ -> NilShape, _ -> [])
 
 (ps_end: forall t: (* -> *) -> *. RestructureOutput[t, NilShape]) = RestructureOutput(
   _ -> NilShape,
@@ -2736,7 +2736,7 @@ def foo[a](a: a) -> a:
 package Foo
 
 struct RecordValue[t](value: t)
-struct RecordGetter[shape, t](
+struct RecordGetter[shape: (* -> *) -> *, t](
   value: shape[RecordValue] -> RecordValue[t]
 )
 

--- a/core/src/test/scala/org/bykn/bosatsu/EvaluationTest.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/EvaluationTest.scala
@@ -1672,12 +1672,12 @@ enum RowEntry[w]:
   REString(value: w[String])
 
 struct RecordField[t](name: String, to_entry: forall w: * -> *. w[t] -> RowEntry[w])
-struct RecordValue[t: *](value: t)
-struct RecordGetter[shape: (* -> *) -> *, t](
+struct RecordValue[t](value: t)
+struct RecordGetter[shape, t](
   field: shape[RecordField] -> RecordField[t],
   value: shape[RecordValue] -> RecordValue[t]
 )
-struct RecordRowEntry[w, t: *](row_entry: RowEntry[w])
+struct RecordRowEntry[w, t](row_entry: RowEntry[w])
 
 struct RecordSet[shape](
   fields: shape[RecordField],

--- a/core/src/test/scala/org/bykn/bosatsu/rankn/RankNInferTest.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/rankn/RankNInferTest.scala
@@ -1341,4 +1341,29 @@ def foo[f: * -> *](b: B[f]) -> C[f]:
 x = 1
 """)
   }
+
+  test("rule out unsound kind operations") {
+    parseProgramIllTyped("""#
+def cast[f: 👻* -> *, a, b](in: f[a]) -> f[b]: in
+
+struct Box(item)
+struct Foo
+struct Bar
+
+x = Box(Foo)
+y: Box[Bar] = cast(x)
+""")
+    parseProgramIllTyped("""#
+def widen[f: +* -> *](in: f[forall a. a]) -> forall a. f[a]: in
+
+enum B: T, F
+
+struct Contra[a](fn: a -> B)
+
+c: Contra[forall a. a] = Contra(nothing -> nothing)
+
+# this is unsound
+d: forall a. Contra[a] = widen(c) 
+""")
+  }
 }

--- a/core/src/test/scala/org/bykn/bosatsu/rankn/RankNInferTest.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/rankn/RankNInferTest.scala
@@ -313,12 +313,13 @@ class RankNInferTest extends AnyFunSuite {
       (Identifier.unsafe("Some"), Type.Fun(Type.IntType, optType))
     )
     val kinds = Type.builtInKinds.updated(optName, Kind(Kind.Type.co))
+    val kindNotGen = Type.builtInKinds.updated(optName, Kind.Type)
 
     def testWithOpt[A: HasRegion](term: Expr[A], ty: Type) =
       Infer.typeCheck(term).runFully(
         withBools ++ asFullyQualified(constructors),
         definedOption ++ boolTypes,
-        kinds) match {
+        kindNotGen) match {
         case Left(err) => assert(false, err)
         case Right(tpe) => assert(tpe.getType == ty, term.toString)
       }

--- a/core/src/test/scala/org/bykn/bosatsu/rankn/RankNInferTest.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/rankn/RankNInferTest.scala
@@ -236,6 +236,11 @@ class RankNInferTest extends AnyFunSuite {
     // Test unbound vars
     assertTypesDisjoint("a", "Int")
     assertTypesDisjoint("Int", "a")
+
+
+    assert_:<:(
+      "forall f: * -> *, a, b. (f[a], a -> f[b]) -> f[b]",
+      "forall f: +* -> *, a, b. (f[a], a -> f[b]) -> f[b]")
   }
 
   test("Basic inferences") {

--- a/core/src/test/scala/org/bykn/bosatsu/rankn/RankNInferTest.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/rankn/RankNInferTest.scala
@@ -1365,5 +1365,17 @@ c: Contra[forall a. a] = Contra(nothing -> nothing)
 # this is unsound
 d: forall a. Contra[a] = widen(c) 
 """)
+    parseProgramIllTyped("""#
+def narrow[f: -* -> *](in: f[exists a. a]) -> forall a. f[a]: in
+
+enum B: T, F
+
+struct Co[a](item: a)
+
+x: Co[exists a. a] = Co(T)
+
+# this is unsound
+y: forall a. Co[a] = narrow(x) 
+""")
   }
 }

--- a/core/src/test/scala/org/bykn/bosatsu/rankn/RankNInferTest.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/rankn/RankNInferTest.scala
@@ -1324,4 +1324,16 @@ b: exists a. a = T
 c: MyBool = b
 """)
   }
+
+  test("pattern instantiation doesn't violate kinds") {
+    parseProgramIllTyped("""#
+struct B[f: * -> *]
+struct C[f: +* -> *]
+
+def foo[f: * -> *](b: B[f]) -> C[f]:
+  match b:
+    case B: C
+x = 1
+""")
+  }
 }

--- a/test_workspace/recordset.bosatsu
+++ b/test_workspace/recordset.bosatsu
@@ -6,12 +6,12 @@ enum RowEntry[w]:
   REString(value: w[String])
 
 struct RecordField[t](name: String, to_entry: forall w: * -> *. w[t] -> RowEntry[w])
-struct RecordValue[t](value: t)
+struct RecordValue[t: *](value: t)
 struct RecordGetter[shape, t](
   field: shape[RecordField] -> RecordField[t],
   value: shape[RecordValue] -> RecordValue[t]
 )
-struct RecordRowEntry[w, t](row_entry: RowEntry[w])
+struct RecordRowEntry[w, t: *](row_entry: RowEntry[w])
 
 struct RecordSet[shape](
   fields: shape[RecordField],
@@ -56,7 +56,7 @@ def concat_records(RecordSet(fields, rows, getters, traverse, record_to_list), m
 struct NilShape[w: * -> *]
 struct PS[t,rest,w](left: w[t], right: rest[w])
 
-new_record_set = RecordSet(NilShape, [], NilShape, NilShape -> _ -> NilShape, NilShape -> [])
+new_record_set = RecordSet(NilShape, [], NilShape, NilShape -> _ -> NilShape, _ -> [])
 
 (ps_end: forall t: (* -> *) -> *. RestructureOutput[t, NilShape]) = RestructureOutput(
   _ -> NilShape,

--- a/test_workspace/recordset.bosatsu
+++ b/test_workspace/recordset.bosatsu
@@ -6,12 +6,12 @@ enum RowEntry[w]:
   REString(value: w[String])
 
 struct RecordField[t](name: String, to_entry: forall w: * -> *. w[t] -> RowEntry[w])
-struct RecordValue[t: *](value: t)
+struct RecordValue[t](value: t)
 struct RecordGetter[shape, t](
   field: shape[RecordField] -> RecordField[t],
   value: shape[RecordValue] -> RecordValue[t]
 )
-struct RecordRowEntry[w, t: *](row_entry: RowEntry[w])
+struct RecordRowEntry[w, t](row_entry: RowEntry[w])
 
 struct RecordSet[shape](
   fields: shape[RecordField],


### PR DESCRIPTION
There were actually two bugs here:

1. we were checking if either kind subsumed the other, which makes no sense.
2. there was also a bug: `Kind.leftSubsumesRight(kind2, kind2)` which always returns true so the check was a no-op.

Fixing the bug exposed some issues with the super complexly typed RecordSet code.