### PR TITLE
Fix StrPat.isTotal

### DIFF
--- a/core/src/main/scala/org/bykn/bosatsu/Pattern.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/Pattern.scala
@@ -408,11 +408,14 @@ object Pattern {
   case class StrPat(parts: NonEmptyList[StrPart]) extends Pattern[Nothing, Nothing] {
     def isEmpty: Boolean = this == StrPat.Empty
 
-    lazy val isTotal: Boolean =
+    lazy val isTotal: Boolean = {
+      import StrPart.{LitStr, WildChar, NamedChar}
+
       !parts.exists {
-        case Pattern.StrPart.LitStr(_) => true
+        case LitStr(_) | WildChar | NamedChar(_) => true
         case _ => false
       }
+    }
 
     lazy val toNamedSeqPattern: NamedSeqPattern[Char] =
       StrPat.toNamedSeqPattern(this)

--- a/core/src/main/scala/org/bykn/bosatsu/pattern/SeqPattern.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/pattern/SeqPattern.scala
@@ -555,8 +555,7 @@ object SeqPattern {
 
             { (s: S) =>
               for {
-                ht <- split.uncons(s)
-                (h, t) = ht
+                (h, t) <- split.uncons(s)
                 rh <- mh(h)
                 rt <- mt(t)
               } yield split.monoidResult.combine(rh, rt) }
@@ -565,8 +564,7 @@ object SeqPattern {
 
             { (s: S) =>
               for {
-                ht <- split.uncons(s)
-                (_, t) = ht
+                (_, t) <- split.uncons(s)
                 rt <- mt(t)
               } yield rt }
           case Cat(Wildcard, t) =>

--- a/core/src/test/scala/org/bykn/bosatsu/Gen.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/Gen.scala
@@ -476,7 +476,7 @@ object Generators {
         }
 
       for {
-        sz <- Gen.choose(1, 5) // don't get too giant, intersections blow up
+        sz <- Gen.choose(1, 4) // don't get too giant, intersections blow up
         inner <- nonEmptyN(genPart, sz)
         p0 = Pattern.StrPat(makeValid(inner))
         notStr <- p0.toLiteralString.fold(Gen.const(p0))(_ => recurse)

--- a/core/src/test/scala/org/bykn/bosatsu/Gen.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/Gen.scala
@@ -445,6 +445,44 @@ object Generators {
       useUnion,
       useAnnotation = false)
 
+    lazy val genStrPat: Gen[Pattern.StrPat] = {
+      val recurse = Gen.lzy(genStrPat)
+
+      val genPart: Gen[Pattern.StrPart] =
+        Gen.oneOf(
+          lowerIdent.map(Pattern.StrPart.LitStr(_)),
+          bindIdentGen.map(Pattern.StrPart.NamedStr(_)),
+          bindIdentGen.map(Pattern.StrPart.NamedChar(_)),
+          Gen.const(Pattern.StrPart.WildStr),
+          Gen.const(Pattern.StrPart.WildChar))
+
+      def isWild(p: Pattern.StrPart): Boolean =
+        p match {
+          case Pattern.StrPart.LitStr(_) |
+            Pattern.StrPart.NamedChar(_) |
+            Pattern.StrPart.WildChar => false
+          case _ => true
+        }
+
+      def makeValid(nel: NonEmptyList[Pattern.StrPart]): NonEmptyList[Pattern.StrPart] =
+        nel match {
+          case NonEmptyList(_, Nil) => nel
+          case NonEmptyList(h1, h2 :: t) if isWild(h1) && isWild(h2) =>
+            makeValid(NonEmptyList(h2, t))
+          case NonEmptyList(Pattern.StrPart.LitStr(h1), Pattern.StrPart.LitStr(h2) :: t) =>
+            makeValid(NonEmptyList(Pattern.StrPart.LitStr(h1 + h2), t))
+          case NonEmptyList(h1, h2 :: t) =>
+            NonEmptyList(h1, makeValid(NonEmptyList(h2, t)).toList)
+        }
+
+      for {
+        sz <- Gen.choose(1, 5) // don't get too giant, intersections blow up
+        inner <- nonEmptyN(genPart, sz)
+        p0 = Pattern.StrPat(makeValid(inner))
+        notStr <- p0.toLiteralString.fold(Gen.const(p0))(_ => recurse)
+      } yield notStr
+    }
+
   def genPatternGen[N, T](genName: List[Pattern[N, T]] => Gen[N], genT: Gen[T], depth: Int, useUnion: Boolean, useAnnotation: Boolean): Gen[Pattern[N, T]] = {
     val recurse = Gen.lzy(genPatternGen(genName, genT, depth - 1, useUnion, useAnnotation))
     val genVar = bindIdentGen.map(Pattern.Var(_))
@@ -457,43 +495,6 @@ object Generators {
       val genTyped = Gen.zip(recurse, genT)
         .map { case (p, t) => Pattern.Annotation(p, t) }
 
-      lazy val genStrPat: Gen[Pattern.StrPat] = {
-        val recurse = Gen.lzy(genStrPat)
-
-        val genPart: Gen[Pattern.StrPart] =
-          Gen.oneOf(
-            lowerIdent.map(Pattern.StrPart.LitStr(_)),
-            bindIdentGen.map(Pattern.StrPart.NamedStr(_)),
-            bindIdentGen.map(Pattern.StrPart.NamedChar(_)),
-            Gen.const(Pattern.StrPart.WildStr),
-            Gen.const(Pattern.StrPart.WildChar))
-
-        def isWild(p: Pattern.StrPart): Boolean =
-          p match {
-            case Pattern.StrPart.LitStr(_) |
-              Pattern.StrPart.NamedChar(_) |
-              Pattern.StrPart.WildChar => false
-            case _ => true
-          }
-
-        def makeValid(nel: NonEmptyList[Pattern.StrPart]): NonEmptyList[Pattern.StrPart] =
-          nel match {
-            case NonEmptyList(_, Nil) => nel
-            case NonEmptyList(h1, h2 :: t) if isWild(h1) && isWild(h2) =>
-              makeValid(NonEmptyList(h2, t))
-            case NonEmptyList(Pattern.StrPart.LitStr(h1), Pattern.StrPart.LitStr(h2) :: t) =>
-              makeValid(NonEmptyList(Pattern.StrPart.LitStr(h1 + h2), t))
-            case NonEmptyList(h1, h2 :: t) =>
-              NonEmptyList(h1, makeValid(NonEmptyList(h2, t)).toList)
-          }
-
-        for {
-          sz <- Gen.choose(1, 4) // don't get too giant, intersections blow up
-          inner <- nonEmptyN(genPart, sz)
-          p0 = Pattern.StrPat(makeValid(inner))
-          notStr <- p0.toLiteralString.fold(Gen.const(p0))(_ => recurse)
-        } yield notStr
-      }
 
       val genStruct =  for {
         cnt <- Gen.choose(0, 6)

--- a/core/src/test/scala/org/bykn/bosatsu/TotalityTest.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/TotalityTest.scala
@@ -266,6 +266,29 @@ enum Either: Left(l), Right(r)
         case List(intr) => assert(p3 == intr)
         case other => fail(s"expected exactly one intersection: $other")
       }
+    
+    // a regression
+    {
+      val p0 :: p1 :: p2 :: Nil = patterns(
+        """["${_}$.{_}$.{_}",
+        "$.{foo}",
+        "baz"]""")
+
+      assert(TotalityCheck(predefTE).intersection(p0, p1).isEmpty)
+      assert(TotalityCheck(predefTE).intersection(p1, p2).isEmpty)
+      
+      import pattern.SeqPattern.{stringUnitMatcher, Cat, Empty}
+      import pattern.SeqPart.AnyElem
+      import pattern.Splitter.stringUnit
+
+      val strPat1 = p1.asInstanceOf[Pattern.StrPat]
+      val seqPat = Cat(AnyElem, Empty)
+      assert(strPat1.toSeqPattern == seqPat)
+      assert(!strPat1.matches("baz"))
+      assert(stringUnitMatcher(seqPat)("baz").isEmpty)
+      assert(stringUnit.uncons("baz") == Some(('b', "az")))
+      assert(!stringUnit.isEmpty("az"))
+    }
   }
 
   test("test some difference examples") {

--- a/core/src/test/scala/org/bykn/bosatsu/pattern/SeqPatternTest.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/pattern/SeqPatternTest.scala
@@ -403,7 +403,7 @@ class BoolSeqPatternTest extends SeqPatternLaws[Set[Boolean], Boolean, List[Bool
 
     Gen.frequency(
       (1, Gen.const(SeqPattern.Empty)),
-      (5, Gen.zip(sp, Gen.lzy(genPattern)).map { case (h, t) => SeqPattern.Cat(h, t) })
+      (4, Gen.zip(sp, Gen.lzy(genPattern)).map { case (h, t) => SeqPattern.Cat(h, t) })
     )
   }
   def genSeq: Gen[List[Boolean]] =


### PR DESCRIPTION
since adding Char literals and patterns in #1052 it seems StrPat.isTotal was broken, and therefore, pattern intersection.

A scalacheck finally detected it by noticing that intersection wasn't associative.

Yah for scalachecks and laws!