### PR TITLE
define tuples up to 32

### DIFF
--- a/core/src/main/resources/bosatsu/predef.bosatsu
+++ b/core/src/main/resources/bosatsu/predef.bosatsu
@@ -9,7 +9,38 @@ export (
   List(),
   String,
   Test(),
-  TupleCons(),
+  Tuple1(),
+  Tuple2(),
+  Tuple3(),
+  Tuple4(),
+  Tuple5(),
+  Tuple6(),
+  Tuple7(),
+  Tuple8(),
+  Tuple9(),
+  Tuple10(),
+  Tuple11(),
+  Tuple12(),
+  Tuple13(),
+  Tuple14(),
+  Tuple15(),
+  Tuple16(),
+  Tuple17(),
+  Tuple18(),
+  Tuple19(),
+  Tuple20(),
+  Tuple21(),
+  Tuple22(),
+  Tuple23(),
+  Tuple24(),
+  Tuple25(),
+  Tuple26(),
+  Tuple27(),
+  Tuple28(),
+  Tuple29(),
+  Tuple30(),
+  Tuple31(),
+  Tuple32(),
   Order(),
   Unit(),
   Dict,
@@ -49,7 +80,38 @@ export (
 )
 
 struct Unit
-struct TupleCons(first, second)
+struct Tuple1[a: +*](item1: a)
+struct Tuple2[a: +*, b: +*](item1: a, item2: b)
+struct Tuple3[a: +*, b: +*, c: +*](item1: a, item2: b, item3: c)
+struct Tuple4[a: +*, b: +*, c: +*, d: +*](item1: a, item2: b, item3: c, item4: d)
+struct Tuple5[a: +*, b: +*, c: +*, d: +*, e: +*](item1: a, item2: b, item3: c, item4: d, item5: e)
+struct Tuple6[a: +*, b: +*, c: +*, d: +*, e: +*, f: +*](item1: a, item2: b, item3: c, item4: d, item5: e, item6: f)
+struct Tuple7[a: +*, b: +*, c: +*, d: +*, e: +*, f: +*, g: +*](item1: a, item2: b, item3: c, item4: d, item5: e, item6: f, item7: g)
+struct Tuple8[a: +*, b: +*, c: +*, d: +*, e: +*, f: +*, g: +*, h: +*](item1: a, item2: b, item3: c, item4: d, item5: e, item6: f, item7: g, item8: h)
+struct Tuple9[a: +*, b: +*, c: +*, d: +*, e: +*, f: +*, g: +*, h: +*, i: +*](item1: a, item2: b, item3: c, item4: d, item5: e, item6: f, item7: g, item8: h, item9: i)
+struct Tuple10[a: +*, b: +*, c: +*, d: +*, e: +*, f: +*, g: +*, h: +*, i: +*, j: +*](item1: a, item2: b, item3: c, item4: d, item5: e, item6: f, item7: g, item8: h, item9: i, item10: j)
+struct Tuple11[a: +*, b: +*, c: +*, d: +*, e: +*, f: +*, g: +*, h: +*, i: +*, j: +*, k: +*](item1: a, item2: b, item3: c, item4: d, item5: e, item6: f, item7: g, item8: h, item9: i, item10: j, item11: k)
+struct Tuple12[a: +*, b: +*, c: +*, d: +*, e: +*, f: +*, g: +*, h: +*, i: +*, j: +*, k: +*, l: +*](item1: a, item2: b, item3: c, item4: d, item5: e, item6: f, item7: g, item8: h, item9: i, item10: j, item11: k, item12: l)
+struct Tuple13[a: +*, b: +*, c: +*, d: +*, e: +*, f: +*, g: +*, h: +*, i: +*, j: +*, k: +*, l: +*, m: +*](item1: a, item2: b, item3: c, item4: d, item5: e, item6: f, item7: g, item8: h, item9: i, item10: j, item11: k, item12: l, item13: m)
+struct Tuple14[a: +*, b: +*, c: +*, d: +*, e: +*, f: +*, g: +*, h: +*, i: +*, j: +*, k: +*, l: +*, m: +*, n: +*](item1: a, item2: b, item3: c, item4: d, item5: e, item6: f, item7: g, item8: h, item9: i, item10: j, item11: k, item12: l, item13: m, item14: n)
+struct Tuple15[a: +*, b: +*, c: +*, d: +*, e: +*, f: +*, g: +*, h: +*, i: +*, j: +*, k: +*, l: +*, m: +*, n: +*, o: +*](item1: a, item2: b, item3: c, item4: d, item5: e, item6: f, item7: g, item8: h, item9: i, item10: j, item11: k, item12: l, item13: m, item14: n, item15: o)
+struct Tuple16[a: +*, b: +*, c: +*, d: +*, e: +*, f: +*, g: +*, h: +*, i: +*, j: +*, k: +*, l: +*, m: +*, n: +*, o: +*, p: +*](item1: a, item2: b, item3: c, item4: d, item5: e, item6: f, item7: g, item8: h, item9: i, item10: j, item11: k, item12: l, item13: m, item14: n, item15: o, item16: p)
+struct Tuple17[a: +*, b: +*, c: +*, d: +*, e: +*, f: +*, g: +*, h: +*, i: +*, j: +*, k: +*, l: +*, m: +*, n: +*, o: +*, p: +*, q: +*](item1: a, item2: b, item3: c, item4: d, item5: e, item6: f, item7: g, item8: h, item9: i, item10: j, item11: k, item12: l, item13: m, item14: n, item15: o, item16: p, item17: q)
+struct Tuple18[a: +*, b: +*, c: +*, d: +*, e: +*, f: +*, g: +*, h: +*, i: +*, j: +*, k: +*, l: +*, m: +*, n: +*, o: +*, p: +*, q: +*, r: +*](item1: a, item2: b, item3: c, item4: d, item5: e, item6: f, item7: g, item8: h, item9: i, item10: j, item11: k, item12: l, item13: m, item14: n, item15: o, item16: p, item17: q, item18: r)
+struct Tuple19[a: +*, b: +*, c: +*, d: +*, e: +*, f: +*, g: +*, h: +*, i: +*, j: +*, k: +*, l: +*, m: +*, n: +*, o: +*, p: +*, q: +*, r: +*, s: +*](item1: a, item2: b, item3: c, item4: d, item5: e, item6: f, item7: g, item8: h, item9: i, item10: j, item11: k, item12: l, item13: m, item14: n, item15: o, item16: p, item17: q, item18: r, item19: s)
+struct Tuple20[a: +*, b: +*, c: +*, d: +*, e: +*, f: +*, g: +*, h: +*, i: +*, j: +*, k: +*, l: +*, m: +*, n: +*, o: +*, p: +*, q: +*, r: +*, s: +*, t: +*](item1: a, item2: b, item3: c, item4: d, item5: e, item6: f, item7: g, item8: h, item9: i, item10: j, item11: k, item12: l, item13: m, item14: n, item15: o, item16: p, item17: q, item18: r, item19: s, item20: t)
+struct Tuple21[a: +*, b: +*, c: +*, d: +*, e: +*, f: +*, g: +*, h: +*, i: +*, j: +*, k: +*, l: +*, m: +*, n: +*, o: +*, p: +*, q: +*, r: +*, s: +*, t: +*, u: +*](item1: a, item2: b, item3: c, item4: d, item5: e, item6: f, item7: g, item8: h, item9: i, item10: j, item11: k, item12: l, item13: m, item14: n, item15: o, item16: p, item17: q, item18: r, item19: s, item20: t, item21: u)
+struct Tuple22[a: +*, b: +*, c: +*, d: +*, e: +*, f: +*, g: +*, h: +*, i: +*, j: +*, k: +*, l: +*, m: +*, n: +*, o: +*, p: +*, q: +*, r: +*, s: +*, t: +*, u: +*, v: +*](item1: a, item2: b, item3: c, item4: d, item5: e, item6: f, item7: g, item8: h, item9: i, item10: j, item11: k, item12: l, item13: m, item14: n, item15: o, item16: p, item17: q, item18: r, item19: s, item20: t, item21: u, item22: v)
+struct Tuple23[a: +*, b: +*, c: +*, d: +*, e: +*, f: +*, g: +*, h: +*, i: +*, j: +*, k: +*, l: +*, m: +*, n: +*, o: +*, p: +*, q: +*, r: +*, s: +*, t: +*, u: +*, v: +*, w: +*](item1: a, item2: b, item3: c, item4: d, item5: e, item6: f, item7: g, item8: h, item9: i, item10: j, item11: k, item12: l, item13: m, item14: n, item15: o, item16: p, item17: q, item18: r, item19: s, item20: t, item21: u, item22: v, item23: w)
+struct Tuple24[a: +*, b: +*, c: +*, d: +*, e: +*, f: +*, g: +*, h: +*, i: +*, j: +*, k: +*, l: +*, m: +*, n: +*, o: +*, p: +*, q: +*, r: +*, s: +*, t: +*, u: +*, v: +*, w: +*, x: +*](item1: a, item2: b, item3: c, item4: d, item5: e, item6: f, item7: g, item8: h, item9: i, item10: j, item11: k, item12: l, item13: m, item14: n, item15: o, item16: p, item17: q, item18: r, item19: s, item20: t, item21: u, item22: v, item23: w, item24: x)
+struct Tuple25[a: +*, b: +*, c: +*, d: +*, e: +*, f: +*, g: +*, h: +*, i: +*, j: +*, k: +*, l: +*, m: +*, n: +*, o: +*, p: +*, q: +*, r: +*, s: +*, t: +*, u: +*, v: +*, w: +*, x: +*, y: +*](item1: a, item2: b, item3: c, item4: d, item5: e, item6: f, item7: g, item8: h, item9: i, item10: j, item11: k, item12: l, item13: m, item14: n, item15: o, item16: p, item17: q, item18: r, item19: s, item20: t, item21: u, item22: v, item23: w, item24: x, item25: y)
+struct Tuple26[a: +*, b: +*, c: +*, d: +*, e: +*, f: +*, g: +*, h: +*, i: +*, j: +*, k: +*, l: +*, m: +*, n: +*, o: +*, p: +*, q: +*, r: +*, s: +*, t: +*, u: +*, v: +*, w: +*, x: +*, y: +*, z: +*](item1: a, item2: b, item3: c, item4: d, item5: e, item6: f, item7: g, item8: h, item9: i, item10: j, item11: k, item12: l, item13: m, item14: n, item15: o, item16: p, item17: q, item18: r, item19: s, item20: t, item21: u, item22: v, item23: w, item24: x, item25: y, item26: z)
+struct Tuple27[a: +*, b: +*, c: +*, d: +*, e: +*, f: +*, g: +*, h: +*, i: +*, j: +*, k: +*, l: +*, m: +*, n: +*, o: +*, p: +*, q: +*, r: +*, s: +*, t: +*, u: +*, v: +*, w: +*, x: +*, y: +*, z: +*, a0: +*](item1: a, item2: b, item3: c, item4: d, item5: e, item6: f, item7: g, item8: h, item9: i, item10: j, item11: k, item12: l, item13: m, item14: n, item15: o, item16: p, item17: q, item18: r, item19: s, item20: t, item21: u, item22: v, item23: w, item24: x, item25: y, item26: z, item27: a0)
+struct Tuple28[a: +*, b: +*, c: +*, d: +*, e: +*, f: +*, g: +*, h: +*, i: +*, j: +*, k: +*, l: +*, m: +*, n: +*, o: +*, p: +*, q: +*, r: +*, s: +*, t: +*, u: +*, v: +*, w: +*, x: +*, y: +*, z: +*, a0: +*, b0: +*](item1: a, item2: b, item3: c, item4: d, item5: e, item6: f, item7: g, item8: h, item9: i, item10: j, item11: k, item12: l, item13: m, item14: n, item15: o, item16: p, item17: q, item18: r, item19: s, item20: t, item21: u, item22: v, item23: w, item24: x, item25: y, item26: z, item27: a0, item28: b0)
+struct Tuple29[a: +*, b: +*, c: +*, d: +*, e: +*, f: +*, g: +*, h: +*, i: +*, j: +*, k: +*, l: +*, m: +*, n: +*, o: +*, p: +*, q: +*, r: +*, s: +*, t: +*, u: +*, v: +*, w: +*, x: +*, y: +*, z: +*, a0: +*, b0: +*, c0: +*](item1: a, item2: b, item3: c, item4: d, item5: e, item6: f, item7: g, item8: h, item9: i, item10: j, item11: k, item12: l, item13: m, item14: n, item15: o, item16: p, item17: q, item18: r, item19: s, item20: t, item21: u, item22: v, item23: w, item24: x, item25: y, item26: z, item27: a0, item28: b0, item29: c0)
+struct Tuple30[a: +*, b: +*, c: +*, d: +*, e: +*, f: +*, g: +*, h: +*, i: +*, j: +*, k: +*, l: +*, m: +*, n: +*, o: +*, p: +*, q: +*, r: +*, s: +*, t: +*, u: +*, v: +*, w: +*, x: +*, y: +*, z: +*, a0: +*, b0: +*, c0: +*, d0: +*](item1: a, item2: b, item3: c, item4: d, item5: e, item6: f, item7: g, item8: h, item9: i, item10: j, item11: k, item12: l, item13: m, item14: n, item15: o, item16: p, item17: q, item18: r, item19: s, item20: t, item21: u, item22: v, item23: w, item24: x, item25: y, item26: z, item27: a0, item28: b0, item29: c0, item30: d0)
+struct Tuple31[a: +*, b: +*, c: +*, d: +*, e: +*, f: +*, g: +*, h: +*, i: +*, j: +*, k: +*, l: +*, m: +*, n: +*, o: +*, p: +*, q: +*, r: +*, s: +*, t: +*, u: +*, v: +*, w: +*, x: +*, y: +*, z: +*, a0: +*, b0: +*, c0: +*, d0: +*, e0: +*](item1: a, item2: b, item3: c, item4: d, item5: e, item6: f, item7: g, item8: h, item9: i, item10: j, item11: k, item12: l, item13: m, item14: n, item15: o, item16: p, item17: q, item18: r, item19: s, item20: t, item21: u, item22: v, item23: w, item24: x, item25: y, item26: z, item27: a0, item28: b0, item29: c0, item30: d0, item31: e0)
+struct Tuple32[a: +*, b: +*, c: +*, d: +*, e: +*, f: +*, g: +*, h: +*, i: +*, j: +*, k: +*, l: +*, m: +*, n: +*, o: +*, p: +*, q: +*, r: +*, s: +*, t: +*, u: +*, v: +*, w: +*, x: +*, y: +*, z: +*, a0: +*, b0: +*, c0: +*, d0: +*, e0: +*, f0: +*](item1: a, item2: b, item3: c, item4: d, item5: e, item6: f, item7: g, item8: h, item9: i, item10: j, item11: k, item12: l, item13: m, item14: n, item15: o, item16: p, item17: q, item18: r, item19: s, item20: t, item21: u, item22: v, item23: w, item24: x, item25: y, item26: z, item27: a0, item28: b0, item29: c0, item30: d0, item31: e0, item32: f0)
 
 enum Bool:
   False, True
@@ -138,13 +200,13 @@ external def mod_Int(a: Int, mod: Int) -> Int
 external def int_loop(intValue: Int, state: a, fn: (Int, a) -> (Int, a)) -> a
 
 def range(exclusiveUpper: Int) -> List[Int]:
-  int_loop(exclusiveUpper, [], \i, tail ->
+  int_loop(exclusiveUpper, [], (i, tail) ->
     inext = i.sub(1)
     (inext, [inext, *tail]))
 
 def range_fold(inclusiveLower: Int, exclusiveUpper: Int, init: a, fn: (a, Int) -> a) -> a:
   diff = exclusiveUpper.sub(inclusiveLower)
-  int_loop(diff, init, \diff0, a ->
+  int_loop(diff, init, (diff0, a) ->
     idx = exclusiveUpper.sub(diff0)
     a1 = fn(a, idx)
     (diff0.sub(1), a1))
@@ -337,7 +399,7 @@ struct Dict[k, v: +*](order: forall a. Order[(k, a)], tree: Tree[(k, v)])
 
 def empty_Dict(comp: Order[k]) -> forall v. Dict[k, v]:
     Order(fn) = comp
-    pair_ord = Order(\(k1, _), (k2, _) -> fn(k1, k2))
+    pair_ord = Order(((k1, _), (k2, _)) -> fn(k1, k2))
     Dict(pair_ord, Empty)
 
 def add_key(dict: Dict[k, v], key: k, value: v) -> Dict[k, v]:

--- a/core/src/main/scala/org/bykn/bosatsu/PackageMap.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/PackageMap.scala
@@ -405,7 +405,11 @@ object PackageMap {
           case Some(inf) => inf
         }
       case Validated.Invalid(errs) =>
-        sys.error(s"expected no errors, found: $errs")
+        val map = Map(PackageName.PredefName -> (LocationMap(Predef.predefString), "<predef>"))
+        errs.iterator.foreach { err =>
+          println(err.message(map, LocationMap.Colorize.None))
+        }
+        sys.error("expected no errors")
     }
   }
 

--- a/core/src/main/scala/org/bykn/bosatsu/Predef.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/Predef.scala
@@ -116,7 +116,7 @@ object PredefImpl {
   def gcd_Int(a: Value, b: Value): Value =
     VInt(gcdBigInteger(i(a), i(b)))
 
-  //def intLoop(intValue: Int, state: a, fn: Int -> a -> TupleCons[Int, TupleCons[a, Unit]]) -> a
+  //def intLoop(intValue: Int, state: a, fn: Int -> a -> Tuple2[Int, a]) -> a
   final def intLoop(intValue: Value, state: Value, fn: Value): Value = {
     val fnT = fn.asFn
 
@@ -125,7 +125,7 @@ object PredefImpl {
       if (bi.compareTo(BigInteger.ZERO) <= 0) state
       else {
         fnT(NonEmptyList(biValue, state :: Nil)) match {
-          case ConsValue(nextI, ConsValue(ConsValue(nextA, _), _)) =>
+          case ConsValue(nextI, ConsValue(nextA, _)) =>
             val n = i(nextI)
             if (n.compareTo(bi) >= 0) {
               // we are done in this case

--- a/core/src/main/scala/org/bykn/bosatsu/Value.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/Value.scala
@@ -137,37 +137,17 @@ object Value {
   val False: SumValue = SumValue(0, UnitValue)
   val True: SumValue = SumValue(1, UnitValue)
 
-  object TupleCons {
-    def unapply(v: Value): Option[(Value, Value)] =
-      v match {
-        case ConsValue(a, ConsValue(b, UnitValue)) => Some((a, b))
-        case _ => None
-      }
-
-    def apply(a: Value, b: Value): ProductValue =
-      ConsValue(a, ConsValue(b, UnitValue))
-  }
-
   object Tuple {
-    /**
-     * Tuples are encoded as:
-     * (1, 2, 3) => TupleCons(1, TupleCons(2, TupleCons(3, ())))
-     * since a Tuple(a, b) is encoded as
-     * ConsValue(a, ConsValue(b, UnitValue))
-     * this gives double wrapping
-     */
     def unapply(v: Value): Option[List[Value]] =
       v match {
-        case TupleCons(a, b) =>
-          unapply(b).map(a :: _)
-        case UnitValue => Some(Nil)
+        case p: ProductValue => Some(p.toList)
         case _ => None
       }
 
     def fromList(vs: List[Value]): ProductValue =
       vs match {
         case Nil => UnitValue
-        case h :: tail => TupleCons(h, fromList(tail))
+        case h :: tail => ConsValue(h, fromList(tail))
       }
 
     def apply(vs: Value*): ProductValue =

--- a/core/src/main/scala/org/bykn/bosatsu/codegen/python/PythonGen.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/codegen/python/PythonGen.scala
@@ -835,7 +835,7 @@ object PythonGen {
                   }
                   .flatten
             }, 2)),
-            //external def int_loop(intValue: Int, state: a, fn: (Int, a) -> TupleCons[Int, TupleCons[a, Unit]]) -> a
+            //external def int_loop(intValue: Int, state: a, fn: (Int, a) -> (Int, a) -> a
             // def int_loop(i, a, fn):
             //   if i <= 0: a
             //   else:
@@ -872,7 +872,7 @@ object PythonGen {
                             Code.block(
                               res := fn(_i, _a),
                               tmp_i := res.get(0),
-                              _a := res.get(1).get(0),
+                              _a := res.get(1),
                               cont := (Code.fromInt(0) :< tmp_i).evalAnd(tmp_i :< _i),
                               _i := tmp_i
                             )

--- a/core/src/main/scala/org/bykn/bosatsu/codegen/python/PythonGen.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/codegen/python/PythonGen.scala
@@ -931,13 +931,13 @@ object PythonGen {
                   // if sep == "": None
                   // else:
                   //   (a, s1, b) = str.partition(sep)
-                  //   if s1: (1, (a, (b, ())))
+                  //   if s1: (1, (a, b))
                   //   else: (0, )
                   val a = res.get(0)
                   val s1 = res.get(1)
                   val b = res.get(2)
                   val success = Code.MakeTuple(Code.fromInt(1) ::
-                    Code.MakeTuple(a :: Code.MakeTuple(b :: Code.Const.Unit :: Nil) :: Nil) ::
+                    Code.MakeTuple(a :: b :: Nil) ::
                     Nil
                     )
                   val fail = Code.MakeTuple(Code.fromInt(0) :: Nil)
@@ -956,13 +956,13 @@ object PythonGen {
                 .flatMap { res =>
                   Env.onLast2(input.head, input.tail.head) { (str, sep) =>
                   // (a, s1, b) = str.partition(sep)
-                  // if s1: (1, (a, (b, ())))
+                  // if s1: (1, (a, b))
                   // else: (0, )
                   val a = res.get(0)
                   val s1 = res.get(1)
                   val b = res.get(2)
                   val success = Code.MakeTuple(Code.fromInt(1) ::
-                    Code.MakeTuple(a :: Code.MakeTuple(b :: Code.Const.Unit :: Nil) :: Nil) ::
+                    Code.MakeTuple(a :: b :: Nil) ::
                     Nil
                     )
                   val fail = Code.MakeTuple(Code.fromInt(0) :: Nil)

--- a/core/src/test/scala/org/bykn/bosatsu/EvaluationTest.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/EvaluationTest.scala
@@ -3231,4 +3231,43 @@ res = cons((1, 0), Empty).uncons()
 test = Assertion(res matches Some(((1, _), Empty)), "one")
 """), "Foo", 1)
   }
+
+  test("tuples bigger than 32 fail") {
+    val testCode = """
+package ErrorCheck
+
+z = (1, 2, 3, 4, 5, 6, 7, 8, 9, 10,
+  11, 12, 13, 14, 15, 16, 17, 18, 19, 20,
+  21, 22, 23, 24, 25, 26, 27, 28, 29, 30,
+  31, 32, 33)
+
+"""
+   evalFail(List(testCode)) { case kie@PackageError.SourceConverterErrorIn(_, _) =>
+      val message = kie.message(Map.empty, Colorize.None)
+      assert(message.contains("invalid tuple size. Found 33, but maximum allowed 32"))
+      assert(message.contains("Region(25,154)"))
+      ()
+    }
+
+    val testCode1 = """
+package ErrorCheck
+
+z = (1, 2, 3, 4, 5, 6, 7, 8, 9, 10,
+  11, 12, 13, 14, 15, 16, 17, 18, 19, 20,
+  21, 22, 23, 24, 25, 26, 27, 28, 29, 30,
+  31, 32)
+
+res = z matches (1, 2, 3, 4, 5, 6, 7, 8, 9, 10,
+  11, 12, 13, 14, 15, 16, 17, 18, 19, 20,
+  21, 22, 23, 24, 25, 26, 27, 28, 29, 30,
+  31, 32, 33)
+
+"""
+   evalFail(List(testCode1)) { case kie@PackageError.SourceConverterErrorIn(_, _) =>
+      val message = kie.message(Map.empty, Colorize.None)
+      assert(message.contains("invalid tuple size. Found 33, but maximum allowed 32"))
+      assert(message.contains("Region(158,297)"))
+      ()
+    }
+  }
 }

--- a/core/src/test/scala/org/bykn/bosatsu/KindFormulaTest.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/KindFormulaTest.scala
@@ -200,7 +200,8 @@ struct Leib[a, b](cast: forall f. f[a] -> f[b])
         "Option" -> "+* -> *",
         "Tree" -> "+* -> *",
         "Unit" -> "*",
-        "TupleCons" -> "+* -> +* -> *",
+        "Tuple2" -> "+* -> +* -> *",
+        "Tuple3" -> "+* -> +* -> +* -> *",
         "Dict" -> "* -> +* -> *"
       )
     )

--- a/core/src/test/scala/org/bykn/bosatsu/rankn/NTypeGen.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/rankn/NTypeGen.scala
@@ -119,15 +119,15 @@ object NTypeGen {
     )
 
     val t1 = List(ListType, OptionType)
-    val t2 = List(FnType(1), TupleConsType, DictType)
+    val t2 = List(FnType(1), Tuple.Arity(2), DictType)
 
     lazy val tupleTypes: Gen[Type] = {
       val recTup = Gen.lzy(tupleTypes)
 
-      // either Unit, TupleConsType(a, tuple)
+      // either Unit, Tuple2(a, b)
       Gen.oneOf(
         Gen.const(UnitType),
-        Gen.zip(recurse, recTup).map { case (h, t) => Type.TyApply(Type.TyApply(TupleConsType, h), t) })
+        Gen.zip(recurse, recTup).map { case (h, t) => Type.TyApply(Type.TyApply(Tuple.Arity(2), h), t) })
     }
 
     Gen.frequency(

--- a/core/src/test/scala/org/bykn/bosatsu/rankn/TypeTest.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/rankn/TypeTest.scala
@@ -363,11 +363,11 @@ class TypeTest extends AnyFunSuite {
   test("tuple syntax looks right") {
     val code = Type.allTupleCode
     (1 to 32).foreach { i =>
-      assert(code.contains(s"struct Tuple$i("))
+      assert(code.contains(s"struct Tuple$i["))
       assert(code.contains(s"Tuple$i(),"))
     }
     List(0, 33).foreach { i =>
-      assert(!code.contains(s"struct Tuple$i("))
+      assert(!code.contains(s"struct Tuple$i["))
       assert(!code.contains(s"Tuple$i(),"))
     }
   }

--- a/core/src/test/scala/org/bykn/bosatsu/rankn/TypeTest.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/rankn/TypeTest.scala
@@ -359,4 +359,16 @@ class TypeTest extends AnyFunSuite {
       }
     }
   }
+
+  test("tuple syntax looks right") {
+    val code = Type.allTupleCode
+    (1 to 32).foreach { i =>
+      assert(code.contains(s"struct Tuple$i("))
+      assert(code.contains(s"Tuple$i(),"))
+    }
+    List(0, 33).foreach { i =>
+      assert(!code.contains(s"struct Tuple$i("))
+      assert(!code.contains(s"Tuple$i(),"))
+    }
+  }
 }

--- a/docs/src/main/paradox/language_guide.md
+++ b/docs/src/main/paradox/language_guide.md
@@ -465,7 +465,7 @@ of inputs in the same position. This gives a simple proof that the loop will ter
 Instead, we implement this function in Predef as an external def that has to be supplied to the
 compiler with a promise that it is indeed total.
 ```
-external def int_loop(intValue: Int, state: a, fn: Int -> a -> TupleCons[Int, TupleCons[a, Unit]]) -> a
+external def int_loop(intValue: Int, state: a, fn: Int -> a -> Tuple2[Int, a]) -> a
 ```
 
 External values and types work exactly like internally defined types from any other point of view.


### PR DESCRIPTION
relates to #1026 #1029 

If we only have functions up to 32, then we can only have types with up to 32 parameters (otherwise their constructors are unrepresentable). So, this removes the cons-cell encoding of variadic tuples and adds 32 concrete tuples.

This should improve runtime performance of tuple heavy code, but I have not benchmarked it.

I could also have implemented this by adding the types and constructor functions directly to the post-source converted code. That may improve test performance (that winds up compiling the predef a lot, but in practice I don't think it would matter, plus it hides the structure and name of the parameters in a harder to see place and makes more types magical).