### PR TITLE
Remember the TyApply is always on a Rho

### DIFF
--- a/cli/src/main/scala/org/bykn/bosatsu/TypedExprToProto.scala
+++ b/cli/src/main/scala/org/bykn/bosatsu/TypedExprToProto.scala
@@ -268,7 +268,7 @@ object ProtoConverter {
             } yield Type.exists(args, inT)
 
           case Value.TypeApply(TypeApply(left, right, _)) =>
-            (tpe(left), tpe(right)).mapN(Type.TyApply(_, _))
+            (tpe(left), tpe(right)).mapN(Type.apply1(_, _))
         }
       }
 

--- a/core/src/main/scala/org/bykn/bosatsu/rankn/DefinedType.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/rankn/DefinedType.scala
@@ -88,7 +88,7 @@ final case class DefinedType[+A](
 
   def fnTypeOf(cf: ConstructorFn)(implicit ev: A <:< Kind.Arg): Type = {
     // evidence to prove that we only ask for this after inference
-    val tc: Type = Type.const(packageName, name)
+    val tc: Type.Rho = Type.const(packageName, name)
 
     val res = typeParams.foldLeft(tc) { (res, v) =>
         Type.TyApply(res, Type.TyVar(v))

--- a/core/src/main/scala/org/bykn/bosatsu/rankn/Type.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/rankn/Type.scala
@@ -20,7 +20,9 @@ object Type {
   /**
    * A type with no top level quantification
    */
-  sealed abstract class Rho extends Type
+  sealed abstract class Rho extends Type {
+    override def normalize: Rho
+  }
   
   object Rho {
     implicit val orderRho: Order[Rho] =
@@ -50,7 +52,7 @@ object Type {
   }
 
   sealed abstract class Leaf extends Rho {
-    def normalize: Type = this
+    override def normalize: Leaf = this
   }
   type Tau = Rho // no forall or exists anywhere
 
@@ -152,8 +154,8 @@ object Type {
       }
   }
 
-  case class TyApply(on: Type, arg: Type) extends Rho {
-    lazy val normalize: Type = TyApply(on.normalize, arg.normalize)
+  case class TyApply(on: Rho, arg: Type) extends Rho {
+    lazy val normalize: Rho = TyApply(on.normalize, arg.normalize)
   }
   case class TyConst(tpe: Const) extends Leaf
   case class TyVar(toVar: Var) extends Leaf
@@ -190,12 +192,55 @@ object Type {
   implicit val typeOrdering: Ordering[Type] = typeOrder.toOrdering
 
   @annotation.tailrec
-  def applyAll(fn: Type, args: List[Type]): Type =
+  def applyAllRho(rho: Rho, args: List[Type]): Rho =
     args match {
-      case Nil => fn
-      case a :: as =>
-        applyAll(TyApply(fn, a), as)
+      case Nil => rho
+      case a :: as => applyAllRho(TyApply(rho, a), as)
     }
+
+  def apply1(fn: Type, arg: Type): Type =
+    fn match {
+      case rho: Rho => TyApply(rho, arg)
+      case q => applyAll(q, arg :: Nil)
+    }
+
+  def applyAll(fn: Type, args: List[Type]): Type =
+    fn match {
+      case rho: Rho => applyAllRho(rho, args)
+      case Quantified(q, rho) =>
+        val freeBound = freeBoundTyVars(fn :: args)
+        if (freeBound.isEmpty) {
+          Quantified(q, applyAllRho(rho, args))
+        }
+        else {
+          val freeBoundSet: Set[Var.Bound] = freeBound.toSet
+          val collisions = q.vars.exists { case (b, _) => freeBoundSet(b) }
+          if (!collisions) {
+            // we don't need to rename the vars
+            Quantified(q, applyAllRho(rho, args))
+          }
+          else {
+            // we have to to rename the collisions so the free set
+            // is unchanged
+            val fa1 = alignBinders(q.forallList, freeBoundSet)
+            val ex1 = alignBinders(q.existList, freeBoundSet ++ fa1.map(_._2))
+            val subMap = (fa1.iterator ++ ex1.iterator).map {
+              case ((b0, _), b1) => (b0, TyVar(b1))
+            }
+            .toMap[Var, Rho]
+
+            val rho1 = substituteRhoVar(rho, subMap)
+
+            val q1 = Quantification.fromLists(
+              forallList = fa1.map { case ((_, k), b) => (b, k)},
+              existList = ex1.map { case ((_, k), b) => (b, k)}
+            )
+            .get // this Option must be defined because we started with a defined q
+
+            Quantified(q1, applyAllRho(rho1, args))
+          }
+        }
+      }
 
   def unapplyAll(fn: Type): (Type, List[Type]) = {
     @annotation.tailrec
@@ -353,7 +398,8 @@ object Type {
   def substituteVar(t: Type, env: Map[Type.Var, Type]): Type =
     if (env.isEmpty) t
     else (t match {
-      case TyApply(on, arg) => TyApply(substituteVar(on, env), substituteVar(arg, env))
+      case TyApply(on, arg) =>
+        apply1(substituteVar(on, env), substituteVar(arg, env))
       case v@TyVar(n) =>
         env.get(n) match {
           case Some(rho) => rho
@@ -370,7 +416,8 @@ object Type {
 
   def substituteRhoVar(t: Type.Rho, env: Map[Type.Var, Type.Rho]): Type.Rho =
     t match {
-      case TyApply(on, arg) => TyApply(substituteVar(on, env), substituteVar(arg, env))
+      case TyApply(on, arg) =>
+        TyApply(substituteRhoVar(on, env), substituteVar(arg, env))
       case v@TyVar(n) =>
         env.get(n) match {
           case Some(rho) => rho
@@ -602,7 +649,7 @@ object Type {
   val TestType: Type.TyConst = TyConst(Const.predef("Test"))
   val UnitType: Type.TyConst = TyConst(Type.Const.predef("Unit"))
 
-  def const(pn: PackageName, name: TypeName): Type =
+  def const(pn: PackageName, name: TypeName): Type.Rho =
     TyConst(Type.Const.Defined(pn, name))
 
   object Fun {
@@ -635,7 +682,7 @@ object Type {
 
     def apply(from: NonEmptyList[Type], to: Type): Type.Rho = {
       val arityFn = FnType.maybeFakeName(from.length)
-      val withArgs = from.foldLeft(arityFn: Type)(TyApply(_, _))
+      val withArgs = from.foldLeft(arityFn: Type.Rho)(TyApply(_, _))
       TyApply(withArgs, to)
     }
     def apply(from: Type, to: Type): Type.Rho =
@@ -684,7 +731,7 @@ object Type {
 
     def apply(ts: List[Type]): Type = {
       val sz = ts.size 
-      val root: Type = Arity(sz)
+      val root: Type.Rho = Arity(sz)
       ts.foldLeft(root) { (acc, t) => TyApply(acc, t)}
     }
 
@@ -920,7 +967,7 @@ object Type {
   def zonkRhoMeta[F[_]: Applicative](t: Type.Rho)(mfn: Meta => F[Option[Type.Rho]]): F[Type.Rho] =
     t match {
       case Type.TyApply(on, arg) =>
-        (zonkMeta(on)(mfn), zonkMeta(arg)(mfn)).mapN(Type.TyApply(_, _))
+        (zonkRhoMeta(on)(mfn), zonkMeta(arg)(mfn)).mapN(Type.TyApply(_, _))
       case t@Type.TyMeta(m) =>
         mfn(m).map {
           case None => t

--- a/core/src/test/scala/org/bykn/bosatsu/TestUtils.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/TestUtils.scala
@@ -49,7 +49,9 @@ object TestUtils {
         case t@Type.TyMeta(_) =>
           sys.error(s"illegal meta ($t) escape in ${te.repr}")
         case Type.TyApply(left, right) =>
-          Type.TyApply(checkType(left, bound), checkType(right, bound))
+          Type.TyApply(
+            checkType(left, bound).asInstanceOf[Type.Rho],
+            checkType(right, bound))
         case q: Type.Quantified =>
           q.copy(in = checkType(q.in, bound ++ q.vars.toList.map(_._1)).asInstanceOf[Type.Rho])
         case Type.TyConst(_) => t

--- a/core/src/test/scala/org/bykn/bosatsu/rankn/RankNInferTest.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/rankn/RankNInferTest.scala
@@ -359,7 +359,7 @@ class RankNInferTest extends AnyFunSuite {
   }
 
   test("match with custom generic types") {
-    def tv(a: String): Type = Type.TyVar(Type.Var.Bound(a))
+    def tv(a: String): Type.Rho = Type.TyVar(Type.Var.Bound(a))
 
     import OptionTypes._
 
@@ -418,7 +418,7 @@ class RankNInferTest extends AnyFunSuite {
   }
 
   test("Test a constructor with ForAll") {
-    def tv(a: String): Type = Type.TyVar(Type.Var.Bound(a))
+    def tv(a: String): Type.Rho = Type.TyVar(Type.Var.Bound(a))
 
     val pureName = defType("Pure")
     val optName = defType("Option")

--- a/core/src/test/scala/org/bykn/bosatsu/rankn/TypeTest.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/rankn/TypeTest.scala
@@ -60,6 +60,18 @@ class TypeTest extends AnyFunSuite {
       (parse("foo"), List(parse("bar"))))
   }
 
+  test("freeBoundVar doesn't change by applyAll") {
+    forAll(NTypeGen.genDepth03, Gen.listOf(NTypeGen.genDepth03)) { (ts, args) =>
+      val applied = Type.applyAll(ts, args)
+      val free0 = Type.freeBoundTyVars(ts :: args)
+      val free1 = Type.freeBoundTyVars(applied :: Nil)
+      assert(free1.toSet == free0.toSet,
+        s"applied = ${Type.typeParser.render(applied)}, (${Type.typeParser.render(ts)})[${
+          args.iterator.map(Type.typeParser.render(_)).mkString(", ")
+        }]})")
+    }
+  }
+
   test("types are well ordered") {
     forAll(NTypeGen.genDepth03, NTypeGen.genDepth03, NTypeGen.genDepth03) {
       org.bykn.bosatsu.OrderingLaws.law(_, _, _)


### PR DESCRIPTION
This is an invariant I realized we were losing. since `(forall x. C[x])[y] == (forall x. C[x, y])` we can always push formal out of TyApply and keep the left hand side a Rho type.

This makes it easier to reason about the types, but also does a minor performance improvement in Infer since we can leverage that the left is a Rho without having to pattern match again.