### PR TITLE
Encode Kinds to Longs in proto

### DIFF
--- a/cli/src/main/protobuf/bosatsu/TypedAst.proto
+++ b/cli/src/main/protobuf/bosatsu/TypedAst.proto
@@ -23,6 +23,7 @@ message Kind {
   oneof value {
     TypeKind type = 1;
     ConsKind cons = 2;
+    int64 encoded = 3;
   }
 }
 


### PR DESCRIPTION
this is just to save a few bytes in the proto since most commonly we just have a few kinds, and those can be represented by 1 byte in almost all common cases.