### PR TITLE
migrate to scala3 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
           - '8'
           - '11'
         scala:
-          - '2.13.11'
+          - '3.3.1'
     timeout-minutes: 30
   testPY:
     runs-on: ubuntu-latest
@@ -44,7 +44,7 @@ jobs:
         java:
           - '11'
         scala:
-          - '2.13.11'
+          - '3.3.1'
         python:
           - '3.9'
     timeout-minutes: 30
@@ -64,7 +64,7 @@ jobs:
         java:
           - '11'
         scala:
-          - '2.13.11'
+          - '3.3.1'
     timeout-minutes: 30
   testWithCoverageReport:
     runs-on: ubuntu-latest
@@ -103,7 +103,7 @@ jobs:
     strategy:
       matrix:
         scala:
-          - '2.13.11'
+          - '3.3.1'
         java:
           - '8'
 name: ci

--- a/.github/workflows/upload_asset.yml
+++ b/.github/workflows/upload_asset.yml
@@ -21,7 +21,7 @@ jobs:
       - name: "build assembly"
         run: |
           sbt ++${{matrix.scala}} cli/assembly
-          cp cli/target/scala-2.13/bosatsu-cli-assembly-*.jar bosatsu.jar
+          cp cli/target/scala-3.3.1/bosatsu-cli-assembly-*.jar bosatsu.jar
       - name: Create Release
         id: create_release
         uses: actions/create-release@v1
@@ -47,5 +47,5 @@ jobs:
         java:
           - '8'
         scala:
-          - '2.13.10'
+          - '3.3.1'
     timeout-minutes: 30

--- a/build.sbt
+++ b/build.sbt
@@ -4,12 +4,10 @@ import Dependencies._
 lazy val commonSettings = Seq(
   organization := "org.bykn",
   version := "0.0.7",
-  addCompilerPlugin(
-    "org.typelevel" %% "kind-projector" % "0.13.2" cross CrossVersion.full
-  ),
-  addCompilerPlugin("com.olegpy" %% "better-monadic-for" % "0.3.1"),
-  scalaVersion := "2.13.12",
-  crossScalaVersions := Seq("2.13.12"),
+  //addCompilerPlugin("org.typelevel" %% "kind-projector" % "0.13.2" cross CrossVersion.full),
+  //addCompilerPlugin("com.olegpy" %% "better-monadic-for" % "0.3.1"),
+  scalaVersion := "3.3.1",
+  crossScalaVersions := Seq("3.3.1"),
   // from: https://tpolecat.github.io/2017/04/25/scalac-flags.html
   scalacOptions ++= Seq(
     "-deprecation", // Emit warning and location for usages of deprecated APIs.
@@ -46,6 +44,9 @@ lazy val commonSettings = Seq(
     /* "-Ywarn-unused:privates",            // Warn if a private member is unused. */
     "-Ywarn-value-discard", // Warn when non-Unit expression results are unused.
     "-Xsource:3",
+    "-source:future",
+    "-rewrite", "-source", "future-migration",
+    "-Ykind-projector",
     "-Ypatmat-exhaust-depth",
     "40",
     "-Wconf:cat=deprecation&msg=.*Stream.*:s"
@@ -106,7 +107,7 @@ lazy val base =
     .settings(
       commonSettings,
       name := "bosatsu-base",
-      libraryDependencies += scalaReflect.value,
+      //libraryDependencies += scalaReflect.value,
       buildInfoKeys := Seq[BuildInfoKey](
         name,
         version,
@@ -176,13 +177,13 @@ lazy val core =
         scalaTest.value % Test,
         scalaTestPlusScalacheck.value % Test,
         // needed for acyclic which we run periodically, not all the time
-        "com.lihaoyi" % "acyclic_2.13.12" % "0.3.9" % "provided"
+        //"com.lihaoyi" % "acyclic_2.13.12" % "0.3.9" % "provided"
       )
     // periodically we use acyclic to ban cyclic dependencies and make compilation faster
     ,
     autoCompilerPlugins := true,
-    addCompilerPlugin("com.lihaoyi" % "acyclic_2.13.12" % "0.3.9"),
-    scalacOptions += "-P:acyclic:force"
+    //addCompilerPlugin("com.lihaoyi" % "acyclic_2.13.12" % "0.3.9"),
+    //scalacOptions += "-P:acyclic:force"
   ).dependsOn(base)
     .jsSettings(commonJsSettings)
 

--- a/build.sbt
+++ b/build.sbt
@@ -45,7 +45,6 @@ lazy val commonSettings = Seq(
     "-Ywarn-value-discard", // Warn when non-Unit expression results are unused.
     "-Xsource:3",
     "-source:future",
-    "-rewrite", "-source", "future-migration",
     "-Ykind-projector",
     "-Ypatmat-exhaust-depth",
     "40",

--- a/cli/src/main/scala/org/bykn/bosatsu/PathModule.scala
+++ b/cli/src/main/scala/org/bykn/bosatsu/PathModule.scala
@@ -4,9 +4,9 @@ import cats.effect.IO
 import com.monovore.decline.Argument
 import org.typelevel.paiges.Doc
 
-import java.nio.file.{Path => JPath}
+import java.nio.file.{Path as JPath}
 
-import cats.implicits._
+import cats.implicits.*
 import cats.effect.ExitCode
 
 object PathModule extends MainModule[IO] {
@@ -165,7 +165,7 @@ object PathModule extends MainModule[IO] {
     }
 
   def pathPackage(roots: List[Path], packFile: Path): Option[PackageName] = {
-    import scala.jdk.CollectionConverters._
+    import scala.jdk.CollectionConverters.*
 
     def getP(p: Path): Option[PackageName] = {
       val subPath = p.relativize(packFile)

--- a/cli/src/main/scala/org/bykn/bosatsu/TypedExprToProto.scala
+++ b/cli/src/main/scala/org/bykn/bosatsu/TypedExprToProto.scala
@@ -1,6 +1,6 @@
 package org.bykn.bosatsu
 
-import _root_.bosatsu.{TypedAst => proto}
+import _root_.bosatsu.{TypedAst as proto}
 import cats.{Foldable, Monad, MonadError}
 import cats.data.{NonEmptyList, ReaderT, StateT}
 import cats.effect.IO
@@ -15,7 +15,7 @@ import scalapb.{GeneratedMessage, GeneratedMessageCompanion}
 
 import Identifier.{Bindable, Constructor}
 
-import cats.implicits._
+import cats.implicits.*
 
 /**
  * convert TypedExpr to and from Protobuf representation
@@ -234,7 +234,7 @@ object ProtoConverter {
 
       def typeFromProto(p: proto.Type, tpe: Int => Try[Type]): Try[Type] = {
         import proto.Type.Value
-        import bosatsu.TypedAst.{Type => _, _}
+        import bosatsu.TypedAst.{Type as _, *}
 
         def str(i: Int): Try[String] =
           ds.tryString(i - 1, s"invalid string idx: $i in $p")
@@ -272,7 +272,7 @@ object ProtoConverter {
         }
       }
 
-      buildTable(types.toArray)(typeFromProto _)
+      buildTable(types.toArray)(typeFromProto)
     }
 
   def buildPatterns(pats: Seq[proto.Pattern]): DTab[Array[Pattern[(PackageName, Constructor), Type]]] =
@@ -349,7 +349,7 @@ object ProtoConverter {
         }
       }
 
-      buildTable(pats.toArray)(patternFromProto _)
+      buildTable(pats.toArray)(patternFromProto)
     }
 
   def recursionKindFromProto(rec: proto.RecursionKind, context: => String): Try[RecursionKind] =
@@ -466,7 +466,7 @@ object ProtoConverter {
         }
       }
 
-      buildTable(exprs.toArray)(expressionFromProto _)
+      buildTable(exprs.toArray)(expressionFromProto)
     }
 
   private def parsePack(pstr: String, context: => String): Try[PackageName] =
@@ -506,7 +506,7 @@ object ProtoConverter {
 
   def typeToProto(p: Type): Tab[Int] = {
     import proto.Type.Value
-    import bosatsu.TypedAst.{Type => _, _}
+    import bosatsu.TypedAst.{Type as _, *}
 
     getProtoTypeTab(p)
       .flatMap {
@@ -694,7 +694,7 @@ object ProtoConverter {
       .flatMap {
         case Some(idx) => tabPure(idx + 1)
         case None =>
-          import TypedExpr._
+          import TypedExpr.*
           te match {
             case g@Generic(quant, expr) =>
               val fas = quant.forallList.traverse { case (v, k) =>

--- a/cli/src/test/scala/org/bykn/bosatsu/JsonTest.scala
+++ b/cli/src/test/scala/org/bykn/bosatsu/JsonTest.scala
@@ -3,7 +3,7 @@ package org.bykn.bosatsu
 import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks.{forAll, PropertyCheckConfiguration }
 import org.typelevel.jawn.ast.{JValue, JParser}
 
-import GenJson._
+import GenJson.*
 import org.scalatest.funsuite.AnyFunSuite
 
 class JsonJawnTest extends AnyFunSuite {
@@ -12,7 +12,7 @@ class JsonJawnTest extends AnyFunSuite {
     PropertyCheckConfiguration(minSuccessful = 500)
 
   def matches(j1: Json, j2: JValue): Unit = {
-    import Json._
+    import Json.*
     j1 match {
       case JString(str) => assert(j2.asString == str); ()
       case JNumberStr(nstr) => assert(BigDecimal(nstr) == j2.asBigDecimal); ()

--- a/cli/src/test/scala/org/bykn/bosatsu/PathModuleTest.scala
+++ b/cli/src/test/scala/org/bykn/bosatsu/PathModuleTest.scala
@@ -6,7 +6,7 @@ import java.nio.file.{Path, Paths}
 import org.scalacheck.{Arbitrary, Gen}
 import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks.forAll
 
-import scala.jdk.CollectionConverters._
+import scala.jdk.CollectionConverters.*
 import scala.util.{Failure, Success, Try}
 import org.scalatest.funsuite.AnyFunSuite
 
@@ -90,7 +90,7 @@ class PathModuleTest extends AnyFunSuite {
     }
 
   test("test direct run of a file") {
-    val out = run("test --input test_workspace/List.bosatsu --input test_workspace/Nat.bosatsu --input test_workspace/Bool.bosatsu --test_file test_workspace/Queue.bosatsu".split("\\s+").toSeq: _*)
+    val out = run("test --input test_workspace/List.bosatsu --input test_workspace/Nat.bosatsu --input test_workspace/Bool.bosatsu --test_file test_workspace/Queue.bosatsu".split("\\s+").toSeq *)
     out match {
       case PathModule.Output.TestOutput(results, _) =>
         val res = results.collect { case (pn, Some(t)) if pn.asString == "Queue" => t.value }
@@ -100,7 +100,7 @@ class PathModuleTest extends AnyFunSuite {
   }
 
   test("test search run of a file") {
-    val out = run("test --package_root test_workspace --search --test_file test_workspace/Bar.bosatsu".split("\\s+").toSeq: _*)
+    val out = run("test --package_root test_workspace --search --test_file test_workspace/Bar.bosatsu".split("\\s+").toSeq *)
     out match {
       case PathModule.Output.TestOutput(results, _) =>
         val res = results.collect { case (pn, Some(t)) if pn.asString == "Bar" => t.value }
@@ -112,7 +112,7 @@ class PathModuleTest extends AnyFunSuite {
   }
 
   test("test python transpile on the entire test_workspace") {
-    val out = run("transpile --input_dir test_workspace/ --outdir pyout --lang python --package_root test_workspace".split("\\s+").toSeq: _*)
+    val out = run("transpile --input_dir test_workspace/ --outdir pyout --lang python --package_root test_workspace".split("\\s+").toSeq *)
     out match {
       case PathModule.Output.TranspileOut(_, _) =>
         assert(true)
@@ -122,7 +122,7 @@ class PathModuleTest extends AnyFunSuite {
 
   test("test search with json write") {
 
-    val out = run("json write --package_root test_workspace --search --main_file test_workspace/Bar.bosatsu".split("\\s+").toSeq: _*)
+    val out = run("json write --package_root test_workspace --search --main_file test_workspace/Bar.bosatsu".split("\\s+").toSeq *)
     out match {
       case PathModule.Output.JsonOutput(j@Json.JObject(_), _) =>
         assert(j.toMap == Map("value" -> Json.JBool(true), "message" -> Json.JString("got the right string")))
@@ -135,7 +135,7 @@ class PathModuleTest extends AnyFunSuite {
     val cmd = "json apply --input_dir test_workspace/ --package_root test_workspace/ --main Bosatsu/Nat::mult --json_string"
       .split("\\s+").toList :+ "[2, 4]"
 
-    run(cmd: _*) match {
+    run(cmd *) match {
       case PathModule.Output.JsonOutput(Json.JNumberStr("8"), _) => succeed
       case other => fail(s"expected json object output: $other")
     }
@@ -145,7 +145,7 @@ class PathModuleTest extends AnyFunSuite {
     val cmd = "json traverse --input_dir test_workspace/ --package_root test_workspace/ --main Bosatsu/Nat::mult --json_string"
       .split("\\s+").toList :+ "[[2, 4], [3, 5]]"
 
-    run(cmd: _*) match {
+    run(cmd *) match {
       case PathModule.Output.JsonOutput(Json.JArray(Vector(Json.JNumberStr("8"), Json.JNumberStr("15"))), _) => succeed
       case other => fail(s"expected json object output: $other")
     }
@@ -193,7 +193,7 @@ class PathModuleTest extends AnyFunSuite {
 
   test("test running all test in test_workspace") {
 
-    val out = run("test --package_root test_workspace --input_dir test_workspace".split("\\s+").toSeq: _*)
+    val out = run("test --package_root test_workspace --input_dir test_workspace".split("\\s+").toSeq *)
     out match {
       case PathModule.Output.TestOutput(res, _) =>
         val noTests = res.collect { case (pn, None) => pn }.toList
@@ -205,7 +205,7 @@ class PathModuleTest extends AnyFunSuite {
   }
 
   test("evaluation by name with shadowing") {
-    run("json write --package_root test_workspace --input test_workspace/Foo.bosatsu --main Foo::x".split("\\s+").toSeq: _*) match {
+    run("json write --package_root test_workspace --input test_workspace/Foo.bosatsu --main Foo::x".split("\\s+").toSeq *) match {
       case PathModule.Output.JsonOutput(Json.JString("this is Foo"), _) => succeed
       case other => fail(s"unexpeced: $other")
     }

--- a/cli/src/test/scala/org/bykn/bosatsu/TestProtoType.scala
+++ b/cli/src/test/scala/org/bykn/bosatsu/TestProtoType.scala
@@ -1,13 +1,13 @@
 package org.bykn.bosatsu
 
-import _root_.bosatsu.{TypedAst => proto}
+import _root_.bosatsu.{TypedAst as proto}
 import cats.Eq
 import cats.effect.{IO, Resource}
 import org.bykn.bosatsu.rankn.Type
 import org.scalacheck.Gen
 import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks.{ forAll, PropertyCheckConfiguration }
 import scala.util.{Failure, Success, Try}
-import cats.implicits._
+import cats.implicits.*
 
 import java.io.File
 import java.nio.file.Path
@@ -93,7 +93,7 @@ class TestProtoType extends AnyFunSuite with ParTest {
         pats  = ProtoConverter.buildPatterns(ss.patterns.inOrder).map(_(idx - 1))
         res <- pats.local[ProtoConverter.DecodeState](_.withTypes(tps))
       } yield res
-    }(Eq.fromUniversalEquals)
+    }(using Eq.fromUniversalEquals)
 
     forAll(Generators.genCompiledPattern(5))(testFn)
   }
@@ -107,14 +107,14 @@ class TestProtoType extends AnyFunSuite with ParTest {
         expr  = ProtoConverter.buildExprs(ss.expressions.inOrder).map(_(idx - 1))
         res <- expr.local[ProtoConverter.DecodeState](_.withTypes(tps).withPatterns(patTab))
       } yield res
-    }(Eq.fromUniversalEquals)
+    }(using Eq.fromUniversalEquals)
 
     forAll(Generators.genTypedExpr(Gen.const(()), 4, rankn.NTypeGen.genDepth03))(testFn)
   }
 
   test("we can roundtrip interface through proto") {
     forAll(Generators.interfaceGen) { iface =>
-      law(iface, ProtoConverter.interfaceToProto _, ProtoConverter.interfaceFromProto _)(Eq.fromUniversalEquals)
+      law(iface, ProtoConverter.interfaceToProto, ProtoConverter.interfaceFromProto)(using Eq.fromUniversalEquals)
     }
   }
 
@@ -128,14 +128,14 @@ class TestProtoType extends AnyFunSuite with ParTest {
 
   test("we can roundtrip interfaces through proto") {
     forAll(Generators.smallDistinctByList(Generators.interfaceGen)(_.name)) { ifaces =>
-      law(ifaces, ProtoConverter.interfacesToProto[List] _, ProtoConverter.interfacesFromProto _)(sortedEq)
+      law(ifaces, ProtoConverter.interfacesToProto[List], ProtoConverter.interfacesFromProto)(using sortedEq)
     }
   }
 
   test("we can roundtrip interfaces from full packages through proto") {
     forAll(Generators.genPackage(Gen.const(()), 10)) { packMap =>
       val ifaces = packMap.iterator.map { case (_, p) => Package.interfaceOf(p) }.toList
-      law(ifaces, ProtoConverter.interfacesToProto[List] _, ProtoConverter.interfacesFromProto _)(sortedEq)
+      law(ifaces, ProtoConverter.interfacesToProto[List], ProtoConverter.interfacesFromProto)(using sortedEq)
     }
   }
 
@@ -167,8 +167,8 @@ bar = 1
 """
       ), "Foo", { (packs, _) =>
       law(packs.toMap.values.toList.sortBy(_.name).map { pt => Package.setProgramFrom(tf.void(pt), ()) },
-        ser _,
-        deser _)(Eq.fromUniversalEquals)
+        ser,
+        deser)(using Eq.fromUniversalEquals)
     })
   }
 
@@ -180,7 +180,7 @@ bar = 1
         ProtoConverter.packagesFromProto(Nil, ps).map { case (_, p) => p.sortBy(_.name) }
 
       val packList = packMap.toList.sortBy(_._1).map(_._2)
-      law(packList, ser _, deser _)(Eq.fromUniversalEquals)
+      law(packList, ser, deser)(using Eq.fromUniversalEquals)
     }
   }
 

--- a/cli/src/test/scala/org/bykn/bosatsu/codegen/python/CodeTest.scala
+++ b/cli/src/test/scala/org/bykn/bosatsu/codegen/python/CodeTest.scala
@@ -4,7 +4,7 @@ import cats.data.NonEmptyList
 import java.math.BigInteger
 import org.scalacheck.Gen
 import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks.{ forAll, PropertyCheckConfiguration }
-import org.python.core.{ParserFacade => JythonParserFacade}
+import org.python.core.{ParserFacade as JythonParserFacade}
 import org.scalatest.funsuite.AnyFunSuite
 
 class CodeTest extends AnyFunSuite {
@@ -205,7 +205,7 @@ class CodeTest extends AnyFunSuite {
   }
 
   test("test bug with IfElse") {
-    import Code._
+    import Code.*
 
     val ifElse = IfElse(NonEmptyList.of((Ident("a"), Ident("b"))), Ident("c"))
     val stmt = addAssign(Ident("bar"), ifElse)
@@ -217,7 +217,7 @@ else:
   }
 
   test("test some Operator examples") {
-    import Code._
+    import Code.*
 
     val apbpc = Op(Ident("a"), Const.Plus, Op(Ident("b"), Const.Plus, Ident("c")))
 
@@ -370,13 +370,13 @@ else:
   }
 
   test("Code.block as at most 1 Pass and if so, only at the end") {
-    import Code._
+    import Code.*
 
     assert(block(Pass) == Pass)
     assert(block(Pass, Pass) == Pass)
 
     forAll(genNel(4, genStatement(3))) { case NonEmptyList(h, t) =>
-      val stmt = block(h, t :_*)
+      val stmt = block(h, t *)
 
       def passCount(s: Statement): Int =
         s match {

--- a/core/src/main/scala/org/bykn/bosatsu/BindingStatement.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/BindingStatement.scala
@@ -9,7 +9,7 @@ object BindingStatement {
 
   implicit def document[A: Document, V: Document, T: Document]: Document[BindingStatement[A, V, T]] =
     Document.instance[BindingStatement[A, V, T]] { let =>
-      import let._
+      import let.*
       Document[A].document(name) + eqDoc + Document[V].document(value) + Document[T].document(in)
     }
 }

--- a/core/src/main/scala/org/bykn/bosatsu/CommentStatement.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/CommentStatement.scala
@@ -1,7 +1,7 @@
 package org.bykn.bosatsu
 
 import cats.data.NonEmptyList
-import cats.parse.{Parser0 => P0, Parser => P}
+import cats.parse.{Parser0 as P0, Parser as P}
 import org.typelevel.paiges.{ Doc, Document }
 
 /**
@@ -15,7 +15,7 @@ object CommentStatement {
 
   implicit def document[T: Document]: Document[CommentStatement[T]] =
     Document.instance[CommentStatement[T]] { comment =>
-      import comment._
+      import comment.*
       val block = Doc.intercalate(Doc.line, message.toList.map { mes => Doc.char('#') + Doc.text(mes) })
       block + Doc.line + Document[T].document(on)
     }

--- a/core/src/main/scala/org/bykn/bosatsu/Declaration.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/Declaration.scala
@@ -3,7 +3,7 @@ package org.bykn.bosatsu
 import Parser.{ Combinators, Indy, maybeSpace, maybeSpacesAndLines, spaces, toEOL1, keySpace, MaybeTupleOrParens }
 import cats.data.NonEmptyList
 import org.bykn.bosatsu.graph.Memoize
-import cats.parse.{Parser0 => P0, Parser => P}
+import cats.parse.{Parser0 as P0, Parser as P}
 import org.typelevel.paiges.{ Doc, Document }
 import scala.collection.immutable.SortedSet
 
@@ -13,12 +13,12 @@ import ListLang.{KVPair, SpliceOrItem}
 
 import Identifier.{Bindable, Constructor}
 
-import cats.implicits._
+import cats.implicits.*
 /**
  * Represents the syntactic version of Expr
  */
 sealed abstract class Declaration {
-  import Declaration._
+  import Declaration.*
 
   def region: Region
 
@@ -46,13 +46,13 @@ sealed abstract class Declaration {
 
         prefix + Doc.char('(') + Doc.intercalate(Doc.text(", "), body.map(_.toDoc)) + Doc.char(')')
       case ApplyOp(left, Identifier.Operator(opStr), right) =>
-        left.toDoc space Doc.text(opStr) space right.toDoc
+        left.toDoc `space` Doc.text(opStr) `space` right.toDoc
       case Binding(b) =>
         val d0 = Document[Padding[Declaration]]
         val withNewLine = Document.instance[Padding[Declaration]] { pd =>
            Doc.line + d0.document(pd)
         }
-        BindingStatement.document(Document[Pattern.Parsed], Document.instance[NonBinding](_.toDoc), withNewLine).document(b)
+        BindingStatement.document(using Document[Pattern.Parsed], Document.instance[NonBinding](_.toDoc), withNewLine).document(b)
       case LeftApply(pat, _, arg, body) =>
         Document[Pattern.Parsed].document(pat) + Doc.text(" <- ") + arg.toDoc + Doc.line +
         Document[Padding[Declaration]].document(body)
@@ -114,7 +114,7 @@ sealed abstract class Declaration {
               caseDoc + Document[Pattern.Parsed].document(pat) + Doc.text(":") + decl.sepDoc + pid.document(decl)
           }
         implicit def linesDoc[T: Document]: Document[NonEmptyList[T]] =
-          Document.instance { ts => Doc.intercalate(Doc.line, ts.toList.map(Document[T].document _)) }
+          Document.instance { ts => Doc.intercalate(Doc.line, ts.toList.map(Document[T].document)) }
 
         val piPat = Document[OptIndent[NonEmptyList[(Pattern.Parsed, OptIndent[Declaration])]]]
         val kindDoc = kind match {

--- a/core/src/main/scala/org/bykn/bosatsu/DefRecursionCheck.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/DefRecursionCheck.scala
@@ -3,7 +3,7 @@ package org.bykn.bosatsu
 import cats.data.{NonEmptyList, Validated, ValidatedNel, StateT}
 import org.typelevel.paiges.Doc
 
-import cats.implicits._
+import cats.implicits.*
 
 import Identifier.Bindable
 
@@ -80,8 +80,8 @@ object DefRecursionCheck {
    * in scope during typechecking, so illegal recursion there simply won't typecheck.
    */
   def checkStatement(s: Statement): Res = {
-    import Statement._
-    import Impl._
+    import Statement.*
+    import Impl.*
     s match {
       case vs: ValueStatement =>
         vs match {
@@ -196,7 +196,7 @@ object DefRecursionCheck {
       args: NonEmptyList[NonEmptyList[Pattern.Parsed]],
       m: Declaration.Match,
       locals: Set[Bindable]): ValidatedNel[RecursionError, (Int, Int)] = {
-      import Declaration._
+      import Declaration.*
       m.arg match {
         case Var(v) =>
           v match {
@@ -413,7 +413,7 @@ object DefRecursionCheck {
      * we have valid recursion
      */
     def checkDecl(decl: Declaration): St[Unit] = {
-      import Declaration._
+      import Declaration.*
       decl match {
         case Annotation(t, _) => checkDecl(t)
         case Apply(fn, args, _) =>

--- a/core/src/main/scala/org/bykn/bosatsu/DefStatement.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/DefStatement.scala
@@ -2,12 +2,12 @@ package org.bykn.bosatsu
 
 import Parser.{Combinators, maybeSpace}
 import cats.data.NonEmptyList
-import cats.parse.{Parser => P}
+import cats.parse.{Parser as P}
 import org.typelevel.paiges.{Doc, Document}
 
 import Identifier.Bindable
 
-import cats.syntax.all._
+import cats.syntax.all.*
 
 case class DefStatement[A, B](
     name: Bindable,
@@ -26,7 +26,7 @@ object DefStatement {
   implicit def document[A: Document, B: Document]
       : Document[DefStatement[A, B]] =
     Document.instance[DefStatement[A, B]] { defs =>
-      import defs._
+      import defs.*
       val res = retType.fold(Doc.empty) { t => arrow + t.toDoc }
       val taDoc = typeArgs match {
         case None     => Doc.empty

--- a/core/src/main/scala/org/bykn/bosatsu/Evaluation.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/Evaluation.scala
@@ -2,9 +2,9 @@ package org.bykn.bosatsu
 
 import cats.Eval
 import org.bykn.bosatsu.rankn.Type
-import scala.collection.mutable.{Map => MMap}
+import scala.collection.mutable.{Map as MMap}
 
-import cats.implicits._
+import cats.implicits.*
 
 import Identifier.Bindable
 
@@ -63,7 +63,7 @@ case class Evaluation[T](pm: PackageMap.Typed[T], externals: Externals) {
 
     type F[A] = List[(Bindable, A)]
     val ffunc = cats.Functor[List].compose(cats.Functor[(Bindable, *)])
-    MatchlessToValue.traverse[F](exprs)(evalFn)(ffunc)
+    MatchlessToValue.traverse[F](exprs)(evalFn)(using ffunc)
   }
 
   private def evaluate(packName: PackageName): Map[Identifier, Eval[Value]] =

--- a/core/src/main/scala/org/bykn/bosatsu/ExportedName.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/ExportedName.scala
@@ -1,8 +1,8 @@
 package org.bykn.bosatsu
 
 import cats.data.{NonEmptyList, Validated, ValidatedNel}
-import cats.implicits._
-import cats.parse.{Parser => P}
+import cats.implicits.*
+import cats.parse.{Parser as P}
 import org.typelevel.paiges.{Doc, Document}
 import scala.util.hashing.MurmurHash3
 

--- a/core/src/main/scala/org/bykn/bosatsu/Expr.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/Expr.scala
@@ -5,7 +5,7 @@ package org.bykn.bosatsu
  * here: http://dev.stephendiehl.com/fun/006_hindley_milner.html
  */
 
-import cats.implicits._
+import cats.implicits.*
 import cats.data.{Chain, Writer, NonEmptyList}
 import cats.Applicative
 import scala.collection.immutable.SortedSet
@@ -22,7 +22,7 @@ sealed abstract class Expr[T] {
    * they appear)
    */
   lazy val freeVarsDup: List[Bindable] = {
-    import Expr._
+    import Expr.*
     // nearly identical code to TypedExpr.freeVarsDup, bugs should be fixed in both places
     this match {
       case Generic(_, expr) =>
@@ -80,7 +80,7 @@ sealed abstract class Expr[T] {
   }
 
   lazy val globals: Set[Expr.Global[T]] = {
-    import Expr._
+    import Expr.*
     this match {
       case Generic(_, expr) =>
         expr.globals
@@ -100,7 +100,7 @@ sealed abstract class Expr[T] {
   }
 
   def replaceTag(t: T): Expr[T] = {
-    import Expr._
+    import Expr.*
     this match {
       case g@Generic(_, e) => g.copy(in = e.replaceTag(t))
       case a@Annotation(_, _, _) => a.copy(tag = t)
@@ -267,7 +267,7 @@ object Expr {
               pat.traverseType(fn(_, bound))
                 .product(traverseType(expr, bound)(fn))
           }
-        val branchB = branches.traverse(branchFn _)
+        val branchB = branches.traverse(branchFn)
         (argB, branchB).mapN(Match(_, _, tag))
     }
 

--- a/core/src/main/scala/org/bykn/bosatsu/FfiCall.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/FfiCall.scala
@@ -39,14 +39,14 @@ object FfiCall {
     def call(t: rankn.Type): Value = callFn(t)
   }
 
-  def getJavaType(t: rankn.Type): List[Class[_]] = {
-    def one(t: rankn.Type): Option[Class[_]] =
+  def getJavaType(t: rankn.Type): List[Class[?]] = {
+    def one(t: rankn.Type): Option[Class[?]] =
       loop(t, false) match {
         case c :: Nil => Some(c)
         case _ => None
       }
 
-    def loop(t: rankn.Type, top: Boolean): List[Class[_]] = {
+    def loop(t: rankn.Type, top: Boolean): List[Class[?]] = {
       t match {
         case rankn.Type.Fun(as, b) if top =>
           val ats = as.map { a =>

--- a/core/src/main/scala/org/bykn/bosatsu/Identifier.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/Identifier.scala
@@ -1,12 +1,12 @@
 package org.bykn.bosatsu
 
 import cats.Order
-import cats.parse.{Parser0 => P0, Parser => P}
+import cats.parse.{Parser0 as P0, Parser as P}
 import org.typelevel.paiges.{ Doc, Document }
 
 import Parser.{lowerIdent, upperIdent}
 
-import cats.implicits._
+import cats.implicits.*
 
 sealed abstract class Identifier {
   def asString: String

--- a/core/src/main/scala/org/bykn/bosatsu/Import.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/Import.scala
@@ -2,8 +2,8 @@ package org.bykn.bosatsu
 
 import cats.{Foldable, Functor}
 import cats.data.NonEmptyList
-import cats.implicits._
-import cats.parse.{Parser => P}
+import cats.implicits.*
+import cats.parse.{Parser as P}
 import org.typelevel.paiges.{Doc, Document}
 
 import Parser.{spaces, Combinators}
@@ -68,7 +68,7 @@ case class Import[A, B](pack: A, items: NonEmptyList[ImportedName[B]]) {
 object Import {
   implicit val document: Document[Import[PackageName, Unit]] =
     Document.instance[Import[PackageName, Unit]] { case Import(pname, items) =>
-      val itemDocs = items.toList.map(Document[ImportedName[Unit]].document _)
+      val itemDocs = items.toList.map(Document[ImportedName[Unit]].document)
 
       Doc.text("from") + Doc.space + Document[PackageName].document(pname) + Doc.space + Doc.text("import") +
         // TODO: use paiges to pack this in nicely using .group or something

--- a/core/src/main/scala/org/bykn/bosatsu/Indented.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/Indented.scala
@@ -2,9 +2,9 @@ package org.bykn.bosatsu
 
 import org.typelevel.paiges.{ Doc, Document }
 
-import cats.parse.{Parser => P}
+import cats.parse.{Parser as P}
 
-import cats.implicits._
+import cats.implicits.*
 
 case class Indented[T](spaces: Int, value: T) {
   require(spaces > 0, s"need non-empty indentation: $spaces")

--- a/core/src/main/scala/org/bykn/bosatsu/Json.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/Json.scala
@@ -2,7 +2,7 @@ package org.bykn.bosatsu
 
 import java.math.{BigInteger, BigDecimal}
 import org.typelevel.paiges.Doc
-import cats.parse.{Parser0 => P0, Parser => P}
+import cats.parse.{Parser0 as P0, Parser as P}
 import cats.Eq
 
 /**
@@ -17,11 +17,11 @@ sealed abstract class Json {
 object Json {
   import Doc.text
 
-  final case class JString(str: String) extends Json {
+  case class JString(str: String) extends Json {
     override def render = "\"%s\"".format(JsonStringUtil.escape('"', str))
     def toDoc = text(render)
   }
-  final case class JNumberStr(asString: String) extends Json {
+  case class JNumberStr(asString: String) extends Json {
     override def render = asString
     def toDoc = text(asString)
 
@@ -53,11 +53,11 @@ object Json {
   }
 
   object JBool {
-    final case object True extends Json {
+    case object True extends Json {
       override val render = "true"
       val toDoc = text(render)
     }
-    final case object False extends Json {
+    case object False extends Json {
       override val render = "false"
       val toDoc = text(render)
     }
@@ -77,11 +77,11 @@ object Json {
 
   }
 
-  final case object JNull extends Json {
+  case object JNull extends Json {
     override val render = "null"
     val toDoc = text(render)
   }
-  final case class JArray(toVector: Vector[Json]) extends Json {
+  case class JArray(toVector: Vector[Json]) extends Json {
     def toDoc = {
       val parts = Doc.intercalate(Doc.comma, toVector.map { j => (Doc.line + j.toDoc).grouped })
       "[" +: ((parts :+ " ]").nested(2))
@@ -91,7 +91,7 @@ object Json {
   }
   // we use a List here to preserve the order in which items
   // were given to us
-  final case class JObject(items: List[(String, Json)]) extends Json {
+  case class JObject(items: List[(String, Json)]) extends Json {
     val toMap: Map[String, Json] = items.toMap
     val keys: List[String] = items.map(_._1).distinct
 

--- a/core/src/main/scala/org/bykn/bosatsu/Kind.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/Kind.scala
@@ -1,10 +1,10 @@
 package org.bykn.bosatsu
 
 import cats.Order
-import cats.parse.{Parser => P, Parser0 => P0}
+import cats.parse.{Parser as P, Parser0 as P0}
 import org.typelevel.paiges.{Doc, Document}
 import scala.annotation.tailrec
-import cats.syntax.all._
+import cats.syntax.all.*
 
 sealed abstract class Kind {
   def toDoc: Doc = Kind.toDoc(this)
@@ -111,7 +111,7 @@ object Kind {
     }
 
   private val varSubMap: Map[Variance, List[Variance]] = {
-    import Variance._
+    import Variance.*
     val pList = phantom :: Nil
     val contraP = contra :: pList
     Map(
@@ -122,7 +122,7 @@ object Kind {
     )
   }
   private val varSupMap: Map[Variance, List[Variance]] = {
-    import Variance._
+    import Variance.*
     val iList = in :: Nil
     val coI = co :: iList
     Map(
@@ -136,7 +136,7 @@ object Kind {
     if (sub) varSubMap(v) else varSupMap(v)
 
   private val varSubMapSize: Map[Variance, Long] = {
-    import Variance._
+    import Variance.*
     Map(
       in -> 4L,
       co -> 2L,
@@ -146,7 +146,7 @@ object Kind {
   }
 
   private val varSupMapSize: Map[Variance, Long] = {
-    import Variance._
+    import Variance.*
     Map(
       in -> 1L,
       co -> 2L,
@@ -242,9 +242,9 @@ object Kind {
               val rest = sortCombine(v, at, bt)
 
               sortMergeIt(
-                sortMergeIt(line1, line2)(ord),
-                insertSortedIt(head, rest)(ord)
-              )(ord)
+                sortMergeIt(line1, line2)(using ord),
+                insertSortedIt(head, rest)(using ord)
+              )(using ord)
             case _ =>
               // at least one is empty
               Iterator.empty
@@ -256,7 +256,7 @@ object Kind {
         vars(v, sub)
           .map(sortCombine(_, k1, k2))
           // there is at least one item in vars(v, sub) so reduce is safe
-          .reduce(sortMergeIt(_, _)(ord))
+          .reduce(sortMergeIt(_, _)(using ord))
           .to(LazyList)
     }
 
@@ -327,7 +327,7 @@ object Kind {
   }
 
   private def varianceToInt(v: Variance): Int = {
-    import Variance._
+    import Variance.*
     v match {
       case Invariant => 3
       case Contravariant => 2

--- a/core/src/main/scala/org/bykn/bosatsu/KindFormula.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/KindFormula.scala
@@ -13,7 +13,7 @@ import org.bykn.bosatsu.rankn.{
   ConstructorFn,
   Ref,
   RefSpace,
-  Type => RankNType,
+  Type as RankNType,
   TypeEnv,
   DefinedType
 }
@@ -21,7 +21,7 @@ import org.bykn.bosatsu.graph.Dag
 import org.bykn.bosatsu.Shape.KnownShape
 import scala.collection.immutable.{LongMap, SortedSet}
 
-import cats.syntax.all._
+import cats.syntax.all.*
 import cats.data.Validated
 
 sealed abstract class KindFormula
@@ -250,7 +250,7 @@ object KindFormula {
       imports: E,
       dts: List[DefinedType[Option[Kind.Arg]]]
   ): IorNec[Error, List[DefinedType[Kind.Arg]]] = {
-    implicit val shapeEnv = IsTypeEnv[E].toShapeEnv
+    implicit val shapeEnv: Shape.IsShapeEnv[E] = IsTypeEnv[E].toShapeEnv
     Shape
       .solveAll(imports, dts)
       .leftMap(_.map(Error.FromShapeError(_)))
@@ -281,7 +281,7 @@ object KindFormula {
       imports: Env,
       dt: DefinedType[Either[KnownShape, Kind.Arg]]
   ): ValidatedNec[Error, DefinedType[Kind.Arg]] = {
-    import Impl._
+    import Impl.*
 
     (for {
       state <- Impl.newState(imports, dt)

--- a/core/src/main/scala/org/bykn/bosatsu/ListLang.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/ListLang.scala
@@ -3,9 +3,9 @@ package org.bykn.bosatsu
 import cats.{Apply, Functor}
 import Parser.{maybeSpacesAndLines, spacesAndLines, Combinators}
 import org.typelevel.paiges.{Doc, Document}
-import cats.parse.{Parser => P}
+import cats.parse.{Parser as P}
 
-import cats.implicits._
+import cats.implicits.*
 
 /**
  * Represents the list construction sublanguage

--- a/core/src/main/scala/org/bykn/bosatsu/ListOrdering.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/ListOrdering.scala
@@ -3,7 +3,7 @@ package org.bykn.bosatsu
 object ListOrdering {
 
   def onType[A](o: Ordering[A]): Ordering[List[A]] =
-    apply(o)
+    apply(using o)
 
   def apply[A: Ordering]: Ordering[List[A]] =
     new Ordering[List[A]] {

--- a/core/src/main/scala/org/bykn/bosatsu/Lit.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/Lit.scala
@@ -2,7 +2,7 @@ package org.bykn.bosatsu
 
 import org.typelevel.paiges.{Document, Doc}
 import java.math.BigInteger
-import cats.parse.{Parser => P}
+import cats.parse.{Parser as P}
 
 import Parser.escape
 

--- a/core/src/main/scala/org/bykn/bosatsu/LocationMap.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/LocationMap.scala
@@ -1,9 +1,9 @@
 package org.bykn.bosatsu
 
 import org.typelevel.paiges.Doc
-import cats.parse.{LocationMap => CPLocationMap}
+import cats.parse.{LocationMap as CPLocationMap}
 
-import cats.implicits._
+import cats.implicits.*
 
 import LocationMap.Colorize
 

--- a/core/src/main/scala/org/bykn/bosatsu/MainModule.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/MainModule.scala
@@ -3,7 +3,7 @@ package org.bykn.bosatsu
 import cats.data.{Chain, Validated, ValidatedNel, NonEmptyList}
 import cats.{Eval, MonadError, Traverse}
 import com.monovore.decline.{Argument, Command, Help, Opts}
-import cats.parse.{Parser0 => P0, Parser => P}
+import cats.parse.{Parser0 as P0, Parser as P}
 import org.typelevel.paiges.Doc
 import scala.util.{Failure, Success, Try}
 
@@ -12,7 +12,7 @@ import Identifier.Bindable
 import IorMethods.IorExtension
 import LocationMap.Colorize
 
-import cats.implicits._
+import cats.implicits.*
 
 /** This is an implementation of the CLI tool where Path is abstracted. The idea
   * is to allow it to be testable and usable in scalajs where we don't have
@@ -188,7 +188,7 @@ abstract class MainModule[IO[_]](implicit
     private def flatTrav[A, B, C](va: Validated[A, B])(
         fn: B => IO[Validated[A, C]]
     ): IO[Validated[A, C]] =
-      va.traverse(fn).map(_.andThen(identity _))
+      va.traverse(fn).map(_.andThen(identity))
 
     /** This parses all the given paths and returns them first, and if the
       * PackageResolver supports it, we look for any missing dependencies that

--- a/core/src/main/scala/org/bykn/bosatsu/Matchless.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/Matchless.scala
@@ -6,7 +6,7 @@ import org.bykn.bosatsu.rankn.{DataRepr, Type, RefSpace}
 
 import Identifier.{Bindable, Constructor}
 
-import cats.implicits._
+import cats.implicits.*
 
 object Matchless {
   sealed abstract class Expr

--- a/core/src/main/scala/org/bykn/bosatsu/MatchlessFromTypedExpr.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/MatchlessFromTypedExpr.scala
@@ -2,7 +2,7 @@ package org.bykn.bosatsu
 
 import Identifier.Bindable
 
-import cats.implicits._
+import cats.implicits.*
 
 object MatchlessFromTypedExpr {
   // compile a set of packages given a set of external remappings

--- a/core/src/main/scala/org/bykn/bosatsu/MatchlessToValue.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/MatchlessToValue.scala
@@ -5,15 +5,15 @@ import cats.data.NonEmptyList
 import cats.evidence.Is
 import java.math.BigInteger
 import scala.collection.immutable.LongMap
-import scala.collection.mutable.{LongMap => MLongMap}
+import scala.collection.mutable.{LongMap as MLongMap}
 
 import Identifier.Bindable
-import Value._
+import Value.*
 
-import cats.implicits._
+import cats.implicits.*
 
 object MatchlessToValue {
-  import Matchless._
+  import Matchless.*
 
   // reuse some cache structures across a number of calls
   def traverse[F[_]: Functor](me: F[Expr])(resolve: (PackageName, Identifier) => Eval[Value]): F[Eval[Value]] = {
@@ -542,7 +542,7 @@ object MatchlessToValue {
       str: String,
       pat: List[StrPart],
       binds: Int): Array[String] = {
-      import Matchless.StrPart._
+      import Matchless.StrPart.*
 
       val strLen = str.length()
       val results = if (binds > 0) new Array[String](binds) else emptyStringArray

--- a/core/src/main/scala/org/bykn/bosatsu/MemoryMain.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/MemoryMain.scala
@@ -5,7 +5,7 @@ import cats.data.Kleisli
 import com.monovore.decline.Argument
 import scala.collection.immutable.SortedMap
 
-import cats.implicits._
+import cats.implicits.*
 
 class MemoryMain[F[_], K: Ordering](split: K => List[String])(
   implicit val pathArg: Argument[K],

--- a/core/src/main/scala/org/bykn/bosatsu/Operators.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/Operators.scala
@@ -1,7 +1,7 @@
 package org.bykn.bosatsu
 
 import cats.data.NonEmptyList
-import cats.parse.{Parser => P}
+import cats.parse.{Parser as P}
 
 object Operators {
 

--- a/core/src/main/scala/org/bykn/bosatsu/OptIndent.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/OptIndent.scala
@@ -1,10 +1,10 @@
 package org.bykn.bosatsu
 
 import cats.Functor
-import cats.implicits._
+import cats.implicits.*
 import org.typelevel.paiges.{Doc, Document}
 
-import cats.parse.{Parser0 => P0, Parser => P}
+import cats.parse.{Parser0 as P0, Parser as P}
 
 import Parser.{maybeSpace, Indy}
 import Indy.IndyMethods

--- a/core/src/main/scala/org/bykn/bosatsu/Package.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/Package.scala
@@ -2,12 +2,12 @@ package org.bykn.bosatsu
 
 import cats.{Functor, Parallel}
 import cats.data.{Ior, ValidatedNel, Validated, NonEmptyList}
-import cats.implicits._
-import cats.parse.{Parser0 => P0, Parser => P}
+import cats.implicits.*
+import cats.parse.{Parser0 as P0, Parser as P}
 import org.typelevel.paiges.{Doc, Document}
 import scala.util.hashing.MurmurHash3
 
-import rankn._
+import rankn.*
 import Parser.{spaces, Combinators}
 
 import FixType.Fix
@@ -27,7 +27,7 @@ final case class Package[A, B, C, +D](
 
   override def equals(that: Any): Boolean =
     that match {
-      case p: Package[_, _, _, _] =>
+      case p: Package[?, ?, ?, ?] =>
         (this eq p) || {
           (name == p.name) &&
           (imports == p.imports) &&
@@ -149,7 +149,7 @@ object Package {
         case Nil => Doc.empty
         case nonEmptyImports =>
           Doc.line +
-            Doc.intercalate(Doc.line, nonEmptyImports.map(Document[Import[PackageName, Unit]].document _)) +
+            Doc.intercalate(Doc.line, nonEmptyImports.map(Document[Import[PackageName, Unit]].document)) +
             Doc.line
       }
       val e = exports match {
@@ -157,7 +157,7 @@ object Package {
         case nonEmptyExports =>
           Doc.line +
             Doc.text("export ") +
-            Doc.intercalate(Doc.text(", "), nonEmptyExports.map(Document[ExportedName[Unit]].document _)) +
+            Doc.intercalate(Doc.text(", "), nonEmptyExports.map(Document[ExportedName[Unit]].document)) +
             Doc.line
       }
       val b = statments.map(Document[Statement].document(_))

--- a/core/src/main/scala/org/bykn/bosatsu/PackageError.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/PackageError.scala
@@ -3,7 +3,7 @@ package org.bykn.bosatsu
 import cats.data.{Chain, NonEmptyList, Writer, NonEmptyMap}
 import org.typelevel.paiges.{Doc, Document}
 
-import rankn._
+import rankn.*
 import LocationMap.Colorize
 
 sealed abstract class PackageError {
@@ -437,7 +437,7 @@ object PackageError {
             .run._1.toList.distinct
           val showT = showTypes(pack, allTypes)
 
-          val doc = Pattern.compiledDocument(Document.instance[Type] { t =>
+          val doc = Pattern.compiledDocument(using Document.instance[Type] { t =>
             showT(t)
           })
 
@@ -449,7 +449,7 @@ object PackageError {
             .run._1.toList.distinct
           val showT = showTypes(pack, allTypes)
 
-          val doc = Pattern.compiledDocument(Document.instance[Type] { t =>
+          val doc = Pattern.compiledDocument(using Document.instance[Type] { t =>
             showT(t)
           })
 
@@ -457,7 +457,7 @@ object PackageError {
             (Doc.intercalate(Doc.char(',') + Doc.lineOrSpace,
               unreachableBranches.toList.map(doc.document(_))))
         case TotalityCheck.InvalidPattern(_, err) =>
-          import TotalityCheck._
+          import TotalityCheck.*
           err match {
             case ArityMismatch((_, n), _, _, exp, found) =>
               Doc.text(s"arity mismatch: ${n.asString} expected $exp parameters, found $found")

--- a/core/src/main/scala/org/bykn/bosatsu/PackageMap.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/PackageMap.scala
@@ -10,7 +10,7 @@ import IorMethods.IorExtension
 
 import rankn.{DataRepr, TypeEnv}
 
-import cats.implicits._
+import cats.implicits.*
 
 case class PackageMap[A, B, C, +D](toMap: SortedMap[PackageName, Package[A, B, C, D]]) {
   def +[D1 >: D](pack: Package[A, B, C, D1]): PackageMap[A, B, C, D1] =
@@ -163,7 +163,7 @@ object PackageMap {
       val (errs0, imap) = ImportMap.fromImports(p.imports)
       val errs =
         NonEmptyList.fromList(errs0)
-          .map(PackageError.DuplicatedImport)
+          .map(PackageError.DuplicatedImport(_))
 
       (errs, p.mapProgram((_, imap)))
     }

--- a/core/src/main/scala/org/bykn/bosatsu/PackageName.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/PackageName.scala
@@ -2,8 +2,8 @@ package org.bykn.bosatsu
 
 import cats.Order
 import cats.data.NonEmptyList
-import cats.implicits._
-import cats.parse.{Parser => P}
+import cats.implicits.*
+import cats.parse.{Parser as P}
 import org.typelevel.paiges.{Doc, Document}
 import Parser.upperIdent
 
@@ -14,7 +14,7 @@ case class PackageName(parts: NonEmptyList[String]) {
 object PackageName {
 
   def parts(first: String, rest: String*): PackageName =
-    PackageName(NonEmptyList.of(first, rest :_*))
+    PackageName(NonEmptyList.of(first, rest *))
 
   implicit val document: Document[PackageName] =
     Document.instance[PackageName] { pn => Doc.text(pn.asString) }

--- a/core/src/main/scala/org/bykn/bosatsu/Padding.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/Padding.scala
@@ -1,7 +1,7 @@
 package org.bykn.bosatsu
 
 import cats.Functor
-import cats.parse.{Parser0 => P0, Parser => P}
+import cats.parse.{Parser0 as P0, Parser as P}
 import org.typelevel.paiges.{ Doc, Document }
 
 import Parser.maybeSpace

--- a/core/src/main/scala/org/bykn/bosatsu/Parser.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/Parser.scala
@@ -1,11 +1,11 @@
 package org.bykn.bosatsu
 
 import cats.data.{Kleisli, Validated, ValidatedNel, NonEmptyList}
-import cats.parse.{Parser0 => P0, Parser => P}
+import cats.parse.{Parser0 as P0, Parser as P}
 import org.typelevel.paiges.Doc
 import scala.collection.immutable.SortedMap
 
-import cats.implicits._
+import cats.implicits.*
 
 object Parser {
   /**

--- a/core/src/main/scala/org/bykn/bosatsu/PathGen.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/PathGen.scala
@@ -2,7 +2,7 @@ package org.bykn.bosatsu
 
 import cats.{Monoid, Monad}
 
-import cats.implicits._
+import cats.implicits.*
 
 sealed abstract class PathGen[IO[_], Path] {
   def read(implicit m: Monad[IO]): IO[List[Path]]

--- a/core/src/main/scala/org/bykn/bosatsu/Pattern.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/Pattern.scala
@@ -2,12 +2,12 @@ package org.bykn.bosatsu
 
 import cats.{Applicative, Foldable}
 import cats.data.NonEmptyList
-import cats.parse.{Parser0 => P0, Parser => P}
+import cats.parse.{Parser0 as P0, Parser as P}
 import org.typelevel.paiges.{ Doc, Document }
 import org.bykn.bosatsu.pattern.{NamedSeqPattern, SeqPattern, SeqPart}
 
 import Parser.{ Combinators, maybeSpace, MaybeTupleOrParens }
-import cats.implicits._
+import cats.implicits.*
 
 import Identifier.{Bindable, Constructor}
 
@@ -259,33 +259,33 @@ object Pattern {
         def field: Bindable
       }
       object FieldKind {
-        final case class Explicit(field: Bindable) extends FieldKind
+        case class Explicit(field: Bindable) extends FieldKind
         // an implicit field can only be associated with a Var of
         // the same name
-        final case class Implicit(field: Bindable) extends FieldKind
+        case class Implicit(field: Bindable) extends FieldKind
       }
-      final case object TupleLike extends Style
+      case object TupleLike extends Style
       // represents the fields like: Foo { bar: x, age }
-      final case class RecordLike(fields: NonEmptyList[FieldKind]) extends Style
+      case class RecordLike(fields: NonEmptyList[FieldKind]) extends Style
     }
     sealed abstract class NamedKind extends StructKind {
       def name: Constructor
       def style: Style
     }
-    final case object Tuple extends StructKind
+    case object Tuple extends StructKind
     // Represents a complete tuple-like pattern Foo(a, b)
-    final case class Named(name: Constructor, style: Style) extends NamedKind
+    case class Named(name: Constructor, style: Style) extends NamedKind
     // Represents a partial tuple-like pattern Foo(a, ...)
-    final case class NamedPartial(name: Constructor, style: Style) extends NamedKind
+    case class NamedPartial(name: Constructor, style: Style) extends NamedKind
   }
 
   sealed abstract class StrPart
   object StrPart {
-    final case object WildStr extends StrPart
-    final case class NamedStr(name: Bindable) extends StrPart
-    final case object WildChar extends StrPart
-    final case class NamedChar(name: Bindable) extends StrPart
-    final case class LitStr(asString: String) extends StrPart
+    case object WildStr extends StrPart
+    case class NamedStr(name: Bindable) extends StrPart
+    case object WildChar extends StrPart
+    case class NamedChar(name: Bindable) extends StrPart
+    case class LitStr(asString: String) extends StrPart
 
     // this is to circumvent scala warnings because these bosatsu
     // patterns like right.
@@ -315,9 +315,9 @@ object Pattern {
     sealed abstract class Glob extends ListPart[Nothing] {
       def map[B](fn: Nothing => B): ListPart[B] = this
     }
-    final case object WildList extends Glob
-    final case class NamedList(name: Bindable) extends Glob
-    final case class Item[A](pat: A) extends ListPart[A] {
+    case object WildList extends Glob
+    case class NamedList(name: Bindable) extends Glob
+    case class Item[A](pat: A) extends ListPart[A] {
       def map[B](fn: A => B): ListPart[B] = Item(fn(pat))
     }
   }
@@ -436,7 +436,7 @@ object Pattern {
    * as binds tighter than |, so use ( ) with groups you want to bind
    */
   case class Named[N, T](name: Bindable, pat: Pattern[N, T]) extends Pattern[N, T]
-  case class ListPat[N, T](parts: List[ListPart[Pattern[N, T]]]) extends Pattern[N, T] {
+  case class ListPat[N, +T](parts: List[ListPart[Pattern[N, T]]]) extends Pattern[N, T] {
     lazy val toNamedSeqPattern: NamedSeqPattern[Pattern[N, T]] =
       ListPat.toNamedSeqPattern(this)
 
@@ -621,7 +621,7 @@ object Pattern {
       val listE = ListOrdering.onType(partOrd(this))
 
       val ordStrPart = new Ordering[StrPart] {
-        import StrPart._
+        import StrPart.*
 
         def compare(a: StrPart, b: StrPart) =
           (a, b) match {

--- a/core/src/main/scala/org/bykn/bosatsu/Predef.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/Predef.scala
@@ -2,21 +2,13 @@ package org.bykn.bosatsu
 
 import cats.data.NonEmptyList
 import java.math.BigInteger
-import language.experimental.macros
 
 object Predef {
-  /**
-   * Loads a file *at compile time* as a means of embedding
-   * external files into strings. This lets us avoid resources
-   * which compilicate matters for scalajs.
-   */
-  private[bosatsu] def loadFileInCompile(file: String): String = macro Macro.loadFileInCompileImpl
-
   /**
    * String representation of the predef
    */
   val predefString: String =
-    loadFileInCompile("core/src/main/resources/bosatsu/predef.bosatsu")
+    Macro.loadFileInCompile("core/src/main/resources/bosatsu/predef.bosatsu")
 
   private def packageName: PackageName =
     PackageName.PredefName
@@ -44,7 +36,7 @@ object Predef {
 
 object PredefImpl {
 
-  import Value._
+  import Value.*
 
   private def i(a: Value): BigInteger =
     a match {
@@ -143,7 +135,7 @@ object PredefImpl {
     Value.Str(i(intValue).toString)
 
   def trace(prefix: Value, v: Value): Value = {
-    val Value.Str(prestr) = prefix
+    val prestr = Value.Str.unapply(prefix).get
     println(s"$prestr: $v")
     v
   }

--- a/core/src/main/scala/org/bykn/bosatsu/Referant.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/Referant.scala
@@ -4,7 +4,7 @@ import cats.data.NonEmptyList
 
 import rankn.{ConstructorFn, DefinedType, Type, TypeEnv}
 
-import Identifier.{Constructor => ConstructorName}
+import Identifier.{Constructor as ConstructorName}
 
 /**
  * A Referant is something that can be exported or imported after resolving

--- a/core/src/main/scala/org/bykn/bosatsu/SelfCallKind.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/SelfCallKind.scala
@@ -4,7 +4,7 @@ import cats.Semigroup
 import Identifier.Bindable
 
 sealed abstract class SelfCallKind {
-  import SelfCallKind._
+  import SelfCallKind.*
 
   // if you have two branches in match what is the result
   def merge(that: => SelfCallKind): SelfCallKind =

--- a/core/src/main/scala/org/bykn/bosatsu/Shape.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/Shape.scala
@@ -5,7 +5,7 @@ import cats.data.{Validated, ValidatedNec, Ior, IorNec}
 import org.bykn.bosatsu.rankn.{ConstructorFn, DefinedType, Type, Ref, RefSpace}
 import org.typelevel.paiges.Doc
 
-import cats.syntax.all._
+import cats.syntax.all.*
 
 // Shape is Kind without variance, and variables
 sealed abstract class Shape

--- a/core/src/main/scala/org/bykn/bosatsu/SourceConverter.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/SourceConverter.scala
@@ -1,33 +1,33 @@
 package org.bykn.bosatsu
 
 import cats.{Applicative, Traverse}
-import cats.data.{ Chain, Ior, NonEmptyChain, NonEmptyList, State }
+import cats.data.{Chain, Ior, NonEmptyChain, NonEmptyList, State}
 import org.bykn.bosatsu.rankn.{ParsedTypeEnv, Type, TypeEnv}
 import scala.collection.immutable.SortedSet
-import scala.collection.mutable.{Map => MMap}
+import scala.collection.mutable.{Map as MMap}
 import org.typelevel.paiges.{Doc, Document}
 
 // this is used to make slightly nicer syntax on Error creation
 import scala.language.implicitConversions
 
-import cats.syntax.all._
+import cats.syntax.all.*
 
 import ListLang.{KVPair, SpliceOrItem}
 
 import Identifier.{Bindable, Constructor}
 
-import Declaration._
+import Declaration.*
 
 import SourceConverter.{success, Result}
 
-/**
- * Convert a source types (a syntactic expression) into
- * the internal representations
- */
+/** Convert a source types (a syntactic expression) into the internal
+  * representations
+  */
 final class SourceConverter(
-  thisPackage: PackageName,
-  imports: List[Import[PackageName, NonEmptyList[Referant[Kind.Arg]]]],
-  localDefs: List[TypeDefinitionStatement]) {
+    thisPackage: PackageName,
+    imports: List[Import[PackageName, NonEmptyList[Referant[Kind.Arg]]]],
+    localDefs: List[TypeDefinitionStatement]
+) {
   /*
    * We should probably error for non-predef name collisions.
    * Maybe we should even error even or predef collisions that
@@ -37,7 +37,8 @@ final class SourceConverter(
   private val localConstructors = localDefs.flatMap(_.constructors).toSet
 
   private val typeCache: MMap[Constructor, Type.Const] = MMap.empty
-  private val consCache: MMap[Constructor, (PackageName, Constructor)] = MMap.empty
+  private val consCache: MMap[Constructor, (PackageName, Constructor)] =
+    MMap.empty
 
   private val importedTypes: Map[Identifier, (PackageName, TypeName)] =
     Referant.importedTypes(imports)
@@ -51,7 +52,10 @@ final class SourceConverter(
   val importedTypeEnv: TypeEnv[Kind.Arg] =
     Referant.importedTypeEnv(imports)(identity)
 
-  private def nameToType(c: Constructor, region: Region): Result[rankn.Type.Const] =
+  private def nameToType(
+      c: Constructor,
+      region: Region
+  ): Result[rankn.Type.Const] =
     typeCache.get(c) match {
       case Some(r) => success(r)
       case None =>
@@ -60,8 +64,7 @@ final class SourceConverter(
           val res = Type.Const.Defined(thisPackage, tc)
           typeCache.update(c, res)
           success(res)
-        }
-        else {
+        } else {
           importedTypes.get(c) match {
             case Some((p, t)) =>
               val res = Type.Const.Defined(p, t)
@@ -72,23 +75,28 @@ final class SourceConverter(
               val bestEffort = Type.Const.Defined(thisPackage, tc)
               SourceConverter.partial(
                 SourceConverter.UnknownTypeName(c, region),
-                bestEffort)
+                bestEffort
+              )
           }
         }
     }
 
   private def nameToCons(c: Constructor): (PackageName, Constructor) =
-    consCache.getOrElseUpdate(c, {
-      if (localConstructors(c)) (thisPackage, c)
-      else resolveImportedCons.getOrElse(c, (thisPackage, c))
-    })
+    consCache.getOrElseUpdate(
+      c, {
+        if (localConstructors(c)) (thisPackage, c)
+        else resolveImportedCons.getOrElse(c, (thisPackage, c))
+      }
+    )
 
   /*
    * This ignores the name completely and just returns the lambda expression here
    */
   private def toLambdaExpr[B](
-    ds: DefStatement[Pattern.Parsed, B], region: Region, tag: Result[Declaration])(
-      resultExpr: B => Result[Expr[Declaration]]): Result[Expr[Declaration]] = {
+      ds: DefStatement[Pattern.Parsed, B],
+      region: Region,
+      tag: Result[Declaration]
+  )(resultExpr: B => Result[Expr[Declaration]]): Result[Expr[Declaration]] = {
     val unTypedBody = resultExpr(ds.result)
 
     val bodyType: Option[Result[Type]] = ds.retType.map(toType(_, region))
@@ -102,7 +110,7 @@ final class SourceConverter(
 
     type Pat = Pattern[(PackageName, Constructor), Type]
     val convertedArgs: Result[NonEmptyList[NonEmptyList[Pat]]] =
-        travNE2.traverse(ds.args)(convertPattern(_, region))
+      travNE2.traverse(ds.args)(convertPattern(_, region))
 
     // If we have the full type of the lambda, apply it. This
     // helps in recursive cases since we can see at the call site
@@ -110,49 +118,63 @@ final class SourceConverter(
     // was incorrect. Without this, type errors become very non-specific.
     val maybeFullyTyped: Result[Option[Type]] =
       (convertedArgs, bodyType.sequence).parMapN { case (args, optResTpe) =>
-        (travNE2.traverse(args)((p: Pat) => p.simpleTypeOf), optResTpe).mapN { case (argsTpe, resTpe) =>
-          argsTpe.toList.foldRight(resTpe) { (args, res) => rankn.Type.Fun(args, res) }
+        (travNE2.traverse(args)((p: Pat) => p.simpleTypeOf), optResTpe).mapN {
+          case (argsTpe, resTpe) =>
+            argsTpe.toList.foldRight(resTpe) { (args, res) =>
+              rankn.Type.Fun(args, res)
+            }
         }
       }
 
-    (convertedArgs,
-      bodyExp,
-      tag,
-      maybeFullyTyped).parMapN { (groups, b, t, fullType) =>
-      val lambda0 = groups.toList.foldRight(b) { case (as, b) => Expr.buildPatternLambda(as, b, t) }
-      val lambda = fullType.fold(lambda0)(Expr.Annotation(lambda0, _, t))
-      ds.typeArgs match {
-        case None => success(lambda)
-        case Some(args) =>
-          val bs = args.map {
-            case (tr, optK) =>
-              (tr.toBoundVar, optK match {
-                case None => Kind.Type
-                case Some(k) => k
-              })
+    (convertedArgs, bodyExp, tag, maybeFullyTyped).parMapN {
+      (groups, b, t, fullType) =>
+        val lambda0 = groups.toList.foldRight(b) { case (as, b) =>
+          Expr.buildPatternLambda(as, b, t)
+        }
+        val lambda = fullType.fold(lambda0)(Expr.Annotation(lambda0, _, t))
+        ds.typeArgs match {
+          case None => success(lambda)
+          case Some(args) =>
+            val bs = args.map { case (tr, optK) =>
+              (
+                tr.toBoundVar,
+                optK match {
+                  case None    => Kind.Type
+                  case Some(k) => k
+                }
+              )
             }
-          val gen = Expr.forAll(bs.toList, lambda)
-          val freeVarsList = Expr.freeBoundTyVars(lambda)
-          val freeVars = freeVarsList.toSet
-          val notFreeDecl = bs.exists { case (a, _) => !freeVars(a) }
-          if (notFreeDecl) {
-            // we have a lint that fails if declTV is not
-            // a superset of what you would derive from the args
-            // the purpose here is to control the *order* of
-            // and to allow introducing phantom parameters, not
-            // it is confusing if some are explicit, but some are not
-            SourceConverter.partial(
-              SourceConverter.InvalidDefTypeParameters(args, freeVarsList, ds, region),
-              gen)
-          }
-          else success(gen)
-      }
-    }
-    .flatten
+            val gen = Expr.forAll(bs.toList, lambda)
+            val freeVarsList = Expr.freeBoundTyVars(lambda)
+            val freeVars = freeVarsList.toSet
+            val notFreeDecl = bs.exists { case (a, _) => !freeVars(a) }
+            if (notFreeDecl) {
+              // we have a lint that fails if declTV is not
+              // a superset of what you would derive from the args
+              // the purpose here is to control the *order* of
+              // and to allow introducing phantom parameters, not
+              // it is confusing if some are explicit, but some are not
+              SourceConverter.partial(
+                SourceConverter.InvalidDefTypeParameters(
+                  args,
+                  freeVarsList,
+                  ds,
+                  region
+                ),
+                gen
+              )
+            } else success(gen)
+        }
+    }.flatten
   }
-  private def resolveToVar[A](ident: Identifier, decl: A, bound: Set[Bindable], topBound: Set[Bindable]): Expr[A] =
+  private def resolveToVar[A](
+      ident: Identifier,
+      decl: A,
+      bound: Set[Bindable],
+      topBound: Set[Bindable]
+  ): Expr[A] =
     ident match {
-      case c@Constructor(_) =>
+      case c @ Constructor(_) =>
         val (p, cons) = nameToCons(c)
         Expr.Global(p, cons, decl)
       case b: Bindable =>
@@ -160,11 +182,10 @@ final class SourceConverter(
         else if (topBound(b)) {
           // local top level bindings can shadow imports after they are imported
           Expr.Global(thisPackage, b, decl)
-        }
-        else {
+        } else {
           importedNames.get(ident) match {
             case Some((p, n)) => Expr.Global(p, n, decl)
-            case None =>
+            case None         =>
               // this is an error, but it will be caught later
               // at type-checking
               Expr.Local(b, decl)
@@ -172,84 +193,98 @@ final class SourceConverter(
         }
     }
 
+  private val unitName = Identifier.Constructor("Unit")
+  // this is lazy so it isn't initialized before Type
+  private lazy val tup: Array[Declaration => Expr[Declaration]] =
+    (Iterator.single(
+      { (tc: Declaration) =>
+        Expr.Global(PackageName.PredefName, unitName, tc)
+      }
+    ) ++ (1 to Type.FnType.MaxSize).iterator
+      .map { idx =>
+        val tup = Type.Tuple.Arity(idx)
+        val defined = tup.tpe.toDefined
+        val pn = defined.packageName
+        val cn = defined.name.ident
 
-    private val unitName = Identifier.Constructor("Unit")
-    // this is lazy so it isn't initialized before Type
-    private lazy val tup: Array[Declaration => Expr[Declaration]] =
-      (Iterator.single(
-        { (tc: Declaration) =>
-          Expr.Global(PackageName.PredefName, unitName, tc)
-        }
-      ) ++ (1 to Type.FnType.MaxSize)
-        .iterator
-        .map { idx =>
-          val tup = Type.Tuple.Arity(idx)
-          val defined = tup.tpe.toDefined
-          val pn = defined.packageName
-          val cn = defined.name.ident
-          
-          { (tc: Declaration) => Expr.Global(pn, cn, tc) }
-        }).toArray
+        { (tc: Declaration) => Expr.Global(pn, cn, tc) }
+      }).toArray
 
-    private def makeTuple(tc: Declaration, args: List[Declaration])(conv: Declaration => Result[Expr[Declaration]]): Result[Expr[Declaration]] =
-      args.traverse(conv)
-        .flatMap { exps =>
-          val size = exps.length
-          if (size <= Type.FnType.MaxSize) {
-            val fn = tup(size)(tc)
-            val res = Expr.buildApp(fn, exps, tc)
-            success(res)
-          }
-          else {
-            SourceConverter.failure(
-              SourceConverter.TooManyConstructorArgs(
-                Type.Tuple.Arity(32).tpe.toDefined.name.ident,
-                size, 32, tc.region)
+  private def makeTuple(tc: Declaration, args: List[Declaration])(
+      conv: Declaration => Result[Expr[Declaration]]
+  ): Result[Expr[Declaration]] =
+    args
+      .traverse(conv)
+      .flatMap { exps =>
+        val size = exps.length
+        if (size <= Type.FnType.MaxSize) {
+          val fn = tup(size)(tc)
+          val res = Expr.buildApp(fn, exps, tc)
+          success(res)
+        } else {
+          SourceConverter.failure(
+            SourceConverter.TooManyConstructorArgs(
+              Type.Tuple.Arity(32).tpe.toDefined.name.ident,
+              size,
+              32,
+              tc.region
             )
-          }
+          )
         }
-
-    private val unitPat = 
-      success(Pattern.PositionalStruct(
-        (PackageName.PredefName, unitName),
-        Nil))
-
-    def makeTuplePattern[A](args: List[Pattern[(PackageName, Constructor), A]], region: Region): Result[Pattern[(PackageName, Constructor), A]] =
-      args match {
-        case Nil => unitPat
-        case nonEmpty =>
-          val size = nonEmpty.size
-          val tupleCons = Type.Tuple.Arity(size)
-          val defined = tupleCons.tpe.toDefined
-          val pat = Pattern.PositionalStruct(
-            (defined.packageName, defined.name.ident),
-            nonEmpty)
-          if (size <= Type.FnType.MaxSize) {
-            success(pat)
-          }
-          else {
-            SourceConverter.partial(
-              SourceConverter.TooManyConstructorArgs(
-                Type.Tuple.Arity(32).tpe.toDefined.name.ident,
-                size, 32, region),
-              pat
-            )
-          }
       }
 
-  private def fromDecl(decl: Declaration, bound: Set[Bindable], topBound: Set[Bindable]): Result[Expr[Declaration]] = {
+  private val unitPat =
+    success(Pattern.PositionalStruct((PackageName.PredefName, unitName), Nil))
+
+  def makeTuplePattern[A](
+      args: List[Pattern[(PackageName, Constructor), A]],
+      region: Region
+  ): Result[Pattern[(PackageName, Constructor), A]] =
+    args match {
+      case Nil => unitPat
+      case nonEmpty =>
+        val size = nonEmpty.size
+        val tupleCons = Type.Tuple.Arity(size)
+        val defined = tupleCons.tpe.toDefined
+        val pat = Pattern.PositionalStruct(
+          (defined.packageName, defined.name.ident),
+          nonEmpty
+        )
+        if (size <= Type.FnType.MaxSize) {
+          success(pat)
+        } else {
+          SourceConverter.partial(
+            SourceConverter.TooManyConstructorArgs(
+              Type.Tuple.Arity(32).tpe.toDefined.name.ident,
+              size,
+              32,
+              region
+            ),
+            pat
+          )
+        }
+    }
+
+  private def fromDecl(
+      decl: Declaration,
+      bound: Set[Bindable],
+      topBound: Set[Bindable]
+  ): Result[Expr[Declaration]] = {
     implicit val parAp = SourceConverter.parallelIor
     def loop(decl: Declaration) = fromDecl(decl, bound, topBound)
-    def withBound(decl: Declaration, newB: Iterable[Bindable]) = fromDecl(decl, bound ++ newB, topBound)
+    def withBound(decl: Declaration, newB: Iterable[Bindable]) =
+      fromDecl(decl, bound ++ newB, topBound)
 
     decl match {
       case Annotation(term, tpe) =>
-        (loop(term), toType(tpe, decl.region)).parMapN(Expr.Annotation(_, _, decl))
+        (loop(term), toType(tpe, decl.region))
+          .parMapN(Expr.Annotation(_, _, decl))
       case Apply(fn, args, _) =>
         (loop(fn), args.toList.traverse(loop(_)))
           .parMapN { Expr.buildApp(_, _, decl) }
-      case ao@ApplyOp(left, op, right) =>
-        val opVar: Expr[Declaration] = resolveToVar(op, ao.opVar, bound, topBound)
+      case ao @ ApplyOp(left, op, right) =>
+        val opVar: Expr[Declaration] =
+          resolveToVar(op, ao.opVar, bound, topBound)
         (loop(left), loop(right)).parMapN { (l, r) =>
           Expr.buildApp(opVar, l :: r :: Nil, decl)
         }
@@ -257,7 +292,10 @@ final class SourceConverter(
         val erest = withBound(rest, pat.names)
 
         val assignRegion = decl.region - value.region
-        def solvePat(pat: Pattern.Parsed, rrhs: Result[Expr[Declaration]]): Result[Expr[Declaration]] =
+        def solvePat(
+            pat: Pattern.Parsed,
+            rrhs: Result[Expr[Declaration]]
+        ): Result[Expr[Declaration]] =
           pat match {
             case Pattern.Var(arg) =>
               (erest, rrhs).parMapN { (e, rhs) =>
@@ -268,19 +306,22 @@ final class SourceConverter(
                 // move the annotation to the right
                 // it's not ideal to use the Declaration of rhs, but it's better
                 // than the entire let
-                val newRhs = rrhs.map { r => Expr.Annotation(r, realTpe, r.tag) }
+                val newRhs = rrhs.map { r =>
+                  Expr.Annotation(r, realTpe, r.tag)
+                }
                 solvePat(pat, newRhs)
               }
             case Pattern.Named(nm, p) =>
-               // this is the same as creating a let nm = value first
+              // this is the same as creating a let nm = value first
               (solvePat(p, rrhs), rrhs).parMapN { (inner, rhs) =>
                 Expr.Let(nm, rhs, inner, RecursionKind.NonRecursive, decl)
               }
             case pat =>
               // TODO: we need the region on the pattern...
-              (convertPattern(pat, assignRegion), erest, rrhs).parMapN { (newPattern, e, rhs) =>
-                val expBranches = NonEmptyList.of((newPattern, e))
-                Expr.Match(rhs, expBranches, decl)
+              (convertPattern(pat, assignRegion), erest, rrhs).parMapN {
+                (newPattern, e, rhs) =>
+                  val expBranches = NonEmptyList.of((newPattern, e))
+                  Expr.Match(rhs, expBranches, decl)
               }
           }
 
@@ -289,23 +330,30 @@ final class SourceConverter(
         loop(decl).map(_.replaceTag(decl))
       case CommentNB(CommentStatement(_, Padding(_, decl))) =>
         loop(decl).map(_.replaceTag(decl))
-      case DefFn(defstmt@DefStatement(_, _, _, _, _)) =>
+      case DefFn(defstmt @ DefStatement(_, _, _, _, _)) =>
         val inExpr = defstmt.result match {
           case (_, Padding(_, in)) => withBound(in, defstmt.name :: Nil)
         }
-        val newBindings = defstmt.name :: defstmt.args.toList.flatMap(_.patternNames)
-        val lambda = toLambdaExpr(defstmt, decl.region, success(decl))({ res => withBound(res._1.get, newBindings) })
+        val newBindings =
+          defstmt.name :: defstmt.args.toList.flatMap(_.patternNames)
+        val lambda = toLambdaExpr(defstmt, decl.region, success(decl))({ res =>
+          withBound(res._1.get, newBindings)
+        })
 
         (inExpr, lambda).parMapN { (in, lam) =>
           // We rely on DefRecursionCheck to rule out bad recursions
           val boundName = defstmt.name
           val rec =
-            if (UnusedLetCheck.freeBound(lam).contains(boundName)) RecursionKind.Recursive
+            if (UnusedLetCheck.freeBound(lam).contains(boundName))
+              RecursionKind.Recursive
             else RecursionKind.NonRecursive
           Expr.Let(boundName, lam, in, recursive = rec, decl)
         }
       case IfElse(ifCases, elseCase) =>
-        def loop0(ifs: NonEmptyList[(Expr[Declaration], Expr[Declaration])], elseC: Expr[Declaration]): Expr[Declaration] =
+        def loop0(
+            ifs: NonEmptyList[(Expr[Declaration], Expr[Declaration])],
+            elseC: Expr[Declaration]
+        ): Expr[Declaration] =
           ifs match {
             case NonEmptyList((cond, ifTrue), Nil) =>
               Expr.ifExpr(cond, ifTrue, elseC, decl)
@@ -319,15 +367,19 @@ final class SourceConverter(
         val else1 = loop(elseCase.get)
 
         (if1, else1).parMapN(loop0(_, _))
-      case tern@Ternary(t, c, f) =>
-        loop(IfElse(NonEmptyList.one((c, OptIndent.same(t))), OptIndent.same(f))(tern.region))
+      case tern @ Ternary(t, c, f) =>
+        loop(
+          IfElse(NonEmptyList.one((c, OptIndent.same(t))), OptIndent.same(f))(
+            tern.region
+          )
+        )
       case Lambda(args, body) =>
         val argsRes = args.traverse(convertPattern(_, decl.region))
         val bodyRes = withBound(body, args.patternNames)
         (argsRes, bodyRes).parMapN { (args, body) =>
           Expr.buildPatternLambda(args, body, decl)
         }
-      case la@LeftApply(_, _, _, _) =>
+      case la @ LeftApply(_, _, _, _) =>
         loop(la.rewrite).map(_.replaceTag(decl))
       case Literal(lit) =>
         success(Expr.Literal(lit, decl))
@@ -346,55 +398,80 @@ final class SourceConverter(
           newPattern.product(withBound(decl, pat.names))
         }
         (loop(arg), expBranches).parMapN(Expr.Match(_, _, decl))
-      case m@Matches(a, p) =>
+      case m @ Matches(a, p) =>
         // x matches p ==
         // match x:
         //   p: True
         //   _: False
-        val True: Expr[Declaration] = Expr.Global(PackageName.PredefName, Identifier.Constructor("True"), m)
-        val False: Expr[Declaration] = Expr.Global(PackageName.PredefName, Identifier.Constructor("False"), m)
+        val True: Expr[Declaration] =
+          Expr.Global(PackageName.PredefName, Identifier.Constructor("True"), m)
+        val False: Expr[Declaration] = Expr.Global(
+          PackageName.PredefName,
+          Identifier.Constructor("False"),
+          m
+        )
         (loop(a), convertPattern(p, m.region)).mapN { (a, p) =>
-          val branches = NonEmptyList((p, True), (Pattern.WildCard, False) :: Nil)
+          val branches =
+            NonEmptyList((p, True), (Pattern.WildCard, False) :: Nil)
           Expr.Match(a, branches, m)
         }
-      case tc@TupleCons(its) => makeTuple(tc, its)(loop)
-      case s@StringDecl(parts) =>
+      case tc @ TupleCons(its)   => makeTuple(tc, its)(loop)
+      case s @ StringDecl(parts) =>
         // a single string item should be converted
         // to that thing,
         // two or more should be converted this to concat_String([items])
 
         def charToString(expr: Expr[Declaration]): Expr[Declaration] = {
           val fnName: Expr[Declaration] =
-            Expr.Global(PackageName.PredefName, Identifier.Name("char_to_String"), expr.tag)
+            Expr.Global(
+              PackageName.PredefName,
+              Identifier.Name("char_to_String"),
+              expr.tag
+            )
 
           Expr.buildApp(fnName, expr :: Nil, expr.tag)
         }
 
         val decls = parts.parTraverse {
           case StringDecl.Literal(r, str) => loop(Literal(Lit(str))(r))
-          case StringDecl.CharExpr(decl) => loop(decl).map(charToString)
-          case StringDecl.StrExpr(decl) => loop(decl)
+          case StringDecl.CharExpr(decl)  => loop(decl).map(charToString)
+          case StringDecl.StrExpr(decl)   => loop(decl)
         }
 
         decls.map {
           case NonEmptyList(one, Nil) => one
           case twoOrMore =>
-            def listOf(expr: List[Expr[Declaration]], restDecl: Declaration): Expr[Declaration] =
+            def listOf(
+                expr: List[Expr[Declaration]],
+                restDecl: Declaration
+            ): Expr[Declaration] =
               expr match {
                 case Nil =>
-                  Expr.Global(PackageName.PredefName, Identifier.Constructor("EmptyList"), restDecl)
+                  Expr.Global(
+                    PackageName.PredefName,
+                    Identifier.Constructor("EmptyList"),
+                    restDecl
+                  )
                 case h :: tail =>
-                  val cons = Expr.Global(PackageName.PredefName, Identifier.Constructor("NonEmptyList"), restDecl)
+                  val cons = Expr.Global(
+                    PackageName.PredefName,
+                    Identifier.Constructor("NonEmptyList"),
+                    restDecl
+                  )
                   val tailExpr = listOf(tail, h.tag)
                   Expr.buildApp(cons, h :: tailExpr :: Nil, restDecl)
               }
 
             val fnName: Expr[Declaration] =
-              Expr.Global(PackageName.PredefName, Identifier.Name("concat_String"), s)
+              Expr.Global(
+                PackageName.PredefName,
+                Identifier.Name("concat_String"),
+                s
+              )
 
             Expr.buildApp(fnName, listOf(twoOrMore.toList, s) :: Nil, s)
         }
-      case l@ListDecl(list) =>
+      case l @ ListDecl(list) =>
         list match {
           case ListLang.Cons(items) =>
             val revDecs: Result[List[SpliceOrItem[Expr[Declaration]]]] =
@@ -412,10 +489,16 @@ final class SourceConverter(
               Expr.Global(pn, Identifier.Name(c), l)
 
             val Empty: Expr[Declaration] = mkC("EmptyList")
-            def cons(head: Expr[Declaration], tail: Expr[Declaration]): Expr[Declaration] =
+            def cons(
+                head: Expr[Declaration],
+                tail: Expr[Declaration]
+            ): Expr[Declaration] =
               Expr.buildApp(mkC("NonEmptyList"), head :: tail :: Nil, l)
 
-            def concat(headList: Expr[Declaration], tail: Expr[Declaration]): Expr[Declaration] =
+            def concat(
+                headList: Expr[Declaration],
+                tail: Expr[Declaration]
+            ): Expr[Declaration] =
               Expr.buildApp(mkN("concat"), headList :: tail :: Nil, l)
 
             revDecs.map(_.foldLeft(Empty) {
@@ -458,10 +541,11 @@ final class SourceConverter(
                 "flat_map_List"
             }
             val newBound = binding.names
-            val opExpr: Expr[Declaration] = Expr.Global(pn, Identifier.Name(opName), l)
+            val opExpr: Expr[Declaration] =
+              Expr.Global(pn, Identifier.Name(opName), l)
             val resExpr: Result[Expr[Declaration]] =
               filter match {
-                case None => withBound(res.value, newBound)
+                case None       => withBound(res.value, newBound)
                 case Some(cond) =>
                   // To do filters, we lift all results into lists,
                   // so single items must be made singleton lists
@@ -473,9 +557,14 @@ final class SourceConverter(
                       // here we lift the result into a a singleton list
                       withBound(r, newBound).map { ritem =>
                         Expr.App(
-                          Expr.Global(pn, Identifier.Constructor("NonEmptyList"), rdec),
+                          Expr.Global(
+                            pn,
+                            Identifier.Constructor("NonEmptyList"),
+                            rdec
+                          ),
                           NonEmptyList(ritem, empty :: Nil),
-                          rdec)
+                          rdec
+                        )
                       }
                     case SpliceOrItem.Splice(r) => withBound(r, newBound)
                   }
@@ -484,34 +573,40 @@ final class SourceConverter(
                     Expr.ifExpr(c, sing, empty, cond)
                   }
               }
-            (convertPattern(binding, decl.region),
-              resExpr,
-              loop(in)).mapN { (newPattern, resExpr, in) =>
-              val fnExpr: Expr[Declaration] =
-                Expr.buildPatternLambda(NonEmptyList.of(newPattern), resExpr, l)
-              Expr.buildApp(opExpr, in :: fnExpr :: Nil, l)
+            (convertPattern(binding, decl.region), resExpr, loop(in)).mapN {
+              (newPattern, resExpr, in) =>
+                val fnExpr: Expr[Declaration] =
+                  Expr.buildPatternLambda(
+                    NonEmptyList.of(newPattern),
+                    resExpr,
+                    l
+                  )
+                Expr.buildApp(opExpr, in :: fnExpr :: Nil, l)
             }
         }
-      case l@DictDecl(dict) =>
+      case l @ DictDecl(dict) =>
         val pn = PackageName.PredefName
         def mkN(n: String): Expr[Declaration] =
           Expr.Global(pn, Identifier.Name(n), l)
         val empty: Expr[Declaration] =
           Expr.App(mkN("empty_Dict"), NonEmptyList.one(mkN("string_Order")), l)
 
-        def add(dict: Expr[Declaration], k: Expr[Declaration], v: Expr[Declaration]): Expr[Declaration] = {
+        def add(
+            dict: Expr[Declaration],
+            k: Expr[Declaration],
+            v: Expr[Declaration]
+        ): Expr[Declaration] = {
           val fn = mkN("add_key")
           Expr.buildApp(fn, dict :: k :: v :: Nil, l)
         }
         dict match {
           case ListLang.Cons(items) =>
             val revDecs: Result[List[KVPair[Expr[Declaration]]]] =
-              items.reverse.traverse {
-                case KVPair(k, v) =>
-                  (loop(k), loop(v)).mapN(KVPair(_, _))
+              items.reverse.traverse { case KVPair(k, v) =>
+                (loop(k), loop(v)).mapN(KVPair(_, _))
               }
-            revDecs.map(_.foldLeft(empty) {
-              case (dict, KVPair(k, v)) => add(dict, k, v)
+            revDecs.map(_.foldLeft(empty) { case (dict, KVPair(k, v)) =>
+              add(dict, k, v)
             })
           case ListLang.Comprehension(KVPair(k, v), binding, in, filter) =>
             /*
@@ -529,19 +624,19 @@ final class SourceConverter(
 
             val newBound = binding.names
             val pn = PackageName.PredefName
-            val opExpr: Expr[Declaration] = Expr.Global(pn, Identifier.Name("foldLeft"), l)
+            val opExpr: Expr[Declaration] =
+              Expr.Global(pn, Identifier.Name("foldLeft"), l)
             val dictSymbol = unusedNames(decl.allNames).next()
             val init: Expr[Declaration] = Expr.Local(dictSymbol, l)
-            val added = (withBound(k, newBound), withBound(v, newBound)).mapN(add(init, _, _))
+            val added = (withBound(k, newBound), withBound(v, newBound)).mapN(
+              add(init, _, _)
+            )
 
             val resExpr: Result[Expr[Declaration]] = filter match {
               case None => added
               case Some(cond0) =>
                 (added, withBound(cond0, newBound)).mapN { (added, cond) =>
-                  Expr.ifExpr(cond,
-                    added,
-                    init,
-                    cond0)
+                  Expr.ifExpr(cond, added, init, cond0)
                 }
             }
             val newPattern = convertPattern(binding, decl.region)
@@ -550,68 +645,84 @@ final class SourceConverter(
                 Expr.buildPatternLambda(
                   NonEmptyList(Pattern.Var(dictSymbol), pat :: Nil),
                   res,
-                  l)
+                  l
+                )
               Expr.buildApp(opExpr, in :: empty :: foldFn :: Nil, l)
             }
-          }
-      case rc@RecordConstructor(name, args) =>
-          val (p, c) = nameToCons(name)
-          val cons: Expr[Declaration] = Expr.Global(p, c, rc)
-          localTypeEnv.flatMap(_.getConstructorParams(p, c) match {
-            case Some(params) =>
-              def argExpr(arg: RecordArg): (Bindable, Result[Expr[Declaration]]) =
-                arg match {
-                  case RecordArg.Simple(b) =>
-                    (b, success(resolveToVar(b, rc, bound, topBound)))
-                  case RecordArg.Pair(k, v) =>
-                    (k, loop(v))
-                }
-              val mappingList = args.toList.map(argExpr)
-              val mapping = mappingList.toMap
-
-              lazy val present =
-                mappingList
-                  .iterator
-                  .map(_._1)
-                  .foldLeft(SortedSet.empty[Bindable])(_ + _)
-
-              def get(b: Bindable): Result[Expr[Declaration]] =
-                mapping.get(b) match {
-                  case Some(expr) => expr
-                  case None =>
-                    SourceConverter.failure(
-                      SourceConverter.MissingArg(name, rc, present, b, rc.region))
-                }
-              val exprArgs = params.traverse { case (b, _) => get(b) }
-
-              val res = exprArgs.map { args =>
-                Expr.buildApp(cons, args.toList, rc)
+        }
+      case rc @ RecordConstructor(name, args) =>
+        val (p, c) = nameToCons(name)
+        val cons: Expr[Declaration] = Expr.Global(p, c, rc)
+        localTypeEnv.flatMap(_.getConstructorParams(p, c) match {
+          case Some(params) =>
+            def argExpr(arg: RecordArg): (Bindable, Result[Expr[Declaration]]) =
+              arg match {
+                case RecordArg.Simple(b) =>
+                  (b, success(resolveToVar(b, rc, bound, topBound)))
+                case RecordArg.Pair(k, v) =>
+                  (k, loop(v))
               }
-              // we also need to check that there are no unused or duplicated
-              // fields
-              val paramNamesList = params.map(_._1)
-              val paramNames = paramNamesList.toSet
-              // here are all the fields we don't understand
-              val extra = mappingList.collect { case (k, _) if !paramNames(k) => k }
-              // Check that the mapping is exactly the right size
-              NonEmptyList.fromList(extra) match {
-                case None => res
-                case Some(extra) =>
-                  SourceConverter
-                    .addError(res,
-                      SourceConverter.UnexpectedField(name, rc, extra, paramNamesList, rc.region))
+            val mappingList = args.toList.map(argExpr)
+            val mapping = mappingList.toMap
+
+            lazy val present =
+              mappingList.iterator
+                .map(_._1)
+                .foldLeft(SortedSet.empty[Bindable])(_ + _)
+
+            def get(b: Bindable): Result[Expr[Declaration]] =
+              mapping.get(b) match {
+                case Some(expr) => expr
+                case None =>
+                  SourceConverter.failure(
+                    SourceConverter.MissingArg(name, rc, present, b, rc.region)
+                  )
               }
-            case None =>
-              SourceConverter.failure(SourceConverter.UnknownConstructor(name, rc, decl.region))
-          })
+            val exprArgs = params.traverse { case (b, _) => get(b) }
+
+            val res = exprArgs.map { args =>
+              Expr.buildApp(cons, args.toList, rc)
+            }
+            // we also need to check that there are no unused or duplicated
+            // fields
+            val paramNamesList = params.map(_._1)
+            val paramNames = paramNamesList.toSet
+            // here are all the fields we don't understand
+            val extra = mappingList.collect {
+              case (k, _) if !paramNames(k) => k
+            }
+            // Check that the mapping is exactly the right size
+            NonEmptyList.fromList(extra) match {
+              case None => res
+              case Some(extra) =>
+                SourceConverter
+                  .addError(
+                    res,
+                    SourceConverter.UnexpectedField(
+                      name,
+                      rc,
+                      extra,
+                      paramNamesList,
+                      rc.region
+                    )
+                  )
+            }
+          case None =>
+            SourceConverter.failure(
+              SourceConverter.UnknownConstructor(name, rc, decl.region)
+            )
+        })
     }
   }
 
   private def toType(t: TypeRef, region: Region): Result[Type] =
     TypeRefConverter[Result](t)(nameToType(_, region))
 
-  def toDefinition(pname: PackageName, tds: TypeDefinitionStatement): Result[rankn.DefinedType[Option[Kind.Arg]]] = {
-    import Statement._
+  def toDefinition(
+      pname: PackageName,
+      tds: TypeDefinitionStatement
+  ): Result[rankn.DefinedType[Option[Kind.Arg]]] = {
+    import Statement.*
 
     type StT = ((Set[Type.TyVar], List[Type.TyVar]), LazyList[Type.TyVar])
     type VarState[A] = State[StT, A]
@@ -637,114 +748,144 @@ final class SourceConverter(
       Type.freeTyVars(pt).map(Type.TyVar(_))
     }
 
-    def buildParams(args: List[(Bindable, Option[Type])]): VarState[List[(Bindable, Type)]] =
-      args.traverse(buildParam _)
+    def buildParams(
+        args: List[(Bindable, Option[Type])]
+    ): VarState[List[(Bindable, Type)]] =
+      args.traverse(buildParam)
 
     // This is a traverse on List[(Bindable, Option[A])]
-    val deep = Traverse[List].compose(Traverse[(Bindable, *)]).compose(Traverse[Option])
+    val deep =
+      Traverse[List].compose(Traverse[(Bindable, *)]).compose(Traverse[Option])
 
     def updateInferedWithDecl(
-      typeArgs: Option[NonEmptyList[(TypeRef.TypeVar, Option[Kind.Arg])]],
-      typeParams0: List[Type.Var.Bound]): Result[List[(Type.Var.Bound, Option[Kind.Arg])]] =
-        typeArgs match {
-          case None => success(typeParams0.map((_, None)))
-          case Some(decl) =>
-            val neBound = decl.map { case (v, k) => (v.toBoundVar, k) }
-            val declSet = neBound.toList.iterator.map(_._1).toSet
-            val missingFromDecl = typeParams0.filterNot(declSet)
-            if ((declSet.size != neBound.size) || missingFromDecl.nonEmpty) {
-              val bestEffort = neBound.toList.distinctBy(_._1) ::: missingFromDecl.map((_, None))
-              // we have a lint that fails if declTV is not
-              // a superset of what you would derive from the args
-              // the purpose here is to control the *order* of
-              // and to allow introducing phantom parameters, not
-              // it is confusing if some are explicit, but some are not
-              SourceConverter.partial(
-                SourceConverter.InvalidTypeParameters(decl, typeParams0, tds),
-                bestEffort)
-            }
-            else success(neBound.toList ::: missingFromDecl.map((_, None)))
-        }
+        typeArgs: Option[NonEmptyList[(TypeRef.TypeVar, Option[Kind.Arg])]],
+        typeParams0: List[Type.Var.Bound]
+    ): Result[List[(Type.Var.Bound, Option[Kind.Arg])]] =
+      typeArgs match {
+        case None => success(typeParams0.map((_, None)))
+        case Some(decl) =>
+          val neBound = decl.map { case (v, k) => (v.toBoundVar, k) }
+          val declSet = neBound.toList.iterator.map(_._1).toSet
+          val missingFromDecl = typeParams0.filterNot(declSet)
+          if ((declSet.size != neBound.size) || missingFromDecl.nonEmpty) {
+            val bestEffort =
+              neBound.toList.distinctBy(_._1) ::: missingFromDecl.map((_, None))
+            // we have a lint that fails if declTV is not
+            // a superset of what you would derive from the args
+            // the purpose here is to control the *order* of
+            // and to allow introducing phantom parameters, not
+            // it is confusing if some are explicit, but some are not
+            SourceConverter.partial(
+              SourceConverter.InvalidTypeParameters(decl, typeParams0, tds),
+              bestEffort
+            )
+          } else success(neBound.toList ::: missingFromDecl.map((_, None)))
+      }
 
-    def validateArgCount(nm: Constructor, args: Int, region: Region): Result[Unit] =
+    def validateArgCount(
+        nm: Constructor,
+        args: Int,
+        region: Region
+    ): Result[Unit] =
       if (args <= Type.FnType.MaxSize) SourceConverter.successUnit
-      else SourceConverter.partial(
-        SourceConverter.TooManyConstructorArgs(nm, args, Type.FnType.MaxSize, region), ())
+      else
+        SourceConverter.partial(
+          SourceConverter
+            .TooManyConstructorArgs(nm, args, Type.FnType.MaxSize, region),
+          ()
+        )
 
     // TODO we have to make sure we don't have more than 8 arguments to a struct
     // or the constructor Fn won't be a valid function
     tds match {
       case Struct(nm, typeArgs, args) =>
         validateArgCount(nm, args.length, tds.region) *>
-          deep.traverse(args)(toType(_, tds.region))
-          .flatMap { argsType =>
-            val declVars = typeArgs.iterator.flatMap(_.toList).map { p => Type.TyVar(p._1.toBoundVar) }
-            val initVars = existingVars(argsType)
-            val initState = ((initVars.toSet ++ declVars, initVars.reverse), Type.allBinders.map(Type.TyVar))
-            val (((_, typeVars), _), params) = buildParams(argsType).run(initState).value
+          deep
+            .traverse(args)(toType(_, tds.region))
+            .flatMap { argsType =>
+              val declVars = typeArgs.iterator.flatMap(_.toList).map { p =>
+                Type.TyVar(p._1.toBoundVar)
+              }
+              val initVars = existingVars(argsType)
+              val initState = (
+                (initVars.toSet ++ declVars, initVars.reverse),
+                Type.allBinders.map(Type.TyVar(_))
+              )
+              val (((_, typeVars), _), params) =
+                buildParams(argsType).run(initState).value
+              // we reverse to make sure we see in traversal order
+              val typeParams0 = reverseMap(typeVars) { tv =>
+                tv.toVar match {
+                  case b @ Type.Var.Bound(_) => b
+                  // $COVERAGE-OFF$ this should be unreachable
+                  case unexpected =>
+                    sys.error(
+                      s"unexpectedly parsed a non bound var: $unexpected"
+                    )
+                  // $COVERAGE-ON$
+                }
+              }
+
+              updateInferedWithDecl(typeArgs, typeParams0).map { typeParams =>
+                val tname = TypeName(nm)
+                val consFn = rankn.ConstructorFn(nm, params)
+
+                rankn.DefinedType(pname, tname, typeParams, consFn :: Nil)
+              }
+            }
+      case Enum(nm, typeArgs, items) =>
+        items.get
+          .traverse { case (nm, args) =>
+            validateArgCount(nm, args.length, tds.region) *>
+              deep
+                .traverse(args)(toType(_, tds.region))
+                .map((nm, _))
+          }
+          .flatMap { conArgs =>
+            val constructorsS = conArgs.traverse { case (nm, argsType) =>
+              buildParams(argsType).map { params =>
+                (nm, params)
+              }
+            }
+            val declVars = typeArgs.iterator.flatMap(_.toList).map { p =>
+              Type.TyVar(p._1.toBoundVar)
+            }
+            val initVars = existingVars(conArgs.toList.flatMap(_._2))
+            val initState = (
+              (initVars.toSet ++ declVars, initVars.reverse),
+              Type.allBinders.map(Type.TyVar(_))
+            )
+            val (((_, typeVars), _), constructors) =
+              constructorsS.run(initState).value
             // we reverse to make sure we see in traversal order
             val typeParams0 = reverseMap(typeVars) { tv =>
               tv.toVar match {
-                case b@Type.Var.Bound(_) => b
+                case b @ Type.Var.Bound(_) => b
                 // $COVERAGE-OFF$ this should be unreachable
                 case unexpected =>
                   sys.error(s"unexpectedly parsed a non bound var: $unexpected")
                 // $COVERAGE-ON$
               }
             }
-
             updateInferedWithDecl(typeArgs, typeParams0).map { typeParams =>
-              val tname = TypeName(nm)
-              val consFn = rankn.ConstructorFn(nm, params)
-
-              rankn.DefinedType(pname,
-                tname,
-                typeParams,
-                consFn :: Nil)
+              val finalCons = constructors.toList.map { case (c, params) =>
+                rankn.ConstructorFn(c, params)
+              }
+              rankn.DefinedType(pname, TypeName(nm), typeParams, finalCons)
             }
           }
-      case Enum(nm, typeArgs, items) =>
-        items.get.traverse { case (nm, args) =>
-          validateArgCount(nm, args.length, tds.region) *>
-            deep.traverse(args)(toType(_, tds.region))
-            .map((nm, _))
-        }
-        .flatMap { conArgs =>
-
-          val constructorsS = conArgs.traverse { case (nm, argsType) =>
-            buildParams(argsType).map { params =>
-              (nm, params)
-            }
-          }
-          val declVars = typeArgs.iterator.flatMap(_.toList).map { p => Type.TyVar(p._1.toBoundVar) }
-          val initVars = existingVars(conArgs.toList.flatMap(_._2))
-          val initState = ((initVars.toSet ++ declVars, initVars.reverse), Type.allBinders.map(Type.TyVar))
-          val (((_, typeVars), _), constructors) = constructorsS.run(initState).value
-          // we reverse to make sure we see in traversal order
-          val typeParams0 = reverseMap(typeVars) { tv =>
-            tv.toVar match {
-              case b@Type.Var.Bound(_) => b
-              // $COVERAGE-OFF$ this should be unreachable
-              case unexpected => sys.error(s"unexpectedly parsed a non bound var: $unexpected")
-              // $COVERAGE-ON$
-            }
-          }
-          updateInferedWithDecl(typeArgs, typeParams0).map { typeParams =>
-            val finalCons = constructors.toList.map { case (c, params) =>
-              rankn.ConstructorFn(c, params)
-            }
-            rankn.DefinedType(pname, TypeName(nm), typeParams, finalCons)
-          }
-        }
       case ExternalStruct(nm, targs) =>
         // TODO make a real check here of allowed kinds
         success(
           rankn.DefinedType(
             pname,
             TypeName(nm),
-            targs.map { case (TypeRef.TypeVar(v), optK) => (Type.Var.Bound(v), optK) },
-            Nil)
+            targs.map { case (TypeRef.TypeVar(v), optK) =>
+              (Type.Var.Bound(v), optK)
+            },
+            Nil
           )
+        )
     }
   }
 
@@ -760,25 +901,44 @@ final class SourceConverter(
     loop(as, Nil)
   }
 
-  private def convertPattern(pat: Pattern.Parsed, region: Region): Result[Pattern[(PackageName, Constructor), rankn.Type]] = {
+  private def convertPattern(
+      pat: Pattern.Parsed,
+      region: Region
+  ): Result[Pattern[(PackageName, Constructor), rankn.Type]] = {
     val nonTupled = unTuplePattern(pat, region)
     val collisions = pat.collisionBinds
     NonEmptyList.fromList(collisions) match {
       case None => nonTupled
       case Some(nel) =>
-        SourceConverter.addError(nonTupled, SourceConverter.PatternShadow(nel, pat, region))
+        SourceConverter.addError(
+          nonTupled,
+          SourceConverter.PatternShadow(nel, pat, region)
+        )
     }
   }
 
-  private[this] val empty = Pattern.PositionalStruct((PackageName.PredefName, Constructor("EmptyList")), Nil)
-  private[this] val nonEmpty = (PackageName.PredefName, Constructor("NonEmptyList"))
+  private[this] val empty = Pattern.PositionalStruct(
+    (PackageName.PredefName, Constructor("EmptyList")),
+    Nil
+  )
+  private[this] val nonEmpty =
+    (PackageName.PredefName, Constructor("NonEmptyList"))
 
-  /**
-   * As much as possible, convert a list pattern into a normal enum pattern which simplifies
-   * matching, and possibly allows us to more easily statically remove more of the match
-   */
-  private def unlistPattern(parts: List[Pattern.ListPart[Pattern[(PackageName, Constructor), rankn.Type]]]): Pattern[(PackageName, Constructor), rankn.Type] = {
-    def loop(parts: List[Pattern.ListPart[Pattern[(PackageName, Constructor), rankn.Type]]], topLevel: Boolean): Pattern[(PackageName, Constructor), rankn.Type] =
+  /** As much as possible, convert a list pattern into a normal enum pattern
+    * which simplifies matching, and possibly allows us to more easily
+    * statically remove more of the match
+    */
+  private def unlistPattern(
+      parts: List[
+        Pattern.ListPart[Pattern[(PackageName, Constructor), rankn.Type]]
+      ]
+  ): Pattern[(PackageName, Constructor), rankn.Type] = {
+    def loop(
+        parts: List[
+          Pattern.ListPart[Pattern[(PackageName, Constructor), rankn.Type]]
+        ],
+        topLevel: Boolean
+    ): Pattern[(PackageName, Constructor), rankn.Type] =
       parts match {
         case Nil => empty
         case Pattern.ListPart.Item(h) :: tail =>
@@ -790,8 +950,7 @@ final class SourceConverter(
             // changing to _ would allow more things to typecheck, which we can't do
             // and we can't annotate because we don't know the type of the list
             Pattern.ListPat(parts)
-          }
-          else {
+          } else {
             // we are already in the tail of a list, so we can just put _ here
             Pattern.WildCard
           }
@@ -801,12 +960,13 @@ final class SourceConverter(
             // changing to _ would allow more things to typecheck, which we can't do
             // and we can't annotate because we don't know the type of the list
             Pattern.ListPat(parts)
-          }
-          else {
+          } else {
             // we are already in the tail of a list, so we can just put n here
             Pattern.Var(n)
           }
-        case (Pattern.ListPart.WildList :: (i@Pattern.ListPart.Item(Pattern.WildCard)) :: tail) =>
+        case (Pattern.ListPart.WildList :: (i @ Pattern.ListPart.Item(
+              Pattern.WildCard
+            )) :: tail) =>
           // [*_, _, x...] = [_, *_, x...]
           loop(i :: Pattern.ListPart.WildList :: tail, topLevel)
         case (Pattern.ListPart.WildList | Pattern.ListPart.NamedList(_)) :: _ =>
@@ -817,138 +977,211 @@ final class SourceConverter(
     loop(parts, true)
   }
 
-  /**
-   * Tuples are converted into standard types using an HList strategy
-   */
-  private def unTuplePattern(pat: Pattern.Parsed, region: Region): Result[Pattern[(PackageName, Constructor), rankn.Type]] =
-    pat.traversePattern[Result, (PackageName, Constructor), rankn.Type]({
-      case (Pattern.StructKind.Tuple, args) =>
-        // this is a tuple pattern
-        args.flatMap(makeTuplePattern(_, region))
-      case (Pattern.StructKind.Named(nm, Pattern.StructKind.Style.TupleLike), rargs) =>
-        rargs.flatMap { args =>
-          val pc@(p, c) = nameToCons(nm)
-          localTypeEnv.flatMap(_.getConstructorParams(p, c) match {
-            case Some(params) =>
-              val argLen = args.size
-              val paramLen = params.size
-              if (argLen == paramLen) {
-                SourceConverter.success(Pattern.PositionalStruct(pc, args))
-              }
-              else {
-                // do the best we can
-                val fixedArgs = (args ::: List.fill(paramLen - argLen)(Pattern.WildCard)).take(paramLen)
-                SourceConverter.partial(
-                  SourceConverter.InvalidArgCount(nm, pat, argLen, paramLen, region),
-                  Pattern.PositionalStruct(pc, fixedArgs))
-              }
-            case None =>
-              SourceConverter.failure(SourceConverter.UnknownConstructor(nm, pat, region))
-          })
-        }
-      case (Pattern.StructKind.NamedPartial(nm, Pattern.StructKind.Style.TupleLike), rargs) =>
-        rargs.flatMap { args =>
-          val pc@(p, c) = nameToCons(nm)
-          localTypeEnv.flatMap(_.getConstructorParams(p, c) match {
-            case Some(params) =>
-              val argLen = args.size
-              val paramLen = params.size
-              if (argLen <= paramLen) {
-                val fixedArgs = if (argLen < paramLen) (args ::: List.fill(paramLen - argLen)(Pattern.WildCard)) else args
-                SourceConverter.success(Pattern.PositionalStruct(pc, fixedArgs))
-              }
-              else {
-                // we have too many
-                val fixedArgs = args.take(paramLen)
-                SourceConverter.partial(
-                  SourceConverter.InvalidArgCount(nm, pat, argLen, paramLen, region),
-                  Pattern.PositionalStruct(pc, fixedArgs))
-              }
-            case None =>
-              SourceConverter.failure(SourceConverter.UnknownConstructor(nm, pat, region))
-          })
-        }
-      case (Pattern.StructKind.Named(nm, Pattern.StructKind.Style.RecordLike(fs)), rargs) =>
-        rargs.flatMap { args =>
-          val pc@(p, c) = nameToCons(nm)
-          localTypeEnv.flatMap(_.getConstructorParams(p, c) match {
-            case Some(params) =>
-              val mapping = fs.toList.iterator.map(_.field).zip(args.iterator).toMap
-              lazy val present = SortedSet(fs.toList.iterator.map(_.field).toList: _*)
-              def get(b: Bindable): Result[Pattern[(PackageName, Constructor), rankn.Type]] =
-                mapping.get(b) match {
-                  case Some(pat) =>
-                    SourceConverter.success(pat)
-                  case None =>
-                    SourceConverter.partial(SourceConverter.MissingArg(nm, pat, present, b, region), Pattern.WildCard)
+  /** Tuples are converted into standard types using an HList strategy
+    */
+  private def unTuplePattern(
+      pat: Pattern.Parsed,
+      region: Region
+  ): Result[Pattern[(PackageName, Constructor), rankn.Type]] =
+    pat.traversePattern[Result, (PackageName, Constructor), rankn.Type](
+      {
+        case (Pattern.StructKind.Tuple, args) =>
+          // this is a tuple pattern
+          args.flatMap(makeTuplePattern(_, region))
+        case (
+              Pattern.StructKind.Named(nm, Pattern.StructKind.Style.TupleLike),
+              rargs
+            ) =>
+          rargs.flatMap { args =>
+            val pc @ (p, c) = nameToCons(nm)
+            localTypeEnv.flatMap(_.getConstructorParams(p, c) match {
+              case Some(params) =>
+                val argLen = args.size
+                val paramLen = params.size
+                if (argLen == paramLen) {
+                  SourceConverter.success(Pattern.PositionalStruct(pc, args))
+                } else {
+                  // do the best we can
+                  val fixedArgs =
+                    (args ::: List.fill(paramLen - argLen)(Pattern.WildCard))
+                      .take(paramLen)
+                  SourceConverter.partial(
+                    SourceConverter
+                      .InvalidArgCount(nm, pat, argLen, paramLen, region),
+                    Pattern.PositionalStruct(pc, fixedArgs)
+                  )
                 }
-              val mapped =
-                params
-                  .traverse { case (b, _) => get(b) }(SourceConverter.parallelIor)
-                  .map(Pattern.PositionalStruct(pc, _))
-
-              val paramNamesList = params.map(_._1)
-              val paramNames = paramNamesList.toSet
-              // here are all the fields we don't understand
-              val extra = fs.toList.iterator.map(_.field).filterNot(paramNames).toList
-              // Check that the mapping is exactly the right size
-              NonEmptyList.fromList(extra) match {
-                case None => mapped
-                case Some(extra) =>
-                  SourceConverter
-                    .addError(mapped,
-                      SourceConverter.UnexpectedField(nm, pat, extra, paramNamesList, region))
-              }
-            case None =>
-              SourceConverter.failure(SourceConverter.UnknownConstructor(nm, pat, region))
-          })
-        }
-      case (Pattern.StructKind.NamedPartial(nm, Pattern.StructKind.Style.RecordLike(fs)), rargs) =>
-        rargs.flatMap { args =>
-          val pc@(p, c) = nameToCons(nm)
-          localTypeEnv.flatMap(_.getConstructorParams(p, c) match {
-            case Some(params) =>
-              val mapping = fs.toList.iterator.map(_.field).zip(args.iterator).toMap
-              def get(b: Bindable): Pattern[(PackageName, Constructor), rankn.Type] =
-                mapping.get(b) match {
-                  case Some(pat) => pat
-                  case None => Pattern.WildCard
+              case None =>
+                SourceConverter.failure(
+                  SourceConverter.UnknownConstructor(nm, pat, region)
+                )
+            })
+          }
+        case (
+              Pattern.StructKind
+                .NamedPartial(nm, Pattern.StructKind.Style.TupleLike),
+              rargs
+            ) =>
+          rargs.flatMap { args =>
+            val pc @ (p, c) = nameToCons(nm)
+            localTypeEnv.flatMap(_.getConstructorParams(p, c) match {
+              case Some(params) =>
+                val argLen = args.size
+                val paramLen = params.size
+                if (argLen <= paramLen) {
+                  val fixedArgs =
+                    if (argLen < paramLen)
+                      (args ::: List.fill(paramLen - argLen)(Pattern.WildCard))
+                    else args
+                  SourceConverter.success(
+                    Pattern.PositionalStruct(pc, fixedArgs)
+                  )
+                } else {
+                  // we have too many
+                  val fixedArgs = args.take(paramLen)
+                  SourceConverter.partial(
+                    SourceConverter
+                      .InvalidArgCount(nm, pat, argLen, paramLen, region),
+                    Pattern.PositionalStruct(pc, fixedArgs)
+                  )
                 }
-              val derefArgs = params.map { case (b, _) => get(b) }
-              val res0 = SourceConverter.success(Pattern.PositionalStruct(pc, derefArgs))
+              case None =>
+                SourceConverter.failure(
+                  SourceConverter.UnknownConstructor(nm, pat, region)
+                )
+            })
+          }
+        case (
+              Pattern.StructKind
+                .Named(nm, Pattern.StructKind.Style.RecordLike(fs)),
+              rargs
+            ) =>
+          rargs.flatMap { args =>
+            val pc @ (p, c) = nameToCons(nm)
+            localTypeEnv.flatMap(_.getConstructorParams(p, c) match {
+              case Some(params) =>
+                val mapping =
+                  fs.toList.iterator.map(_.field).zip(args.iterator).toMap
+                lazy val present =
+                  SortedSet(fs.toList.iterator.map(_.field).toList *)
+                def get(
+                    b: Bindable
+                ): Result[Pattern[(PackageName, Constructor), rankn.Type]] =
+                  mapping.get(b) match {
+                    case Some(pat) =>
+                      SourceConverter.success(pat)
+                    case None =>
+                      SourceConverter.partial(
+                        SourceConverter.MissingArg(nm, pat, present, b, region),
+                        Pattern.WildCard
+                      )
+                  }
+                val mapped =
+                  params
+                    .traverse { case (b, _) => get(b) }(
+                      SourceConverter.parallelIor
+                    )
+                    .map(Pattern.PositionalStruct(pc, _))
 
-              val paramNamesList = params.map(_._1)
-              val paramNames = paramNamesList.toSet
-              // here are all the fields we don't understand
-              val extra = fs.toList.iterator.map(_.field).filterNot(paramNames).toList
-              // Check that the mapping is exactly the right size
-              NonEmptyList.fromList(extra) match {
-                case None => res0
-                case Some(extra) =>
-                  SourceConverter
-                    .addError(res0,
-                      SourceConverter.UnexpectedField(nm, pat, extra, paramNamesList, region))
-              }
-            case None =>
-              SourceConverter.failure(SourceConverter.UnknownConstructor(nm, pat, region))
-          })
-        }
+                val paramNamesList = params.map(_._1)
+                val paramNames = paramNamesList.toSet
+                // here are all the fields we don't understand
+                val extra =
+                  fs.toList.iterator.map(_.field).filterNot(paramNames).toList
+                // Check that the mapping is exactly the right size
+                NonEmptyList.fromList(extra) match {
+                  case None => mapped
+                  case Some(extra) =>
+                    SourceConverter
+                      .addError(
+                        mapped,
+                        SourceConverter.UnexpectedField(
+                          nm,
+                          pat,
+                          extra,
+                          paramNamesList,
+                          region
+                        )
+                      )
+                }
+              case None =>
+                SourceConverter.failure(
+                  SourceConverter.UnknownConstructor(nm, pat, region)
+                )
+            })
+          }
+        case (
+              Pattern.StructKind
+                .NamedPartial(nm, Pattern.StructKind.Style.RecordLike(fs)),
+              rargs
+            ) =>
+          rargs.flatMap { args =>
+            val pc @ (p, c) = nameToCons(nm)
+            localTypeEnv.flatMap(_.getConstructorParams(p, c) match {
+              case Some(params) =>
+                val mapping =
+                  fs.toList.iterator.map(_.field).zip(args.iterator).toMap
+                def get(
+                    b: Bindable
+                ): Pattern[(PackageName, Constructor), rankn.Type] =
+                  mapping.get(b) match {
+                    case Some(pat) => pat
+                    case None      => Pattern.WildCard
+                  }
+                val derefArgs = params.map { case (b, _) => get(b) }
+                val res0 = SourceConverter.success(
+                  Pattern.PositionalStruct(pc, derefArgs)
+                )
+
+                val paramNamesList = params.map(_._1)
+                val paramNames = paramNamesList.toSet
+                // here are all the fields we don't understand
+                val extra =
+                  fs.toList.iterator.map(_.field).filterNot(paramNames).toList
+                // Check that the mapping is exactly the right size
+                NonEmptyList.fromList(extra) match {
+                  case None => res0
+                  case Some(extra) =>
+                    SourceConverter
+                      .addError(
+                        res0,
+                        SourceConverter.UnexpectedField(
+                          nm,
+                          pat,
+                          extra,
+                          paramNamesList,
+                          region
+                        )
+                      )
+                }
+              case None =>
+                SourceConverter.failure(
+                  SourceConverter.UnknownConstructor(nm, pat, region)
+                )
+            })
+          }
       },
       { t => toType(t, region) },
       { items => items.map(unlistPattern) }
-    )(SourceConverter.parallelIor) // use the parallel, not the default Applicative which is Monadic
+    )(
+      using SourceConverter.parallelIor
+    ) // use the parallel, not the default Applicative which is Monadic
 
   private lazy val toTypeEnv: Result[ParsedTypeEnv[Option[Kind.Arg]]] = {
     val sunit = success(())
 
-    val dupTypes = localDefs.groupByNel(_.name)
+    val dupTypes = localDefs
+      .groupByNel(_.name)
       .toList
       .traverse { case (n, tes) =>
         if (tes.tail.isEmpty) sunit
         else {
           val dupRegions = tes.map(_.region)
-          SourceConverter.partial(SourceConverter.Duplication(n, SourceConverter.DupKind.TypeName, dupRegions),
-            ())
+          SourceConverter.partial(
+            SourceConverter
+              .Duplication(n, SourceConverter.DupKind.TypeName, dupRegions),
+            ()
+          )
         }
       }
 
@@ -962,11 +1195,13 @@ final class SourceConverter(
           // these are colliding constructors, but if they also collide on type
           // name we have already reported it above
           sunit
-        }
-        else {
+        } else {
           val dupRegions = tes.map(_._2.region)
-          SourceConverter.partial(SourceConverter.Duplication(n, SourceConverter.DupKind.Constructor, dupRegions),
-            ())
+          SourceConverter.partial(
+            SourceConverter
+              .Duplication(n, SourceConverter.DupKind.Constructor, dupRegions),
+            ()
+          )
         }
       }
 
@@ -983,9 +1218,7 @@ final class SourceConverter(
     toTypeEnv.map { p => importedTypeEnv ++ TypeEnv.fromParsed(p) }
 
   private def anonNameStrings(): Iterator[String] =
-    rankn.Type
-      .allBinders
-      .iterator
+    rankn.Type.allBinders.iterator
       .map(_.name)
 
   private def unusedNames(allNames: Bindable => Boolean): Iterator[Bindable] =
@@ -993,13 +1226,14 @@ final class SourceConverter(
       .map(Identifier.Name(_))
       .filterNot(allNames)
 
-  /**
-   * Externals are not permitted to be shadowed at the top level
-   */
-  private def checkExternalDefShadowing(values: List[Statement.ValueStatement]): Result[Unit] = {
+  /** Externals are not permitted to be shadowed at the top level
+    */
+  private def checkExternalDefShadowing(
+      values: List[Statement.ValueStatement]
+  ): Result[Unit] = {
     val extDefNames =
-      values.collect {
-        case ed@Statement.ExternalDef(name, _, _) => (name, ed.region)
+      values.collect { case ed @ Statement.ExternalDef(name, _, _) =>
+        (name, ed.region)
       }
 
     val sunit = success(())
@@ -1014,15 +1248,22 @@ final class SourceConverter(
           case NonEmptyList(_, Nil) => sunit
           case NonEmptyList((_, r1), (_, r2) :: rest) =>
             SourceConverter.partial(
-              SourceConverter.Duplication(name, SourceConverter.DupKind.ExtDef, NonEmptyList(r1, r2 :: rest.map(_._2))),
-              ())
+              SourceConverter.Duplication(
+                name,
+                SourceConverter.DupKind.ExtDef,
+                NonEmptyList(r1, r2 :: rest.map(_._2))
+              ),
+              ()
+            )
         }
       }
 
-      def bindOrDef(s: Statement.ValueStatement): Option[Either[Statement.Bind, Statement.Def]] =
+      def bindOrDef(
+          s: Statement.ValueStatement
+      ): Option[Either[Statement.Bind, Statement.Def]] =
         s match {
-          case b@Statement.Bind(_) => Some(Left(b))
-          case d@Statement.Def(_) => Some(Right(d))
+          case b @ Statement.Bind(_)          => Some(Left(b))
+          case d @ Statement.Def(_)           => Some(Right(d))
           case Statement.ExternalDef(_, _, _) => None
         }
 
@@ -1034,16 +1275,15 @@ final class SourceConverter(
 
             val shadows = names.filter(extDefNamesSet)
             NonEmptyList.fromList(shadows) match {
-              case None => sunit
+              case None      => sunit
               case Some(nel) =>
                 // we are shadowing
                 SourceConverter.partial(
-                  SourceConverter.ExtDefShadow(
-                    SourceConverter.BindKind.Bind,
-                    nel,
-                    s.region),
-                  ())
-              }
+                  SourceConverter
+                    .ExtDefShadow(SourceConverter.BindKind.Bind, nel, s.region),
+                  ()
+                )
+            }
         }
 
       dupRes *> values.traverse_(checkDefBind)
@@ -1051,9 +1291,9 @@ final class SourceConverter(
   }
 
   // Flatten pattern bindings out
-  private def bindingsDecl(
-    b: Pattern.Parsed,
-    decl: Declaration)(alloc: () => Bindable): NonEmptyList[(Bindable, Declaration)] =
+  private def bindingsDecl(b: Pattern.Parsed, decl: Declaration)(
+      alloc: () => Bindable
+  ): NonEmptyList[(Bindable, Declaration)] =
     b match {
       case Pattern.Var(nm) =>
         NonEmptyList.one((nm, decl))
@@ -1076,8 +1316,7 @@ final class SourceConverter(
           if (decl.isCheap) {
             // no need to make a new var to point to a var
             (Nil, decl)
-          }
-          else {
+          } else {
             val ident = alloc()
             val v = Var(ident)(decl.region)
             ((ident, decl) :: Nil, v)
@@ -1090,7 +1329,8 @@ final class SourceConverter(
           Match(
             RecursionKind.NonRecursive,
             rhsNB,
-            OptIndent.same(NonEmptyList.one((pat, resOI))))(decl.region)
+            OptIndent.same(NonEmptyList.one((pat, resOI)))
+          )(decl.region)
         }
 
         val tail: List[(Bindable, Declaration)] =
@@ -1113,16 +1353,17 @@ final class SourceConverter(
         }
     }
 
-  private def parFold[F[_], S, A, B](s0: S, as: List[A])(fn: (S, A) => (S, F[B]))(implicit F: Applicative[F]): F[List[B]] = {
+  private def parFold[F[_], S, A, B](s0: S, as: List[A])(
+      fn: (S, A) => (S, F[B])
+  )(implicit F: Applicative[F]): F[List[B]] = {
     val avec = as.toVector
     def loop(start: Int, end: Int, s: S): (S, F[Chain[B]]) =
       if (start >= end) (s, F.pure(Chain.empty))
       else if (start == (end - 1)) {
         val (s1, fb) = fn(s, avec(start))
         (s1, fb.map(Chain.one(_)))
-      }
-      else {
-        val mid = start + (end - start)/2
+      } else {
+        val mid = start + (end - start) / 2
         val (s1, f1) = loop(start, mid, s)
         val (s2, f2) = loop(mid, end, s1)
         (s2, F.map2(f1, f2)(_ ++ _))
@@ -1131,17 +1372,16 @@ final class SourceConverter(
     loop(0, avec.size, s0)._2.map(_.toList)
   }
 
-  /**
-   * Return the lets in order they appear
-   */
-  private def toLets(stmts: Seq[Statement.ValueStatement]): Result[List[(Bindable, RecursionKind, Expr[Declaration])]] = {
-    import Statement._
+  /** Return the lets in order they appear
+    */
+  private def toLets(
+      stmts: Seq[Statement.ValueStatement]
+  ): Result[List[(Bindable, RecursionKind, Expr[Declaration])]] = {
+    import Statement.*
 
     val newName: () => Bindable = {
       lazy val allNames: Set[Bindable] =
-        stmts
-          .flatMap { v => v.names.iterator ++ v.allNames.iterator }
-          .toSet
+        stmts.flatMap { v => v.names.iterator ++ v.allNames.iterator }.toSet
 
       // Each time we need a name, we can call anonNames.next()
       // it is mutable, but in a limited scope
@@ -1154,15 +1394,14 @@ final class SourceConverter(
 
     val flatList: List[(Bindable, RecursionKind, Flattened)] =
       stmts.toList.flatMap {
-        case d@Def(_) =>
+        case d @ Def(_) =>
           (d.defstatement.name, RecursionKind.Recursive, Left(d)) :: Nil
         case ExternalDef(_, _, _) =>
           // we don't allow external defs to shadow at all, so skip it here
           Nil
         case Bind(BindingStatement(bound, decl, _)) =>
-          bindingsDecl(bound, decl)(newName)
-            .toList
-            .map { case pair@(b, _) =>
+          bindingsDecl(bound, decl)(newName).toList
+            .map { case pair @ (b, _) =>
               (b, RecursionKind.NonRecursive, Right(pair))
             }
       }
@@ -1173,45 +1412,52 @@ final class SourceConverter(
         // TODO make a better name, close to the original, but also not colliding
         // by using idx
         val newNameV: Bindable = newName()
-        val fn: Flattened => Flattened =
-          {
-            case Left(d@Def(dstmt)) =>
-              val d1 = if (dstmt.name === bind) dstmt.copy(name = newNameV) else dstmt
-              val res =
-                if (dstmt.args.flatten.iterator.flatMap(_.names).exists(_ == bind)) {
-                  // the args are shadowing the binding, so we don't need to substitute
-                  dstmt.result
-                }
-                else {
-                  dstmt.result.map { body =>
-                    Declaration.substitute(bind, Var(newNameV)(body.region), body) match {
-                      case Some(body1) => body1
-                      case None =>
-                        // $COVERAGE-OFF$
-                        throw new IllegalStateException("we know newName can't mask")
-                        // $COVERAGE-ON$
-                    }
+        val fn: Flattened => Flattened = {
+          case Left(d @ Def(dstmt)) =>
+            val d1 =
+              if (dstmt.name === bind) dstmt.copy(name = newNameV) else dstmt
+            val res =
+              if (
+                dstmt.args.flatten.iterator.flatMap(_.names).exists(_ == bind)
+              ) {
+                // the args are shadowing the binding, so we don't need to substitute
+                dstmt.result
+              } else {
+                dstmt.result.map { body =>
+                  Declaration.substitute(
+                    bind,
+                    Var(newNameV)(body.region),
+                    body
+                  ) match {
+                    case Some(body1) => body1
+                    case None        =>
+                      // $COVERAGE-OFF$
+                      throw new IllegalStateException(
+                        "we know newName can't mask"
+                      )
+                    // $COVERAGE-ON$
                   }
                 }
-              Left(Def(d1.copy(result = res))(d.region))
-            case Right((b0, d)) =>
-              // we don't need to update b0, we discard it anyway
-              Declaration.substitute(bind, Var(newNameV)(d.region), d) match {
-                case Some(d1) => Right((b0, d1))
-                // $COVERAGE-OFF$
-                case None =>
-                  throw new IllegalStateException("we know newName can't mask")
-                  // $COVERAGE-ON$
               }
-          }
+            Left(Def(d1.copy(result = res))(d.region))
+          case Right((b0, d)) =>
+            // we don't need to update b0, we discard it anyway
+            Declaration.substitute(bind, Var(newNameV)(d.region), d) match {
+              case Some(d1) => Right((b0, d1))
+              // $COVERAGE-OFF$
+              case None =>
+                throw new IllegalStateException("we know newName can't mask")
+              // $COVERAGE-ON$
+            }
+        }
 
         (newNameV, fn)
       }
 
     val withEx: List[Either[ExternalDef, Flattened]] =
-      stmts.collect { case e@ExternalDef(_, _, _) => Left(e) }.toList :::
+      stmts.collect { case e @ ExternalDef(_, _, _) => Left(e) }.toList :::
         flatIn.map {
-          case (b, _, Left(d@Def(dstmt))) =>
+          case (b, _, Left(d @ Def(dstmt))) =>
             Right(Left(Def(dstmt.copy(name = b))(d.region)))
           case (b, _, Right((_, d))) => Right(Right((b, d)))
         }
@@ -1219,15 +1465,20 @@ final class SourceConverter(
     parFold(Set.empty[Bindable], withEx) { case (topBound, stmt) =>
       stmt match {
         case Right(Right((nm, decl))) =>
-
-          val r = fromDecl(decl, Set.empty, topBound).map((nm, RecursionKind.NonRecursive, _) :: Nil)
+          val r = fromDecl(decl, Set.empty, topBound).map(
+            (nm, RecursionKind.NonRecursive, _) :: Nil
+          )
           // make sure all the free types are Generic
           // we have to do this at the top level because in Declaration => Expr
           // we allow closing over type variables defined at a higher level
-          val r1 = r.map { exs => exs.map { case (n, r, e) => (n, r, Expr.quantifyFrees(e)) } }
+          val r1 = r.map { exs =>
+            exs.map { case (n, r, e) => (n, r, Expr.quantifyFrees(e)) }
+          }
           (topBound + nm, r1)
 
-        case Right(Left(d @ Def(defstmt@DefStatement(_, _, argGroups, _, _)))) =>
+        case Right(
+              Left(d @ Def(defstmt @ DefStatement(_, _, argGroups, _, _)))
+            ) =>
           // using body for the outer here is a bummer, but not really a good outer otherwise
 
           val boundName = defstmt.name
@@ -1238,15 +1489,20 @@ final class SourceConverter(
             toLambdaExpr[OptIndent[Declaration]](
               defstmt,
               d.region,
-              success(defstmt.result.get))(
-                { (res: OptIndent[Declaration]) =>
-                  fromDecl(res.get, argGroups.flatten.iterator.flatMap(_.names).toSet + boundName, topBound1)
-                })
+              success(defstmt.result.get)
+            )({ (res: OptIndent[Declaration]) =>
+              fromDecl(
+                res.get,
+                argGroups.flatten.iterator.flatMap(_.names).toSet + boundName,
+                topBound1
+              )
+            })
 
           val r = lam.map { (l: Expr[Declaration]) =>
             // We rely on DefRecursionCheck to rule out bad recursions
             val rec =
-              if (UnusedLetCheck.freeBound(l).contains(boundName)) RecursionKind.Recursive
+              if (UnusedLetCheck.freeBound(l).contains(boundName))
+                RecursionKind.Recursive
               else RecursionKind.NonRecursive
             // make sure all the free types are Generic
             // we have to do this at the top level because in Declaration => Expr
@@ -1259,14 +1515,21 @@ final class SourceConverter(
           (topBound + n, success(Nil))
       }
     }(SourceConverter.parallelIor)
-    .map(_.flatten)
+      .map(_.flatten)
   }
 
-  def toProgram(ss: List[Statement]): Result[Program[(TypeEnv[Kind.Arg], ParsedTypeEnv[Option[Kind.Arg]]), Expr[Declaration], List[Statement]]] = {
+  def toProgram(
+      ss: List[Statement]
+  ): Result[Program[(TypeEnv[Kind.Arg], ParsedTypeEnv[Option[Kind.Arg]]), Expr[
+    Declaration
+  ], List[Statement]]] = {
     val stmts = Statement.valuesOf(ss).toList
-    stmts.collect {
-      case ed@Statement.ExternalDef(name, params, result) =>
-        (params.traverse { p => toType(p._2, ed.region) }, toType(result, ed.region))
+    stmts
+      .collect { case ed @ Statement.ExternalDef(name, params, result) =>
+        (
+          params.traverse { p => toType(p._2, ed.region) },
+          toType(result, ed.region)
+        )
           .flatMapN { (paramTypes, resType) =>
             NonEmptyList.fromList(paramTypes) match {
               case None => success(resType)
@@ -1276,7 +1539,10 @@ final class SourceConverter(
                   case None =>
                     val invalid = rankn.Type.Fun(nel, resType)
                     SourceConverter
-                      .partial(SourceConverter.InvalidArity(nel.length, ed.region), invalid)
+                      .partial(
+                        SourceConverter.InvalidArity(nel.length, ed.region),
+                        invalid
+                      )
                 }
             }
           }
@@ -1284,32 +1550,34 @@ final class SourceConverter(
             val freeVars = rankn.Type.freeTyVars(tpe :: Nil)
             // these vars were parsed so they are never skolem vars
             val freeBound = freeVars.map {
-              case b@rankn.Type.Var.Bound(_) => b
-              case s@rankn.Type.Var.Skolem(_, _, _, _) =>
+              case b @ rankn.Type.Var.Bound(_)           => b
+              case s @ rankn.Type.Var.Skolem(_, _, _, _) =>
                 // $COVERAGE-OFF$ this should be unreachable
                 sys.error(s"invariant violation: parsed a skolem var: $s")
-                // $COVERAGE-ON$
+              // $COVERAGE-ON$
             }
             // TODO: Kind support parsing kinds
-            val maybeForAll = rankn.Type.forAll(freeBound.map { n => (n, Kind.Type) }, tpe)
+            val maybeForAll =
+              rankn.Type.forAll(freeBound.map { n => (n, Kind.Type) }, tpe)
             (name, maybeForAll)
           }
-    }
-    // TODO: we could implement Iterable[Ior[A, B]] => Ior[A, Iterble[B]]
-    // where we drop all total failures in order to make more progress
-    .sequence
-    .flatMap { exts =>
-      val pte1 = toTypeEnv.map { p =>
-        exts.foldLeft(p) { case (pte, (name, tpe)) =>
-          pte.addExternalValue(thisPackage, name, tpe)
+      }
+      // TODO: we could implement Iterable[Ior[A, B]] => Ior[A, Iterble[B]]
+      // where we drop all total failures in order to make more progress
+      .sequence
+      .flatMap { exts =>
+        val pte1 = toTypeEnv.map { p =>
+          exts.foldLeft(p) { case (pte, (name, tpe)) =>
+            pte.addExternalValue(thisPackage, name, tpe)
+          }
+        }
+
+        implicit val parallel = SourceConverter.parallelIor
+        (checkExternalDefShadowing(stmts), toLets(stmts), pte1).mapN {
+          (_, binds, pte1) =>
+            Program((importedTypeEnv, pte1), binds, exts.map(_._1).toList, ss)
         }
       }
-
-      implicit val parallel = SourceConverter.parallelIor
-      (checkExternalDefShadowing(stmts), toLets(stmts), pte1).mapN { (_, binds, pte1) =>
-        Program((importedTypeEnv, pte1), binds, exts.map(_._1).toList, ss)
-      }
-    }
   }
 }
 
@@ -1319,7 +1587,8 @@ object SourceConverter {
 
   def success[A](a: A): Result[A] = Ior.Right(a)
   val successUnit: Result[Unit] = success(())
-  def partial[A](err: Error, a: A): Result[A] = Ior.Both(NonEmptyChain.one(err), a)
+  def partial[A](err: Error, a: A): Result[A] =
+    Ior.Both(NonEmptyChain.one(err), a)
   def failure[A](err: Error): Result[A] = Ior.Left(NonEmptyChain.one(err))
 
   def addError[A](r: Result[A], err: Error): Result[A] =
@@ -1329,114 +1598,124 @@ object SourceConverter {
   private val parallelIor: Applicative[Result] =
     Ior.catsDataParallelForIor[NonEmptyChain[Error]].applicative
 
-  def toProgram( 
-    thisPackage: PackageName,
-    imports: List[Import[PackageName, NonEmptyList[Referant[Kind.Arg]]]],
-    stmts: List[Statement]): Result[Program[(TypeEnv[Kind.Arg], ParsedTypeEnv[Option[Kind.Arg]]), Expr[Declaration], List[Statement]]] =
-      (new SourceConverter(thisPackage, imports, Statement.definitionsOf(stmts).toList)).toProgram(stmts)
+  def toProgram(
+      thisPackage: PackageName,
+      imports: List[Import[PackageName, NonEmptyList[Referant[Kind.Arg]]]],
+      stmts: List[Statement]
+  ): Result[Program[(TypeEnv[Kind.Arg], ParsedTypeEnv[Option[Kind.Arg]]), Expr[
+    Declaration
+  ], List[Statement]]] =
+    (new SourceConverter(
+      thisPackage,
+      imports,
+      Statement.definitionsOf(stmts).toList
+    )).toProgram(stmts)
 
   private def concat[A](ls: List[A], tail: NonEmptyList[A]): NonEmptyList[A] =
     ls match {
-      case Nil => tail
+      case Nil    => tail
       case h :: t => NonEmptyList(h, t ::: tail.toList)
     }
 
-  /**
-   * For all duplicate binds, for all but the final
-   * value, rename them
-   */
-  def makeLetsUnique[D](
-    lets: List[(Bindable, RecursionKind, D)])(
-    newName: (Bindable, Int) => (Bindable, D => D)): List[(Bindable, RecursionKind, D)] =
-      NonEmptyList.fromList(lets) match {
-        case None => Nil
-        case Some(nelets) =>
-          // there is at least 1 let, but maybe no duplicates
-          val dups: Map[Bindable, Int] =
-            nelets.foldLeft(Map.empty[Bindable, Int]) {
-              case (bound, (b, _, _)) =>
-                bound.get(b) match {
-                  case Some(c) => bound.updated(b, c + 1)
-                  case None => bound.updated(b, 1)
-                }
+  /** For all duplicate binds, for all but the final value, rename them
+    */
+  def makeLetsUnique[D](lets: List[(Bindable, RecursionKind, D)])(
+      newName: (Bindable, Int) => (Bindable, D => D)
+  ): List[(Bindable, RecursionKind, D)] =
+    NonEmptyList.fromList(lets) match {
+      case None         => Nil
+      case Some(nelets) =>
+        // there is at least 1 let, but maybe no duplicates
+        val dups: Map[Bindable, Int] =
+          nelets
+            .foldLeft(Map.empty[Bindable, Int]) { case (bound, (b, _, _)) =>
+              bound.get(b) match {
+                case Some(c) => bound.updated(b, c + 1)
+                case None    => bound.updated(b, 1)
+              }
             }
             .filter { case (_, v) => v > 1 }
 
-          if (dups.isEmpty) {
-            // no duplicated top level names
-            lets
-          }
-          else {
-            // we rename all but the last name for each duplicate
-            type BRD = (Bindable, RecursionKind, D)
+        if (dups.isEmpty) {
+          // no duplicated top level names
+          lets
+        } else {
+          // we rename all but the last name for each duplicate
+          type BRD = (Bindable, RecursionKind, D)
 
-            /*
-             * Invariant, lets.exists(_._1 == name) == true
-             * if this is false, this method will throw
-             */
-            @annotation.tailrec
-            def renameUntilNext(name: Bindable, lets: NonEmptyList[BRD], acc: List[BRD])(fn: D => D): NonEmptyList[BRD] = {
-              // note this is a total match:
-              val NonEmptyList(head @ (b, r, d), tail) = lets
+          /*
+           * Invariant, lets.exists(_._1 == name) == true
+           * if this is false, this method will throw
+           */
+          @annotation.tailrec
+          def renameUntilNext(
+              name: Bindable,
+              lets: NonEmptyList[BRD],
+              acc: List[BRD]
+          )(fn: D => D): NonEmptyList[BRD] = {
+            // note this is a total match:
+            val NonEmptyList(head @ (b, r, d), tail) = lets
 
-              if (b == name) {
-                val head1 =
-                  if (r.isRecursive) {
-                    // the new b is in scope right away
-                    head
-                  }
-                  else {
-                    // the old b1 is in scope for this one
-                    (b, r, fn(d))
-                  }
-                NonEmptyList(head1, acc).reverse.concat(tail)
-              }
-              else {
-                // if b != name, then that implies there is
-                // at least one item in the tail with b,
-                // so tail cannot be empty
-                val netail = NonEmptyList.fromListUnsafe(tail)
-                renameUntilNext(name, netail, (b, r, fn(d)) :: acc)(fn)
-              }
+            if (b == name) {
+              val head1 =
+                if (r.isRecursive) {
+                  // the new b is in scope right away
+                  head
+                } else {
+                  // the old b1 is in scope for this one
+                  (b, r, fn(d))
+                }
+              NonEmptyList(head1, acc).reverse.concat(tail)
+            } else {
+              // if b != name, then that implies there is
+              // at least one item in the tail with b,
+              // so tail cannot be empty
+              val netail = NonEmptyList.fromListUnsafe(tail)
+              renameUntilNext(name, netail, (b, r, fn(d)) :: acc)(fn)
             }
-
-            @annotation.tailrec
-            def loop(lets: NonEmptyList[BRD], state: Map[Bindable, (Int, Int)], acc: List[BRD]): NonEmptyList[BRD] = {
-              val head = lets.head
-              NonEmptyList.fromList(lets.tail) match {
-                case Some(netail) =>
-                  val (b, r, d) = head
-                  state.get(b) match {
-                    case Some((cnt, sz)) if cnt < (sz - 1) =>
-                      val newState = state.updated(b, (cnt + 1, sz))
-                      // we have to rename until the next bind
-                      val (b1, renamer) = newName(b, cnt)
-                      val d1 =
-                        if (r.isRecursive) renamer(d)
-                        else d
-
-                      val head1 = (b1, r, d1)
-                      // since cnt < (sz - 1) we know that
-                      // b must occur at least once in netail
-                      val tail1 = renameUntilNext(b, netail, Nil)(renamer)
-                      loop(tail1, newState, head1 :: acc)
-                    case _ =>
-                      // this is the last one or not a duplicate, we don't change it
-                      loop(netail, state, head :: acc)
-                  }
-                case None =>
-                  // the last one is never renamed
-                  NonEmptyList(head, acc).reverse
-              }
-            }
-
-            // there are duplicates
-            val dupState: Map[Bindable, (Int, Int)] =
-              dups.iterator.map { case (k, sz) => (k, (0, sz)) }.toMap
-
-            loop(nelets, dupState, Nil).toList
           }
+
+          @annotation.tailrec
+          def loop(
+              lets: NonEmptyList[BRD],
+              state: Map[Bindable, (Int, Int)],
+              acc: List[BRD]
+          ): NonEmptyList[BRD] = {
+            val head = lets.head
+            NonEmptyList.fromList(lets.tail) match {
+              case Some(netail) =>
+                val (b, r, d) = head
+                state.get(b) match {
+                  case Some((cnt, sz)) if cnt < (sz - 1) =>
+                    val newState = state.updated(b, (cnt + 1, sz))
+                    // we have to rename until the next bind
+                    val (b1, renamer) = newName(b, cnt)
+                    val d1 =
+                      if (r.isRecursive) renamer(d)
+                      else d
+
+                    val head1 = (b1, r, d1)
+                    // since cnt < (sz - 1) we know that
+                    // b must occur at least once in netail
+                    val tail1 = renameUntilNext(b, netail, Nil)(renamer)
+                    loop(tail1, newState, head1 :: acc)
+                  case _ =>
+                    // this is the last one or not a duplicate, we don't change it
+                    loop(netail, state, head :: acc)
+                }
+              case None =>
+                // the last one is never renamed
+                NonEmptyList(head, acc).reverse
+            }
+          }
+
+          // there are duplicates
+          val dupState: Map[Bindable, (Int, Int)] =
+            dups.iterator.map { case (k, sz) => (k, (0, sz)) }.toMap
+
+          loop(nelets, dupState, Nil).toList
         }
+    }
 
   sealed abstract class Error {
     def region: Region
@@ -1450,11 +1729,15 @@ object SourceConverter {
 
   sealed abstract class BindKind(val asString: String)
   object BindKind {
-    final case object Def extends BindKind("def")
-    final case object Bind extends BindKind("bind")
+    case object Def extends BindKind("def")
+    case object Bind extends BindKind("bind")
   }
 
-  final case class ExtDefShadow(kind: BindKind, names: NonEmptyList[Bindable], region: Region) extends Error {
+  case class ExtDefShadow(
+      kind: BindKind,
+      names: NonEmptyList[Bindable],
+      region: Region
+  ) extends Error {
     def message = {
       val ns = names.toList.iterator.map(_.sourceCodeRepr).mkString(", ")
       s"${kind.asString} names $ns shadow external def"
@@ -1468,13 +1751,21 @@ object SourceConverter {
     case object Constructor extends DupKind("constructor")
   }
 
-  final case class Duplication(name: Identifier, kind: DupKind, duplicates: NonEmptyList[Region]) extends Error {
+  case class Duplication(
+      name: Identifier,
+      kind: DupKind,
+      duplicates: NonEmptyList[Region]
+  ) extends Error {
     def region = duplicates.head
     def message =
       s"${kind.asString}: ${name.sourceCodeRepr} defined multiple times"
   }
 
-  final case class PatternShadow(names: NonEmptyList[Bindable], pattern: Pattern.Parsed, region: Region) extends Error {
+  case class PatternShadow(
+      names: NonEmptyList[Bindable],
+      pattern: Pattern.Parsed,
+      region: Region
+  ) extends Error {
     def message = {
       val str = names.toList.map(_.sourceCodeRepr).mkString(", ")
       "repeated bindings in pattern: " + str
@@ -1485,10 +1776,11 @@ object SourceConverter {
     def toDoc: Doc
   }
   object ConstructorSyntax {
-    final case class Pat(toPattern: Pattern.Parsed) extends ConstructorSyntax {
+    case class Pat(toPattern: Pattern.Parsed) extends ConstructorSyntax {
       def toDoc = Document[Pattern.Parsed].document(toPattern)
     }
-    final case class RecCons(toDeclaration: Declaration.RecordConstructor) extends ConstructorSyntax {
+    case class RecCons(toDeclaration: Declaration.RecordConstructor)
+        extends ConstructorSyntax {
       def toDoc = toDeclaration.toDoc
     }
 
@@ -1499,10 +1791,19 @@ object SourceConverter {
       RecCons(c)
   }
 
-  final case class UnknownConstructor(name: Constructor, syntax: ConstructorSyntax, region: Region) extends ConstructorError {
+  case class UnknownConstructor(
+      name: Constructor,
+      syntax: ConstructorSyntax,
+      region: Region
+  ) extends ConstructorError {
     def message = {
       val maybeDoc = syntax match {
-        case ConstructorSyntax.Pat(Pattern.PositionalStruct(Pattern.StructKind.Named(n, Pattern.StructKind.Style.TupleLike), Nil)) if n == name =>
+        case ConstructorSyntax.Pat(
+              Pattern.PositionalStruct(
+                Pattern.StructKind.Named(n, Pattern.StructKind.Style.TupleLike),
+                Nil
+              )
+            ) if n == name =>
           // the pattern is just name
           Doc.empty
         case _ =>
@@ -1511,28 +1812,59 @@ object SourceConverter {
       (Doc.text(s"unknown constructor ${name.asString}") + maybeDoc).render(80)
     }
   }
-  final case class InvalidArgCount(name: Constructor, syntax: ConstructorSyntax, argCount: Int, expected: Int, region: Region) extends ConstructorError {
+  case class InvalidArgCount(
+      name: Constructor,
+      syntax: ConstructorSyntax,
+      argCount: Int,
+      expected: Int,
+      region: Region
+  ) extends ConstructorError {
     def message =
-      (Doc.text(s"invalid argument count in ${name.asString}, found $argCount expected $expected") + Doc.lineOrSpace + syntax.toDoc).render(80)
+      (Doc.text(
+        s"invalid argument count in ${name.asString}, found $argCount expected $expected"
+      ) + Doc.lineOrSpace + syntax.toDoc).render(80)
   }
-  final case class MissingArg(name: Constructor, syntax: ConstructorSyntax, present: SortedSet[Bindable], missing: Bindable, region: Region) extends ConstructorError {
+  case class MissingArg(
+      name: Constructor,
+      syntax: ConstructorSyntax,
+      present: SortedSet[Bindable],
+      missing: Bindable,
+      region: Region
+  ) extends ConstructorError {
     def message =
-      (Doc.text(s"missing field ${missing.asString} in ${name.asString}") + Doc.lineOrSpace + syntax.toDoc).render(80)
+      (Doc.text(
+        s"missing field ${missing.asString} in ${name.asString}"
+      ) + Doc.lineOrSpace + syntax.toDoc).render(80)
   }
-  final case class UnexpectedField(name: Constructor, syntax: ConstructorSyntax, unexpected: NonEmptyList[Bindable], expected: List[Bindable], region: Region) extends ConstructorError {
+  case class UnexpectedField(
+      name: Constructor,
+      syntax: ConstructorSyntax,
+      unexpected: NonEmptyList[Bindable],
+      expected: List[Bindable],
+      region: Region
+  ) extends ConstructorError {
     def message = {
       val plural = if (unexpected.tail.isEmpty) "field" else "fields"
-      val unexDoc = Doc.intercalate(Doc.comma + Doc.lineOrSpace, unexpected.toList.map { b => Doc.text(b.asString) })
-      val exDoc = Doc.intercalate(Doc.comma + Doc.lineOrSpace, expected.map { b => Doc.text(b.asString) })
+      val unexDoc = Doc.intercalate(
+        Doc.comma + Doc.lineOrSpace,
+        unexpected.toList.map { b => Doc.text(b.asString) }
+      )
+      val exDoc = Doc.intercalate(
+        Doc.comma + Doc.lineOrSpace,
+        expected.map { b => Doc.text(b.asString) }
+      )
       (Doc.text(s"unexpected $plural: ") + unexDoc + Doc.lineOrSpace +
-        Doc.text(s"in ${name.asString}, expected: ") + exDoc + Doc.lineOrSpace + syntax.toDoc).render(80)
-      }
+        Doc.text(
+          s"in ${name.asString}, expected: "
+        ) + exDoc + Doc.lineOrSpace + syntax.toDoc).render(80)
+    }
   }
 
-  final case class InvalidTypeParameters(
-    declaredParams: NonEmptyList[(TypeRef.TypeVar, Option[Kind.Arg])],
-    discoveredTypes: List[Type.Var.Bound],
-    statement: TypeDefinitionStatement) extends Error {
+  case class InvalidTypeParameters(
+      declaredParams: NonEmptyList[(TypeRef.TypeVar, Option[Kind.Arg])],
+      discoveredTypes: List[Type.Var.Bound],
+      statement: TypeDefinitionStatement
+  ) extends Error {
 
     def region = statement.region
     def message = {
@@ -1540,50 +1872,69 @@ object SourceConverter {
         l.iterator.map(_.name).mkString("[", ", ", "]")
 
       val decl =
-        TypeRef.docTypeArgs(declaredParams.toList) {
-          case None => Doc.empty
-          case Some(ka) => Doc.text(": ") + Kind.argDoc(ka)
-        }.renderTrim(80)
+        TypeRef
+          .docTypeArgs(declaredParams.toList) {
+            case None     => Doc.empty
+            case Some(ka) => Doc.text(": ") + Kind.argDoc(ka)
+          }
+          .renderTrim(80)
       val disc = tstr(discoveredTypes)
       s"${statement.name.asString} found declared: $decl, not a superset of $disc"
     }
   }
 
-  final case class InvalidDefTypeParameters[B](
-    declaredParams: NonEmptyList[(TypeRef.TypeVar, Option[Kind])],
-    free: List[Type.Var.Bound],
-    defstmt: DefStatement[Pattern.Parsed, B],
-    region: Region) extends Error {
+  case class InvalidDefTypeParameters[B](
+      declaredParams: NonEmptyList[(TypeRef.TypeVar, Option[Kind])],
+      free: List[Type.Var.Bound],
+      defstmt: DefStatement[Pattern.Parsed, B],
+      region: Region
+  ) extends Error {
 
     def message = {
       def tstr(l: List[Type.Var.Bound]): String =
         l.iterator.map(_.name).mkString("[", ", ", "]")
 
-      val decl = TypeRef.docTypeArgs(declaredParams.toList) {
-        case None => Doc.empty
-        case Some(k) => Doc.text(": ") + Kind.toDoc(k)
-      }.renderTrim(80)
+      val decl = TypeRef
+        .docTypeArgs(declaredParams.toList) {
+          case None    => Doc.empty
+          case Some(k) => Doc.text(": ") + Kind.toDoc(k)
+        }
+        .renderTrim(80)
 
       val freeStr = tstr(free)
       s"${defstmt.name.asString} found declared types: $decl, not a subset of $freeStr"
     }
   }
 
-  final case class UnknownTypeName(tpe: Constructor, region: Region) extends Error {
+  case class UnknownTypeName(tpe: Constructor, region: Region)
+      extends Error {
     def message = s"unknown type: ${tpe.asString}"
   }
 
-  final case class InvalidArity(size: Int, region: Region) extends Error {
-    def message = s"invalid function arguments = $size, maximum = ${rankn.Type.FnType.MaxSize}"
+  case class InvalidArity(size: Int, region: Region) extends Error {
+    def message =
+      s"invalid function arguments = $size, maximum = ${rankn.Type.FnType.MaxSize}"
   }
 
-  final case class TooManyConstructorArgs(name: Constructor, argCount: Int, max: Int, region: Region) extends Error {
+  case class TooManyConstructorArgs(
+      name: Constructor,
+      argCount: Int,
+      max: Int,
+      region: Region
+  ) extends Error {
     def message =
       if (name.asString == "Tuple32") {
-        Doc.text(s"invalid tuple size. Found $argCount, but maximum allowed ${Type.FnType.MaxSize}").render(80)
-      }
-      else {
-        Doc.text(s"invalid argument count in constructor for ${name.asString} found $argCount maximum allowed $max").render(80)
+        Doc
+          .text(
+            s"invalid tuple size. Found $argCount, but maximum allowed ${Type.FnType.MaxSize}"
+          )
+          .render(80)
+      } else {
+        Doc
+          .text(
+            s"invalid argument count in constructor for ${name.asString} found $argCount maximum allowed $max"
+          )
+          .render(80)
       }
   }
 }

--- a/core/src/main/scala/org/bykn/bosatsu/Statement.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/Statement.scala
@@ -2,8 +2,8 @@ package org.bykn.bosatsu
 
 import Parser.{ Combinators, Indy, maybeSpace, keySpace, toEOL }
 import cats.data.NonEmptyList
-import cats.implicits._
-import cats.parse.{Parser0 => P0, Parser => P}
+import cats.implicits.*
+import cats.parse.{Parser0 as P0, Parser as P}
 import org.typelevel.paiges.{ Doc, Document }
 import scala.collection.immutable.SortedSet
 
@@ -19,7 +19,7 @@ sealed abstract class Statement {
   def region: Region
 
   def replaceRegions(r: Region): Statement = {
-    import Statement._
+    import Statement.*
 
     this match {
       case Bind(BindingStatement(p, v, in)) =>
@@ -261,7 +261,7 @@ object Statement {
 
   private def constructor(name: Constructor, taDoc: Doc, args: List[(Bindable, Option[TypeRef])]): Doc =
     Document[Identifier].document(name) + taDoc +
-      (if (args.nonEmpty) { Doc.char('(') + Doc.intercalate(Doc.text(", "), args.toList.map(TypeRef.argDoc[Bindable] _)) + Doc.char(')') }
+      (if (args.nonEmpty) { Doc.char('(') + Doc.intercalate(Doc.text(", "), args.toList.map(TypeRef.argDoc[Bindable])) + Doc.char(')') }
       else Doc.empty)
 
   private val colonSpace = Doc.text(": ")
@@ -281,7 +281,7 @@ object Statement {
       Document.instance[OptIndent[Declaration]] {
         body =>
           body.sepDoc +
-          OptIndent.document(Declaration.document).document(body)
+          OptIndent.document(using Declaration.document).document(body)
       }
     val dd = DefStatement.document[Pattern.Parsed, OptIndent[Declaration]]
 
@@ -315,10 +315,11 @@ object Statement {
 
         implicit def neDoc[T: Document]: Document[NonEmptyList[T]] =
           Document.instance { ne =>
-            Doc.intercalate(itemSep, ne.toList.map(Document[T].document _))
+            val docT = Document[T]
+            Doc.intercalate(itemSep, ne.toList.map(docT.document))
           }
 
-        val indentedCons = OptIndent.document(neDoc(consDoc)).document(parts)
+        val indentedCons = OptIndent.document(using neDoc(using consDoc)).document(parts)
 
         val taDoc = typeArgs match {
           case None => Doc.empty

--- a/core/src/main/scala/org/bykn/bosatsu/StringUtil.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/StringUtil.scala
@@ -1,6 +1,6 @@
 package org.bykn.bosatsu
 
-import cats.parse.{Parser0 => P0, Parser => P, Accumulator, Appender}
+import cats.parse.{Parser0 as P0, Parser as P, Accumulator, Appender}
 
 abstract class GenericStringUtil {
   protected def decodeTable: Map[Char, Char]

--- a/core/src/main/scala/org/bykn/bosatsu/Test.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/Test.scala
@@ -83,7 +83,7 @@ object Test {
   }
 
   def fromValue(value: Value): Test = {
-    import Value._
+    import Value.*
     def toAssert(a: ProductValue): Test =
       a match {
         case ConsValue(True, ConsValue(Str(message), UnitValue)) =>

--- a/core/src/main/scala/org/bykn/bosatsu/TotalityCheck.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/TotalityCheck.scala
@@ -2,13 +2,13 @@ package org.bykn.bosatsu
 
 import cats.Eq
 import cats.data.{NonEmptyList, Validated, ValidatedNel}
-import cats.implicits._
+import cats.implicits.*
 import org.bykn.bosatsu.pattern.{SeqPattern, SeqPart, SetOps}
 
 import org.bykn.bosatsu.graph.Memoize.memoizeDagHashed
 
 import rankn.{Type, TypeEnv}
-import Pattern._
+import Pattern.*
 
 import Identifier.{Bindable, Constructor}
 
@@ -43,7 +43,7 @@ object TotalityCheck {
  * don't describe the same type.
  */
 case class TotalityCheck(inEnv: TypeEnv[Any]) {
-  import TotalityCheck._
+  import TotalityCheck.*
 
   /**
    * Constructors must match all items to be legal
@@ -113,7 +113,7 @@ case class TotalityCheck(inEnv: TypeEnv[Any]) {
    * a NonEmptyList of matches that are not total
    */
   def checkExpr[A](expr: Expr[A]): ValidatedNel[ExprError[A], Unit] = {
-    import Expr._
+    import Expr.*
     expr match {
       case Annotation(e, _, _) => checkExpr(e)
       case Generic(_, e) => checkExpr(e)

--- a/core/src/main/scala/org/bykn/bosatsu/TypeName.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/TypeName.scala
@@ -1,7 +1,7 @@
 package org.bykn.bosatsu
 
 import cats.Order
-import cats.implicits._
+import cats.implicits.*
 
 case class TypeName(ident: Identifier.Constructor)
 

--- a/core/src/main/scala/org/bykn/bosatsu/TypeParser.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/TypeParser.scala
@@ -1,9 +1,9 @@
 package org.bykn.bosatsu
 
 import cats.data.NonEmptyList
-import cats.parse.{Parser => P}
+import cats.parse.{Parser as P}
 import org.typelevel.paiges.{ Doc, Document }
-import cats.syntax.all._
+import cats.syntax.all.*
 
 import Parser.{ Combinators, MaybeTupleOrParens, lowerIdent, maybeSpace, maybeSpacesAndLines, keySpace }
 
@@ -88,7 +88,7 @@ abstract class TypeParser[A] {
   }
 
   final def toDoc(a: A): Doc = {
-    import TypeParser._
+    import TypeParser.*
 
     def p(d: Doc): Doc = Doc.char('(') + (d + Doc.char(')'))
     /*

--- a/core/src/main/scala/org/bykn/bosatsu/TypeRef.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/TypeRef.scala
@@ -2,10 +2,10 @@ package org.bykn.bosatsu
 
 import cats.Order
 import cats.data.NonEmptyList
-import cats.implicits._
-import cats.parse.{Parser => P, Parser0}
+import cats.implicits.*
+import cats.parse.{Parser as P, Parser0}
 import org.bykn.bosatsu.rankn.Type
-import org.bykn.bosatsu.{TypeName => Name}
+import org.bykn.bosatsu.{TypeName as Name}
 import org.typelevel.paiges.{ Doc, Document }
 
 import Parser.{lowerIdent, maybeSpace, Combinators}
@@ -17,7 +17,7 @@ import Parser.{lowerIdent, maybeSpace, Combinators}
  * whereas we use a recursion/cons style in Type
  */
 sealed abstract class TypeRef {
-  import TypeRef._
+  import TypeRef.*
 
   def toDoc: Doc =
     TypeRef.document.document(this)

--- a/core/src/main/scala/org/bykn/bosatsu/TypeRefConverter.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/TypeRefConverter.scala
@@ -5,7 +5,7 @@ import cats.data.NonEmptyList
 import org.bykn.bosatsu.rankn.Type
 import org.bykn.bosatsu.Identifier.Constructor
 
-import cats.implicits._
+import cats.implicits.*
 
 object TypeRefConverter {
   /**
@@ -15,8 +15,8 @@ object TypeRefConverter {
   def apply[F[_]: Applicative](t: TypeRef)(nameToType: Constructor => F[Type.Const]): F[Type] = {
     def toType(t: TypeRef): F[Type] = apply(t)(nameToType)
 
-    import Type._
-    import TypeRef._
+    import Type.*
+    import TypeRef.*
 
     t match {
       case TypeVar(v) => Applicative[F].pure(TyVar(Type.Var.Bound(v)))
@@ -55,8 +55,8 @@ object TypeRefConverter {
     onSkolem: Type.Var.Skolem => F[TypeRef],
     onMeta: Long => F[TypeRef],
     onConst: Type.Const.Defined => F[TypeRef]): F[TypeRef] = {
-    import Type._
-    import TypeRef._
+    import Type.*
+    import TypeRef.*
 
     def loop(tpe: Type) = fromTypeA(tpe, onSkolem, onMeta, onConst)
 

--- a/core/src/main/scala/org/bykn/bosatsu/TypedExpr.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/TypedExpr.scala
@@ -3,7 +3,7 @@ package org.bykn.bosatsu
 import cats.{Applicative, Eval, Monad, Traverse}
 import cats.arrow.FunctionK
 import cats.data.{NonEmptyList, Writer}
-import cats.implicits._
+import cats.implicits.*
 import org.bykn.bosatsu.rankn.Type
 import org.typelevel.paiges.{Doc, Document }
 import scala.collection.immutable.SortedSet
@@ -13,7 +13,7 @@ import Identifier.{Bindable, Constructor}
 import org.bykn.bosatsu.rankn.Type.Var.Skolem
 
 sealed abstract class TypedExpr[+T] { self: Product =>
-  import TypedExpr._
+  import TypedExpr.*
 
   // It is really important to cache the hashcode and these large dags if
   // we use them as hash keys
@@ -753,16 +753,16 @@ object TypedExpr {
             }
             .toList
             Type.forAll(nonpulled, Type.applyAll(cons, pulledArgs))
-          }
-        case notForAll =>
+        }
+      case notForAll =>
           // TODO: we can push down existentials too
-          notForAll
-      }
+        notForAll
+    }
 
   // We know initTpe <:< instTpe, we may be able to simply
   // fix some of the universally quantified variables
   def instantiateTo[A](gen: Generic[A], instTpe: Type.Rho, kinds: Type => Option[Kind]): TypedExpr[A] = {
-    import Type._
+    import Type.*
 
     def solve(left: Type,
       right: Type,
@@ -1011,7 +1011,7 @@ object TypedExpr {
     freeVarsDup(ts).distinct
 
   def freeVarsSet[A](ts: List[TypedExpr[A]]): SortedSet[Bindable] =
-    SortedSet(freeVarsDup(ts): _*)
+    SortedSet(freeVarsDup(ts) *)
 
   private def freeVarsDup[A](ts: List[TypedExpr[A]]): List[Bindable] =
     ts.flatMap(_.freeVarsDup)
@@ -1246,7 +1246,7 @@ object TypedExpr {
         // we not uncommonly add an annotation just to make a generic wrapper to get back where
         term
       case _ =>
-        import Type.Quantification._
+        import Type.Quantification.*
         // We cannot rebind to any used typed inside of expr, but we can reuse
         // any that are q
         val frees: Set[Type.Var.Bound] =

--- a/core/src/main/scala/org/bykn/bosatsu/TypedExprNormalization.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/TypedExprNormalization.scala
@@ -6,10 +6,10 @@ import org.bykn.bosatsu.rankn.{Type, TypeEnv}
 
 import Identifier.{Bindable, Constructor}
 
-import cats.syntax.all._
+import cats.syntax.all.*
 
 object TypedExprNormalization {
-  import TypedExpr._
+  import TypedExpr.*
 
   type ScopeT[A, S] = Map[(Option[PackageName], Bindable), (RecursionKind, TypedExpr[A], S)]
   type Scope[A] = FixType.Fix[ScopeT[A, *]]
@@ -568,7 +568,7 @@ object TypedExprNormalization {
     type Pat = Pattern[(PackageName, Constructor), Type]
     type Branch[A] = (Pat, TypedExpr[A])
 
-    def maybeEvalMatch[A](m: Match[_ <: A], scope: Scope[A]): Option[TypedExpr[A]] =
+    def maybeEvalMatch[A](m: Match[? <: A], scope: Scope[A]): Option[TypedExpr[A]] =
       evaluate(m.arg, scope).flatMap {
         case EvalResult.Cons(p, c, args) =>
 

--- a/core/src/main/scala/org/bykn/bosatsu/UnusedLetCheck.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/UnusedLetCheck.scala
@@ -2,9 +2,9 @@ package org.bykn.bosatsu
 
 import cats.Applicative
 import cats.data.{Chain, NonEmptyList, Validated, ValidatedNec, Writer, NonEmptyChain}
-import cats.implicits._
+import cats.implicits.*
 
-import Expr._
+import Expr.*
 import Identifier.Bindable
 
 object UnusedLetCheck {
@@ -92,5 +92,5 @@ object UnusedLetCheck {
    * Return the free Bindable names in this expression
    */
   def freeBound[A](e: Expr[A]): Set[Bindable] =
-    loop(e)(HasRegion.instance(_ => Region(0, 0))).run._2
+    loop(e)(using HasRegion.instance(_ => Region(0, 0))).run._2
 }

--- a/core/src/main/scala/org/bykn/bosatsu/Value.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/Value.scala
@@ -12,7 +12,7 @@ import scala.collection.immutable.SortedMap
  * most of the API
  */
 sealed abstract class Value {
-  import Value._
+  import Value.*
 
   def asFn: NonEmptyList[Value] => Value =
     this match {

--- a/core/src/main/scala/org/bykn/bosatsu/ValueToDoc.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/ValueToDoc.scala
@@ -1,13 +1,13 @@
 package org.bykn.bosatsu
 
 import cats.Eval
-import cats.implicits._
+import cats.implicits.*
 import java.math.BigInteger
 import org.bykn.bosatsu.rankn.{DefinedType, Type, DataFamily}
 import org.typelevel.paiges.{Doc, Document}
-import scala.collection.mutable.{Map => MMap}
+import scala.collection.mutable.{Map as MMap}
 
-import Value._
+import Value.*
 import Identifier.Constructor
 
 import JsonEncodingError.IllTyped

--- a/core/src/main/scala/org/bykn/bosatsu/ValueToJson.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/ValueToJson.scala
@@ -2,14 +2,14 @@ package org.bykn.bosatsu
 
 import cats.Eval
 import cats.data.NonEmptyList
-import cats.implicits._
+import cats.implicits.*
 import java.math.BigInteger
 import org.bykn.bosatsu.rankn.{DefinedType, Type, DataFamily}
-import scala.collection.mutable.{Map => MMap}
+import scala.collection.mutable.{Map as MMap}
 
-import Value._
+import Value.*
 
-import JsonEncodingError._
+import JsonEncodingError.*
 
 case class ValueToJson(getDefinedType: Type.Const => Option[DefinedType[Any]]) {
 

--- a/core/src/main/scala/org/bykn/bosatsu/Variance.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/Variance.scala
@@ -3,7 +3,7 @@ package org.bykn.bosatsu
 import cats.kernel.{BoundedSemilattice, Order}
 
 sealed abstract class Variance {
-  import Variance._
+  import Variance.*
 
   def unary_- : Variance =
     this match {

--- a/core/src/main/scala/org/bykn/bosatsu/codegen/python/PythonGen.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/codegen/python/PythonGen.scala
@@ -2,15 +2,15 @@ package org.bykn.bosatsu.codegen.python
 
 import cats.Monad
 import cats.data.{NonEmptyList, State}
-import cats.parse.{Parser => P}
+import cats.parse.{Parser as P}
 import org.bykn.bosatsu.{PackageName, Identifier, Matchless, Par, Parser, RecursionKind}
 import org.bykn.bosatsu.rankn.Type
 import org.typelevel.paiges.Doc
 
 import Identifier.Bindable
-import Matchless._
+import Matchless.*
 
-import cats.implicits._
+import cats.implicits.*
 
 object PythonGen {
   import Code.{ValueLike, Statement, Expression}
@@ -19,13 +19,13 @@ object PythonGen {
 
   sealed abstract class Env[+A]
   object Env {
-    import Code._
+    import Code.*
 
     def pure[A](a: A): Env[A] = envMonad.pure(a)
 
     implicit def envMonad: Monad[Env] =
       new Monad[Env] {
-        import Impl._
+        import Impl.*
 
         val m = Monad[State[EnvState, *]]
         def pure[A](a: A): Env[A] = EnvImpl(m.pure(a))
@@ -197,7 +197,7 @@ object PythonGen {
               case None => res
               case Some(nel) =>
                 val stmts = nel.reverse
-                val stmt = Code.block(stmts.head, stmts.tail :_*)
+                val stmt = Code.block(stmts.head, stmts.tail *)
                 res.map(stmt.withValue(_))
             }
           case (e: Expression) :: t => loop(t, setup, e :: args)
@@ -586,7 +586,7 @@ object PythonGen {
       Env.topLevelName(name)
       )
       .mapN { (importedName, tmpVar, testName) =>
-        import Impl._
+        import Impl.*
 
         val loopName = Code.Ident("test_loop")
         val argName = Code.Ident("value")

--- a/core/src/main/scala/org/bykn/bosatsu/graph/Dag.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/graph/Dag.scala
@@ -2,7 +2,7 @@ package org.bykn.bosatsu.graph
 
 import cats.data.NonEmptyList
 import scala.collection.immutable.SortedSet
-import scala.collection.mutable.{Map => MMap}
+import scala.collection.mutable.{Map as MMap}
 import org.bykn.bosatsu.ListOrdering
 
 sealed trait Dag[A] {
@@ -41,7 +41,7 @@ sealed trait Dag[A] {
 
   override def equals(that: Any) =
     that match {
-      case thatDag: Dag[_] =>
+      case thatDag: Dag[?] =>
         def eqDag[B](bs: Dag[B]): Boolean = {
           (nodes == bs.nodes) && {
             nodes.iterator.zip(bs.nodes.iterator).forall { case (a, b) =>

--- a/core/src/main/scala/org/bykn/bosatsu/graph/Toposort.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/graph/Toposort.scala
@@ -1,7 +1,7 @@
 package org.bykn.bosatsu.graph
 
 import cats.data.NonEmptyList
-import cats.syntax.all._
+import cats.syntax.all.*
 
 object Toposort {
 

--- a/core/src/main/scala/org/bykn/bosatsu/graph/Tree.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/graph/Tree.scala
@@ -1,7 +1,7 @@
 package org.bykn.bosatsu.graph
 
 import cats.data.{NonEmptyList, Validated, ValidatedNel}
-import cats.implicits._
+import cats.implicits.*
 
 case class Tree[+A](item: A, children: List[Tree[A]])
 

--- a/core/src/main/scala/org/bykn/bosatsu/pattern/NamedSeqPattern.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/pattern/NamedSeqPattern.scala
@@ -3,8 +3,8 @@ package org.bykn.bosatsu.pattern
 import cats.Monoid
 
 sealed trait NamedSeqPattern[+A] {
-  import NamedSeqPattern._
-  import SeqPart._
+  import NamedSeqPattern.*
+  import SeqPart.*
 
   def unname: SeqPattern[A] = {
     def loop(n: NamedSeqPattern[A], right: List[SeqPart[A]]): List[SeqPart[A]] =

--- a/core/src/main/scala/org/bykn/bosatsu/pattern/SeqPattern.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/pattern/SeqPattern.scala
@@ -3,7 +3,7 @@ package org.bykn.bosatsu.pattern
 import cats.data.NonEmptyList
 
 sealed trait SeqPattern[+A] {
-  import SeqPattern._
+  import SeqPattern.*
   import SeqPart.{AnyElem, Lit, Wildcard}
 
   def matchesAny: Boolean =

--- a/core/src/main/scala/org/bykn/bosatsu/pattern/Splitter.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/pattern/Splitter.scala
@@ -2,7 +2,7 @@ package org.bykn.bosatsu.pattern
 
 import cats.Monoid
 
-import cats.implicits._
+import cats.implicits.*
 
 abstract class Splitter[-Elem, Item, Sequence, R] {
   def matcher: Matcher[Elem, Item, R]

--- a/core/src/main/scala/org/bykn/bosatsu/rankn/DefinedType.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/rankn/DefinedType.scala
@@ -6,7 +6,7 @@ import scala.collection.immutable.SortedMap
 
 import Identifier.Constructor
 
-import cats.implicits._
+import cats.implicits.*
 import cats.data.NonEmptyList
 
 final case class DefinedType[+A](
@@ -109,7 +109,7 @@ final case class DefinedType[+A](
   }
 
   def kindOf(implicit ev: A <:< Kind.Arg): Kind =
-    Kind(toAnnotatedKinds.map(_._2): _*)
+    Kind(toAnnotatedKinds.map(_._2) *)
 }
 
 object DefinedType {
@@ -117,7 +117,7 @@ object DefinedType {
     Type.Const.Defined(pn, nm)
 
   def listToMap[A](dts: List[DefinedType[A]]): SortedMap[(PackageName, TypeName), DefinedType[A]] =
-    SortedMap(dts.map { dt => (dt.packageName, dt.name) -> dt }: _*)
+    SortedMap(dts.map { dt => (dt.packageName, dt.name) -> dt } *)
 
   def toKindMap[F[_]: Foldable](dts: F[DefinedType[Kind.Arg]]): Map[Type.Const.Defined, Kind] =
     dts.foldLeft(

--- a/core/src/main/scala/org/bykn/bosatsu/rankn/Infer.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/rankn/Infer.scala
@@ -522,7 +522,7 @@ object Infer {
      * new meta variables for each bound variable in ForAll or skolemize
      * which replaces the ForAll variables with skolem variables
      */
-    def assertRho(t: Type, context: => String, region: Region): Infer[Type.Rho] =
+    inline def assertRho(t: Type, context: => String, region: Region): Infer[Type.Rho] =
       t match {
         case r: Type.Rho => pure(r)
         // $COVERAGE-OFF$ this should be unreachable

--- a/core/src/main/scala/org/bykn/bosatsu/rankn/Ref.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/rankn/Ref.scala
@@ -2,7 +2,7 @@ package org.bykn.bosatsu.rankn
 
 import cats.{StackSafeMonad, Eval}
 // java HashMap performs better than scala in most benchmarks
-import scala.collection.mutable.{LongMap => MutableMap}
+import scala.collection.mutable.{LongMap as MutableMap}
 import java.util.concurrent.atomic.AtomicLong
 
 /**

--- a/core/src/main/scala/org/bykn/bosatsu/rankn/Type.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/rankn/Type.scala
@@ -1,14 +1,14 @@
 package org.bykn.bosatsu.rankn
 
 import cats.data.NonEmptyList
-import cats.parse.{Parser => P, Numbers}
+import cats.parse.{Parser as P, Numbers}
 import cats.{Applicative, Monad, Order}
 import org.typelevel.paiges.{Doc, Document}
 import org.bykn.bosatsu.{Kind, PackageName, Lit, TypeName, Identifier, Parser, TypeParser}
 import org.bykn.bosatsu.graph.Memoize.memoizeDagHashedConcurrent
 import scala.collection.immutable.{SortedSet, SortedMap}
 
-import cats.implicits._
+import cats.implicits.*
 
 sealed abstract class Type {
   def sameAs(that: Type): Boolean = Type.sameType(this, that)
@@ -783,7 +783,7 @@ object Type {
     val FnKinds: List[(Type.TyConst, Kind)] = {
       // -* -> -* ... -> +* -> *
       def kindSize(n: Int): Kind =
-        Kind((Vector.fill(n)(Kind.Type.contra) :+ Kind.Type.co): _*)
+        Kind((Vector.fill(n)(Kind.Type.contra) :+ Kind.Type.co) *)
 
       tpes
         .iterator
@@ -929,7 +929,7 @@ object Type {
     val Kinds: List[(Type.TyConst, Kind)] = {
       // +* -> +* ... -> +* -> *
       def kindSize(n: Int): Kind =
-        Kind(Vector.fill(n)(Kind.Type.co): _*)
+        Kind(Vector.fill(n)(Kind.Type.co) *)
 
       (1 to 32)
         .iterator

--- a/core/src/main/scala/org/bykn/bosatsu/rankn/TypeEnv.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/rankn/TypeEnv.scala
@@ -11,7 +11,7 @@ class TypeEnv[+A] private (
 
   override def equals(that: Any): Boolean =
     that match {
-      case te: TypeEnv[_] =>
+      case te: TypeEnv[?] =>
         (values == te.values) &&
         (constructors == te.constructors) &&
         (definedTypes == te.definedTypes)

--- a/core/src/test/scala/org/bykn/bosatsu/DeclarationTest.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/DeclarationTest.scala
@@ -116,9 +116,9 @@ class DeclarationTest extends AnyFunSuite {
     val regressions: List[(Bindable, Declaration.NonBinding, Declaration)] =
       List(
         {
-          import Declaration._
+          import Declaration.*
           import Identifier.{Name, Constructor, Backticked}
-          import OptIndent._
+          import OptIndent.*
 
           val b = Identifier.Backticked("")
           val d1 = Literal(Lit.fromInt(0))

--- a/core/src/test/scala/org/bykn/bosatsu/DefRecursionCheckTest.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/DefRecursionCheckTest.scala
@@ -2,7 +2,7 @@ package org.bykn.bosatsu
 
 import cats.data.Validated
 
-import cats.implicits._
+import cats.implicits.*
 import org.scalatest.funsuite.AnyFunSuite
 
 class DefRecursionCheckTest extends AnyFunSuite {

--- a/core/src/test/scala/org/bykn/bosatsu/EvaluationTest.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/EvaluationTest.scala
@@ -1,13 +1,13 @@
 package org.bykn.bosatsu
 
-import Value._
+import Value.*
 
 import LocationMap.Colorize
 import org.scalatest.funsuite.AnyFunSuite
 
 class EvaluationTest extends AnyFunSuite with ParTest {
 
-  import TestUtils._
+  import TestUtils.*
 
   test("simple evaluation") {
     evalTest(

--- a/core/src/test/scala/org/bykn/bosatsu/GenJson.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/GenJson.scala
@@ -59,7 +59,7 @@ object GenJson {
   ): Shrink[Json] =
     Shrink[Json](new Function1[Json, Stream[Json]] {
       def apply(j: Json): Stream[Json] = {
-        import Json._
+        import Json.*
         j match {
           case JString(str) => ss.shrink(str).map(JString(_))
           case JNumberStr(_) => Stream.empty

--- a/core/src/test/scala/org/bykn/bosatsu/GenValue.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/GenValue.scala
@@ -2,7 +2,7 @@ package org.bykn.bosatsu
 
 import cats.data.NonEmptyList
 import org.scalacheck.{Arbitrary, Cogen, Gen}
-import Value._
+import Value.*
 
 object GenValue {
 

--- a/core/src/test/scala/org/bykn/bosatsu/JsonTest.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/JsonTest.scala
@@ -1,14 +1,14 @@
 package org.bykn.bosatsu
 
 import cats.Eq
-import cats.implicits._
+import cats.implicits.*
 import org.scalacheck.Gen
 import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks.{forAll, PropertyCheckConfiguration }
 import TestUtils.typeEnvOf
 
 import rankn.{NTypeGen, Type, TypeEnv}
 
-import GenJson._
+import GenJson.*
 import org.scalatest.funsuite.AnyFunSuite
 
 class JsonTest extends AnyFunSuite {

--- a/core/src/test/scala/org/bykn/bosatsu/KindParseTest.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/KindParseTest.scala
@@ -6,7 +6,7 @@ import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks.{
   PropertyCheckConfiguration
 }
 
-import rankn.NTypeGen.{genKind, genKindArg => genArg, shrinkKind}
+import rankn.NTypeGen.{genKind, genKindArg as genArg, shrinkKind}
 
 class KindParseTest extends ParserTestBase {
   override def config: PropertyCheckConfiguration =
@@ -79,11 +79,11 @@ class KindParseTest extends ParserTestBase {
 
   test("toArgs and Kind.apply are inverses") {
     forAll(genKind) { k =>
-      assert(Kind(k.toArgs: _*) == k)
+      assert(Kind(k.toArgs *) == k)
     }
 
     forAll(Gen.listOf(genArg)) { args =>
-      assert(Kind(args: _*).toArgs == args)
+      assert(Kind(args *).toArgs == args)
     }
   }
 
@@ -194,8 +194,8 @@ class KindParseTest extends ParserTestBase {
     }
 
     val regressions = {
-      import Variance._
-      import Kind._
+      import Variance.*
+      import Kind.*
 
       // -* -> (?* -> *)
       Cons(Arg(Contravariant, Type), Cons(Arg(Phantom, Type), Type)) ::

--- a/core/src/test/scala/org/bykn/bosatsu/LocationMapTest.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/LocationMapTest.scala
@@ -31,7 +31,7 @@ class LocationMapTest extends AnyFunSuite {
       val lm = LocationMap(str)
 
       val reconstruct = Iterator.iterate(0)(_ + 1)
-        .map(lm.getLine _)
+        .map(lm.getLine)
         .takeWhile(_.isDefined)
         .collect { case Some(l) => l }
         .mkString("\n")

--- a/core/src/test/scala/org/bykn/bosatsu/MatchlessTests.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/MatchlessTests.scala
@@ -7,7 +7,7 @@ import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks.{forAll, PropertyCh
 import Identifier.{Bindable, Constructor}
 import rankn.DataRepr
 
-import cats.implicits._
+import cats.implicits.*
 import org.scalatest.funsuite.AnyFunSuite
 
 class MatchlessTest extends AnyFunSuite {

--- a/core/src/test/scala/org/bykn/bosatsu/OperatorTest.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/OperatorTest.scala
@@ -2,7 +2,7 @@ package org.bykn.bosatsu
 
 import org.typelevel.paiges.{ Doc, Document }
 
-import cats.parse.{Parser => P}
+import cats.parse.{Parser as P}
 
 import Parser.Combinators
 

--- a/core/src/test/scala/org/bykn/bosatsu/OrderingLaws.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/OrderingLaws.scala
@@ -1,7 +1,7 @@
 package org.bykn.bosatsu
 
 import cats.Order
-import org.scalatest.Assertions._
+import org.scalatest.Assertions.*
 
 object OrderingLaws {
   def law[A: Ordering](a: A, b: A, c: A): Unit = {
@@ -39,6 +39,6 @@ object OrderingLaws {
   }
 
   def forOrder[A: Order](a: A, b: A, c: A) = {
-    law(a, b, c)(Order[A].toOrdering)
+    law(a, b, c)(using Order[A].toOrdering)
   }
 }

--- a/core/src/test/scala/org/bykn/bosatsu/ParserTest.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/ParserTest.scala
@@ -6,8 +6,8 @@ import org.scalacheck.{Arbitrary, Gen}
 import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks.{ forAll, PropertyCheckConfiguration }
 import org.typelevel.paiges.{Doc, Document}
 
-import cats.implicits._
-import cats.parse.{Parser0 => P0, Parser => P}
+import cats.implicits.*
+import cats.parse.{Parser0 as P0, Parser as P}
 import Parser.{optionParse, unsafeParse, Indy}
 
 import Generators.{shrinkDecl, shrinkStmt}
@@ -480,7 +480,7 @@ class ParserTest extends ParserTestBase {
 
   test("we can parse fully pathed types") {
     import rankn.Type
-    import Type._
+    import Type.*
 
     def check(s: String, t: Type) = parseTestAll(Type.fullyResolvedParser, s, t)
 
@@ -640,9 +640,9 @@ x""")
   }
 
   test("we can parse any Apply") {
-    import Declaration._
+    import Declaration.*
 
-    import ApplyKind.{Dot => ADot, Parens => AParens }
+    import ApplyKind.{Dot as ADot, Parens as AParens }
 
     parseTestAll(parser(""),
       "x(f)",
@@ -734,7 +734,7 @@ x""")
     forAll(Generators.patternDecl(4))(law1(_))
 
     val regressions = {
-      import Declaration._
+      import Declaration.*
       import Identifier.{Name, Operator, Constructor}
       // this operator application can be a pattern
       List(
@@ -777,7 +777,7 @@ x""")
   }
 
   test("we can parse bind") {
-    import Declaration._
+    import Declaration.*
 
     parseTestAll(parser(""),
       """x = 4
@@ -804,7 +804,7 @@ x""",
   }
 
   test("we can parse if") {
-    import Declaration._
+    import Declaration.*
 
     val liftVar = Parser.Indy.lift(varP: P[Declaration])
     val liftVar0 = Parser.Indy.lift(varP: P[NonBinding])

--- a/core/src/test/scala/org/bykn/bosatsu/Regressions.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/Regressions.scala
@@ -3,7 +3,7 @@ package org.bykn.bosatsu
 import org.scalatest.funsuite.AnyFunSuite
 
 class Regressions extends AnyFunSuite with ParTest {
-  import TestUtils._
+  import TestUtils.*
 
   test("test complex recursion case from #196") {
     evalFail(List("""

--- a/core/src/test/scala/org/bykn/bosatsu/SelfCallKindTest.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/SelfCallKindTest.scala
@@ -19,7 +19,7 @@ class SelfCallKindTest extends AnyFunSuite {
     gen(Gen.const(()))
 
   test("test selfCallKind") {
-    import SelfCallKind.{NoCall, NonTailCall, TailCall, apply => selfCallKind}
+    import SelfCallKind.{NoCall, NonTailCall, TailCall, apply as selfCallKind}
 
     checkLast(
       """
@@ -79,7 +79,7 @@ def for_all(xs: List[a], fn: a -> B) -> B:
   }
 
   test("SelfCallKind forms a lattice") {
-    import SelfCallKind._
+    import SelfCallKind.*
     val scs = List(NoCall, TailCall, NonTailCall)
 
     for {

--- a/core/src/test/scala/org/bykn/bosatsu/ShapeTest.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/ShapeTest.scala
@@ -3,7 +3,7 @@ package org.bykn.bosatsu
 import org.bykn.bosatsu.rankn.TypeEnv
 import org.scalatest.funsuite.AnyFunSuite
 
-import cats.syntax.all._
+import cats.syntax.all.*
 
 class ShapeTest extends AnyFunSuite {
 

--- a/core/src/test/scala/org/bykn/bosatsu/SourceConverterTest.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/SourceConverterTest.scala
@@ -5,7 +5,7 @@ import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks.{forAll, PropertyCh
 
 import Identifier.Bindable
 
-import cats.implicits._
+import cats.implicits.*
 import org.scalatest.funsuite.AnyFunSuite
 
 class SourceConverterTest extends AnyFunSuite {

--- a/core/src/test/scala/org/bykn/bosatsu/TestUtils.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/TestUtils.scala
@@ -1,8 +1,8 @@
 package org.bykn.bosatsu
 
 import cats.data.{Ior, Validated}
-import cats.implicits._
-import org.bykn.bosatsu.rankn._
+import cats.implicits.*
+import org.bykn.bosatsu.rankn.*
 import org.scalatest.{Assertion, Assertions}
 
 import Assertions.{succeed, fail}

--- a/core/src/test/scala/org/bykn/bosatsu/TotalityTest.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/TotalityTest.scala
@@ -7,7 +7,7 @@ import org.scalacheck.Gen
 
 import org.bykn.bosatsu.pattern.{SetOps, SetOpsLaws}
 
-import rankn._
+import rankn.*
 
 import Parser.Combinators
 
@@ -120,7 +120,7 @@ enum Bool: False, True
       }
 
     Parser.unsafeParse(Pattern.matchParser.listSyntax, str)
-      .map(parsedToExpr _)
+      .map(parsedToExpr)
   }
 
   def notTotal(te: TypeEnv[Any], pats: List[Pattern[(PackageName, Constructor), Type]], testMissing: Boolean = true): Unit = {
@@ -255,13 +255,13 @@ enum Either: Left(l), Right(r)
 
 
   test("test intersection") {
-    val p0 :: p1 :: p1norm :: Nil = patterns("[[*_], [*_, _], [_, *_]]")
+    val p0 :: p1 :: p1norm :: Nil = patterns("[[*_], [*_, _], [_, *_]]"): @unchecked
       TotalityCheck(predefTE).intersection(p0, p1) match {
         case List(intr) => assert(intr == p1norm)
         case other => fail(s"expected exactly one intersection: $other")
       }
 
-    val p2 :: p3 :: Nil = patterns("[[*_], [_, _]]")
+    val p2 :: p3 :: Nil = patterns("[[*_], [_, _]]"): @unchecked
       TotalityCheck(predefTE).intersection(p2, p3) match {
         case List(intr) => assert(p3 == intr)
         case other => fail(s"expected exactly one intersection: $other")
@@ -272,7 +272,7 @@ enum Either: Left(l), Right(r)
       val p0 :: p1 :: p2 :: Nil = patterns(
         """["${_}$.{_}$.{_}",
         "$.{foo}",
-        "baz"]""")
+        "baz"]"""): @unchecked
 
       assert(TotalityCheck(predefTE).intersection(p0, p1).isEmpty)
       assert(TotalityCheck(predefTE).intersection(p1, p2).isEmpty)
@@ -295,7 +295,7 @@ enum Either: Left(l), Right(r)
     val tc = TotalityCheck(predefTE)
     import tc.eqPat.eqv
     {
-      val p0 :: p1 :: Nil = patterns("[[1], [\"foo\", _]]")
+      val p0 :: p1 :: Nil = patterns("[[1], [\"foo\", _]]"): @unchecked
       tc.difference(p0, p1) match {
         case diff :: Nil => assert(eqv(p0, diff))
         case many => fail(s"expected exactly one difference: ${showPats(many)}")
@@ -303,7 +303,7 @@ enum Either: Left(l), Right(r)
     }
 
     {
-      val p0 :: p1 :: Nil = patterns("[[_, _], [[*foo]]]")
+      val p0 :: p1 :: Nil = patterns("[[_, _], [[*foo]]]"): @unchecked
       TotalityCheck(predefTE).difference(p1, p0) match {
         case diff :: Nil => assert(eqv(diff, p1))
         case many => fail(s"expected exactly one difference: ${showPats(many)}")
@@ -315,7 +315,7 @@ enum Either: Left(l), Right(r)
     }
 
     {
-      val p0 :: p1 :: Nil = patterns("[[*_, _], [_, *_]]")
+      val p0 :: p1 :: Nil = patterns("[[*_, _], [_, *_]]"): @unchecked
       TotalityCheck(predefTE).intersection(p0, p1) match {
         case List(res) if res == p0 || res == p1 => succeed
         case Nil => fail("these do overlap")
@@ -325,7 +325,7 @@ enum Either: Left(l), Right(r)
   }
 
   test("(a - b) n c == (a n c) - (b n c) regressions") {
-    import Pattern._
+    import Pattern.*
     import StrPart.{LitStr, NamedStr, WildStr}
     import ListPart.{NamedList, Item}
     import Identifier.Name
@@ -376,8 +376,8 @@ enum Either: Left(l), Right(r)
   }
 
   test("difference is idempotent regressions") {
-    import Pattern._
-    import ListPart._
+    import Pattern.*
+    import ListPart.*
     import Identifier.Name
     import StrPart.WildStr
 
@@ -394,8 +394,8 @@ enum Either: Left(l), Right(r)
 
   test("if a n b = 0 then a - b = a regressions") {
 
-    import Pattern._
-    import ListPart._
+    import Pattern.*
+    import ListPart.*
     import Identifier.Name
     import StrPart.WildStr
 

--- a/core/src/test/scala/org/bykn/bosatsu/TypedExprTest.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/TypedExprTest.scala
@@ -1,7 +1,7 @@
 package org.bykn.bosatsu
 
 import cats.data.{NonEmptyList, State, Writer}
-import cats.implicits._
+import cats.implicits.*
 import org.scalacheck.{Arbitrary, Gen}
 import org.scalatest.funsuite.AnyFunSuite
 import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks.{ forAll, PropertyCheckConfiguration }
@@ -45,7 +45,7 @@ class TypedExprTest extends AnyFunSuite {
       assert(missing.isEmpty, s"expression:\n\n${te.repr}\n\nallVars: $av\n\nfrees: $frees")
     }
 
-    forAll(genTypedExpr)(law _)
+    forAll(genTypedExpr)(law)
 
     checkLast("""
 enum AB: A, B(x)
@@ -663,7 +663,7 @@ x = Foo
       // All the vars that are used in bounds
       val bounds: Set[Type.Var] = te.traverseType { (t: Type) =>
         t match {
-          case q: Type.Quantified => Writer(SortedSet[Type.Var](q.vars.toList.map(_._1): _*), t)
+          case q: Type.Quantified => Writer(SortedSet[Type.Var](q.vars.toList.map(_._1) *), t)
           case _ => Writer(SortedSet[Type.Var](), t)
         }
       }.run._1.toSet[Type.Var]

--- a/core/src/test/scala/org/bykn/bosatsu/ValueTest.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/ValueTest.scala
@@ -2,7 +2,7 @@ package org.bykn.bosatsu
 
 import org.scalacheck.{Arbitrary, Gen}
 import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks.{ forAll, PropertyCheckConfiguration }
-import Value._
+import Value.*
 import org.scalatest.funsuite.AnyFunSuite
 
 class ValueTest extends AnyFunSuite {

--- a/core/src/test/scala/org/bykn/bosatsu/graph/DagTest.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/graph/DagTest.scala
@@ -10,7 +10,7 @@ import org.bykn.bosatsu.MonadGen.genMonad
 import org.bykn.bosatsu.ListOrdering
 import scala.collection.immutable.SortedSet
 
-import cats.syntax.all._
+import cats.syntax.all.*
 
 class DagTest extends AnyFunSuite {
   implicit val generatorDrivenConfig: PropertyCheckConfiguration =
@@ -97,10 +97,11 @@ class DagTest extends AnyFunSuite {
       assert(allNodes == graph.keys.to(SortedSet))
 
       // if we toposort a dag, we always succeed
-      implicit val setOrd = ListOrdering.byIterator[SortedSet[Int], Int]
+      implicit val setOrd: Ordering[SortedSet[Int]] = ListOrdering.byIterator[SortedSet[Int], Int]
+
       val sortRes @ Toposort.Success(_, _) = Toposort.sort(dag.nodes) { n =>
         dag.deps(n).toList
-      }
+      }: @unchecked
       assert(sortRes.isSuccess)
       sortRes.layers.zipWithIndex.foreach { case (nodes, layer) =>
         nodes.toList.foreach { n =>

--- a/core/src/test/scala/org/bykn/bosatsu/graph/ToposortTest.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/graph/ToposortTest.scala
@@ -5,7 +5,7 @@ import cats.data.NonEmptyList
 import org.scalacheck.Gen
 import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks.{ forAll, PropertyCheckConfiguration }
 
-import cats.implicits._
+import cats.implicits.*
 import org.scalatest.funsuite.AnyFunSuite
 
 class ToposortTest extends AnyFunSuite {
@@ -65,7 +65,7 @@ class ToposortTest extends AnyFunSuite {
     val genDag = Gen.mapOf(pair).map(Dag(_))
     forAll(genDag) { case Dag(graph) =>
       val allNodes = graph.flatMap { case (h, t) => h :: t }.toSet
-      val Toposort.Success(sorted, _) = Toposort.sort(allNodes)(graph.getOrElse(_, Nil))
+      val Toposort.Success(sorted, _) = Toposort.sort(allNodes)(graph.getOrElse(_, Nil)): @unchecked
       assert(sorted.flatMap(_.toList).sorted == allNodes.toList.sorted)
       noEdgesToLater(sorted)(n => graph.getOrElse(n, Nil))
       layersAreSorted(sorted)

--- a/core/src/test/scala/org/bykn/bosatsu/graph/TreeTest.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/graph/TreeTest.scala
@@ -4,7 +4,7 @@ import cats.data.{NonEmptyList, Validated}
 import org.scalacheck.Gen
 import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks.forAll
 
-import cats.implicits._
+import cats.implicits.*
 import org.scalatest.funsuite.AnyFunSuite
 
 class TreeTest extends AnyFunSuite {

--- a/core/src/test/scala/org/bykn/bosatsu/pattern/SeqPatternTest.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/pattern/SeqPatternTest.scala
@@ -6,7 +6,7 @@ import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks.{ forAll, PropertyC
 import SeqPattern.{Cat, Empty}
 import SeqPart.{Wildcard, AnyElem, Lit}
 
-import cats.implicits._
+import cats.implicits.*
 import org.scalatest.funsuite.AnyFunSuite
 
 object StringSeqPatternGen {
@@ -23,7 +23,7 @@ object StringSeqPatternGen {
     } yield list.mkString
 
   val genPart: Gen[SeqPart[Char]] = {
-    import SeqPart._
+    import SeqPart.*
 
     Gen.frequency(
       (15, Gen.oneOf(Lit('0'), Lit('1'))),
@@ -384,7 +384,7 @@ class BoolSeqPatternTest extends SeqPatternLaws[Set[Boolean], Boolean, List[Bool
     Gen.oneOf(List(Set(true), Set(false), Set(true, false)))
 
   def genPart: Gen[SeqPart[Set[Boolean]]] = {
-    import SeqPart._
+    import SeqPart.*
 
     Gen.frequency(
       (15, genSetBool.map(Lit(_))),
@@ -585,7 +585,7 @@ class BoolSeqPatternTest extends SeqPatternLaws[Set[Boolean], Boolean, List[Bool
 }
 
 class SeqPatternTest extends SeqPatternLaws[Char, Char, String, Unit] {
-  import SeqPart._
+  import SeqPart.*
 
   def genPattern = StringSeqPatternGen.genPat
   def genNamed = StringSeqPatternGen.genNamed
@@ -606,7 +606,7 @@ class SeqPatternTest extends SeqPatternLaws[Char, Char, String, Unit] {
   implicit val setOpsChar: SetOps[Char] = SetOps.distinct[Char]
   def setOps: SetOps[Pattern] = Pattern.seqPatternSetOps[Char]
 
-  import StringSeqPatternGen._
+  import StringSeqPatternGen.*
 
   def toPattern(s: String): Pattern =
     s.toList.foldRight(Pattern.Empty: Pattern) { (c, r) =>
@@ -713,7 +713,7 @@ class SeqPatternTest extends SeqPatternLaws[Char, Char, String, Unit] {
 
   test("Named.matches agrees with Pattern.matches regressions") {
 
-    import Named._
+    import Named.*
     val regressions: List[(Named, String)] =
       (NCat(NEmpty,NCat(NSeqPart(Lit('1')),NSeqPart(Wildcard))), "1") ::
       (NCat(NSeqPart(Lit('1')),NSeqPart(Wildcard)), "1") ::

--- a/core/src/test/scala/org/bykn/bosatsu/pattern/SetOpsLaws.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/pattern/SetOpsLaws.scala
@@ -15,7 +15,7 @@ abstract class SetOpsLaws[A] extends AnyFunSuite {
   def eqA: Gen[Eq[A]] =
     eqUnion.map(Eq.by { (a: A) => a :: Nil }(_))
 
-  import setOps._
+  import setOps.*
 
   def intersectionIsCommutative(a1: A, a2: A, eqA: Eq[List[A]]) = {
     val a12 = intersection(a1, a2)

--- a/core/src/test/scala/org/bykn/bosatsu/pattern/StringSeqPatternSetLaws.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/pattern/StringSeqPatternSetLaws.scala
@@ -4,7 +4,7 @@ import cats.Eq
 import org.scalacheck.Gen
 import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks.PropertyCheckConfiguration
 
-import cats.implicits._
+import cats.implicits.*
 
 class StringSeqPatternSetLaws extends SetOpsLaws[SeqPattern[Char]] {
   type Pattern = SeqPattern[Char]

--- a/core/src/test/scala/org/bykn/bosatsu/rankn/NTypeGen.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/rankn/NTypeGen.scala
@@ -88,7 +88,7 @@ object NTypeGen {
   }
 
   implicit val shrinkType: Shrink[Type] = {
-    import Type._
+    import Type.*
     def shrink(t: Type): Stream[Type] =
       t match {
         case ForAll(items, in) =>
@@ -106,7 +106,7 @@ object NTypeGen {
     Gen.zip(genVariance, genKind).map { case (v, k) => Kind.Arg(v, k) }
 
   val genPredefType: Gen[Type] = {
-    import Type._
+    import Type.*
 
     val recurse = Gen.lzy(genPredefType)
 

--- a/core/src/test/scala/org/bykn/bosatsu/rankn/RankNInferTest.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/rankn/RankNInferTest.scala
@@ -1,9 +1,9 @@
 package org.bykn.bosatsu.rankn
 
 import cats.data.{Ior, NonEmptyList}
-import org.bykn.bosatsu._
+import org.bykn.bosatsu.*
 
-import Expr._
+import Expr.*
 import Type.Var.Bound
 import Type.forAll
 
@@ -13,7 +13,7 @@ import Identifier.Constructor
 
 import org.scalatest.funsuite.AnyFunSuite
 
-import cats.syntax.all._
+import cats.syntax.all.*
 
 class RankNInferTest extends AnyFunSuite {
 
@@ -316,7 +316,7 @@ class RankNInferTest extends AnyFunSuite {
   }
 
   test("match with custom non-generic types") {
-    import OptionTypes._
+    import OptionTypes.*
 
     val constructors = Map(
       (Identifier.unsafe("Some"), Type.Fun(Type.IntType, optType))
@@ -365,7 +365,7 @@ class RankNInferTest extends AnyFunSuite {
   test("match with custom generic types") {
     def tv(a: String): Type.Rho = Type.TyVar(Type.Var.Bound(a))
 
-    import OptionTypes._
+    import OptionTypes.*
 
     val kinds = Type.builtInKinds.updated(optName, Kind(Kind.Type.co))
 

--- a/core/src/test/scala/org/bykn/bosatsu/rankn/TypeTest.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/rankn/TypeTest.scala
@@ -101,10 +101,10 @@ class TypeTest extends AnyFunSuite {
     }
     
     {
-      import Type._
+      import Type.*
       import Var.Bound
-      import org.bykn.bosatsu.Variance._
-      import org.bykn.bosatsu.Kind.{Arg, Cons, Type => KType}
+      import org.bykn.bosatsu.Variance.*
+      import org.bykn.bosatsu.Kind.{Arg, Cons, Type as KType}
       
       val qt1 = Quantified(Quantification.Dual(
         NonEmptyList((Bound("qsnMgkhqY"), Cons(Arg(Covariant, Cons(Arg(Covariant, KType), KType)), Cons(Arg(Phantom, KType), KType))), List((Bound("u"), Cons(Arg(Contravariant, KType), Cons(Arg(Invariant, KType), KType))))),
@@ -218,7 +218,7 @@ class TypeTest extends AnyFunSuite {
       else assert(allT.exists { t => !Type.hasNoVars(t) }, "hasNoVars == false")
     }
 
-    forAll(NTypeGen.genDepth03)(law _)
+    forAll(NTypeGen.genDepth03)(law)
 
     val pastFails =
       List(
@@ -287,7 +287,7 @@ class TypeTest extends AnyFunSuite {
       assert(t2 == t1)
     }
 
-    forAll(NTypeGen.genDepth03, genSubs(3))(law _)
+    forAll(NTypeGen.genDepth03, genSubs(3))(law)
 
     val ba: Type.Var = Type.Var.Bound("a")
 
@@ -311,7 +311,7 @@ class TypeTest extends AnyFunSuite {
       assert((Type.freeBoundTyVars(t1 :: Nil).toSet & subs1.keySet) == Set.empty)
     }
 
-    forAll(NTypeGen.genDepth03, genSubs(3))(law _)
+    forAll(NTypeGen.genDepth03, genSubs(3))(law)
   }
 
   test("we can substitute to get an instantiation") {
@@ -341,13 +341,13 @@ class TypeTest extends AnyFunSuite {
 
   test("some example instantiations") {
     def check(forall: String, matches: String, subs: List[(String, String)]) = {
-      val Type.ForAll(fas, t) = parse(forall)
+      val Type.ForAll(fas, t) = parse(forall): @unchecked
       val targ = parse(matches)
       Type.instantiate(fas.iterator.toMap, t, targ) match {
         case Some((frees, subMap)) =>
           assert(subMap.size == subs.size)
           subs.foreach { case (k, v) =>
-            val Type.TyVar(b: Type.Var.Bound) = parse(k)
+            val Type.TyVar(b: Type.Var.Bound) = parse(k): @unchecked
             assert(subMap(b)._2 == parse(v))
           }
         case None =>
@@ -356,7 +356,7 @@ class TypeTest extends AnyFunSuite {
     }
 
     def noSub(forall: String, matches: String) = {
-      val Type.ForAll(fas, t) = parse(forall)
+      val Type.ForAll(fas, t) = parse(forall): @unchecked
       val targ = parse(matches)
       val res = Type.instantiate(fas.iterator.toMap, t, targ)
       assert(res == None)
@@ -471,7 +471,7 @@ class TypeTest extends AnyFunSuite {
 
   test("allConsts laws") {
     forAll(NTypeGen.genDepth03) { t =>
-      import Type._
+      import Type.*
 
       val consts = allConsts(t :: Nil)
       t match {

--- a/jsapi/src/main/scala/org/bykn/bosatsu/jsapi/JsApi.scala
+++ b/jsapi/src/main/scala/org/bykn/bosatsu/jsapi/JsApi.scala
@@ -6,9 +6,9 @@ import org.typelevel.paiges.Doc
 import scala.scalajs.js
 
 import js.|
-import js.annotation._
+import js.annotation.*
 
-import cats.implicits._
+import cats.implicits.*
 
 @JSExportTopLevel("Bosatsu")
 object JsApi {
@@ -39,8 +39,8 @@ object JsApi {
       case Left(err) =>
         new Error(s"error: ${err.getMessage}")
       case Right(module.Output.EvaluationResult(_, tpe, resDoc)) =>
-          val tDoc = rankn.Type.fullyResolvedDocument.document(tpe)
-          val doc = resDoc.value + (Doc.lineOrEmpty + Doc.text(": ") + tDoc).nested(4)
+        val tDoc = rankn.Type.fullyResolvedDocument.document(tpe)
+        val doc = resDoc.value + (Doc.lineOrEmpty + Doc.text(": ") + tDoc).nested(4)
         new EvalSuccess(doc.render(80))
       case Right(other) =>
         new Error(s"internal error. got unexpected result: $other")
@@ -67,7 +67,7 @@ object JsApi {
         js.Dictionary[js.Any](
           kvs.map { case (k, v) =>
             (k, jsonToAny(v))
-          } :_*)
+          } *)
     }
 
   /**


### PR DESCRIPTION
migrate the code to scala3 only.

I could work harder to do 2.13 and 3, but that would mean I couldn't use any of the nice new scala 3 features. Since bosatsu is intended to be used as a cli or as a uber-jar which could be shaded, I don't think the version of scala we are using should matter to anyone.