### PR TITLE
Attempt to fix 1108

### DIFF
--- a/core/src/main/scala/org/bykn/bosatsu/pattern/SeqPattern.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/pattern/SeqPattern.scala
@@ -269,6 +269,10 @@ object SeqPattern {
               // we know that right can't match empty,
               // let's see if that helps us rule out matches on the left
               subsetList(p1, AnyElem :: Wildcard :: t2)
+          case (Wildcard :: (a1: SeqPart1[A]) :: t1, _) if isAny(a1) =>
+              // we know that left can't match empty,
+              // let's see if that helps us rule out matches on the left
+              subsetList(AnyElem :: Wildcard :: t1, p2)
           // either t1 or t2 also ends with Wildcard
           case (_ :: _, Wildcard :: _) if p2.last.notWild =>
             // wild on the right but not at the end

--- a/core/src/test/scala/org/bykn/bosatsu/TotalityTest.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/TotalityTest.scala
@@ -452,4 +452,16 @@ enum Either: Left(l), Right(r)
     val diff1 = tc.missingBranches(ps1)
     assert(diff1 == Nil)
   }
+
+  override def missingBranchesIfAddedRegressions: List[List[Pat]] = {
+    // these are ill typed because the first pattern matches type
+    // List[String] but the second matches List[List[String]]
+    /*
+    val r1 @ (_ :: _ :: _) = patterns("""[[*foo, "$.{_}", "1"], [[_, *_]]]""")
+
+    patterns("""[[*foo, "$.{_}", "$.{_}"], [[b, *_]]]""") ::
+    r1 ::
+      */
+    Nil
+  }
 }

--- a/core/src/test/scala/org/bykn/bosatsu/pattern/SeqPatternTest.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/pattern/SeqPatternTest.scala
@@ -767,4 +767,11 @@ class SeqPatternTest extends SeqPatternLaws[Char, Char, String, Unit] {
     val p1 = (named("bar") + (Named.Wild + named("baz")).name("baz")).name("foo")
     assert(namedMatch(p1, "bar and baz") == Some(Map("foo" -> "bar and baz", "baz" -> " and baz")))
   }
+
+  test("regression subset example") {
+    val p1 = Cat(AnyElem,Cat(Wildcard,Empty))
+    val p2 = Cat(Wildcard,Cat(Lit('0'),Cat(Lit('1'),Empty)))
+
+    assert(setOps.subset(p2, p1))
+  }
 }

--- a/core/src/test/scala/org/bykn/bosatsu/pattern/SetOpsLaws.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/pattern/SetOpsLaws.scala
@@ -239,6 +239,8 @@ abstract class SetOpsLaws[A] extends AnyFunSuite {
   }
   */
 
+  def missingBranchesIfAddedRegressions: List[List[A]] = Nil
+
   test("missing branches, if added are total and none of the missing are unreachable") {
 
     def law(top: A, pats: List[A]) = {
@@ -257,6 +259,8 @@ abstract class SetOpsLaws[A] extends AnyFunSuite {
     top.foreach { t =>
       val pats = Gen.choose(0, 10).flatMap(Gen.listOfN(_, genItem))
       forAll(pats)(law(t, _))
+
+      missingBranchesIfAddedRegressions.foreach(law(t, _))
     }
   }
 
@@ -410,7 +414,8 @@ class SetOpsTests extends AnyFunSuite {
     }
 
     forAll(genMat, Gen.listOfN(5, genMat)) { (v0, prods) =>
-      val res = SetOps.greedySearch(5, v0, prods)({(v, ps) => ps.foldLeft(v)(mult(_, _))})(norm(_))
+      val ord = Ordering.by[Vector[Vector[Double]], Double](norm)
+      val res = SetOps.greedySearch(5, v0, prods)({(v, ps) => ps.foldLeft(v)(mult(_, _))})(ord)
       val normRes = norm(res)
       val naive = norm(prods.foldLeft(v0)(mult(_, _)))
       assert(normRes <= naive)


### PR DESCRIPTION
I tried to fix #1108 but I couldn't find a fix. It's not a real bug exactly since TotalityTest checks the laws on ill-typed patterns and the pattern in question is ill-typed.

A probably better test for TotalityCheck would be to generate well-typed patterns only, and we could probably find more issues that way.

I did find a few minor things that seemed like improvements, but since no tests changed, maybe they aren't better. Who knows.