### PR TITLE
leverage UnionRelatable

### DIFF
--- a/core/src/main/scala/org/bykn/bosatsu/TotalityCheck.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/TotalityCheck.scala
@@ -609,10 +609,10 @@ case class TotalityCheck(inEnv: TypeEnv[Any]) {
             u.exists(isTopCheap(_))
         }
 
-      def subset(a0: Pattern[Cons, Type], b0: Pattern[Cons, Type]): Boolean =
+      override def subset(a0: Pattern[Cons, Type], b0: Pattern[Cons, Type]): Boolean =
         isTopCheap(b0) || relate(a0, b0).isSubtype
 
-      override def relate(a0: Pattern[Cons,Type], b0: Pattern[Cons,Type]): Rel = {
+      def relate(a0: Pattern[Cons,Type], b0: Pattern[Cons,Type]): Rel = {
         def loop(a: Pattern[Cons, Type], b: Pattern[Cons, Type]): Rel =
           (a, b) match {
             case _ if a == b => Rel.Same
@@ -749,6 +749,6 @@ case class TotalityCheck(inEnv: TypeEnv[Any]) {
   val eqPat: Eq[Pattern[Cons, Type]] =
     new Eq[Pattern[Cons, Type]] {
       def eqv(l: Pattern[Cons, Type], r: Pattern[Cons, Type]) =
-        normalizePattern(l) == normalizePattern(r)
+        patternSetOps.equiv(l, r)
     }
 }

--- a/core/src/main/scala/org/bykn/bosatsu/TotalityCheck.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/TotalityCheck.scala
@@ -302,7 +302,15 @@ case class TotalityCheck(inEnv: TypeEnv[Any]) {
         def deunion(a: Option[Pattern[Cons,Type]]): Either[(Option[Pattern[Cons,Type]], Option[Pattern[Cons,Type]]) => Rel.SuperOrSame,(Option[Pattern[Cons,Type]], Option[Pattern[Cons,Type]])] =
           a.get match {
             case Pattern.Union(head, rest) =>
-              Right((Some(head), Some(Pattern.union(rest.head, rest.tail))))
+              // we know there are at list 2 items here
+              // split in half to minimize recursion depth
+              val pats = head :: rest.toList
+              val patSize = pats.size
+              val (left, right) = pats.splitAt(patSize / 2)
+              Right(
+                (Some(Pattern.union(left.head, left.tail)),
+                  Some(Pattern.union(right.head, right.tail)))
+              )
             case Pattern.Literal(_) =>
               // if a literal is >= something it is same, no partial supersets
               Left((_, _) => Rel.Same)

--- a/core/src/main/scala/org/bykn/bosatsu/TotalityCheck.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/TotalityCheck.scala
@@ -759,7 +759,7 @@ case class TotalityCheck(inEnv: TypeEnv[Any]) {
             .distinct
 
             if (notListStr.exists(isTop)) topList
-            else (lps ::: sps ::: distinctStrs ::: notListStr /*notListStr.flatMap(unwrap(_).toList)*/ ::: structs).sorted
+            else (lps ::: sps ::: distinctStrs ::: notListStr ::: structs).sorted
           }
         }
       }
@@ -776,6 +776,7 @@ case class TotalityCheck(inEnv: TypeEnv[Any]) {
       case Var(_) => WildCard
       case Named(_, p) => normalizePattern(p)
       case Annotation(p, _) => normalizePattern(p)
+      case _ if patternSetOps.isTop(p) => WildCard
       case u@Union(_, _) =>
         val flattened = Pattern.flatten(u).map(normalizePattern(_))
 
@@ -786,8 +787,6 @@ case class TotalityCheck(inEnv: TypeEnv[Any]) {
             sys.error("unreachable: union can't remove items")
             // $COVERAGE-ON$
         }
-
-      case _ if patternSetOps.isTop(p) => WildCard
       case strPat@StrPat(_) =>
         strPat.toLiteralString match {
           case Some(str) => Literal(Lit.Str(str))

--- a/core/src/main/scala/org/bykn/bosatsu/pattern/SeqPart.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/pattern/SeqPart.scala
@@ -1,6 +1,6 @@
 package org.bykn.bosatsu.pattern
 
-import org.bykn.bosatsu.set.SetOps
+import org.bykn.bosatsu.set.{Rel, SetOps}
 
 sealed trait SeqPart[+Elem] {
   def notWild: Boolean = false
@@ -78,13 +78,31 @@ object SeqPart {
             else anyDiff(a2)
         }
 
-      def subset(p1: SeqPart1[A], p2: SeqPart1[A]): Boolean =
+      override def subset(p1: SeqPart1[A], p2: SeqPart1[A]): Boolean =
         p2 match {
           case AnyElem => true
           case Lit(c2) =>
             p1 match {
               case Lit(c1) => setOpsA.subset(c1, c2)
               case AnyElem => setOpsA.isTop(c2)
+            }
+        }
+
+      def relate(p1: SeqPart1[A], p2: SeqPart1[A]): Rel =
+        p2 match {
+          case AnyElem =>
+            p1 match {
+              case AnyElem => Rel.Same
+              case Lit(c1) =>
+                if (setOpsA.isTop(c1)) Rel.Same
+                else Rel.Sub
+            }
+          case Lit(c2) =>
+            p1 match {
+              case Lit(c1) => setOpsA.relate(c1, c2)
+              case AnyElem =>
+                if (setOpsA.isTop(c2)) Rel.Same
+                else Rel.Super
             }
         }
 

--- a/core/src/main/scala/org/bykn/bosatsu/pattern/SeqPattern.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/pattern/SeqPattern.scala
@@ -1,7 +1,8 @@
 package org.bykn.bosatsu.pattern
 
 import cats.data.NonEmptyList
-import org.bykn.bosatsu.set.SetOps
+import org.bykn.bosatsu.set.{Rel, SetOps}
+import org.bykn.bosatsu.set.Relatable
 
 sealed trait SeqPattern[+A] {
   import SeqPattern._
@@ -140,7 +141,7 @@ object SeqPattern {
     }
 
   implicit def seqPatternSetOps[A](implicit part1SetOps: SetOps[SeqPart.SeqPart1[A]], ordA: Ordering[A]): SetOps[SeqPattern[A]] =
-    new SetOps[SeqPattern[A]] {
+    new SetOps[SeqPattern[A]] { self =>
       import SeqPart.{SeqPart1, AnyElem, Wildcard}
 
       val top: Option[SeqPattern[A]] = Some(Wild)
@@ -239,13 +240,16 @@ object SeqPattern {
       /**
        * return true if p1 <= p2, can give false negatives
        */
-      def subset(p1: SeqPattern[A], p2: SeqPattern[A]): Boolean =
+      override def subset(p1: SeqPattern[A], p2: SeqPattern[A]): Boolean =
         p2.matchesAny || {
           // if p2 doesn't matchEmpty but p1 does, we are done
           // check that case quickly
           if (!p2.matchesEmpty && p1.matchesEmpty) false
           else subsetList(p1.toList, p2.toList)
         }
+
+      def relate(p1: SeqPattern[A], p2: SeqPattern[A]): Rel =
+        relateList(p1.toList, p2.toList)
 
       @inline
       final def isAny(p: SeqPart1[A]): Boolean =
@@ -305,6 +309,57 @@ object SeqPattern {
             //  but right starts with *, so (_:*:t1 <= right) = (*:t1 <= *:t2)
             //  which is the current question
             subsetList(t1, p2)
+        }
+
+      private val viaIntersection: Relatable[SeqPattern[A]] =
+        Relatable.fromSubsetIntersects(
+          self.subset(_, _),
+          (l, r) => self.intersection(l, r).nonEmpty
+        )
+
+      private def relateList(p1: List[SeqPart[A]], p2: List[SeqPart[A]]): Rel =
+        (p1, p2) match {
+          case (Nil, Nil) => Rel.Same
+          case (Nil, (_: SeqPart1[A]) :: _) =>
+            // [] is h :: t are disjoint when h matches at least 1
+            Rel.Disjoint
+          case (Nil, Wildcard :: t) =>
+            // [] <:> * :: t, if t matchesEmpty, this is subset,
+            if (t.exists {
+              case _: SeqPart1[A] => true
+              case Wildcard => false
+            }) Rel.Disjoint
+            else Rel.Sub
+          case (_ :: _, Nil) => relateList(p2, p1).invert
+          case ((h1: SeqPart1[A]) :: t1, (h2: SeqPart1[A]) :: t2) =>
+            part1SetOps.relate(h1, h2).lazyCombine(relateList(t1, t2))
+          case (Wildcard :: Wildcard :: t1, _) =>
+              // normalize the left:
+              relateList(Wildcard :: t1, p2)
+          case (_, Wildcard :: Wildcard :: t2) =>
+              // normalize the right:
+              relateList(p1, Wildcard :: t2)
+          case (_, Wildcard :: (a2: SeqPart1[A]) :: t2) if isAny(a2) =>
+              // we know that right can't match empty,
+              // let's see if that helps us rule out matches on the left
+              relateList(p1, AnyElem :: Wildcard :: t2)
+          case (Wildcard :: (a1: SeqPart1[A]) :: t1, _) if isAny(a1) =>
+              // we know that left can't match empty,
+              // let's see if that helps us rule out matches on the left
+              relateList(AnyElem :: Wildcard :: t1, p2)
+          // either t1 or t2 also ends with Wildcard
+          case (_ :: _, Wildcard :: _) if p2.last.notWild =>
+            // wild on the right but not at the end
+            // yields an approximation. avoid that
+            // if possible
+            relateList(p1.reverse, p2.reverse)
+          case (Wildcard :: _, _ :: _) if p1.last.notWild && p2.last.notWild =>
+            // if we don't check both here we can loop
+            relateList(p1.reverse, p2.reverse)
+          case _ =>
+            viaIntersection.relate(
+              SeqPattern.fromList(p1),
+              SeqPattern.fromList(p2))
         }
 
       private def min(p1: SeqPattern[A], p2: SeqPattern[A]): SeqPattern[A] = {
@@ -455,11 +510,13 @@ object SeqPattern {
        * but some of them also match p2
        */
       def difference(p1: SeqPattern[A], p2: SeqPattern[A]): List[SeqPattern[A]] =
+        relate(p1, p2) match {
+          case Rel.Sub | Rel.Same => Nil
+          case Rel.Disjoint => p1 :: Nil
+          case _ =>
+            // We know p1 is a strict super set of p2 or it
+            // intersects. We can never return Nil or p1 :: Nil
         (p1, p2) match {
-          case (Empty, _) => if (p2.matchesEmpty) Nil else p1 :: Nil
-          case (Cat(_: SeqPart1[A], _), Empty) =>
-            // Cat(SeqPart1[A], _) does not match Empty
-            p1 :: Nil
           case (Cat(Wildcard, t1@Cat(Wildcard, _)), _) =>
             // unnormalized
             difference(t1, p2)
@@ -473,38 +530,24 @@ object SeqPattern {
             // *. == .*, push Wildcards to the end
             difference(p1, Cat(AnyElem, Cat(Wildcard, t2)))
           case (Cat(Wildcard, t1), Empty) =>
-            if (!t1.matchesEmpty) p1 :: Nil
-            else {
-              // use (A + B) - C = (A - C) + (B - C)
-              // *:t1 = t1 + _:p1
-              // _:p1 - [] = _:p1
-              unifyUnion(Cat(AnyElem, p1) :: difference(t1, Empty))
-            }
-          case (_, _) if subset(p1, p2) =>
-            // p2 has to be bigger
-            Nil
+            // we know that t1 matches empty or these wouldn't intersect
+            // use (A + B) - C = (A - C) + (B - C)
+            // *:t1 = t1 + _:p1
+            // _:p1 - [] = _:p1
+            unifyUnion(Cat(AnyElem, p1) :: difference(t1, Empty))
           case (Cat(h1: SeqPart1[A], t1), Cat(h2: SeqPart1[A], t2)) =>
             // h1:t1 - h2:t2 = (h1 n h2):(t1 - t2) + (h1 - h2):t1
             //               = (t1 n t2):(h1 - h2) + (t1 - t2):h1
             // if t1 n t2 = 0 then t1 - t2 == t1
             val intH = part1SetOps.intersection(h1, h2)
-            if (intH.isEmpty) {
-              // then h1 - h2 = h1
-              p1 :: Nil
-            }
-            else if (disjoint(t1, t2)) {
-              p1 :: Nil
-            }
-            else {
-              val d1 =
-                for {
-                  h <- intH
-                  t <- difference(t1, t2)
-                } yield Cat(h, t)
+            val d1 =
+              for {
+                h <- intH
+                t <- difference(t1, t2)
+              } yield Cat(h, t)
 
-              val d2 = part1SetOps.difference(h1, h2).map(Cat(_, t1))
-              unifyUnion(d1 ::: d2)
-            }
+            val d2 = part1SetOps.difference(h1, h2).map(Cat(_, t1))
+            unifyUnion(d1 ::: d2)
           case (Cat(h1: SeqPart1[A], t1), Cat(Wildcard, t2)) =>
             // h1:t1 - (*:t2) = ((h1:t1 - _:p2) - t2)
             //
@@ -605,7 +648,12 @@ object SeqPattern {
                 unifyUnion(intr)
               }
             }
+          // $COVERAGE-OFF$
+          case pair =>
+            sys.error(s"unreachable shouldn't be Super or Intersects: $pair")
+          // $COVERAGE-ON$
         }
+      }
     }
 
   def matcher[A, I, S, R](split: Splitter[A, I, S, R]): Matcher[SeqPattern[A], S, R] =

--- a/core/src/main/scala/org/bykn/bosatsu/pattern/SeqPattern.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/pattern/SeqPattern.scala
@@ -156,10 +156,10 @@ object SeqPattern {
       // this is an incomplete heuristic now, not a complete solution
       def unifyUnion(union: List[SeqPattern[A]]): List[SeqPattern[A]] =
         unifyUnionList {
-            union
-              .map(_.normalize)
-              .distinct
-              .map(_.toList)
+          union
+            .map(_.normalize)
+            .distinct
+            .map(_.toList)
           }
           .map(SeqPattern.fromList(_).normalize)
           .sorted

--- a/core/src/main/scala/org/bykn/bosatsu/set/Rel.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/set/Rel.scala
@@ -44,6 +44,10 @@ sealed abstract class Rel { lhs =>
       case (_, Same) => lhs
       case _ => Intersects
     }
+
+  def lazyCombine(rhs: => Rel): Rel =
+    if (lhs == Disjoint) Disjoint
+    else (lhs |+| rhs)
 }
 
 object Rel {

--- a/core/src/main/scala/org/bykn/bosatsu/set/Relatable.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/set/Relatable.scala
@@ -58,7 +58,7 @@ object Relatable {
                 Right((ls.splitAt(sz / 2)))
             }
 
-          def cheapUnion(u: List[List[A]]) = u.flatten.distinct
+          def cheapUnion(head: List[A], tail: List[List[A]]) = (head :: tail).flatten.distinct
 
           def intersect(a: List[A], b: List[A]): List[A] =
             if (a.isEmpty || b.isEmpty) Nil
@@ -167,7 +167,7 @@ object Relatable {
      * This can be a cheap union, not a totally
      * normalizing union.
      */
-    def cheapUnion(as: List[A]): A
+    def cheapUnion(head: A, tail: List[A]): A
 
     def intersect(a: A, b: A): A
 
@@ -200,9 +200,9 @@ object Relatable {
           // Note, a is never empty here because if it is, unionRelCompare1 is Sub
           (deunion(a), p) match {
             case (Right((a1, a2)), SubIntersects) =>
-              val intrs =
-                intersect(b1, a1) :: intersect(b2, a1) :: intersect(b1, a2) :: intersect(b2, a2) :: Nil
-              val ab = cheapUnion(intrs)
+              val head = intersect(b1, a1)
+              val tail = intersect(b2, a1) :: intersect(b1, a2) :: intersect(b2, a2) :: Nil
+              val ab = cheapUnion(head, tail)
               subIntersectsCase(ab, a1, a2)
             case (Right((a1, a2)), SuperSame) =>
               // if we have SuperSame and invert(p1) what is the result
@@ -214,7 +214,7 @@ object Relatable {
 
               // we know that a1 and a2 are not empty because they are the result
               // of a deunion
-              unionRelCompare1(cheapUnion(b1 :: b2 :: Nil), a1, a2)(relatable) match {
+              unionRelCompare1(cheapUnion(b1, b2 :: Nil), a1, a2)(relatable) match {
                 case Left(r) => andInvert(r)
                 case Right(r) => r.invert
               }

--- a/core/src/main/scala/org/bykn/bosatsu/set/SetOps.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/set/SetOps.scala
@@ -229,28 +229,18 @@ object SetOps {
         toList(u.foldLeft(Set.empty[A])(_ | _))
 
       override def subset(a: Set[A], b: Set[A]): Boolean = a.subsetOf(b)
-      override def relate(a: Set[A], b: Set[A]) = {
-        val aSubB = a.subsetOf(b)
-        val bSubA = b.subsetOf(a)
-        if (aSubB) {
-          if (bSubA) Rel.Same
-          else Rel.Sub
-        }
-        else if (bSubA) Rel.Super
-        else {
+      private val rel = Relatable.fromSubsetIntersects[Set[A]](
+        _.subsetOf(_),
+        (a, b) => {
           // Disjoint or Intersects
           val sa = a.size
           val sb = b.size
-          if (sa <= sb) {
-            if (a.exists(b)) Rel.Intersects
-            else Rel.Disjoint
-          }
-          else {
-            if (b.exists(a)) Rel.Intersects
-            else Rel.Disjoint
-          }
+          if (sa <= sb) a.exists(b)
+          else b.exists(a)
         }
-      }
+      )
+      
+      def relate(a: Set[A], b: Set[A]) = rel.relate(a, b)
     }
 
   // for types with only one value, Null, Unit, Nil

--- a/core/src/main/scala/org/bykn/bosatsu/set/SetOps.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/set/SetOps.scala
@@ -26,7 +26,7 @@ trait SetOps[A] extends Relatable[A] {
       if (subset(a2, a1)) Rel.Same
       else Rel.Sub
     }
-    else if (subset(a2, a1)) Rel.Sub
+    else if (subset(a2, a1)) Rel.Super
     else {
       val inter = intersection(a1, a2)
       if (inter.isEmpty) Rel.Disjoint
@@ -228,6 +228,28 @@ object SetOps {
         toList(u.foldLeft(Set.empty[A])(_ | _))
 
       def subset(a: Set[A], b: Set[A]): Boolean = a.subsetOf(b)
+      override def relate(a: Set[A], b: Set[A]) = {
+        val aSubB = a.subsetOf(b)
+        val bSubA = b.subsetOf(a)
+        if (aSubB) {
+          if (bSubA) Rel.Same
+          else Rel.Sub
+        }
+        else if (bSubA) Rel.Super
+        else {
+          // Disjoint or Intersects
+          val sa = a.size
+          val sb = b.size
+          if (sa <= sb) {
+            if (a.exists(b)) Rel.Intersects
+            else Rel.Disjoint
+          }
+          else {
+            if (b.exists(a)) Rel.Intersects
+            else Rel.Disjoint
+          }
+        }
+      }
     }
 
   // for types with only one value, Null, Unit, Nil

--- a/core/src/test/scala/org/bykn/bosatsu/TotalityTest.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/TotalityTest.scala
@@ -5,7 +5,7 @@ import cats.data.NonEmptyList
 import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks.{ forAll, PropertyCheckConfiguration }
 import org.scalacheck.Gen
 
-import org.bykn.bosatsu.set.{SetOps, SetOpsLaws}
+import org.bykn.bosatsu.set.{SetOps, SetOpsLaws, Rel}
 
 import rankn._
 
@@ -463,5 +463,13 @@ enum Either: Left(l), Right(r)
     r1 ::
       */
     Nil
+  }
+
+  test("var pattern is super or same") {
+    val tc = TotalityCheck(predefTE)
+
+    val p1 :: p2 :: _ = patterns("""[foo, Bar(1)]""")
+    val rel = tc.patternSetOps.relate(p1, p2)
+    assertEquals(rel, Rel.Super) 
   }
 }

--- a/core/src/test/scala/org/bykn/bosatsu/TotalityTest.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/TotalityTest.scala
@@ -346,8 +346,9 @@ enum Either: Left(l), Right(r)
 
   test("x - top = 0 regressions") {
     // see: https://github.com/johnynek/bosatsu/issues/475
-    def law(x: Pat, y: Pat) = {
-      if (setOps.isTop(y)) assert(setOps.difference(x, y).isEmpty)
+    def law(x: Pat, y: Pat)(implicit loc: munit.Location) = {
+      if (setOps.isTop(y))
+        assert(setOps.difference(x, y).isEmpty, s"x = ${showPat(x)}, y = ${showPat(y)}")
     }
 
     val regressions: List[(Pat, Pat)] =

--- a/core/src/test/scala/org/bykn/bosatsu/TotalityTest.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/TotalityTest.scala
@@ -476,8 +476,16 @@ enum Either: Left(l), Right(r)
   test("union commutes") {
     val tc = TotalityCheck(predefTE)
 
-    val p1 :: p2 :: _ = patterns("""[Some(1 | 2), Some(1) | Some(2)]""")
-    val rel = tc.patternSetOps.relate(p1, p2)
-    assertEquals(rel, Rel.Same) 
+    {
+      val p1 :: p2 :: _ = patterns("""[Some(1 | 2), Some(1) | Some(2)]""")
+      val rel = tc.patternSetOps.relate(p1, p2)
+      assertEquals(rel, Rel.Same) 
+    }
+
+    {
+      val p1 :: p2 :: _ = patterns("""[Some(1 | 2 | 3), Some(1) | Some(2)]""")
+      val rel = tc.patternSetOps.relate(p1, p2)
+      assertEquals(rel, Rel.Super) 
+    }
   }
 }

--- a/core/src/test/scala/org/bykn/bosatsu/TotalityTest.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/TotalityTest.scala
@@ -140,7 +140,7 @@ enum Bool: False, True
   }
 
   def notTotal(te: TypeEnv[Any], pats: List[Pattern[(PackageName, Constructor), Type]], testMissing: Boolean = true): Unit = {
-    val res = TotalityCheck(te).isTotal(pats)
+    val res = TotalityCheck(te).missingBranches(pats).isEmpty
     assert(!res, pats.toString)
 
     if (testMissing) {

--- a/core/src/test/scala/org/bykn/bosatsu/TotalityTest.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/TotalityTest.scala
@@ -141,10 +141,10 @@ enum Bool: False, True
     }
   }
 
-  def testTotality(te: TypeEnv[Any], pats: List[Pattern[(PackageName, Constructor), Type]], tight: Boolean = false) = {
+  def testTotality(te: TypeEnv[Any], pats: List[Pattern[(PackageName, Constructor), Type]], tight: Boolean = false)(implicit loc: munit.Location) = {
     val res = TotalityCheck(te).missingBranches(pats)
     val asStr = res.map(showPat)
-    assert(asStr == Nil, showPats(pats))
+    assertEquals(asStr, Nil, showPats(pats))
 
     // any missing pattern shouldn't be total:
     def allButOne[A](head: A, tail: List[A]): List[List[A]] =
@@ -471,5 +471,13 @@ enum Either: Left(l), Right(r)
     val p1 :: p2 :: _ = patterns("""[foo, Bar(1)]""")
     val rel = tc.patternSetOps.relate(p1, p2)
     assertEquals(rel, Rel.Super) 
+  }
+
+  test("union commutes") {
+    val tc = TotalityCheck(predefTE)
+
+    val p1 :: p2 :: _ = patterns("""[Some(1 | 2), Some(1) | Some(2)]""")
+    val rel = tc.patternSetOps.relate(p1, p2)
+    assertEquals(rel, Rel.Same) 
   }
 }

--- a/core/src/test/scala/org/bykn/bosatsu/TotalityTest.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/TotalityTest.scala
@@ -558,4 +558,16 @@ enum Either: Left(l), Right(r)
       }
     }
   }
+
+  property("normalizePattern(p) <:> q == p <:> q") {
+    forAll(genPattern, genPattern) { (p, q) =>
+      val normp = PredefTotalityCheck.normalizePattern(p)
+      assertEquals(
+        setOps.relate(normp, q),
+        setOps.relate(p, q),
+      )  
+
+      assertEquals(setOps.relate(normp, p), Rel.Same)
+    }
+  }
 }

--- a/core/src/test/scala/org/bykn/bosatsu/pattern/SeqPatternTest.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/pattern/SeqPatternTest.scala
@@ -1,6 +1,6 @@
 package org.bykn.bosatsu.pattern
 
-import org.bykn.bosatsu.set.SetOps
+import org.bykn.bosatsu.set.{Rel, SetOps}
 import org.scalacheck.{Arbitrary, Gen, Shrink}
 import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks.{ forAll, PropertyCheckConfiguration }
 
@@ -774,5 +774,13 @@ class SeqPatternTest extends SeqPatternLaws[Char, Char, String, Unit] {
     val p2 = Cat(Wildcard,Cat(Lit('0'),Cat(Lit('1'),Empty)))
 
     assert(setOps.subset(p2, p1))
+  }
+
+  test("intersection regression") {
+    val p1 = Cat(Wildcard,Cat(Lit('0'),Cat(Lit('1'),Empty)))
+    val p2 = Cat(Lit('0'),Cat(Lit('0'),Cat(Lit('0'),Cat(Wildcard,Empty))))
+
+    assert(setOps.relate(p2, p1) == Rel.Intersects)
+    assert(setOps.intersection(p1, p2).nonEmpty)
   }
 }

--- a/core/src/test/scala/org/bykn/bosatsu/pattern/SeqPatternTest.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/pattern/SeqPatternTest.scala
@@ -18,7 +18,7 @@ object StringSeqPatternGen {
   // generate a string of 0s and 1s to make matches more likely
   val genBitString: Gen[String] =
     for {
-      sz <- Gen.choose(0, 4)
+      sz <- Gen.geometric(4.0)
       g = Gen.oneOf(0, 1)
       list <- Gen.listOfN(sz, g)
     } yield list.mkString

--- a/core/src/test/scala/org/bykn/bosatsu/pattern/StringSeqPatternSetLaws.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/pattern/StringSeqPatternSetLaws.scala
@@ -1,9 +1,9 @@
 package org.bykn.bosatsu.pattern
 
+import org.bykn.bosatsu.Platform
 import org.bykn.bosatsu.set.{Rel, SetOps, SetOpsLaws}
 import cats.Eq
 import org.scalacheck.Gen
-import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks.PropertyCheckConfiguration
 
 import SeqPattern.{Cat, Empty}
 import SeqPart.{AnyElem, Lit, Wildcard}
@@ -14,10 +14,10 @@ class StringSeqPatternSetLaws extends SetOpsLaws[SeqPattern[Char]] {
   type Pattern = SeqPattern[Char]
   val Pattern = SeqPattern
 
-  implicit val generatorDrivenConfig: PropertyCheckConfiguration =
-    //PropertyCheckConfiguration(minSuccessful = 50000)
-    PropertyCheckConfiguration(minSuccessful = 5000)
-    //PropertyCheckConfiguration(minSuccessful = 5)
+  override def scalaCheckTestParameters =
+    super.scalaCheckTestParameters
+      .withMinSuccessfulTests(if (Platform.isScalaJvm) 1000 else 10)
+      .withMaxDiscardRatio(10)
 
   // if there are too many wildcards the intersections will blow up
   def genItem: Gen[Pattern] = StringSeqPatternGen.genPat.map { p =>

--- a/core/src/test/scala/org/bykn/bosatsu/pattern/StringSeqPatternSetLaws.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/pattern/StringSeqPatternSetLaws.scala
@@ -1,9 +1,12 @@
 package org.bykn.bosatsu.pattern
 
-import org.bykn.bosatsu.set.{SetOps, SetOpsLaws}
+import org.bykn.bosatsu.set.{Rel, SetOps, SetOpsLaws}
 import cats.Eq
 import org.scalacheck.Gen
 import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks.PropertyCheckConfiguration
+
+import SeqPattern.{Cat, Empty}
+import SeqPart.{AnyElem, Lit, Wildcard}
 
 import cats.implicits._
 
@@ -69,9 +72,6 @@ class StringSeqPatternSetLaws extends SetOpsLaws[SeqPattern[Char]] {
   }
 
   test("(a - b) n c = (a n c) - (b n c) regressions") {
-    import SeqPattern.{Cat, Empty}
-    import SeqPart.{AnyElem, Lit, Wildcard}
-
     val regressions: List[(SeqPattern[Char], SeqPattern[Char], SeqPattern[Char])] =
       (Cat(Wildcard, Empty),
         Cat(AnyElem,Cat(Lit('1'),Cat(AnyElem,Empty))),
@@ -95,5 +95,15 @@ class StringSeqPatternSetLaws extends SetOpsLaws[SeqPattern[Char]] {
       Nil
 
     regressions.foreach { case (a, b, c) => diffIntersectionLaw(a, b, c) }
+  }
+
+  test("intersection regression") {
+    val p1 = Cat(Wildcard,Cat(Lit('0'),Cat(Lit('1'),Empty)))
+    val p2 = Cat(Lit('0'),Cat(Lit('0'),Cat(Lit('0'),Cat(Wildcard,Empty))))
+
+    assert(setOps.relate(p1, p2) == Rel.Intersects)
+    assert(setOps.relate(p2, p1) == Rel.Intersects)
+    assert(setOps.intersection(p1, p2).nonEmpty)
+    assert(setOps.intersection(p2, p1).nonEmpty)
   }
 }

--- a/core/src/test/scala/org/bykn/bosatsu/rankn/TypeTest.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/rankn/TypeTest.scala
@@ -344,7 +344,7 @@ class TypeTest extends AnyFunSuite {
       val Type.ForAll(fas, t) = parse(forall)
       val targ = parse(matches)
       Type.instantiate(fas.iterator.toMap, t, targ) match {
-        case Some((frees, subMap)) =>
+        case Some((_, subMap)) =>
           assert(subMap.size == subs.size)
           subs.foreach { case (k, v) =>
             val Type.TyVar(b: Type.Var.Bound) = parse(k)

--- a/core/src/test/scala/org/bykn/bosatsu/set/RelLaws.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/set/RelLaws.scala
@@ -35,6 +35,12 @@ class RelLaws extends munit.ScalaCheckSuite {
     }
   }
 
+  property("|+| and lazyCombine are the same") {
+    forAll { (a: Rel, b: Rel) =>
+      assertEquals(a |+| b, a.lazyCombine(b))
+    }
+  }
+
   property("invert.invert is identity") {
     forAll { (a: Rel) =>
       assertEquals(a.invert.invert, a)
@@ -336,11 +342,8 @@ abstract class SetGenRelLaws[A](implicit val arbSet: Arbitrary[Set[A]], val arbE
     def deunion(a: S): Either[(S, S) => Rel.SuperOrSame, (S, S)] =
       if (a.size > 1) Right((Set(a.head), a.tail))
       else Left({(s1, s2) => if (a == (s1 | s2)) Rel.Same else Rel.Super })
-    /**
-     * This can be a cheap union, not a totally
-     * normalizing union.
-     */
-    def cheapUnion(as: List[S]): S = as.foldLeft(Set.empty[A])(_ | _)
+
+    def cheapUnion(head: S, tail: List[S]): S = tail.foldLeft(head)(_ | _)
 
     def intersect(a: S, b: S): S = a.intersect(b)
 

--- a/core/src/test/scala/org/bykn/bosatsu/set/RelLaws.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/set/RelLaws.scala
@@ -398,7 +398,10 @@ class ListUnionRelatableTests extends munit.ScalaCheckSuite {
     },
     { i =>
       val sz = i.size
-      if (sz >= 2) {
+      // we can actually solve this both ways
+      // exercise both paths by only using splitting
+      // when the hash code ends in 1
+      if ((sz >= 2) && ((i.hashCode & 1) == 1)) {
         val (l, r) = i.toList.splitAt(sz / 2)
         Right((l.toSet, r.toSet))
       }

--- a/core/src/test/scala/org/bykn/bosatsu/set/SetOpsLaws.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/set/SetOpsLaws.scala
@@ -8,6 +8,7 @@ abstract class SetOpsLaws[A] extends munit.ScalaCheckSuite {
   val setOps: SetOps[A]
 
   def genItem: Gen[A]
+  def genUnion: Gen[List[A]] = Gen.listOf(genItem)
 
   def eqUnion: Gen[Eq[List[A]]]
 
@@ -63,10 +64,11 @@ abstract class SetOpsLaws[A] extends munit.ScalaCheckSuite {
   }
 
   test("unify union makes size <= input") {
-    forAll(Gen.listOf(genItem)) { (ps: List[A]) =>
+    forAll(genUnion) { (ps: List[A]) =>
       val unified = unifyUnion(ps)
 
-      assert(ps.size >= unified.size, s"unified = $unified")
+      assert(ps.size >= unified.size,
+      s"input(${ps.size}): $ps\n\nunified(${unified.size}) = $unified\n\n")
     }
   }
 

--- a/core/src/test/scala/org/bykn/bosatsu/set/SetOpsLaws.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/set/SetOpsLaws.scala
@@ -272,6 +272,43 @@ abstract class SetOpsLaws[A] extends munit.ScalaCheckSuite {
       assert(rest == rest.distinct)
     }
   }
+
+  test("relate consistency") {
+    forAll(genItem, genItem, eqUnion) { (a, b, eqv) =>
+      setOps.relate(a, b) match {
+        case Rel.Same =>
+          val intr = setOps.intersection(a, b)
+          assert(eqv.eqv(intr, a :: Nil))
+          assert(eqv.eqv(intr, b :: Nil))
+        case Rel.Sub =>
+          val intr = setOps.intersection(a, b)
+          assert(eqv.eqv(intr, a :: Nil))
+          val diffB = setOps.difference(b, a)
+          assert(!eqv.eqv(diffB, Nil))
+        case Rel.Super =>
+          val intr = setOps.intersection(a, b)
+          assert(eqv.eqv(intr, b :: Nil))
+          val diffA = setOps.difference(a, b)
+          assert(!eqv.eqv(diffA, Nil))
+        case Rel.Disjoint =>
+          val intr = setOps.intersection(a, b)
+          assert(eqv.eqv(intr, Nil))
+          val diffA = setOps.difference(a, b)
+          val diffB = setOps.difference(b, a)
+          assert(eqv.eqv(diffA, a :: Nil))
+          assert(eqv.eqv(diffB, b :: Nil))
+        case Rel.Intersects =>
+          val intr = setOps.intersection(a, b)
+          assert(!eqv.eqv(intr, a :: Nil))
+          assert(!eqv.eqv(intr, b :: Nil))
+          assert(!eqv.eqv(intr, Nil))
+          val diffA = setOps.difference(a, b)
+          val diffB = setOps.difference(b, a)
+          assert(!eqv.eqv(diffA, Nil))
+          assert(!eqv.eqv(diffB, Nil))
+      }
+    }
+  }
 }
 
 class DistinctSetOpsTest extends SetOpsLaws[Byte] {

--- a/core/src/test/scala/org/bykn/bosatsu/set/SetOpsLaws.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/set/SetOpsLaws.scala
@@ -277,27 +277,34 @@ abstract class SetOpsLaws[A] extends munit.ScalaCheckSuite {
 
   test("relate consistency") {
     forAll(genItem, genItem, eqUnion) { (a, b, eqv) =>
-      setOps.relate(a, b) match {
+      val relAb = setOps.relate(a, b)
+      assertEquals(setOps.relate(b, a).invert, relAb)
+      relAb match {
         case Rel.Same =>
           val intr = setOps.intersection(a, b)
           assert(setOps.subset(a, b))
+          assert(setOps.subset(b, a))
+          assert(!setOps.disjoint(a, b))
           assert(eqv.eqv(intr, a :: Nil))
           assert(eqv.eqv(intr, b :: Nil))
         case Rel.Sub =>
           val intr = setOps.intersection(a, b)
           assert(setOps.subset(a, b))
+          assert(!setOps.disjoint(a, b))
           assert(eqv.eqv(intr, a :: Nil))
           val diffB = setOps.difference(b, a)
           assert(!eqv.eqv(diffB, Nil))
         case Rel.Super =>
           val intr = setOps.intersection(a, b)
           assert(setOps.subset(b, a))
+          assert(!setOps.disjoint(a, b))
           assert(eqv.eqv(intr, b :: Nil))
           val diffA = setOps.difference(a, b)
           assert(!eqv.eqv(diffA, Nil))
         case Rel.Disjoint =>
           val intr = setOps.intersection(a, b)
           assert(intr.isEmpty)
+          assert(setOps.disjoint(a, b))
           val diffA = setOps.difference(a, b)
           val diffB = setOps.difference(b, a)
           assert(eqv.eqv(diffA, a :: Nil))
@@ -309,8 +316,8 @@ abstract class SetOpsLaws[A] extends munit.ScalaCheckSuite {
           assert(intr.nonEmpty, s"a = $a, b = $b , intr = $intr")
           val diffA = setOps.difference(a, b)
           val diffB = setOps.difference(b, a)
-          assert(!eqv.eqv(diffA, Nil))
-          assert(!eqv.eqv(diffB, Nil))
+          assert(diffA.nonEmpty)
+          assert(diffB.nonEmpty)
       }
     }
   }

--- a/core/src/test/scala/org/bykn/bosatsu/set/SetOpsLaws.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/set/SetOpsLaws.scala
@@ -322,12 +322,13 @@ abstract class SetOpsLaws[A] extends munit.ScalaCheckSuite {
           assert(!eqv.eqv(a :: Nil, b :: Nil))
         case Rel.Intersects =>
           val intr = setOps.intersection(a, b)
-          assert(!eqv.eqv(intr, a :: Nil))
-          assert(!eqv.eqv(intr, b :: Nil))
-          assert(!eqv.eqv(a :: Nil, b :: Nil))
-          assert(intr.nonEmpty, s"a = $a, b = $b , intr = $intr")
           val diffA = setOps.difference(a, b)
           val diffB = setOps.difference(b, a)
+
+          assert(!eqv.eqv(intr, a :: Nil))
+          assert(!eqv.eqv(intr, b :: Nil), s"intr = $intr")
+          assert(!eqv.eqv(a :: Nil, b :: Nil))
+          assert(intr.nonEmpty, s"a = $a, b = $b , intr = $intr")
           assert(diffA.nonEmpty)
           assert(diffB.nonEmpty)
       }

--- a/core/src/test/scala/org/bykn/bosatsu/set/SetOpsLaws.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/set/SetOpsLaws.scala
@@ -287,6 +287,7 @@ abstract class SetOpsLaws[A] extends munit.ScalaCheckSuite {
           assert(!setOps.disjoint(a, b))
           assert(eqv.eqv(intr, a :: Nil))
           assert(eqv.eqv(intr, b :: Nil))
+          assert(eqv.eqv(a :: Nil, b :: Nil))
         case Rel.Sub =>
           val intr = setOps.intersection(a, b)
           assert(setOps.subset(a, b))
@@ -309,10 +310,12 @@ abstract class SetOpsLaws[A] extends munit.ScalaCheckSuite {
           val diffB = setOps.difference(b, a)
           assert(eqv.eqv(diffA, a :: Nil))
           assert(eqv.eqv(diffB, b :: Nil))
+          assert(!eqv.eqv(a :: Nil, b :: Nil))
         case Rel.Intersects =>
           val intr = setOps.intersection(a, b)
           assert(!eqv.eqv(intr, a :: Nil))
           assert(!eqv.eqv(intr, b :: Nil))
+          assert(!eqv.eqv(a :: Nil, b :: Nil))
           assert(intr.nonEmpty, s"a = $a, b = $b , intr = $intr")
           val diffA = setOps.difference(a, b)
           val diffB = setOps.difference(b, a)

--- a/core/src/test/scala/org/bykn/bosatsu/set/SetOpsLaws.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/set/SetOpsLaws.scala
@@ -1,13 +1,16 @@
 package org.bykn.bosatsu.set
 
 import cats.Eq
-import org.scalacheck.{Arbitrary, Cogen, Gen}
+import org.scalacheck.{Arbitrary, Cogen, Gen, Shrink}
 import org.scalacheck.Prop.forAll
 
 abstract class SetOpsLaws[A] extends munit.ScalaCheckSuite {
   val setOps: SetOps[A]
 
   def genItem: Gen[A]
+  implicit def shrinkItem: Shrink[A] =
+    Shrink(_ => Stream.empty)
+
   def genUnion: Gen[List[A]] = Gen.listOf(genItem)
 
   def eqUnion: Gen[Eq[List[A]]]
@@ -24,7 +27,7 @@ abstract class SetOpsLaws[A] extends munit.ScalaCheckSuite {
     assert(eqA.eqv(a12, a21), s"$a12 != $a21")
   }
 
-  def differenceIsIdempotent(a: A, b: A, eqAs: Eq[List[A]]) = {
+  def differenceIsIdempotent(a: A, b: A, eqAs: Eq[List[A]])(implicit loc: munit.Location) = {
     val c = unifyUnion(difference(a, b))
     val c1 = unifyUnion(differenceAll(c, b :: Nil))
     assert(eqAs.eqv(c, c1), s"c = $c\n\nc1 = $c1")

--- a/core/src/test/scala/org/bykn/bosatsu/set/SetOpsLaws.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/set/SetOpsLaws.scala
@@ -81,10 +81,10 @@ abstract class SetOpsLaws[A] extends munit.ScalaCheckSuite {
 
   def selfDifferenceLaw(p1: A, p2: A) = {
     if (p1 == p2) {
-      assert(difference(p1, p2) == Nil)
+      assertEquals(difference(p1, p2), Nil)
     }
-    assert(difference(p1, p1) == Nil)
-    assert(difference(p2, p2) == Nil)
+    assertEquals(difference(p1, p1), Nil)
+    assertEquals(difference(p2, p2), Nil)
   }
 
   test("a - a == 0") {
@@ -102,7 +102,7 @@ abstract class SetOpsLaws[A] extends munit.ScalaCheckSuite {
   test("x - top = 0") {
     top.foreach { t =>
       forAll(genItem) { (x) =>
-        assert(difference(x, t) == Nil)
+        assertEquals(difference(x, t), Nil)
       }
     }
 
@@ -128,7 +128,7 @@ abstract class SetOpsLaws[A] extends munit.ScalaCheckSuite {
     forAll(genItem, genItem) { (x: A, y: A) =>
       val z = difference(x, y)
       val z1 = unifyUnion(differenceAll(z, z))
-      assert(z1 == Nil, s"z = $z")
+      assertEquals(z1, Nil, s"z = $z")
     }
   }
 
@@ -138,16 +138,20 @@ abstract class SetOpsLaws[A] extends munit.ScalaCheckSuite {
   def isSubsetDiff(a: A, b: A) =
     difference(a, b).isEmpty
 
-  def subsetConsistencyLaw(a: A, b: A, eqAs: Eq[List[A]]) = {
+  def subsetConsistencyLaw(a: A, b: A, eqAs: Eq[List[A]])(implicit loc: munit.Location) = {
     val intSub = isSubsetIntr(a, b, eqAs)
     val diffSub = isSubsetDiff(a, b)
 
     if (subset(a, b)) {
       assert(intSub)
       assert(diffSub)
+      assertEquals(intSub, diffSub)
     }
-
-    assert(intSub == diffSub)
+    else {
+      // we can have false positives of intSub
+      // when we have a sampling equality
+      assertEquals(diffSub, false)
+    }
   }
 
   test("subset consistency: a n b == a <=> a - b = 0") {
@@ -157,14 +161,14 @@ abstract class SetOpsLaws[A] extends munit.ScalaCheckSuite {
   test("difference returns distinct values") {
     forAll(genItem, genItem) { (a, b) =>
       val c = difference(a, b)
-      assert(c == c.distinct)
+      assertEquals(c, c.distinct)
     }
   }
 
   test("intersection returns distinct values") {
     forAll(genItem, genItem) { (a, b) =>
       val c = intersection(a, b)
-      assert(c == c.distinct)
+      assertEquals(c, c.distinct)
     }
   }
 
@@ -232,7 +236,7 @@ abstract class SetOpsLaws[A] extends munit.ScalaCheckSuite {
       }
       else {
         val rightu = unifyUnion(right)
-        assert(leftu == rightu, s"diffAB = $diffab, intAC = $intAC, intBC = $intBC")
+        assertEquals(leftu, rightu, s"diffAB = $diffab, intAC = $intAC, intBC = $intBC")
       }
     }
   }
@@ -256,7 +260,7 @@ abstract class SetOpsLaws[A] extends munit.ScalaCheckSuite {
       val rest1 = missingBranches(top :: Nil, pats ::: rest)
       if (rest1.isEmpty) {
         val unreach = unreachableBranches(pats ::: rest)
-        assert(unreach.filter(rest.toSet) == Nil, s"\n\nrest = ${rest}\n\ninit: ${pats}")
+        assertEquals(unreach.filter(rest.toSet), Nil, s"\n\nrest = ${rest}\n\ninit: ${pats}")
       }
       else {
         fail(s"after adding ${rest} we still need ${rest1}")
@@ -276,7 +280,7 @@ abstract class SetOpsLaws[A] extends munit.ScalaCheckSuite {
 
     forAll(pats, pats) { (top, pats) =>
       val rest = missingBranches(top, pats)
-      assert(rest == rest.distinct)
+      assertEquals(rest, rest.distinct)
     }
   }
 
@@ -441,10 +445,10 @@ class SetOpsTests extends munit.ScalaCheckSuite {
         if (i <= 1) acc
         else fact(i - 1, i * acc)
 
-      assert(perms.length == fact(is0.size, 1))
+      assertEquals(perms.length, fact(is0.size, 1))
 
       perms.foreach { p =>
-        assert(p.sorted == is.sorted)
+        assertEquals(p.sorted, is.sorted)
       }
       val pi = perms.zipWithIndex
 
@@ -539,7 +543,7 @@ class SetOpsTests extends munit.ScalaCheckSuite {
         val ba = pa(b)
         val bb = pb(b)
         val bc = pc(b)
-        assert(left(b) == right(b), s"ba = $ba, bb = $bb, bc = $bc, ${left(b)} != ${right(b)}")
+        assertEquals(left(b), right(b), s"ba = $ba, bb = $bb, bc = $bc, ${left(b)} != ${right(b)}")
       }
     }
   }
@@ -564,7 +568,7 @@ class SetOpsTests extends munit.ScalaCheckSuite {
       val left = a1.product(b1) - a2.product(b2)
       val right = (a1 && a2).product(b1 - b2) || (a1 - a2).product(b1)
       checks.foreach { ab =>
-        assert(left(ab) == right(ab))
+        assertEquals(left(ab), right(ab))
       }
     }
   }


### PR DESCRIPTION
The idea here is to use the UnionRelModule to improve relation computation for Patterns.

Computing the relationships of patterns in the presence of nested unions and non-normalized representations is pretty challenging.

The UnionRelModule allows you to have a recursive structure that is well tested. So you only have to solve simpler problems and be sure it's correct.

This and the added test coverage wound up fixing some lurking bugs in the original set relationship calculations on Patterns, but since TotalityCheck is only a compilation lint, the bugs could only have manifested by a runtime error of a non-total pattern match (which I never saw so far).