### PR TITLE
Improve python code gen for top level names

### DIFF
--- a/core/src/main/scala/org/bykn/bosatsu/codegen/python/PythonGen.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/codegen/python/PythonGen.scala
@@ -59,9 +59,6 @@ object PythonGen {
             Code.Ident(escapeRaw("___b", b.asString + c.toString))
           }
 
-        def bindTop(b: Bindable): EnvState =
-          subs(b, escape(b))
-
         // in loops we need to substitute
         // bindings for mutable variables
         def subs(b: Bindable, c: Code.Ident): EnvState =
@@ -151,9 +148,6 @@ object PythonGen {
       Impl.env(_.bind(b))
 
     // point this name to the top level name
-    def bindTop(b: Bindable): Env[Unit] =
-      Impl.update(_.bindTop(b))
-
     def subs(b: Bindable, i: Code.Ident): Env[Unit] =
       Impl.update(_.subs(b, i))
 

--- a/core/src/main/scala/org/bykn/bosatsu/codegen/python/PythonGen.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/codegen/python/PythonGen.scala
@@ -263,9 +263,8 @@ object PythonGen {
           for {
             // allocate a new unshadowable var
             cv <- Env.newAssignableVar
-            assigned = cv := cx
             res <- ifElse(NonEmptyList((cv, t), rest), elseV)
-          } yield assigned.withValue(res)
+          } yield (cv := cx).withValue(res)
       }
     }
 
@@ -1550,9 +1549,8 @@ object PythonGen {
                   bi <- Env.bind(b)
                   tl <- topFn(bi, fn, slotName)
                   ine <- inF
-                  wv = tl.withValue(ine)
                   _ <- Env.unbind(b)
-                } yield wv
+                } yield tl.withValue(ine)
               case Left(LocalAnon(l)) =>
                 // anonymous names never shadow
                 Env.nameForAnon(l)
@@ -1573,9 +1571,8 @@ object PythonGen {
                     bi <- Env.bind(b)
                     v <- loop(notFn, slotName)
                     ine <- inF
-                    wv = (bi := v).withValue(ine)
                     _ <- Env.unbind(b)
-                  } yield wv
+                  } yield ((bi := v).withValue(ine))
                 }
                 else {
                   // value b is in scope after ve
@@ -1583,9 +1580,8 @@ object PythonGen {
                     ve <- loop(notFn, slotName)
                     bi <- Env.bind(b)
                     ine <- inF
-                    wv = (bi := ve).withValue(ine)
                     _ <- Env.unbind(b)
-                  } yield wv
+                  } yield ((bi := ve).withValue(ine))
                 }
               case Left(LocalAnon(l)) =>
                 // anonymous names never shadow


### PR DESCRIPTION
Since function parameter names shadow the same in python and bosatsu, we can escape those directly rather than allocating new ones to simulate the scoping rules.

Here is a small diff:

```
--- pyout/Bosatsu/BinNat.py	2024-02-03 11:40:29
+++ pyout_new/Bosatsu/BinNat.py	2024-02-03 11:27:31
@@ -2,188 +2,180 @@
 import Bosatsu.Predef as ___iPredef1
 import unittest as ___iunittest2
 
-def ___btoInt0(___bb1):
-    if ___bb1[0] == 0:
+def toInt(b):
+    if b[0] == 0:
         return 0
-    elif ___bb1[0] == 1:
-        ___bn2 = ___bb1[1]
-        return (___btoInt0(___bn2) * 2) + 1
+    elif b[0] == 1:
+        ___bn0 = b[1]
+        return (toInt(___bn0) * 2) + 1
     else:
-        ___bn3 = ___bb1[1]
-        return (___btoInt0(___bn3) * 2) + 2
-toInt = ___btoInt0
+        ___bn1 = b[1]
+        return (toInt(___bn1) * 2) + 2
 
-def ___btoNat0(___bb3):
-    if ___bb3[0] == 0:
+def toNat(b):
+    if b[0] == 0:
         return 0
-    elif ___bb3[0] == 1:
-        ___bn6 = ___bb3[1]
-        return ___iNat0.times2(___btoNat0(___bn6)) + 1
+    elif b[0] == 1:
+        ___bn2 = b[1]
+        return ___iNat0.times2(toNat(___bn2)) + 1
     else:
-        ___bn7 = ___bb3[1]
-        return ___iNat0.times2(___btoNat0(___bn7)) + 2
-toNat = ___btoNat0
+        ___bn3 = b[1]
+        return ___iNat0.times2(toNat(___bn3)) + 2
 

```