### PR TITLE
Inline applying lambda in Python code generation

### DIFF
--- a/cli/src/test/scala/org/bykn/bosatsu/codegen/python/CodeTest.scala
+++ b/cli/src/test/scala/org/bykn/bosatsu/codegen/python/CodeTest.scala
@@ -496,4 +496,10 @@ else:
       assert(Code.substitute(Map.empty, x) == x)  
     }
   }
+
+  test("simplify creates subsets of freeIdents (we can remove ternary branches)") {
+    forAll(genExpr(4)) { x =>
+      assert(Code.freeIdents(x.simplify).subsetOf(Code.freeIdents(x)))
+    }
+  }
 }

--- a/cli/src/test/scala/org/bykn/bosatsu/codegen/python/CodeTest.scala
+++ b/cli/src/test/scala/org/bykn/bosatsu/codegen/python/CodeTest.scala
@@ -475,6 +475,22 @@ else:
     }
   }
 
+  test("(lambda x: lambda y: x + y)(y)") {
+    val x = Code.Ident("x")
+    val y = Code.Ident("y")
+    val hardCase = Code.Lambda(List(x),
+      Code.Lambda(List(y), x + y)
+    )
+
+    val applied = hardCase(y).simplify
+    val y0 = Code.Ident("y0")
+    assert(applied == Code.Lambda(List(y0), y + y0))
+
+    val z = Code.Ident("z")
+    val applied1 = hardCase(z).simplify
+    assert(applied1 == Code.Lambda(List(y), z + y))
+  }
+
   test("simplify(Map.empty, x) == x") {
     forAll(genExpr(4)) { x =>
       assert(Code.substitute(Map.empty, x) == x)  


### PR DESCRIPTION
Here is an example:
```
 def log2(i):
-    ___t64 = 0 < i
-    ___t65 = 0
-    ___t66 = i
-    ___t67 = 0
-    while ___t64:
-        ___t65 = (lambda n, cnt: (n // 2, cnt + 1))(___t66, ___t67)
-        ___t68 = ___t65[0]
-        ___t67 = ___t65[1]
-        ___t64 = (0 < ___t68) and (___t68 < ___t66)
-        ___t66 = ___t68
-    return ___t67
+    ___t16 = 0 < i
+    ___t17 = 0
+    ___t18 = i
+    ___t19 = 0
+    while ___t16:
+        ___t20 = ___t18 // 2
+        ___t19 = ___t19 + 1
+        ___t16 = (0 < ___t20) and (___t20 < ___t18)
+        ___t18 = ___t20
+    return ___t19
```

In the `int_loop` built-in function, we often wind up with `(lambda x, y: ...)(x_arg, y_arg)` patterns, which could be inlined. Also, in this example, we know we are returning a tuple2. So, we can try to inline the lambda, and if that works, we can often avoid allocating the tuple as well.