### PR TITLE
Add deps tool to show dependencies

### DIFF
--- a/cli/src/main/scala/org/bykn/bosatsu/PathModule.scala
+++ b/cli/src/main/scala/org/bykn/bosatsu/PathModule.scala
@@ -6,8 +6,11 @@ import org.typelevel.paiges.{Doc, Document}
 
 import java.nio.file.{Path => JPath}
 
-import cats.implicits._
+import cats.data.NonEmptyList
 import cats.effect.ExitCode
+
+import cats.implicits.catsKernelOrderingForOrder
+import cats.syntax.all._
 
 object PathModule extends MainModule[IO] {
   type Path = JPath
@@ -16,14 +19,14 @@ object PathModule extends MainModule[IO] {
     Argument.readPath
 
   def readPath(path: Path): IO[String] =
-    IO(new String(java.nio.file.Files.readAllBytes(path), "utf-8"))
+    IO.blocking(new String(java.nio.file.Files.readAllBytes(path), "utf-8"))
 
   val resolvePath: Some[(Path, PackageName) => IO[Option[Path]]] =
     Some(
       { (root: Path, pack: PackageName) =>
         val dir = pack.parts.init.foldLeft(root)(_.resolve(_))
         val filePath = dir.resolve(pack.parts.last + ".bosatsu")
-        IO {
+        IO.blocking {
           // this is a side-effect since file is mutable
           // and talks to the file system
           val file = filePath.toFile
@@ -47,11 +50,11 @@ object PathModule extends MainModule[IO] {
 
   def unfoldDir: Option[Path => IO[Option[IO[List[Path]]]]] = Some {
     { (path: Path) =>
-      IO {
+      IO.blocking {
         val f = path.toFile
 
         if (f.isDirectory()) {
-          Some(IO {
+          Some(IO.blocking {
             f.listFiles.iterator.map(_.toPath).toList
           })
         }
@@ -64,7 +67,7 @@ object PathModule extends MainModule[IO] {
     { (path: Path) => path.toString.endsWith(str) }
 
   def print(str: => String): IO[Unit] =
-    IO(println(str))
+    IO.println(str)
 
   def delay[A](a: => A): IO[A] = IO(a)
 
@@ -72,6 +75,21 @@ object PathModule extends MainModule[IO] {
     io.attempt.flatMap {
       case Right(out) => reportOutput(out)
       case Left(err) => reportException(err).as(ExitCode.Error)
+    }
+
+
+  private def writeOut(doc: Doc, out: Option[Path]): IO[Unit] =
+    out match {
+      case None =>
+        IO.blocking {
+          doc.renderStreamTrim(80)
+            .iterator
+            .foreach(System.out.print)
+
+          System.out.println("")
+        }
+      case Some(p) =>
+        CodeGenWrite.writeDoc(p, doc)
     }
 
   def reportOutput(out: Output): IO[ExitCode] =
@@ -125,11 +143,8 @@ object PathModule extends MainModule[IO] {
         val doc = resDoc.value + (Doc.lineOrEmpty + Doc.text(": ") + tDoc).nested(4)
         print(doc.render(100)).as(ExitCode.Success)
       case Output.JsonOutput(json, pathOpt) =>
-        val jdoc = json.toDoc
-        (pathOpt match {
-          case Some(path) => CodeGenWrite.writeDoc(path, jdoc)
-          case None => IO(println(jdoc.renderTrim(80)))
-        }).as(ExitCode.Success)
+        writeOut(json.toDoc, pathOpt)
+          .as(ExitCode.Success)
 
       case Output.TranspileOut(outs, base) =>
         def path(p: List[String]): Path =
@@ -163,19 +178,114 @@ object PathModule extends MainModule[IO] {
         }
 
         val doc = Doc.intercalate(Doc.hardLine, idocs ::: pdocs)
-        output match {
-          case None =>
-            IO.blocking {
-              doc.renderStreamTrim(80)
-                .iterator
-                .foreach(System.out.print)
+        writeOut(doc, output).as(ExitCode.Success)
 
-              System.out.println("")
+      case Output.DepsOutput(depinfo, output, style) => 
+        style match {
+          case GraphOutput.Json => 
+            def toJson(dep: (Path, PackageName, FileKind, List[PackageName])): Json =
+              Json.JObject(
+                ("path", Json.JString(dep._1.toString())) ::
+                ("package", Json.JString(dep._2.asString)) ::
+                ("kind", Json.JString(dep._3.name)) ::
+                ("dependsOn", Json.JArray(
+                  dep._4.map { pn => Json.JString(pn.asString) }.toVector
+                )) ::
+                Nil
+              )
+
+            val asJson = Json.JArray(depinfo
+              .sortBy { case (path, pn, fk, _) => (path, pn, fk.name) }
+              .map(toJson)
+              .toVector)
+
+            writeOut(asJson.toDoc, output).as(ExitCode.Success)
+          case GraphOutput.Dot =>
+
+            def shapeOf(fk: FileKind): String =
+              fk match {
+                case FileKind.Iface => "diamond"
+                case FileKind.Pack => "box"
+                case FileKind.Source => "circle"
+              }
+
+            type Ident = String
+            def makeNode(idx: Int, dep: (Path, PackageName, FileKind, List[PackageName])): (Ident, String) = {
+              // C [shape=box, fillcolor=lightgrey, label="Node C"];
+              val ident = s"N$idx"
+              val decl = s"$ident [shape=${shapeOf(dep._3)}, label=\"${dep._2.asString}\"];"
+              (ident, decl)
             }
-            .as(ExitCode.Success)
-          case Some(p) =>
-            CodeGenWrite.writeDoc(p, doc)
-              .as(ExitCode.Success)
+            def makeMissing(idx: Int, pack: PackageName): (Ident, String) = {
+              // C [shape=box, fillcolor=lightgrey, label="Node C"];
+              val ident = s"N$idx"
+              val decl = s"$ident [shape=octogon, label=\"${pack.asString}\"];"
+              (ident, decl)
+            }
+
+            val knownPacks = depinfo.map(_._2).toSet
+            val allPacks = depinfo.flatMap { dep => dep._2 :: dep._4 }.distinct.sorted
+            val unknownPacks = allPacks.filterNot(knownPacks)
+            type NodeMap = Map[PackageName, NonEmptyList[(Int, Option[FileKind], String, String)]]
+            val depinfoSize = depinfo.size
+            val nodes: NodeMap =
+              (depinfo.zipWithIndex.map { case (dep, idx) =>
+                val (ident, nstr) = makeNode(idx, dep)  
+                (dep._2, (idx, Some(dep._3), ident, nstr))
+              } ::: unknownPacks.mapWithIndex { (pn, idx0) =>
+                val idx = depinfoSize + idx0
+                val (ident, nstr) = makeMissing(idx, pn)  
+                (pn, (idx, None, ident, nstr))
+              })
+              .groupByNel(_._1)
+              .map { case (k, v) =>
+                (k, v.map(_._2))  
+              }
+
+            // now NodeMap has everything
+            def makeEdge(src: PackageName, k: FileKind, dst: PackageName, nm: NodeMap): String = {
+              implicit val orderKind: cats.Order[Option[FileKind]] = 
+                new cats.Order[Option[FileKind]] {
+                  def compare(a: Option[FileKind], b: Option[FileKind]) =
+                    (a, b) match {
+                      case (None, None) => 0
+                      case (Some(_), None) => -1
+                      case (None, Some(_)) => 1
+                      case (Some(FileKind.Iface), Some(FileKind.Iface)) => 0
+                      case (Some(FileKind.Iface), Some(_)) => -1
+                      case (Some(FileKind.Pack), Some(FileKind.Iface)) => 1
+                      case (Some(FileKind.Pack), Some(FileKind.Pack)) => 0
+                      case (Some(FileKind.Pack), Some(FileKind.Source)) => -1
+                      case (Some(FileKind.Source), Some(FileKind.Source)) => 0
+                      case (Some(FileKind.Source), Some(_)) => 1
+                    }
+                }
+
+              val srcNode = nm(src).find { case (_, sk, _, _) => sk == Some(k) }.get
+              val dstNode = nm(dst).sortBy { rec => (rec._2, rec._1) }.head
+              s"${srcNode._3} -> ${dstNode._3};"
+            }
+
+            val header = Doc.text("digraph G {")
+            val allNodes: List[Doc] = nodes.iterator.flatMap { case (_, ns) =>
+                ns.map { rec => (rec._1, Doc.text(rec._4)) }.toList  
+              }
+              .toList
+              .sortBy(_._1)
+              .map(_._2)
+            val nodesDoc = Doc.intercalate(Doc.hardLine, allNodes)
+            val edges: List[Doc] =
+              depinfo.flatMap { case (_, pn, k, deps) =>
+                deps.map { dep =>
+                  Doc.text(makeEdge(pn, k, dep, nodes))
+                }
+              }
+            val edgesDoc = Doc.intercalate(Doc.hardLine, edges)
+
+            val fullDoc = header + (Doc.hardLine + nodesDoc + Doc.hardLine + edgesDoc).nested(2) +
+              Doc.hardLine + Doc.char('}')
+
+            writeOut(fullDoc, output).as(ExitCode.Success)
         }
     }
 
@@ -185,7 +295,7 @@ object PathModule extends MainModule[IO] {
         IO.consoleForIO.errorln(msg)
       case None =>
         IO.consoleForIO.errorln("unknown error:\n") *>
-          IO(ex.printStackTrace(System.err))
+          IO.blocking(ex.printStackTrace(System.err))
     }
 
   def pathPackage(roots: List[Path], packFile: Path): Option[PackageName] = {

--- a/core/src/main/scala/org/bykn/bosatsu/ExportedName.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/ExportedName.scala
@@ -6,7 +6,7 @@ import cats.parse.{Parser => P}
 import org.typelevel.paiges.{Doc, Document}
 import scala.util.hashing.MurmurHash3
 
-import rankn.TypeEnv
+import rankn.{DefinedType, TypeEnv}
 
 sealed abstract class ExportedName[+T] { self: Product =>
   def name: Identifier
@@ -43,6 +43,7 @@ sealed abstract class ExportedName[+T] { self: Product =>
          }
      }
 }
+
 object ExportedName {
   case class Binding[T](name: Identifier.Bindable, tag: T) extends ExportedName[T]
   case class TypeName[T](name: Identifier.Constructor, tag: T) extends ExportedName[T]
@@ -117,6 +118,13 @@ object ExportedName {
   def typeEnvFromExports[A](packageName: PackageName, exports: List[ExportedName[Referant[A]]]): TypeEnv[A] =
     exports.foldLeft((TypeEnv.empty): TypeEnv[A]) { (te, exp) =>
       exp.tag.addTo(packageName, exp.name, te)
+    }
+
+  def definedType[A](ex: ExportedName[Referant[A]]): Option[DefinedType[A]] =
+    ex.tag match {
+      case Referant.Constructor(dt, _) => Some(dt)
+      case Referant.DefinedT(dt) => Some(dt)
+      case Referant.Value(_) => None
     }
 }
 

--- a/core/src/main/scala/org/bykn/bosatsu/FirstOrSecond.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/FirstOrSecond.scala
@@ -1,0 +1,28 @@
+package org.bykn.bosatsu
+
+import cats.Order
+
+sealed abstract class FirstOrSecond[+A, +B]
+object FirstOrSecond {
+  case class First[A](first: A) extends FirstOrSecond[A, Nothing]
+  case class Second[B](second: B) extends FirstOrSecond[Nothing, B]
+
+  implicit def orderFS[A: Order, B: Order]: Order[FirstOrSecond[A, B]] = 
+    new Order[FirstOrSecond[A, B]] {
+      def compare(a: FirstOrSecond[A, B], b: FirstOrSecond[A, B]) =
+        (a, b) match {
+          case (First(fa), First(fb)) =>
+            Order[A].compare(fa, fb)
+          case (Second(sa), Second(sb)) =>
+            Order[B].compare(sa, sb)
+          case (First(_), Second(_)) => -1
+          case (Second(_), First(_)) => 1
+        }
+    }
+
+  def someFirst[A](opt: Option[A]): FirstOrSecond[A, Unit] =
+    opt match {
+      case Some(a) => FirstOrSecond.First(a)
+      case None => FirstOrSecond.Second(())
+    }
+}

--- a/core/src/main/scala/org/bykn/bosatsu/Import.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/Import.scala
@@ -73,6 +73,9 @@ case class Import[A, B](pack: A, items: NonEmptyList[ImportedName[B]]) {
       case Some(i1) => Some(Import(pack, i1))
       case None => None
     }
+
+  def map[C](fn: B => C): Import[A, C] =
+    Import(pack, items.map(_.map(fn)))
 }
 
 object Import {

--- a/core/src/main/scala/org/bykn/bosatsu/MainModule.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/MainModule.scala
@@ -1262,7 +1262,7 @@ abstract class MainModule[IO[_]](implicit
           parsed <- moduleIOMonad.fromTry(toTry(this, maybeParsed, errColor))
         } yield 
           parsed.map { case (path, (pn, imps, _)) =>
-            (path, pn, FileKind.Source, Package.distinctNonPredef(imps.map(_.pack)))  
+            (path, pn, FileKind.Source, PackageName.distinctNonPredef(imps.map(_.pack)))  
           }
 
       def run =

--- a/core/src/main/scala/org/bykn/bosatsu/Package.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/Package.scala
@@ -393,4 +393,28 @@ object Package {
           Doc.intercalate(Doc.hardLine, all)
         }.nested(4)
     }
+
+  def ifaceDeps(iface: Package.Interface): List[PackageName] = {
+    val pn = iface.name
+    distinctNonPredef(iface.exports
+      .iterator
+      .flatMap { n =>
+        n.tag match {
+          case Referant.Value(t) => Iterator.single(t)
+          case _ => Iterator.empty
+        }
+      }
+      .flatMap(rankn.Type.constantsOf)
+      .collect { case rankn.Type.Const.Defined(p, _) if p != pn => p }
+      .toList)
+  }
+
+  def distinctNonPredef(lst: List[PackageName]): List[PackageName] =
+    lst
+      .filterNot(_ == PackageName.PredefName)
+      .distinct
+      .sorted
+
+  def packageDeps(pack: Package.Typed[Any]): List[PackageName] =
+    distinctNonPredef(pack.imports.map(_.pack.name))
 }

--- a/core/src/main/scala/org/bykn/bosatsu/Package.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/Package.scala
@@ -9,6 +9,7 @@ import scala.util.hashing.MurmurHash3
 
 import rankn._
 import Parser.{spaces, Combinators}
+import PackageName.distinctNonPredef
 
 import FixType.Fix
 /**
@@ -408,12 +409,6 @@ object Package {
       .collect { case rankn.Type.Const.Defined(p, _) if p != pn => p }
       .toList)
   }
-
-  def distinctNonPredef(lst: List[PackageName]): List[PackageName] =
-    lst
-      .filterNot(_ == PackageName.PredefName)
-      .distinct
-      .sorted
 
   def packageDeps(pack: Package.Typed[Any]): List[PackageName] =
     distinctNonPredef(pack.imports.map(_.pack.name))

--- a/core/src/main/scala/org/bykn/bosatsu/Package.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/Package.scala
@@ -72,6 +72,8 @@ object Package {
     Program[TypeEnv[Kind.Arg], TypedExpr[T], Any]]
   type Inferred = Typed[Declaration]
 
+  type Header = (PackageName, List[Import[PackageName, Unit]], List[ExportedName[Unit]])
+
   val typedFunctor: Functor[Typed] =
     new Functor[Typed] {
       def map[A, B](fa: Typed[A])(fn: A => B): Typed[B] = {
@@ -164,7 +166,7 @@ object Package {
       Doc.intercalate(Doc.empty, p :: i :: e :: b)
     }
 
-  def parser(defaultPack: Option[PackageName]): P0[Package[PackageName, Unit, Unit, List[Statement]]] = {
+  def headerParser(defaultPack: Option[PackageName]): P0[Header] = {
     // TODO: support comments before the Statement
     val parsePack = Padding.parser((P.string("package").soft ~ spaces) *> PackageName.parser <* Parser.toEOL).map(_.padded)
     val pname: P0[PackageName] =
@@ -175,9 +177,14 @@ object Package {
 
     val im = Padding.parser(Import.parser <* Parser.toEOL).map(_.padded).rep0
     val ex = Padding.parser((P.string("export").soft ~ spaces) *> ExportedName.parser.itemsMaybeParens.map(_._2) <* Parser.toEOL).map(_.padded)
+
+    (pname, im, Parser.nonEmptyListToList(ex)).tupled
+  }
+
+  def parser(defaultPack: Option[PackageName]): P0[Package[PackageName, Unit, Unit, List[Statement]]] = {
     val body: P0[List[Statement]] = Statement.parser
-    (pname, im, Parser.nonEmptyListToList(ex), body)
-      .mapN { (p, i, e, b) => Package(p, i, e, b) }
+    (headerParser(defaultPack), body)
+      .mapN { case ((p, i, e), b) => Package(p, i, e, b) }
   }
 
   /**

--- a/core/src/main/scala/org/bykn/bosatsu/PackageCustoms.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/PackageCustoms.scala
@@ -171,13 +171,7 @@ object PackageCustoms {
 
   private def checkValuesHaveExportedTypes[V](pn: PackageName, exports: List[ExportedName[Referant[V]]]): ValidatedNec[PackageError, Unit] = {
     val exportedTypes: List[DefinedType[V]] = exports
-      .iterator
-      .map(_.tag)
-      .collect {
-        case Referant.Constructor(dt, _) => dt
-        case Referant.DefinedT(dt) => dt
-      }
-      .toList
+      .flatMap(ExportedName.definedType(_))
       .distinct
 
     val exportedTE = TypeEnv.fromDefinitions(exportedTypes)
@@ -193,7 +187,6 @@ object PackageCustoms {
       }
       .flatMap { case (t, n) => Type.constantsOf(t).map((_, n, t)) }
       .filter { case (Type.Const.Defined(p, _), _, _) => p === pn }
-
 
     def errorFor(t: (Type.Const, Exp, Type)): List[PackageError] =
       exportedTE.toDefinedType(t._1) match {

--- a/core/src/main/scala/org/bykn/bosatsu/PackageName.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/PackageName.scala
@@ -41,5 +41,11 @@ object PackageName {
 
   val PredefName: PackageName =
     PackageName(NonEmptyList.of("Bosatsu", "Predef"))
+
+  def distinctNonPredef(lst: List[PackageName]): List[PackageName] =
+    lst
+      .filterNot(_ == PackageName.PredefName)
+      .distinct
+      .sorted
 }
 

--- a/core/src/main/scala/org/bykn/bosatsu/deps/FileKind.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/deps/FileKind.scala
@@ -1,0 +1,27 @@
+package org.bykn.bosatsu.deps
+
+import cats.Order
+
+sealed abstract class FileKind(val name: String)
+object FileKind {
+  case object Source extends FileKind("source")
+  case object Iface extends FileKind("interface")
+  case object Pack extends FileKind("package")
+
+  // order such that less information comes before more information
+  implicit val orderKind: cats.Order[FileKind] = 
+    new cats.Order[FileKind] {
+      def compare(a: FileKind, b: FileKind) =
+        (a, b) match {
+          case (FileKind.Iface, FileKind.Iface) => 0
+          case (FileKind.Iface, _) => -1
+          case (FileKind.Pack, FileKind.Iface) => 1
+          case (FileKind.Pack, FileKind.Pack) => 0
+          case (FileKind.Pack, FileKind.Source) => -1
+          case (FileKind.Source, FileKind.Source) => 0
+          case (FileKind.Source, _) => 1
+        }
+    }
+
+  implicit def orderingKind: Ordering[FileKind] = orderKind.toOrdering
+}

--- a/core/src/test/scala/org/bykn/bosatsu/FirstOrSecondTests.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/FirstOrSecondTests.scala
@@ -31,4 +31,13 @@ class FirstOrSecondTests extends munit.ScalaCheckSuite {
       }
     }
   }
+  property("someFirst is the reverse of the usual order") {
+    forAll { (o1: Option[Byte], o2: Option[Byte]) =>
+      val ord1 = Order[Option[Byte]].toOrdering.reverse  
+      val ord2 = FirstOrSecond.orderFS(Order.fromOrdering(Ordering[Byte].reverse), Order[Unit])
+
+      assertEquals(ord1.compare(o1, o2).signum,
+        ord2.compare(FirstOrSecond.someFirst(o1), FirstOrSecond.someFirst(o2)).signum)
+    }
+  }
 }

--- a/core/src/test/scala/org/bykn/bosatsu/FirstOrSecondTests.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/FirstOrSecondTests.scala
@@ -1,0 +1,34 @@
+package org.bykn.bosatsu
+
+import cats.Order
+import org.scalacheck.{Arbitrary, Gen, Prop}
+import Prop.forAll
+
+class FirstOrSecondTests extends munit.ScalaCheckSuite {
+
+  implicit def arbFirstSec[A: Arbitrary, B: Arbitrary]: Arbitrary[FirstOrSecond[A, B]] =
+    Arbitrary(
+      Gen.oneOf(
+        Arbitrary.arbitrary[A].map(FirstOrSecond.First(_)),
+        Arbitrary.arbitrary[B].map(FirstOrSecond.Second(_))
+      )
+    )
+
+  property("first or second ordering is lawful") {
+    forAll { (f1: FirstOrSecond[Int, String], f2: FirstOrSecond[Int, String], f3: FirstOrSecond[Int, String]) =>
+      OrderingLaws.forOrder(f1, f2, f3)  
+    }
+  }
+
+  property("first < second") {
+    forAll { (f1: FirstOrSecond[Int, String], f2: FirstOrSecond[Int, String]) =>
+      (f1, f2) match {
+        case (FirstOrSecond.First(_), FirstOrSecond.Second(_)) =>
+          assert(Order[FirstOrSecond[Int, String]].lt(f1, f2))
+        case (FirstOrSecond.Second(_), FirstOrSecond.First(_)) =>
+          assert(Order[FirstOrSecond[Int, String]].gt(f1, f2))
+        case _ => ()
+      }
+    }
+  }
+}

--- a/core/src/test/scala/org/bykn/bosatsu/PackageNameTest.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/PackageNameTest.scala
@@ -1,0 +1,22 @@
+package org.bykn.bosatsu
+
+import org.scalacheck.Gen
+import org.scalacheck.Prop.forAll
+import rankn.NTypeGen.packageNameGen
+
+class PackageNameTest extends munit.ScalaCheckSuite {
+  property("ordering is lawful") {
+    forAll(packageNameGen, packageNameGen, packageNameGen)(OrderingLaws.law(_, _, _))
+  }
+
+  property("distinctNonPredef does what it says") {
+    forAll(Gen.listOf(packageNameGen)) { packs =>
+      assertEquals(PackageName.distinctNonPredef(packs),
+        packs.distinct.sorted.filterNot(_ == PackageName.PredefName))
+    }
+  }
+
+  property("distinctNonPredef doesn't have predef") {
+    assertEquals(PackageName.distinctNonPredef(PackageName.PredefName :: Nil), Nil)
+  }
+}

--- a/core/src/test/scala/org/bykn/bosatsu/deps/FileKindTest.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/deps/FileKindTest.scala
@@ -1,0 +1,14 @@
+package org.bykn.bosatsu.deps
+
+import org.scalacheck.Prop.forAll
+import org.scalacheck.Gen
+
+class FileKindTest extends munit.ScalaCheckSuite {
+  val genFileKind = Gen.oneOf[FileKind](FileKind.Source, FileKind.Iface, FileKind.Pack)
+
+  property("ordering works") {
+    forAll(genFileKind, genFileKind, genFileKind) { (a, b, c) =>
+      org.bykn.bosatsu.OrderingLaws.law(a, b, c)
+    }
+  }
+}

--- a/core/src/test/scala/org/bykn/bosatsu/rankn/RankNInferTest.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/rankn/RankNInferTest.scala
@@ -170,7 +170,7 @@ class RankNInferTest extends AnyFunSuite {
 
   // this could be used to test the string representation of expressions
   def checkTERepr(statement: String, repr: String) =
-    checkLast(statement) { te => assert(te.repr == repr) }
+    checkLast(statement) { te => assert(te.repr.render(80) == repr) }
 
   /**
    * Test that a program is ill-typed


### PR DESCRIPTION
This adds a new subcommand, `deps` to show the dependencies between packages without having to compile. It works on sources, interfaces and compiled packages.

It can output json or dot graphs, the latter purely for visualization.