### PR TITLE
Support comments in headers

### DIFF
--- a/core/src/main/scala/org/bykn/bosatsu/CommentStatement.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/CommentStatement.scala
@@ -31,12 +31,12 @@ object CommentStatement {
       val commentBlock: P[NonEmptyList[String]] =
         // if the next line is part of the comment until we see the # or not
         (Parser.maybeSpace.with1.soft *> commentPart)
-          .repSep(sep = sep) <* Parser.newline.orElse(P.end)
+          .repSep(sep = sep) <* Parser.termination
 
       (commentBlock ~ onP(indent))
         .map { case (m, on) => CommentStatement(m, on) }
     }
 
   val commentPart: P[String] =
-    P.char('#') *> P.until0(P.char('\n'))
+    P.char('#') *> P.until0(Parser.termination)
 }

--- a/core/src/main/scala/org/bykn/bosatsu/Package.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/Package.scala
@@ -190,10 +190,12 @@ object Package {
         Doc.intercalate(Doc.empty, p :: i :: e :: b)
     }
 
+
   def headerParser(defaultPack: Option[PackageName]): P0[Header] = {
     val spaceComment: P0[Unit] =
-      (Parser.spaces | (P.char('#') <* P.charsWhile0(_ != '\n'))).?.void
-    val eol = Parser.commentToEOL.void | Parser.toEOL
+      (Parser.spaces.? ~ CommentStatement.commentPart.?).void
+
+    val eol = spaceComment <* Parser.termination
     val parsePack = Padding
       .parser(
         (P.string("package")

--- a/core/src/main/scala/org/bykn/bosatsu/Padding.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/Padding.scala
@@ -22,12 +22,14 @@ object Padding {
 
   /** This allows an empty padding
     */
-  def parser[T](p: P[T]): P[Padding[T]] = {
-    val spacing = (maybeSpace.with1.soft ~ Parser.newline).void.rep0
+  def parser[T](p: P[T], space: P0[Unit]): P[Padding[T]] = {
+    val spacing = (space.with1.soft ~ Parser.newline).void.rep0
 
     (spacing.with1.soft ~ p)
       .map { case (vec, t) => Padding(vec.size, t) }
   }
+
+  def parser[T](p: P[T]): P[Padding[T]] = parser(p, maybeSpace)
 
   /** Parses a padding of length 1 or more, then p
     */

--- a/core/src/main/scala/org/bykn/bosatsu/Parser.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/Parser.scala
@@ -448,7 +448,11 @@ object Parser {
     (P.char('(') ~ ws) *> pa <* (ws ~ P.char(')'))
 
   val newline: P[Unit] = P.char('\n')
-  val toEOL: P0[Unit] = maybeSpace *> newline.orElse(P.end)
+  // The comment excluding the leading # up to the EOL or EOF
+  val termination: P0[Unit] = newline.orElse(P.end)
+  val commentToEOL: P[String] =
+    P.char('#') *> P.charsWhile0(_ != '\n') <* termination
+  val toEOL: P0[Unit] = maybeSpace *> termination
   val toEOL1: P[Unit] = maybeSpace.with1 *> newline
 
   def optionParse[A](pa: P0[A], str: String): Option[A] =

--- a/core/src/main/scala/org/bykn/bosatsu/Parser.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/Parser.scala
@@ -448,10 +448,7 @@ object Parser {
     (P.char('(') ~ ws) *> pa <* (ws ~ P.char(')'))
 
   val newline: P[Unit] = P.char('\n')
-  // The comment excluding the leading # up to the EOL or EOF
   val termination: P0[Unit] = newline.orElse(P.end)
-  val commentToEOL: P[String] =
-    P.char('#') *> P.charsWhile0(_ != '\n') <* termination
   val toEOL: P0[Unit] = maybeSpace *> termination
   val toEOL1: P[Unit] = maybeSpace.with1 *> newline
 

--- a/core/src/test/scala/org/bykn/bosatsu/ParserTest.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/ParserTest.scala
@@ -1722,9 +1722,12 @@ external def foo2(i: Integer, b: a) -> String
     roundTrip(
       Package.parser(None),
       """
+# we can comment the package
 package Foo/Bar
+# comments are allowed
 from Baz import Bippy
-export foo
+# even here
+export foo # or here
 
 foo = 1
 """


### PR DESCRIPTION
this allows comments in headers, but discards them: it does not retain them in the parsed AST.

This is convenient when we are really strict about imports and exports.