### PR TITLE
Change test evaluation

### DIFF
--- a/core/src/main/scala/org/bykn/bosatsu/Evaluation.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/Evaluation.scala
@@ -90,7 +90,7 @@ case class Evaluation[T](pm: PackageMap.Typed[T], externals: Externals) {
   /** Return the last test, if any, in the package. this is the test that is run
     * when we test the package
     */
-  def lastTest(p: PackageName): Option[Eval[Value]] =
+  def testValue(p: PackageName): Option[Eval[Value]] =
     for {
       pack <- pm.toMap.get(p)
       (name, _, _) <- Package.testValue(pack)
@@ -123,7 +123,7 @@ case class Evaluation[T](pm: PackageMap.Typed[T], externals: Externals) {
    */
 
   def evalTest(ps: PackageName): Option[Eval[Test]] =
-    lastTest(ps).map { ea =>
+    testValue(ps).map { ea =>
       ea.map(Test.fromValue(_))
     }
 

--- a/core/src/main/scala/org/bykn/bosatsu/Test.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/Test.scala
@@ -1,6 +1,5 @@
 package org.bykn.bosatsu
 
-import cats.Eval
 import org.typelevel.paiges.Doc
 
 sealed abstract class Test {
@@ -100,12 +99,12 @@ object Test {
   }
 
   def outputFor(
-      resultList: List[(PackageName, Option[Eval[Test]])],
+      resultList: List[(PackageName, Option[Test])],
       color: LocationMap.Colorize
   ): Report = {
     val noTests = resultList.collect { case (p, None) => p }
     val results = resultList
-      .collect { case (p, Some(t)) => (p, Test.report(t.value, color)) }
+      .collect { case (p, Some(t)) => (p, Test.report(t, color)) }
       .sortBy(_._1)
 
     val successes = results.iterator.map { case (_, Report(s, _, _)) => s }.sum

--- a/jsui/src/main/scala/org/bykn/bosatsu/jsui/Store.scala
+++ b/jsui/src/main/scala/org/bykn/bosatsu/jsui/Store.scala
@@ -51,7 +51,8 @@ object Store {
         )
         val handler: HandlerFn = {
           case memoryMain.Output.TestOutput(resMap, color) =>
-            val testReport = Test.outputFor(resMap, color)
+            val evaluatedTests = resMap.map { case (p, opt) => (p, opt.map(_.value)) }
+            val testReport = Test.outputFor(evaluatedTests, color)
             testReport.doc.render(80)
           case other =>
             s"internal error. got unexpected result: $other"


### PR DESCRIPTION
related to #1180

Just using parallelism doesn't work because MatchlessToValue uses mutable state and it seems that threading breaks.

Considering how to make that work when values can be evaluated in parallel requires some thought. Probably using Eval at all won't work, and we will need something smarter.