### PR TITLE
Improve external def parsing

### DIFF
--- a/core/src/main/scala/org/bykn/bosatsu/DefRecursionCheck.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/DefRecursionCheck.scala
@@ -109,7 +109,7 @@ object DefRecursionCheck {
           case Def(defn) =>
             // make this the same shape as a in declaration
             checkDef(TopLevel, defn.copy(result = (defn.result, ())))
-          case ExternalDef(_, _, _) =>
+          case ExternalDef(_, _, _, _) =>
             unitValid
         }
       case _ => unitValid

--- a/core/src/main/scala/org/bykn/bosatsu/PackageError.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/PackageError.scala
@@ -364,6 +364,20 @@ object PackageError {
               context
 
             (doc, Some(region))
+          case Infer.Error.KindExpectedType(tpe, kind, region) =>
+            val tmap = showTypes(pack, tpe :: Nil)
+            val context =
+              lm.showRegion(region, 2, errColor)
+                .getOrElse(
+                  Doc.str(region)
+                ) // we should highlight the whole region
+            val doc = Doc.text("expected type ") +
+              tmap(tpe) + Doc.text(
+                " to have kind *, which is to say be a valid value, but it is kind "
+              ) + Kind.toDoc(kind) + Doc.hardLine +
+              context
+
+            (doc, Some(region))
           case Infer.Error.KindInvalidApply(applied, leftK, rightK, region) =>
             val leftT = applied.on
             val rightT = applied.arg

--- a/core/src/main/scala/org/bykn/bosatsu/TypeRefConverter.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/TypeRefConverter.scala
@@ -21,7 +21,7 @@ object TypeRefConverter {
     import TypeRef._
 
     t match {
-      case TypeVar(v)  => Applicative[F].pure(TyVar(Type.Var.Bound(v)))
+      case tv @ TypeVar(_)  => Applicative[F].pure(TyVar(tv.toBoundVar))
       case TypeName(n) => nameToType(n.ident).map(TyConst(_))
       case TypeArrow(as, b) =>
         (as.traverse(toType(_)), toType(b)).mapN(Fun(_, _))

--- a/core/src/main/scala/org/bykn/bosatsu/rankn/Infer.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/rankn/Infer.scala
@@ -2663,7 +2663,9 @@ object Infer {
 
     val checkExternals =
       GetEnv.flatMap { env =>
-        externals.toList
+        externals
+          .toList
+          .sortBy { case (_, (_, region)) => region }
           .parTraverse_ { case (_, (t, region)) =>
             env.getKind(t, region) match {
               case Right(Kind.Type) => unit

--- a/core/src/main/scala/org/bykn/bosatsu/rankn/Infer.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/rankn/Infer.scala
@@ -184,7 +184,7 @@ object Infer {
     ) extends TypeError
     case class KindExpectedType(
       tpe: Type,
-      kind: Kind,
+      kind: Kind.Cons,
       region: Region
     ) extends TypeError
     case class KindMismatch(

--- a/core/src/test/scala/org/bykn/bosatsu/EvaluationTest.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/EvaluationTest.scala
@@ -3990,4 +3990,21 @@ test = TestSuite("bases",
       12
     )
   }
+
+  test("external defs with explicit type parameters exactly match") {
+    val testCode = """
+package ErrorCheck
+
+external def foo[b](lst: List[a]) -> a
+
+"""
+    evalFail(List(testCode)) {
+      case kie @ PackageError.SourceConverterErrorsIn(_, _, _) =>
+        val message = kie.message(Map.empty, Colorize.None)
+        assert(message.contains("Region(30,59)"))
+        assert(message.contains("[b], not the same as [a]"))
+        assert(testCode.substring(30, 59) == "def foo[b](lst: List[a]) -> a")
+        ()
+    }
+  }
 }

--- a/core/src/test/scala/org/bykn/bosatsu/Gen.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/Gen.scala
@@ -1120,11 +1120,13 @@ object Generators {
   val genExternalDef: Gen[Statement] =
     for {
       name <- bindIdentGen
+      tas0 <- Gen.option(smallList(Gen.zip(typeRefVarGen, Gen.option(NTypeGen.genKind))))
       argc <- Gen.choose(0, 5)
       argG = Gen.zip(bindIdentGen, typeRefGen)
       args <- Gen.listOfN(argc, argG)
+      tas = if (args.isEmpty) None else tas0
       res <- typeRefGen
-    } yield Statement.ExternalDef(name, args, res)(emptyRegion)
+    } yield Statement.ExternalDef(name, tas.flatMap(NonEmptyList.fromList(_)), args, res)(emptyRegion)
 
   val genEnum: Gen[Statement] =
     for {

--- a/core/src/test/scala/org/bykn/bosatsu/ParserTest.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/ParserTest.scala
@@ -1716,6 +1716,13 @@ external def foo(i: Integer, b: a) -> String
 external def foo2(i: Integer, b: a) -> String
 """
     )
+    roundTrip(
+      Statement.parser,
+      """# header
+external def foo[a](i: Integer, b: a) -> String
+external def foo_co[a: +* -> *](i: Integer, b: a) -> String
+""")
+
   }
 
   test("we can parse any package") {

--- a/core/src/test/scala/org/bykn/bosatsu/rankn/RankNInferTest.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/rankn/RankNInferTest.scala
@@ -126,7 +126,8 @@ class RankNInferTest extends AnyFunSuite {
         testPackage,
         terms.map { case (k, v, _) =>
           (Identifier.Name(k), RecursionKind.NonRecursive, v)
-        }
+        },
+        Map.empty
       )
       .runFully(withBools, boolTypes, Type.builtInKinds) match {
       case Left(err) => assert(false, err)
@@ -224,7 +225,7 @@ class RankNInferTest extends AnyFunSuite {
         fail(
           "expected an invalid program, but got:\n\n" + program.lets
             .map { case (b, r, t) =>
-              s"$b: $r = ${t.repr}"
+              s"$b: $r = ${t.repr.render(80)}"
             }
             .mkString("\n\n")
         )
@@ -1907,5 +1908,14 @@ struct Box[a](item: a)
 
 f = foo(Box(Foo))
     """, "Foo")
+  }
+
+  test("ill kinded external defs are not allowed") {
+    parseProgramIllTyped("""#
+struct Foo
+external def foo[f: * -> *](function: f) -> f
+
+f = Foo
+""")
   }
 }

--- a/core/src/test/scala/org/bykn/bosatsu/rankn/RankNInferTest.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/rankn/RankNInferTest.scala
@@ -1917,5 +1917,13 @@ external def foo[f: * -> *](function: f) -> f
 
 f = Foo
 """)
+
+    parseProgramIllTyped("""#
+struct Box[a](item: a)
+external foo: Box
+
+struct Foo
+f = Foo
+""")
   }
 }

--- a/core/src/test/scala/org/bykn/bosatsu/rankn/RankNInferTest.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/rankn/RankNInferTest.scala
@@ -1897,4 +1897,15 @@ ignore: exists a. a = Tup(refl_bottom, refl_bottom1, refl_Foo, refl_any)
       "exists a. a"
     )
   }
+
+  test("test external def with kinds") {
+    parseProgram("""
+struct Foo
+external def foo[f: * -> *](f: f[Foo]) -> Foo
+
+struct Box[a](item: a)
+
+f = foo(Box(Foo))
+    """, "Foo")
+  }
 }


### PR DESCRIPTION
close #1170 

This does a few things:

1. allows external def to have type parameters. This allows setting the kinds on the type parameters other than kind `*`.
2. error if the type parameters do not exactly match the free types in the external def.
3. verify that the final type of the external def is well kinded. Previously, we just took parsed syntax and accepted whatever was claimed, but that allowed to make values of the wrong kind.