### PR TITLE
Optimize if-matches case

### DIFF
--- a/core/src/main/scala/org/bykn/bosatsu/SourceConverter.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/SourceConverter.scala
@@ -348,6 +348,19 @@ final class SourceConverter(
             else RecursionKind.NonRecursive
           Expr.Let(boundName, lam, in, recursive = rec, decl)
         }
+      case IfElse(NonEmptyList((Matches(a, p), res), Nil), elseCase) =>
+        // if x matches p: res
+        // else: elseCase
+        // same as: match x:
+        //            case p: res
+        //            case _: elseCase
+        loop(Match(
+          RecursionKind.NonRecursive,
+          a,
+          OptIndent.same(NonEmptyList(
+            (p, res),
+            (Pattern.WildCard, elseCase) :: Nil
+          )))(decl.region))
       case IfElse(ifCases, elseCase) =>
         def loop0(
             ifs: NonEmptyList[(Expr[Declaration], Expr[Declaration])],

--- a/core/src/main/scala/org/bykn/bosatsu/SourceConverter.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/SourceConverter.scala
@@ -348,18 +348,30 @@ final class SourceConverter(
             else RecursionKind.NonRecursive
           Expr.Let(boundName, lam, in, recursive = rec, decl)
         }
-      case IfElse(NonEmptyList((Matches(a, p), res), Nil), elseCase) =>
+      case IfElse(NonEmptyList((Matches(a, p), res), tail), elseCase) if p.names.isEmpty =>
         // if x matches p: res
         // else: elseCase
         // same as: match x:
         //            case p: res
         //            case _: elseCase
+        //
+        // we filter on p.names.isEmpty to ensure this is valid, if it isn't valid
+        // we want to give the most localized version of Matches to the unusued
+        // let checker to give the best error message.
+        val restDecl: OptIndent[Declaration] =
+          NonEmptyList.fromList(tail) match {
+            case None => elseCase
+            case Some(nel) =>
+              val restRegion = nel.map(_._2.get.region).reduce[Region](_ + _)
+              // keep the OptIndent from the first item
+              nel.head._2.map(_ => IfElse(nel, elseCase)(restRegion))
+          }
         loop(Match(
           RecursionKind.NonRecursive,
           a,
           OptIndent.same(NonEmptyList(
             (p, res),
-            (Pattern.WildCard, elseCase) :: Nil
+            (Pattern.WildCard, restDecl) :: Nil
           )))(decl.region))
       case IfElse(ifCases, elseCase) =>
         def loop0(

--- a/core/src/test/scala/org/bykn/bosatsu/EvaluationTest.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/EvaluationTest.scala
@@ -4004,4 +4004,20 @@ external def foo[b](lst: List[a]) -> a
         ()
     }
   }
+
+  test("test nested if matches") {
+    runBosatsuTest(
+      List("""
+package Foo
+
+export fn
+
+def fn(x):
+  if x matches True: False
+  elif x matches False: True
+  else: False
+
+test = Assertion(fn(False), "")
+"""), "Foo", 1)
+  }
 }


### PR DESCRIPTION
the pattern:
```
if x matches p:
  trueCase
else:
  falseCase
```

was being compiled into:
```
b = match x:
  case p: True
  case _: False

match b:
  case True: trueCase
  case False: falseCase
```
rather than relying on optimization later, it's easy to detect this pattern while still at the source AST and directly convert to:
```
match x:
  case p: trueCase
  case _: falseCase
```
