### PR TITLE
Improve duplicate imports

### DIFF
--- a/cli/src/main/scala/org/bykn/bosatsu/TypedExprToProto.scala
+++ b/cli/src/main/scala/org/bykn/bosatsu/TypedExprToProto.scala
@@ -1816,7 +1816,7 @@ object ProtoConverter {
                 importsFromProto(_, loadIface, loadDT)
               )
               impMap <- ReaderT.liftF(
-                ImportMap.fromImports(imps)((_, _) => None) match {
+                ImportMap.fromImports(imps)((_, _) => ImportMap.Unify.Error) match {
                   case (Nil, im) => Success(im)
                   case (nel, _) =>
                     Failure(new Exception(s"duplicated imports in package: $nel"))

--- a/cli/src/main/scala/org/bykn/bosatsu/TypedExprToProto.scala
+++ b/cli/src/main/scala/org/bykn/bosatsu/TypedExprToProto.scala
@@ -1552,7 +1552,7 @@ object ProtoConverter {
     // the Int is in index in the list of definedTypes:
     val allDts
         : SortedMap[(PackageName, TypeName), (DefinedType[Kind.Arg], Int)] =
-      cpack.program.types.definedTypes.mapWithIndex((dt, idx) => (dt, idx))
+      cpack.types.definedTypes.mapWithIndex((dt, idx) => (dt, idx))
     val dtVect: Vector[DefinedType[Kind.Arg]] =
       allDts.values.iterator.map(_._1).toVector
     val tab =
@@ -1560,10 +1560,9 @@ object ProtoConverter {
         nmId <- getId(cpack.name.asString)
         imps <- cpack.imports.traverse(importToProto(allDts, _))
         exps <- cpack.exports.traverse(expNameToProto(allDts, _))
-        prog = cpack.program
-        lets <- prog.lets.traverse(letToProto)
-        exdefs <- prog.externalDefs.traverse { nm =>
-          extDefToProto(nm, prog.types.getValue(cpack.name, nm))
+        lets <- cpack.lets.traverse(letToProto)
+        exdefs <- cpack.externalDefs.traverse { nm =>
+          extDefToProto(nm, cpack.types.getValue(cpack.name, nm))
         }
         dts <- dtVect.traverse(definedTypeToProto)
       } yield { (ss: SerState) =>
@@ -1774,7 +1773,7 @@ object ProtoConverter {
               case Left((_, dt)) =>
                 dt.toDefinedType(tc)
               case Right(comp) =>
-                comp.program.types.toDefinedType(tc)
+                comp.types.toDefinedType(tc)
             }
 
             res.flatMap {
@@ -1816,13 +1815,19 @@ object ProtoConverter {
               imps <- pack.imports.toList.traverse(
                 importsFromProto(_, loadIface, loadDT)
               )
+              impMap <- ReaderT.liftF(
+                ImportMap.fromImports(imps)((_, _) => None) match {
+                  case (Nil, im) => Success(im)
+                  case (nel, _) =>
+                    Failure(new Exception(s"duplicated imports in package: $nel"))
+                })
               exps <- pack.exports.toList.traverse(
                 exportedNameFromProto(loadDT, _)
               )
               lets <- pack.lets.toList.traverse(letsFromProto)
               eds <- pack.externalDefs.toList.traverse(externalDefsFromProto)
               prog <- buildProgram(packageName, lets, eds)
-            } yield Package(packageName, imps, exps, prog)
+            } yield Package(packageName, imps, exps, (prog, impMap))
 
           // build up the decoding state by decoding the tables in order
           val tab1 = Scoped.run(

--- a/cli/src/test/scala/org/bykn/bosatsu/TestProtoType.scala
+++ b/cli/src/test/scala/org/bykn/bosatsu/TestProtoType.scala
@@ -46,12 +46,12 @@ class TestProtoType extends AnyFunSuite with ParTest {
         .map(_._2)
         .getOrElse(0)
 
-    val context = 100
+    val context = 1000
     assert(
       Eq[A].eqv(a, orig),
       s"${a.toString.drop(diffIdx - context / 2).take(context)} != ${orig.toString.drop(diffIdx - context / 2).take(context)}"
     )
-    // assert(Eq[A].eqv(a, orig), s"$a\n\n!=\n\n$orig")
+    //assert(Eq[A].eqv(a, orig), s"$a\n\n!=\n\n$orig")
   }
 
   def testWithTempFile(fn: Path => IO[Unit]): Unit = {
@@ -59,7 +59,7 @@ class TestProtoType extends AnyFunSuite with ParTest {
       val f = File.createTempFile("proto_test", ".proto")
       f.toPath
     }) { path =>
-      IO {
+      IO.blocking {
         val _ = path.toFile.delete
         ()
       }

--- a/core/src/main/scala/org/bykn/bosatsu/Evaluation.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/Evaluation.scala
@@ -16,9 +16,9 @@ case class Evaluation[T](pm: PackageMap.Typed[T], externals: Externals) {
     MMap.empty
 
   private def externalEnv(p: Package.Typed[T]): Map[Identifier, Eval[Value]] = {
-    val externalNames = p.program.externalDefs
+    val externalNames = p.externalDefs
     externalNames.iterator.map { n =>
-      val tpe = p.program.types.getValue(p.name, n) match {
+      val tpe = p.types.getValue(p.name, n) match {
         case Some(t) => t
         case None    =>
           // $COVERAGE-OFF$
@@ -70,7 +70,7 @@ case class Evaluation[T](pm: PackageMap.Typed[T], externals: Externals) {
     envCache.getOrElseUpdate(
       packName, {
         val pack = pm.toMap(packName)
-        externalEnv(pack) ++ evalLets(packName, pack.program.lets)
+        externalEnv(pack) ++ evalLets(packName, pack.lets)
       }
     )
 
@@ -81,7 +81,7 @@ case class Evaluation[T](pm: PackageMap.Typed[T], externals: Externals) {
   ): Option[(Eval[Value], Type)] =
     for {
       pack <- pm.toMap.get(p)
-      (_, _, tpe) <- pack.program.lets.filter { case (n, _, _) =>
+      (_, _, tpe) <- pack.lets.filter { case (n, _, _) =>
         n == name
       }.lastOption
       value <- evaluate(p).get(name)
@@ -133,7 +133,7 @@ case class Evaluation[T](pm: PackageMap.Typed[T], externals: Externals) {
   val valueToJson: ValueToJson = ValueToJson { case Type.Const.Defined(pn, t) =>
     for {
       pack <- pm.toMap.get(pn)
-      dt <- pack.program.types.getType(pn, t)
+      dt <- pack.types.getType(pn, t)
     } yield dt
   }
 
@@ -143,7 +143,7 @@ case class Evaluation[T](pm: PackageMap.Typed[T], externals: Externals) {
   val valueToDoc: ValueToDoc = ValueToDoc { case Type.Const.Defined(pn, t) =>
     for {
       pack <- pm.toMap.get(pn)
-      dt <- pack.program.types.getType(pn, t)
+      dt <- pack.types.getType(pn, t)
     } yield dt
   }
 }

--- a/core/src/main/scala/org/bykn/bosatsu/ImportMap.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/ImportMap.scala
@@ -1,0 +1,65 @@
+package org.bykn.bosatsu
+
+import cats.{Applicative, Order}
+import scala.collection.immutable.SortedMap
+
+import cats.syntax.all._
+
+/** There are all the distinct imported names and the original ImportedName
+  */
+case class ImportMap[A, B](toMap: SortedMap[Identifier, (A, ImportedName[B])]) {
+  def apply(name: Identifier): Option[(A, ImportedName[B])] =
+    toMap.get(name)
+
+  def +(that: (A, ImportedName[B])): ImportMap[A, B] =
+    ImportMap(toMap.updated(that._2.localName, that))
+
+  def toList(implicit ord: Order[A]): List[Import[A, B]] =
+    toMap.iterator
+      .map { case (_, ab) => ab }
+      .toList
+      .groupByNel(_._1)
+      .iterator
+      .map { case (a, bs) =>
+        Import(a, bs.map(_._2))       
+      }
+      .toList
+
+  def traverse[F[_]: Applicative, C, D](fn: (A, ImportedName[B]) => F[(C, ImportedName[D])]): F[ImportMap[C, D]] =
+    toMap.traverse[F, (C, ImportedName[D])] { case (a, ib) => fn(a, ib) }
+      .map(ImportMap(_))
+}
+
+object ImportMap {
+  def empty[A, B]: ImportMap[A, B] = ImportMap(SortedMap.empty)
+
+  // Return the list of collisions in local names along with a map
+  // with the last name overwriting the import
+  def fromImports[A, B](
+      is: List[Import[A, B]]
+  )(unify: (A, A) => Option[Either[Unit, Unit]]): (List[(A, ImportedName[B])], ImportMap[A, B]) =
+    is.iterator
+      .flatMap { case Import(p, is) => is.toList.iterator.map((p, _)) }
+      .foldLeft((List.empty[(A, ImportedName[B])], ImportMap.empty[A, B])) {
+        case (old @ (dups, imap), pim @ (pack, im)) =>
+          val (dups1, imap1) = imap(im.localName) match {
+            case Some(nm) =>
+              val oldPack = nm._1
+              unify(oldPack, pack) match {
+                case None =>
+                  // pim and nm are a collision, add both
+                  (pim :: nm :: dups, imap + pim)
+                case Some(Left(_)) => old
+                case Some(Right(_)) => (dups, imap + pim)
+              }
+            case None     => (dups, imap + pim)
+          }
+
+          (dups1.reverse.distinct, imap1)
+      }
+
+  // This is only safe after verifying there are not collisions
+  // which has been done on compiled packages
+  def fromImportsUnsafe[A, B](is: List[Import[A, B]]): ImportMap[A, B] =
+    fromImports(is)((a, b) => sys.error(s"collision in $a and $b: $is"))._2
+}

--- a/core/src/main/scala/org/bykn/bosatsu/ImportedName.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/ImportedName.scala
@@ -1,0 +1,64 @@
+package org.bykn.bosatsu
+
+import cats.Functor
+import cats.parse.{Parser => P}
+import org.typelevel.paiges.{Doc, Document}
+import Parser.spaces
+
+sealed abstract class ImportedName[+T] {
+  def originalName: Identifier
+  def localName: Identifier
+  def tag: T
+  def isRenamed: Boolean = originalName != localName
+  def withTag[U](tag: U): ImportedName[U]
+
+  def map[U](fn: T => U): ImportedName[U] =
+    this match {
+      case ImportedName.OriginalName(n, t) =>
+        ImportedName.OriginalName(n, fn(t))
+      case ImportedName.Renamed(o, l, t) =>
+        ImportedName.Renamed(o, l, fn(t))
+    }
+
+  def traverse[F[_], U](
+      fn: T => F[U]
+  )(implicit F: Functor[F]): F[ImportedName[U]] =
+    this match {
+      case ImportedName.OriginalName(n, t) =>
+        F.map(fn(t))(ImportedName.OriginalName(n, _))
+      case ImportedName.Renamed(o, l, t) =>
+        F.map(fn(t))(ImportedName.Renamed(o, l, _))
+    }
+}
+
+object ImportedName {
+  case class OriginalName[T](originalName: Identifier, tag: T)
+      extends ImportedName[T] {
+    def localName = originalName
+    def withTag[U](tag: U): ImportedName[U] = copy(tag = tag)
+  }
+  case class Renamed[T](originalName: Identifier, localName: Identifier, tag: T)
+      extends ImportedName[T] {
+    def withTag[U](tag: U): ImportedName[U] = copy(tag = tag)
+  }
+
+  implicit val document: Document[ImportedName[Unit]] =
+    Document.instance[ImportedName[Unit]] {
+      case ImportedName.OriginalName(nm, _) => Document[Identifier].document(nm)
+      case ImportedName.Renamed(from, to, _) =>
+        Document[Identifier].document(from) + Doc.text(" as ") +
+          Document[Identifier].document(to)
+    }
+
+  val parser: P[ImportedName[Unit]] = {
+    def basedOn(of: P[Identifier]): P[ImportedName[Unit]] =
+      (of ~ (spaces.soft *> P.string("as") *> spaces *> of).?)
+        .map {
+          case (from, Some(to)) => ImportedName.Renamed(from, to, ())
+          case (orig, None)     => ImportedName.OriginalName(orig, ())
+        }
+
+    basedOn(Identifier.bindableParser)
+      .orElse(basedOn(Identifier.consParser))
+  }
+}

--- a/core/src/main/scala/org/bykn/bosatsu/MainModule.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/MainModule.scala
@@ -654,7 +654,7 @@ abstract class MainModule[IO[_]](implicit
               ).get
 
               val evalMap = pm.toMap.iterator.flatMap { case (n, p) =>
-                val optEval = p.program.lets.findLast { case (_, _, te) =>
+                val optEval = p.lets.findLast { case (_, _, te) =>
                   typeEvalMap.contains(te.getType)
                 }
                 optEval.map { case (b, _, te) =>

--- a/core/src/main/scala/org/bykn/bosatsu/MatchlessFromTypedExpr.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/MatchlessFromTypedExpr.scala
@@ -17,7 +17,7 @@ object MatchlessFromTypedExpr {
     val allItemsList = pm.toMap.toList
       .traverse[Par.F, (PackageName, List[(Bindable, Matchless.Expr)])] {
         case (pname, pack) =>
-          val lets = pack.program.lets
+          val lets = pack.lets
 
           Par.start {
             val exprs: List[(Bindable, Matchless.Expr)] =

--- a/core/src/main/scala/org/bykn/bosatsu/NameKind.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/NameKind.scala
@@ -23,16 +23,14 @@ object NameKind {
       defType: rankn.Type
   ) extends NameKind[T]
 
-  def externals[T](from: Package.Typed[T]): Iterable[ExternalDef[T]] = {
-    val prog = from.program
-    prog._1.externalDefs.to(LazyList).map { n =>
+  def externals[T](from: Package.Typed[T]): Iterable[ExternalDef[T]] =
+    from.externalDefs.to(LazyList).map { n =>
       // The type could be an import, so we need to check for the type
       // in the TypeEnv
       val pn = from.name
-      val tpe = prog._1.types.getExternalValue(pn, n).get
+      val tpe = from.types.getExternalValue(pn, n).get
       ExternalDef[T](pn, n, tpe)
     }
-  }
 
   def apply[T](
       from: Package.Typed[T],

--- a/core/src/main/scala/org/bykn/bosatsu/NameKind.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/NameKind.scala
@@ -25,11 +25,11 @@ object NameKind {
 
   def externals[T](from: Package.Typed[T]): Iterable[ExternalDef[T]] = {
     val prog = from.program
-    prog.externalDefs.to(LazyList).map { n =>
+    prog._1.externalDefs.to(LazyList).map { n =>
       // The type could be an import, so we need to check for the type
       // in the TypeEnv
       val pn = from.name
-      val tpe = prog.types.getExternalValue(pn, n).get
+      val tpe = prog._1.types.getExternalValue(pn, n).get
       ExternalDef[T](pn, n, tpe)
     }
   }
@@ -42,12 +42,12 @@ object NameKind {
 
     def getLet: Option[NameKind[T]] =
       item.toBindable.flatMap { b =>
-        prog.getLet(b).map { case (rec, d) => Let[T](b, rec, d) }
+        prog._1.getLet(b).map { case (rec, d) => Let[T](b, rec, d) }
       }
 
     def getConstructor: Option[NameKind[T]] =
       item.toConstructor.flatMap { cn =>
-        prog.types
+        prog._1.types
           .getConstructor(from.name, cn)
           .map { case (dt, cfn) =>
             Constructor(cn, cfn.args, dt, dt.fnTypeOf(cfn))

--- a/core/src/main/scala/org/bykn/bosatsu/Package.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/Package.scala
@@ -357,7 +357,7 @@ object Package {
               (fullTypeEnv, Program(typeEnv, lets, extDefs, stmts))
             }
             .left
-            .map(PackageError.TypeErrorIn(_, p))
+            .map(PackageError.TypeErrorIn(_, p, lets, theseExternals))
 
           val checkUnusedLets =
             lets
@@ -467,7 +467,7 @@ object Package {
           val tpes = Doc.text("types: ") + Doc
             .intercalate(
               Doc.comma + Doc.line,
-              pack.program._1.types.definedTypes.toList.map { case (_, t) =>
+              pack.types.definedTypes.toList.map { case (_, t) =>
                 Doc.text(t.name.ident.sourceCodeRepr)
               }
             )
@@ -520,8 +520,8 @@ object Package {
     def externalDefs: List[Identifier.Bindable] =
       pack.program._1.externalDefs
 
-  def localImport(n: Identifier): Option[(Package.Interface, ImportedName[NonEmptyList[Referant[Kind.Arg]]])] =
-    pack.program._2(n)
+    def localImport(n: Identifier): Option[(Package.Interface, ImportedName[NonEmptyList[Referant[Kind.Arg]]])] =
+      pack.program._2(n)
   }
 
   def orderByName[A, B, C, D]: Order[Package[A, B, C, D]] =

--- a/core/src/main/scala/org/bykn/bosatsu/Package.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/Package.scala
@@ -1,6 +1,6 @@
 package org.bykn.bosatsu
 
-import cats.{Functor, Parallel}
+import cats.{Functor, Order, Parallel}
 import cats.data.{Ior, ValidatedNel, Validated, NonEmptyList}
 import cats.implicits._
 import cats.parse.{Parser0 => P0, Parser => P}
@@ -39,12 +39,6 @@ final case class Package[A, B, C, +D](
       case _ => false
     }
 
-  // TODO, this isn't great
-  private lazy val importMap: ImportMap[A, B] =
-    ImportMap.fromImports(imports)._2
-
-  def localImport(n: Identifier): Option[(A, ImportedName[B])] = importMap(n)
-
   def withImport(i: Import[A, B]): Package[A, B, C, D] =
     copy(imports = i :: imports)
 
@@ -72,7 +66,11 @@ object Package {
     FixPackage[Unit, Unit, (List[Statement], ImportMap[PackageName, Unit])]
   type Typed[T] = Package[Interface, NonEmptyList[Referant[Kind.Arg]], Referant[
     Kind.Arg
-  ], Program[TypeEnv[Kind.Arg], TypedExpr[T], Any]]
+  ], (
+    Program[TypeEnv[Kind.Arg], TypedExpr[T], Any],
+    ImportMap[Interface, NonEmptyList[Referant[Kind.Arg]]]
+    )
+  ]
   type Inferred = Typed[Declaration]
 
   type Header =
@@ -81,10 +79,11 @@ object Package {
   val typedFunctor: Functor[Typed] =
     new Functor[Typed] {
       def map[A, B](fa: Typed[A])(fn: A => B): Typed[B] = {
-        val mapLet = fa.program.lets.map { case (n, r, te) =>
+        val mapLet = fa.lets.map { case (n, r, te) =>
           (n, r, Functor[TypedExpr].map(te)(fn))
         }
-        fa.copy(program = fa.program.copy(lets = mapLet))
+        val (prog, imap) = fa.program
+        fa.copy(program = (prog.copy(lets = mapLet), imap))
       }
     }
 
@@ -93,14 +92,14 @@ object Package {
   def testValue[A](
       tp: Typed[A]
   ): Option[(Identifier.Bindable, RecursionKind, TypedExpr[A])] =
-    tp.program.lets.filter { case (_, _, te) =>
+    tp.lets.filter { case (_, _, te) =>
       te.getType == Type.TestType
     }.lastOption
 
   def mainValue[A](
       tp: Typed[A]
   ): Option[(Identifier.Bindable, RecursionKind, TypedExpr[A])] =
-    tp.program.lets.lastOption
+    tp.lets.lastOption
 
   /** Discard any top level values that are not referenced, exported, the final
     * test value, or the final expression
@@ -110,13 +109,13 @@ object Package {
   def discardUnused[A](tp: Typed[A]): Typed[A] = {
     val pinned: Set[Identifier] =
       tp.exports.iterator.map(_.name).toSet ++
-        tp.program.lets.lastOption.map(_._1) ++
+        tp.lets.lastOption.map(_._1) ++
         testValue(tp).map(_._1)
 
     def topLevels(s: Set[(PackageName, Identifier)]): Set[Identifier] =
       s.collect { case (p, i) if p === tp.name => i }
 
-    val letWithGlobals = tp.program.lets.map { case tup @ (_, _, te) =>
+    val letWithGlobals = tp.lets.map { case tup @ (_, _, te) =>
       (tup, topLevels(te.globals))
     }
 
@@ -136,7 +135,7 @@ object Package {
     val reachedLets = letWithGlobals.collect {
       case (tup @ (bn, _, _), _) if reached(bn) => tup
     }
-    tp.copy(program = tp.program.copy(lets = reachedLets))
+    tp.copy(program = (tp.program._1.copy(lets = reachedLets), tp.program._2))
   }
 
   def fix[A, B, C](p: PackageF[A, B, C]): FixPackage[A, B, C] =
@@ -155,7 +154,7 @@ object Package {
     inferred.mapProgram(_ => ()).replaceImports(Nil)
 
   def setProgramFrom[A, B](t: Typed[A], newFrom: B): Typed[A] =
-    t.copy(program = t.program.copy(from = newFrom))
+    t.copy(program = (t.program._1.copy(from = newFrom), t.program._2))
 
   implicit val document
       : Document[Package[PackageName, Unit, Unit, List[Statement]]] =
@@ -468,7 +467,7 @@ object Package {
           val tpes = Doc.text("types: ") + Doc
             .intercalate(
               Doc.comma + Doc.line,
-              pack.program.types.definedTypes.toList.map { case (_, t) =>
+              pack.program._1.types.definedTypes.toList.map { case (_, t) =>
                 Doc.text(t.name.ident.sourceCodeRepr)
               }
             )
@@ -478,7 +477,7 @@ object Package {
           val eqDoc = Doc.text(" = ")
           val exprs = Doc.intercalate(
             Doc.hardLine + Doc.hardLine,
-            pack.program.lets.map { case (n, _, te) =>
+            pack.lets.map { case (n, _, te) =>
               Doc.text(n.sourceCodeRepr) + eqDoc + te.repr
             }
           )
@@ -510,4 +509,21 @@ object Package {
           Doc.intercalate(Doc.hardLine, all)
         }.nested(4)
     }
+
+  implicit class TypedMethods[A](private val pack: Typed[A]) extends AnyVal {
+    def lets: List[(Identifier.Bindable, RecursionKind, TypedExpr[A])] =
+      pack.program._1.lets
+
+    def types: TypeEnv[Kind.Arg] =
+      pack.program._1.types
+
+    def externalDefs: List[Identifier.Bindable] =
+      pack.program._1.externalDefs
+
+  def localImport(n: Identifier): Option[(Package.Interface, ImportedName[NonEmptyList[Referant[Kind.Arg]]])] =
+    pack.program._2(n)
+  }
+
+  def orderByName[A, B, C, D]: Order[Package[A, B, C, D]] =
+    Order.by[Package[A, B, C, D], PackageName](_.name)
 }

--- a/core/src/test/scala/org/bykn/bosatsu/EvaluationTest.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/EvaluationTest.scala
@@ -234,7 +234,7 @@ def go(x):
   y
 
 main = go(IntCase(42))
-""")) { case PackageError.TypeErrorIn(_, _) => () }
+""")) { case _: PackageError.TypeErrorIn => () }
 
     val errPack = """
 package Err
@@ -250,7 +250,7 @@ main = go(IntCase(42))
 """
     val packs =
       Map((PackageName.parts("Err"), (LocationMap(errPack), "Err.bosatsu")))
-    evalFail(List(errPack)) { case te @ PackageError.TypeErrorIn(_, _) =>
+    evalFail(List(errPack)) { case te: PackageError.TypeErrorIn =>
       val msg = te.message(packs, Colorize.None)
       assert(
         msg.contains(
@@ -667,7 +667,7 @@ main = if True:
   1
 else:
   "1"
-""")) { case PackageError.TypeErrorIn(_, _) => () }
+""")) { case _: PackageError.TypeErrorIn => () }
   }
 
   test(
@@ -741,7 +741,7 @@ struct W(wf: f[a, b] -> a -> b)
 def apply(w):
   W(fn) = w
   fn(w)
-""")) { case err @ PackageError.TypeErrorIn(_, _) =>
+""")) { case err: PackageError.TypeErrorIn =>
       val message = err.message(Map.empty, Colorize.None)
       assert(message.contains("illegal recursive type or function"))
       ()
@@ -877,7 +877,7 @@ def getValue(v):
     case IsInt(i, _): i
 
 main = getValue(int)
-""")) { case PackageError.TypeErrorIn(_, _) => () }
+""")) { case _: PackageError.TypeErrorIn => () }
 
   }
 
@@ -890,7 +890,7 @@ def plus(x: a, y):
   x.add(y)
 
 main = plus(1, 2)
-""")) { case PackageError.TypeErrorIn(_, _) => () }
+""")) { case _: PackageError.TypeErrorIn => () }
   }
 
   test("unused let fails compilation") {
@@ -1715,7 +1715,7 @@ main = a""")) { case PackageError.UnknownImportPackage(_, _) => () }
     evalFail(List("""
 package B
 
-main = a""")) { case te @ PackageError.TypeErrorIn(_, _) =>
+main = a""")) { case te: PackageError.TypeErrorIn =>
       val msg = te.message(Map.empty, Colorize.None)
       assert(!msg.contains("Name("))
       assert(msg.contains("package B\nname \"a\" unknown"))
@@ -1909,7 +1909,7 @@ def fn(x, y):
     case x: x
 
 main = fn(0, 1, 2)
-""")) { case te @ PackageError.TypeErrorIn(_, _) =>
+""")) { case te: PackageError.TypeErrorIn =>
       assert(
         te.message(Map.empty, Colorize.None)
           .contains("does not match function with 3 arguments at:")
@@ -1928,7 +1928,7 @@ def fn(x):
 
 main = fn([1, 2])
 """
-    evalFail(code1571 :: Nil) { case te @ PackageError.TypeErrorIn(_, _) =>
+    evalFail(code1571 :: Nil) { case te: PackageError.TypeErrorIn =>
       // Make sure we point at the function directly
       assert(code1571.substring(67, 69) == "fn")
       assert(
@@ -2769,24 +2769,6 @@ main = Foo(1, "2")
     }
   }
 
-  test("test duplicate import message") {
-    evalFail(List("""
-package Err
-
-from Bosatsu/Predef import foldLeft
-
-main = 1
-""")) { case sce @ PackageError.DuplicatedImport(_) =>
-      assert(
-        sce.message(
-          Map.empty,
-          Colorize.None
-        ) == "duplicate import in <unknown source> package Bosatsu/Predef imports foldLeft as foldLeft"
-      )
-      ()
-    }
-  }
-
   test("test duplicate package message") {
     val pack =
       """
@@ -3341,7 +3323,7 @@ struct RecordGetter[shape, t](
 def get[shape](sh: shape[RecordValue], RecordGetter(getter): RecordGetter[shape, t]) -> t:
   RecordValue(result) = sh.getter()
   result
-""")) { case PackageError.TypeErrorIn(_, _) => () }
+""")) { case _: PackageError.TypeErrorIn => () }
   }
 
   test("test quicklook example") {
@@ -3462,7 +3444,7 @@ struct Id(a)
 # this code could run if we ignored kinds
 def makeFoo(v: Int): Foo(Id(v))
 
-""")) { case kie @ PackageError.TypeErrorIn(_, _) =>
+""")) { case kie: PackageError.TypeErrorIn =>
       assert(
         kie.message(Map.empty, Colorize.None) ==
           """in file: <unknown source>, package Foo
@@ -3485,7 +3467,7 @@ struct Id(a)
 # this code could run if we ignored kinds
 def makeFoo(v: Int) -> Foo[Id, Int]: Foo(Id(v))
 
-""")) { case kie @ PackageError.TypeErrorIn(_, _) =>
+""")) { case kie: PackageError.TypeErrorIn =>
       assert(
         kie.message(Map.empty, Colorize.None) ==
           """in file: <unknown source>, package Foo
@@ -3512,7 +3494,7 @@ def quick_sort0(cmp, left, right):
         # we accidentally omit bigger below
         bigs = quick_sort0(cmp, tail)
         [*smalls, *bigs]
-""")) { case kie @ PackageError.TypeErrorIn(_, _) =>
+""")) { case kie: PackageError.TypeErrorIn =>
       assert(kie.message(Map.empty, Colorize.None) == """in file: <unknown source>, package QS
 type error: expected type Bosatsu/Predef::Fn3[(?13, ?9) -> Bosatsu/Predef::Comparison]
 Region(403,414)
@@ -3536,7 +3518,7 @@ def toInt(n: N, acc: Int) -> Int:
     case S(n): toInt(n, "foo")
 
 """
-    evalFail(List(testCode)) { case kie @ PackageError.TypeErrorIn(_, _) =>
+    evalFail(List(testCode)) { case kie: PackageError.TypeErrorIn =>
       val message = kie.message(Map.empty, Colorize.None)
       assert(message.contains("Region(122,127)"))
       val badRegion = testCode.substring(122, 127)
@@ -3757,7 +3739,7 @@ x: Int = "1"
 y: String = 1
 
 """
-    evalFail(List(testCode)) { case kie @ PackageError.TypeErrorIn(_, _) =>
+    evalFail(List(testCode)) { case kie: PackageError.TypeErrorIn =>
       val message = kie.message(Map.empty, Colorize.None)
       assert(message.contains("Region(30,33)"))
       assert(testCode.substring(30, 33) == "\"1\"")
@@ -3778,7 +3760,7 @@ z = (
 )
 
 """
-    evalFail(List(testCode)) { case kie @ PackageError.TypeErrorIn(_, _) =>
+    evalFail(List(testCode)) { case kie: PackageError.TypeErrorIn =>
       val message = kie.message(Map.empty, Colorize.None)
       assert(message.contains("Region(38,41)"))
       assert(testCode.substring(38, 41) == "\"1\"")
@@ -4019,5 +4001,91 @@ def fn(x):
 
 test = Assertion(fn(False), "")
 """), "Foo", 1)
+  }
+
+  test("test duplicate import error messages") {
+    val testCode = List("""
+package P1
+export foo
+
+foo = 1
+
+""", """
+package P2
+export foo
+
+foo = 2
+""", """
+package P3
+
+from P1 import foo
+from P2 import foo
+
+main = foo
+""")
+
+    evalFail(testCode) {
+      case kie @ PackageError.DuplicatedImport(_, _) =>
+        val message = kie.message(Map.empty, Colorize.None)
+        assert(message == "duplicate import in <unknown source> package P3\n\tfrom P1 import foo\n\tfrom P2 import foo\n")
+        ()
+    }
+
+    // explicit predefs are allowed
+    runBosatsuTest(List("""
+package P
+
+from Bosatsu/Predef import foldLeft
+
+main = Assertion(True, "")
+"""), "P", 1)
+    // explicit predefs renamed are allowed
+    runBosatsuTest(List("""
+package P
+
+from Bosatsu/Predef import foldLeft as fl
+
+res = [].fl(True, (_, _) -> False)
+
+main = Assertion(res, "")
+"""), "P", 1)
+    evalFail(List("""
+package P
+
+from Bosatsu/Predef import concat as fl
+from Bosatsu/Predef import foldLeft as fl
+
+res = [].fl(True, (_, _) -> False)
+
+main = Assertion(res, "")
+    """)) {
+      case kie @ PackageError.DuplicatedImport(_, _) =>
+        val message = kie.message(Map.empty, Colorize.None)
+        assert(message == "duplicate import in <unknown source> package P\n\tfrom Bosatsu/Predef import concat as fl\n\tfrom Bosatsu/Predef import foldLeft as fl\n")
+        ()
+    }
+  }
+
+  test("we always suggest names which share a prefix with an unknown name") {
+    val testCode = List("""
+package P1
+
+fofoooooooo = 1
+
+ofof = 2
+
+main = fof
+""")
+
+    evalFail(testCode) {
+      case kie: PackageError.TypeErrorIn =>
+        val message = kie.message(Map.empty, Colorize.None)
+        assert(message == """in file: <unknown source>, package P1
+name "fof" unknown.
+Closest: fofoooooooo, ofof.
+
+Region(47,50)""")
+        ()
+    }
   }
 }

--- a/core/src/test/scala/org/bykn/bosatsu/Gen.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/Gen.scala
@@ -1676,10 +1676,12 @@ object Generators {
       pn <- packageNameGen
       // we can't reuse package names
       if !existing.contains(pn)
-      imps <- genImports
+      imps0 <- genImports
+      impMap = ImportMap.fromImports(imps0)((_, _) => None)._2
+      imps = impMap.toList(Package.orderByName)
       prog <- genProg(pn, imps)
       exps <- genExports(pn, prog)
-    } yield Package(pn, imps, exps, prog)
+    } yield Package(pn, imps, exps, (prog, impMap))
   }
 
   def genPackagesSt[A](

--- a/core/src/test/scala/org/bykn/bosatsu/Gen.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/Gen.scala
@@ -1677,7 +1677,7 @@ object Generators {
       // we can't reuse package names
       if !existing.contains(pn)
       imps0 <- genImports
-      impMap = ImportMap.fromImports(imps0)((_, _) => None)._2
+      impMap = ImportMap.fromImports(imps0)((_, _) => ImportMap.Unify.Error)._2
       imps = impMap.toList(Package.orderByName)
       prog <- genProg(pn, imps)
       exps <- genExports(pn, prog)

--- a/core/src/test/scala/org/bykn/bosatsu/MatchlessTests.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/MatchlessTests.scala
@@ -38,15 +38,15 @@ class MatchlessTest extends AnyFunSuite {
     Generators
       .genPackage(Gen.const(()), 5)
       .flatMap { (m: Map[PackageName, Package.Typed[Unit]]) =>
-        val candidates = m.filter { case (_, t) => t.program.lets.nonEmpty }
+        val candidates = m.filter { case (_, t) => t.lets.nonEmpty }
 
         if (candidates.isEmpty) genInputs
         else
           for {
             packName <- Gen.oneOf(candidates.keys.toSeq)
-            prog = m(packName).program
-            (b, r, t) <- Gen.oneOf(prog.lets)
-            fn = fnFromTypeEnv(prog.types)
+            pack = m(packName)
+            (b, r, t) <- Gen.oneOf(pack.lets)
+            fn = fnFromTypeEnv(pack.types)
           } yield (b, r, t, fn)
       }
 

--- a/core/src/test/scala/org/bykn/bosatsu/Regressions.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/Regressions.scala
@@ -23,6 +23,6 @@ def applyFields(fields, row):
 
 hlist = (Field("a", x -> "a"), Some((Field("b", x -> "b"), None)))
 main = applyFields(hlist, 1)
-""")) { case PackageError.TypeErrorIn(_, _) => () }
+""")) { case _: PackageError.TypeErrorIn => () }
   }
 }

--- a/core/src/test/scala/org/bykn/bosatsu/TestUtils.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/TestUtils.scala
@@ -227,8 +227,8 @@ object TestUtils {
 
       case Validated.Invalid(errs) =>
         val tes = errs.toList
-          .collect { case PackageError.TypeErrorIn(te, _) =>
-            te.toString
+          .collect { case te: PackageError.TypeErrorIn =>
+            te.tpeErr.toString
           }
           .mkString("\n")
         fail(tes + "\n" + errs.toString)


### PR DESCRIPTION
I noticed if I made a duplicate import that does not exist to a name that collides with a predef name, the error message is bad.

I should add a test exercising this error message to be sure. There were two things:

1. we didn't see both imports, just one.
2. the predef import said "unknown source" which means that we need to handle predef separately in error messages.