### PR TITLE
Don't translate unreachable code

### DIFF
--- a/core/src/main/scala/org/bykn/bosatsu/MainModule.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/MainModule.scala
@@ -616,7 +616,6 @@ abstract class MainModule[IO[_]](implicit
           import codegen.python.PythonGen
 
           val allExternals = pm.allExternals
-          val cmp = MatchlessFromTypedExpr.compile(pm)
           moduleIOMonad.catchNonFatal {
             val parsedExt =
               externals.map(Parser.unsafeParse(PythonGen.externalParser, _))
@@ -668,6 +667,13 @@ abstract class MainModule[IO[_]](implicit
                 }
               }.toMap
 
+              val allRoots: Set[(PackageName, Identifier)] =
+                tests.iterator.toSet ++
+                  evalMap.iterator.map { case (n, (b, _, _)) =>
+                    (n, b) 
+                  }
+              val cleanPm = PackageMap.treeShake(pm, allRoots)
+              val cmp = MatchlessFromTypedExpr.compile(cleanPm)
               val docs = PythonGen
                 .renderAll(cmp, extMap, tests, evalMap)
                 .iterator

--- a/core/src/main/scala/org/bykn/bosatsu/Package.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/Package.scala
@@ -64,16 +64,17 @@ object Package {
   type Parsed = Package[PackageName, Unit, Unit, List[Statement]]
   type Resolved =
     FixPackage[Unit, Unit, (List[Statement], ImportMap[PackageName, Unit])]
+  type TypedProgram[T] = (
+        Program[TypeEnv[Kind.Arg], TypedExpr[T], Any],
+        ImportMap[Interface, NonEmptyList[Referant[Kind.Arg]]]
+    )
   type Typed[T] = Package[
     Interface,
     NonEmptyList[Referant[Kind.Arg]],
     Referant[
       Kind.Arg
     ],
-    (
-        Program[TypeEnv[Kind.Arg], TypedExpr[T], Any],
-        ImportMap[Interface, NonEmptyList[Referant[Kind.Arg]]]
-    )
+    TypedProgram[T]
   ]
   type Inferred = Typed[Declaration]
 
@@ -528,6 +529,13 @@ object Package {
       (Package.Interface, ImportedName[NonEmptyList[Referant[Kind.Arg]]])
     ] =
       pack.program._2(n)
+
+    def filterLets(fn: Identifier => Boolean): Typed[A] = {
+      val lets = pack.program._1.lets
+      val prog1: Program[TypeEnv[Kind.Arg], TypedExpr[A], Any] =
+        pack.program._1.copy(lets = lets.filter { case (b, _, _) => fn(b) })
+      pack.copy(program = (prog1, pack.program._2))
+    }
   }
 
   def orderByName[A, B, C, D]: Order[Package[A, B, C, D]] =


### PR DESCRIPTION
After we have typechecked, if code can't be reached from an evaluated value or a test, there is no reason to translate to Matchless, or to code (except for debugging the compiler itself). Since we should test the compiler directly or can write special methods, let's avoid translating unreachable code.

This is also planned to be used for a C backend which will generate a single C file for the entire main or test run.