### PR TITLE
evaluate static string matches in TypedExprNormalization

### DIFF
--- a/core/src/main/scala/org/bykn/bosatsu/Lit.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/Lit.scala
@@ -46,14 +46,14 @@ object Lit {
   }
 
   // Means this lit could be the result of a string match
-  sealed trait StringMatchResult {
+  sealed abstract class StringMatchResult extends Lit {
     def asStr: String
   }
-  case class Str(toStr: String) extends Lit with StringMatchResult {
+  case class Str(toStr: String) extends StringMatchResult {
     def unboxToAny: Any = toStr
     def asStr = toStr
   }
-  case class Chr(asStr: String) extends Lit with StringMatchResult {
+  case class Chr(asStr: String) extends StringMatchResult {
     def toCodePoint: Int = asStr.codePointAt(0)
     def unboxToAny: Any = asStr
   }

--- a/core/src/main/scala/org/bykn/bosatsu/Lit.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/Lit.scala
@@ -45,10 +45,15 @@ object Lit {
       } else new Integer(BigInteger.valueOf(l))
   }
 
-  case class Str(toStr: String) extends Lit {
-    def unboxToAny: Any = toStr
+  // Means this lit could be the result of a string match
+  sealed trait StringMatchResult {
+    def asStr: String
   }
-  case class Chr(asStr: String) extends Lit {
+  case class Str(toStr: String) extends Lit with StringMatchResult {
+    def unboxToAny: Any = toStr
+    def asStr = toStr
+  }
+  case class Chr(asStr: String) extends Lit with StringMatchResult {
     def toCodePoint: Int = asStr.codePointAt(0)
     def unboxToAny: Any = asStr
   }

--- a/core/src/main/scala/org/bykn/bosatsu/Matchless.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/Matchless.scala
@@ -82,6 +82,127 @@ object Matchless {
             else AtLeast(l.charCount + r.charCount)
         }
     }
+
+    private[this] val emptyStringArray: Array[String] = new Array[String](0)
+    /**
+     * This performs the matchstring algorithm on a literal string
+     * it returns null if there is no match, or the array of binds
+     * in order if there is a match
+     */
+    def matchString(
+        str: String,
+        pat: List[StrPart],
+        binds: Int
+    ): Array[String] = {
+      val strLen = str.length()
+      val results =
+        if (binds > 0) new Array[String](binds) else emptyStringArray
+
+      def loop(offset: Int, pat: List[StrPart], next: Int): Boolean =
+        pat match {
+          case Nil => offset == strLen
+          case LitStr(expect) :: tail =>
+            val len = expect.length
+            str.regionMatches(offset, expect, 0, len) && loop(
+              offset + len,
+              tail,
+              next
+            )
+          case (c: CharPart) :: tail =>
+            try {
+              val nextOffset = str.offsetByCodePoints(offset, 1)
+              val n =
+                if (c.capture) {
+                  results(next) = str.substring(offset, nextOffset)
+                  next + 1
+                } else next
+
+              loop(nextOffset, tail, n)
+            } catch {
+              case _: IndexOutOfBoundsException => false
+            }
+          case (h: Glob) :: tail =>
+            tail match {
+              case Nil =>
+                // we capture all the rest
+                if (h.capture) {
+                  results(next) = str.substring(offset)
+                }
+                true
+              case rest @ ((_: CharPart) :: _) =>
+                val matchableSizes = MatchSize[List](rest)
+
+                def canMatch(off: Int): Boolean =
+                  matchableSizes.canMatch(str.codePointCount(off, strLen))
+
+                // (.*)(.)tail2
+                // this is a naive algorithm that just
+                // checks at all possible later offsets
+                // a smarter algorithm could see if there
+                // are Lit parts that can match or not
+                var matched = false
+                var off1 = offset
+                val n1 = if (h.capture) (next + 1) else next
+                while (!matched && (off1 < strLen)) {
+                  matched = canMatch(off1) && loop(off1, rest, n1)
+                  if (!matched) {
+                    off1 = off1 + Character.charCount(str.codePointAt(off1))
+                  }
+                }
+
+                matched && {
+                  if (h.capture) {
+                    results(next) = str.substring(offset, off1)
+                  }
+                  true
+                }
+              case LitStr(expect) :: tail2 =>
+                val next1 = if (h.capture) next + 1 else next
+
+                val matchableSizes = MatchSize(tail2)
+
+                def canMatch(off: Int): Boolean =
+                  matchableSizes.canMatchUtf16Count(strLen - off)
+
+                var start = offset
+                var result = false
+                while (start >= 0) {
+                  val candidate = str.indexOf(expect, start)
+                  if (candidate >= 0) {
+                    // we have to skip the current expect string
+                    val nextOff = candidate + expect.length
+                    val check1 =
+                      canMatch(nextOff) && loop(nextOff, tail2, next1)
+                    if (check1) {
+                      // this was a match, write into next if needed
+                      if (h.capture) {
+                        results(next) = str.substring(offset, candidate)
+                      }
+                      result = true
+                      start = -1
+                    } else {
+                      // we couldn't match here, try just after candidate
+                      start = candidate + Character.charCount(
+                        str.codePointAt(candidate)
+                      )
+                    }
+                  } else {
+                    // no more candidates
+                    start = -1
+                  }
+                }
+                result
+              // $COVERAGE-OFF$
+              case (_: Glob) :: _ =>
+                // this should be an error at compile time since it
+                // is never meaningful to have two adjacent globs
+                sys.error(s"invariant violation, adjacent globs: $pat")
+              // $COVERAGE-ON$
+            }
+        }
+
+      if (loop(0, pat, 0)) results else null
+    }
   }
 
   // name is set for recursive (but not tail recursive) methods
@@ -527,10 +648,6 @@ object Matchless {
                 case Pattern.StrPart.NamedChar(n) => n
               }
 
-          val muts = sbinds.traverse { b =>
-            makeAnon.map(LocalAnonMut(_)).map((b, _))
-          }
-
           val pat = items.toList.map {
             case Pattern.StrPart.NamedStr(_)  => StrPart.IndexStr
             case Pattern.StrPart.NamedChar(_) => StrPart.IndexChar
@@ -539,10 +656,13 @@ object Matchless {
             case Pattern.StrPart.LitStr(s)    => StrPart.LitStr(s)
           }
 
-          muts.map { binds =>
+          sbinds.traverse { b =>
+            makeAnon.map(LocalAnonMut(_)).map((b, _))
+          }
+          .map { binds =>
             val ms = binds.map(_._2)
 
-            NonEmptyList.of((ms, MatchString(arg, pat, ms), binds))
+            NonEmptyList.one((ms, MatchString(arg, pat, ms), binds))
           }
         case lp @ Pattern.ListPat(_) =>
           lp.toPositionalStruct(empty, cons) match {
@@ -810,63 +930,139 @@ object Matchless {
         LetMut(anon, rest)
       }
 
+    def staticMatch(arg: Expr, branches: NonEmptyList[
+        (Pattern[(PackageName, Constructor), Type], Expr)
+      ]
+    ): Option[Expr] =
+      arg match {
+        case Literal(Lit.Str(s)) =>
+          // we can always match a literal string
+          def loop(branches: List[
+            (Pattern[(PackageName, Constructor), Type], Expr)
+          ]): Option[Expr] =
+            branches match {
+              case Nil => None
+              case (Pattern.WildCard, e) :: _ => Some(e)
+              case (Pattern.Var(n), e) :: _ =>
+                Some(Let(Right(n), arg, e))
+              case (Pattern.Literal(Lit.Str(s1)), e) :: tail =>
+                if (s == s1) Some(e)
+                else loop(tail)
+              case (Pattern.Named(b, p), e) :: tail =>
+                loop((p, e) :: Nil) match {
+                  case None => loop(tail)
+                  case Some(e) =>
+                    Some(Let(Right(b), arg, e))
+                }
+              case (Pattern.StrPat(items), e) :: tail =>
+                val sbinds: List[String => Expr => Expr] =
+                  items.toList
+                    .collect {
+                      // that each name is distinct
+                      // should be checked in the SourceConverter/TotalityChecking code
+                      case Pattern.StrPart.NamedStr(n)  =>
+                        { (value: String) =>
+                            (result: Expr) => Let(Right(n), Literal(Lit.Str(value)), result)  
+                        }
+                      case Pattern.StrPart.NamedChar(n) =>
+                        { (value: String) =>
+                            (result: Expr) => Let(Right(n), Literal(Lit.Chr(value)), result)  
+                        }
+                    }
+
+                val pat = items.toList.map {
+                  case Pattern.StrPart.NamedStr(_)  => StrPart.IndexStr
+                  case Pattern.StrPart.NamedChar(_) => StrPart.IndexChar
+                  case Pattern.StrPart.WildStr      => StrPart.WildStr
+                  case Pattern.StrPart.WildChar     => StrPart.WildChar
+                  case Pattern.StrPart.LitStr(s)    => StrPart.LitStr(s)
+                }
+
+                val result = StrPart.matchString(s, pat, sbinds.length)
+                if (result == null) loop(tail)
+                else {
+                  // we match:
+                  val matched = result.toList
+                    .zip(sbinds)
+                    .map { case (m, fn) => fn(m) }
+                    .foldRight(e) { (fn, e1) => fn(e1) }
+
+                  Some(matched)
+                }
+              case (Pattern.ListPat(_) | Pattern.PositionalStruct(_, _) | Pattern.Literal(_), _) :: tail =>
+                // a string is not a list or struct or other literal
+                loop(tail)
+              case (Pattern.Union(h, t), e) :: rest =>
+                loop((h :: t).toList.map((_, e)) ::: rest)
+              case ((Pattern.Annotation(p, _), e) :: tail) =>
+                loop((p, e) :: tail)
+            }
+
+            loop(branches.toList)
+        case _ =>
+          // TODO there are others we could match
+          None
+      }
+
     def matchExpr(
         arg: Expr,
         tmp: F[Long],
         branches: NonEmptyList[
           (Pattern[(PackageName, Constructor), Type], Expr)
         ]
-    ): F[Expr] = {
+    ): F[Expr] =
+      staticMatch(arg, branches) match {
+        case Some(expr) => Monad[F].pure(expr)
+        case None =>
+          def recur(
+              arg: CheapExpr,
+              branches: NonEmptyList[
+                (Pattern[(PackageName, Constructor), Type], Expr)
+              ]
+          ): F[Expr] = {
+            val (p1, r1) = branches.head
 
-      def recur(
-          arg: CheapExpr,
-          branches: NonEmptyList[
-            (Pattern[(PackageName, Constructor), Type], Expr)
-          ]
-      ): F[Expr] = {
-        val (p1, r1) = branches.head
-
-        def loop(
-            cbs: NonEmptyList[
-              (List[LocalAnonMut], BoolExpr, List[(Bindable, Expr)])
-            ]
-        ): F[Expr] =
-          cbs match {
-            case NonEmptyList((b0, TrueConst, binds), _) =>
-              // this is a total match, no fall through
-              val right = lets(binds, r1)
-              Monad[F].pure(checkLets(b0, right))
-            case NonEmptyList((b0, cond, binds), others) =>
-              val thisBranch = lets(binds, r1)
-              val res = others match {
-                case oh :: ot =>
-                  loop(NonEmptyList(oh, ot)).map { te =>
-                    If(cond, thisBranch, te)
-                  }
-                case Nil =>
-                  branches.tail match {
-                    case Nil =>
-                      // this must be total, but we still need
-                      // to evaluate cond since it can have side
-                      // effects
-                      Monad[F].pure(always(cond, thisBranch))
-                    case bh :: bt =>
-                      recur(arg, NonEmptyList(bh, bt)).map { te =>
+            def loop(
+                cbs: NonEmptyList[
+                  (List[LocalAnonMut], BoolExpr, List[(Bindable, Expr)])
+                ]
+            ): F[Expr] =
+              cbs match {
+                case NonEmptyList((b0, TrueConst, binds), _) =>
+                  // this is a total match, no fall through
+                  val right = lets(binds, r1)
+                  Monad[F].pure(checkLets(b0, right))
+                case NonEmptyList((b0, cond, binds), others) =>
+                  val thisBranch = lets(binds, r1)
+                  val res = others match {
+                    case oh :: ot =>
+                      loop(NonEmptyList(oh, ot)).map { te =>
                         If(cond, thisBranch, te)
                       }
+                    case Nil =>
+                      branches.tail match {
+                        case Nil =>
+                          // this must be total, but we still need
+                          // to evaluate cond since it can have side
+                          // effects
+                          Monad[F].pure(always(cond, thisBranch))
+                        case bh :: bt =>
+                          recur(arg, NonEmptyList(bh, bt)).map { te =>
+                            If(cond, thisBranch, te)
+                          }
+                      }
                   }
+
+                  res.map(checkLets(b0, _))
               }
 
-              res.map(checkLets(b0, _))
+            doesMatch(arg, p1, branches.tail.isEmpty).flatMap(loop)
           }
 
-        doesMatch(arg, p1, branches.tail.isEmpty).flatMap(loop)
-      }
+          val argFn = maybeMemo(tmp)(recur(_, branches))
 
-      val argFn = maybeMemo(tmp)(recur(_, branches))
-
-      argFn(arg)
-    }
+          argFn(arg)
+        }
 
     loopLetVal(name, te, rec, LambdaState(None, Map.empty))
   }

--- a/core/src/main/scala/org/bykn/bosatsu/MatchlessToValue.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/MatchlessToValue.scala
@@ -4,6 +4,7 @@ import cats.{Eval, Functor, Applicative}
 import cats.data.NonEmptyList
 import cats.evidence.Is
 import java.math.BigInteger
+import org.bykn.bosatsu.pattern.StrPart
 import scala.collection.immutable.LongMap
 import scala.collection.mutable.{LongMap => MLongMap}
 

--- a/core/src/main/scala/org/bykn/bosatsu/Pattern.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/Pattern.scala
@@ -478,16 +478,16 @@ object Pattern {
     def matches(str: String): Boolean =
       isTotal || matcher(str).isDefined
 
+    /**
+     * Convert to a regular expression matching this pattern, which
+     * uses reluctant modifiers
+     */
     def toRegex: RegexPattern = {
-      def mapPart(p: StrPart, isLast: Boolean): String = 
+      def mapPart(p: StrPart): String = 
         p match {
-          case StrPart.NamedStr(_) =>
-            if (isLast) "(.*)"
-            else "(.*?)"
+          case StrPart.NamedStr(_) => "(.*?)"
+          case StrPart.WildStr  => ".*?"
           case StrPart.NamedChar(_) => "(.)"
-          case StrPart.WildStr  =>
-            if (isLast) ".*"
-            else ".*?"
           case StrPart.WildChar => "."
           case StrPart.LitStr(s) =>
             // we need to escape any characters that may be in regex
@@ -495,8 +495,8 @@ object Pattern {
         }
       RegexPattern.compile(
         parts.init
-          .map(mapPart(_, false))
-          .mkString("", "", mapPart(parts.last, true)),
+          .map(mapPart(_))
+          .mkString("", "", mapPart(parts.last)),
         RegexPattern.DOTALL
       )
     }

--- a/core/src/main/scala/org/bykn/bosatsu/Pattern.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/Pattern.scala
@@ -494,9 +494,10 @@ object Pattern {
             RegexPattern.quote(s)
         }
       RegexPattern.compile(
-        parts.init
+        parts
+          .iterator
           .map(mapPart(_))
-          .mkString("", "", mapPart(parts.last)),
+          .mkString,
         RegexPattern.DOTALL
       )
     }

--- a/core/src/main/scala/org/bykn/bosatsu/StringUtil.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/StringUtil.scala
@@ -211,6 +211,25 @@ object StringUtil extends GenericStringUtil {
       ('t', '\t'),
       ('v', 11.toChar)
     ) // vertical tab
+
+  def codePoints(s: String): List[Int] = {
+    // .codePoints isn't available in scalajs
+    var idx = 0
+    val bldr = List.newBuilder[Int]
+    while (idx < s.length) {
+      val cp = s.codePointAt(idx)
+      idx += Character.charCount(cp)
+      bldr += cp
+    }
+
+    bldr.result()
+  }
+
+  def fromCodePoints(it: Iterable[Int]): String = {
+    val bldr = new java.lang.StringBuilder
+    it.foreach(bldr.appendCodePoint(_))
+    bldr.toString
+  }
 }
 
 object JsonStringUtil extends GenericStringUtil {

--- a/core/src/main/scala/org/bykn/bosatsu/TotalityCheck.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/TotalityCheck.scala
@@ -237,9 +237,9 @@ case class TotalityCheck(inEnv: TypeEnv[Any]) {
     )
 
   private val strPatternSetOps: SetOps[StrPat] =
-    SetOps.imap[SeqPattern[Char], StrPat](
+    SetOps.imap[SeqPattern[Int], StrPat](
       SeqPattern.seqPatternSetOps(
-        SeqPart.part1SetOps(SetOps.distinct[Char]),
+        SeqPart.part1SetOps(SetOps.distinct[Int]),
         implicitly
       ),
       StrPat.fromSeqPattern(_),

--- a/core/src/main/scala/org/bykn/bosatsu/codegen/python/PythonGen.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/codegen/python/PythonGen.scala
@@ -11,6 +11,7 @@ import org.bykn.bosatsu.{
   Parser,
 }
 import org.bykn.bosatsu.codegen.Idents
+import org.bykn.bosatsu.pattern.StrPart
 import org.bykn.bosatsu.rankn.Type
 import org.typelevel.paiges.Doc
 

--- a/core/src/main/scala/org/bykn/bosatsu/pattern/Matcher.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/pattern/Matcher.scala
@@ -39,8 +39,8 @@ object Matcher {
       }
     }
 
-  val charMatcher: Matcher[Char, Char, Unit] = eqMatcher(
-    Eq.fromUniversalEquals[Char]
+  val intMatcher: Matcher[Int, Int, Unit] = eqMatcher(
+    Eq.fromUniversalEquals[Int]
   )
 
   def fnMatch[A]: Matcher[A => Boolean, A, Unit] =

--- a/core/src/main/scala/org/bykn/bosatsu/pattern/SeqPattern.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/pattern/SeqPattern.scala
@@ -746,6 +746,6 @@ object SeqPattern {
         }
     }
 
-  val stringUnitMatcher: Matcher[SeqPattern[Char], String, Unit] =
+  val stringUnitMatcher: Matcher[SeqPattern[Int], String, Unit] =
     matcher(Splitter.stringUnit)
 }

--- a/core/src/main/scala/org/bykn/bosatsu/pattern/StrPart.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/pattern/StrPart.scala
@@ -1,0 +1,221 @@
+package org.bykn.bosatsu.pattern
+
+import cats.Monoid
+import org.bykn.bosatsu.{Pattern, Lit, Identifier}
+
+sealed abstract class StrPart
+object StrPart {
+  sealed abstract class Glob(val capture: Boolean) extends StrPart
+  sealed abstract class CharPart(val capture: Boolean) extends StrPart
+  case object WildStr extends Glob(false)
+  case object IndexStr extends Glob(true)
+  case object WildChar extends CharPart(false)
+  case object IndexChar extends CharPart(true)
+  case class LitStr(asString: String) extends StrPart
+
+  sealed abstract class MatchSize(val isExact: Boolean) {
+    def charCount: Int
+    def canMatch(cp: Int): Boolean
+    // we know chars/2 <= cpCount <= chars for utf16
+    def canMatchUtf16Count(chars: Int): Boolean
+  }
+  object MatchSize {
+    case class Exactly(charCount: Int) extends MatchSize(true) {
+      def canMatch(cp: Int): Boolean = cp == charCount
+      def canMatchUtf16Count(chars: Int): Boolean = {
+        val cpmin = chars / 2
+        val cpmax = chars
+        (cpmin <= charCount) && (charCount <= cpmax)
+      }
+    }
+    case class AtLeast(charCount: Int) extends MatchSize(false) {
+      def canMatch(cp: Int): Boolean = charCount <= cp
+      def canMatchUtf16Count(chars: Int): Boolean = {
+        val cpmax = chars
+        // we have any cp in [cpmin, cpmax]
+        // but we require charCount <= cp
+        (charCount <= cpmax)
+      }
+    }
+
+    private val atLeast0 = AtLeast(0)
+    private val exactly0 = Exactly(0)
+    private val exactly1 = Exactly(1)
+
+    def from(sp: StrPart): MatchSize =
+      sp match {
+        case _: Glob     => atLeast0
+        case _: CharPart => exactly1
+        case LitStr(str) =>
+          Exactly(str.codePointCount(0, str.length))
+      }
+
+    def apply[F[_]: cats.Foldable](f: F[StrPart]): MatchSize =
+      cats.Foldable[F].foldMap(f)(from)
+
+    implicit val monoidMatchSize: Monoid[MatchSize] =
+      new Monoid[MatchSize] {
+        def empty: MatchSize = exactly0
+        def combine(l: MatchSize, r: MatchSize) =
+          if (l.isExact && r.isExact) Exactly(l.charCount + r.charCount)
+          else AtLeast(l.charCount + r.charCount)
+      }
+  }
+
+  private[this] val emptyStringArray: Array[String] = new Array[String](0)
+  /**
+   * This performs the matchstring algorithm on a literal string
+   * it returns null if there is no match, or the array of binds
+   * in order if there is a match
+   */
+  def matchString(
+      str: String,
+      pat: List[StrPart],
+      binds: Int
+  ): Array[String] = {
+    val strLen = str.length()
+    val results =
+      if (binds > 0) new Array[String](binds) else emptyStringArray
+
+    def loop(offset: Int, pat: List[StrPart], next: Int): Boolean =
+      pat match {
+        case Nil => offset == strLen
+        case LitStr(expect) :: tail =>
+          val len = expect.length
+          str.regionMatches(offset, expect, 0, len) && loop(
+            offset + len,
+            tail,
+            next
+          )
+        case (c: CharPart) :: tail =>
+          try {
+            val nextOffset = str.offsetByCodePoints(offset, 1)
+            val n =
+              if (c.capture) {
+                results(next) = str.substring(offset, nextOffset)
+                next + 1
+              } else next
+
+            loop(nextOffset, tail, n)
+          } catch {
+            case _: IndexOutOfBoundsException => false
+          }
+        case (h: Glob) :: tail =>
+          tail match {
+            case Nil =>
+              // we capture all the rest
+              if (h.capture) {
+                results(next) = str.substring(offset)
+              }
+              true
+            case rest @ ((_: CharPart) :: _) =>
+              val matchableSizes = MatchSize[List](rest)
+
+              def canMatch(off: Int): Boolean =
+                matchableSizes.canMatch(str.codePointCount(off, strLen))
+
+              // (.*)(.)tail2
+              // this is a naive algorithm that just
+              // checks at all possible later offsets
+              // a smarter algorithm could see if there
+              // are Lit parts that can match or not
+              var matched = false
+              var off1 = offset
+              val n1 = if (h.capture) (next + 1) else next
+              while (!matched && (off1 < strLen)) {
+                matched = canMatch(off1) && loop(off1, rest, n1)
+                if (!matched) {
+                  off1 = off1 + Character.charCount(str.codePointAt(off1))
+                }
+              }
+
+              matched && {
+                if (h.capture) {
+                  results(next) = str.substring(offset, off1)
+                }
+                true
+              }
+            case LitStr(expect) :: tail2 =>
+              val next1 = if (h.capture) next + 1 else next
+
+              val matchableSizes = MatchSize(tail2)
+
+              def canMatch(off: Int): Boolean =
+                matchableSizes.canMatchUtf16Count(strLen - off)
+
+              var start = offset
+              var result = false
+              while (start >= 0) {
+                val candidate = str.indexOf(expect, start)
+                if (candidate >= 0) {
+                  // we have to skip the current expect string
+                  val nextOff = candidate + expect.length
+                  val check1 =
+                    canMatch(nextOff) && loop(nextOff, tail2, next1)
+                  if (check1) {
+                    // this was a match, write into next if needed
+                    if (h.capture) {
+                      results(next) = str.substring(offset, candidate)
+                    }
+                    result = true
+                    start = -1
+                  } else {
+                    // we couldn't match here, try just after candidate
+                    start = candidate + Character.charCount(
+                      str.codePointAt(candidate)
+                    )
+                  }
+                } else {
+                  // no more candidates
+                  start = -1
+                }
+              }
+              result
+            // $COVERAGE-OFF$
+            case (_: Glob) :: _ =>
+              // this should be an error at compile time since it
+              // is never meaningful to have two adjacent globs
+              sys.error(s"invariant violation, adjacent globs: $pat")
+            // $COVERAGE-ON$
+          }
+      }
+
+    if (loop(0, pat, 0)) results else null
+  }
+
+  def matchPattern(str: String, pattern: Pattern.StrPat): Option[List[(Identifier.Bindable, Lit.StringMatchResult)]] = {
+    val partList = pattern.parts.toList
+
+    val sbinds: List[String => (Identifier.Bindable, Lit.StringMatchResult)] =
+      partList
+        .collect {
+          // that each name is distinct
+          // should be checked in the SourceConverter/TotalityChecking code
+          case Pattern.StrPart.NamedStr(n)  =>
+            { (value: String) => (n, Lit.Str(value)) }
+          case Pattern.StrPart.NamedChar(n) =>
+            { (value: String) => (n, Lit.Chr(value)) }
+        }
+
+    val pat = partList.map {
+      case Pattern.StrPart.NamedStr(_)  => StrPart.IndexStr
+      case Pattern.StrPart.NamedChar(_) => StrPart.IndexChar
+      case Pattern.StrPart.WildStr      => StrPart.WildStr
+      case Pattern.StrPart.WildChar     => StrPart.WildChar
+      case Pattern.StrPart.LitStr(s)    => StrPart.LitStr(s)
+    }
+
+    val result = StrPart.matchString(str, pat, sbinds.length)
+    if (result == null) None
+    else {
+      // we match:
+      val matched = result
+        .iterator
+        .zip(sbinds.iterator)
+        .map { case (m, fn) => fn(m) }
+        .toList
+
+      Some(matched)
+    }
+  }
+}

--- a/core/src/test/scala/org/bykn/bosatsu/pattern/SeqPatternTest.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/pattern/SeqPatternTest.scala
@@ -878,7 +878,7 @@ class SeqPatternTest extends SeqPatternLaws[Int, Int, String, Unit] {
   test("Named.matches + render agree") {
     def law(n: Named, str: String) =
       namedMatch(n, str).foreach { m =>
-        n.render(m)(_.toString) match {
+        n.render(m) { codePoint => StringUtil.fromCodePoints(codePoint :: Nil) } match {
           case Some(s0) => assert(s0 == str, s"m = $m")
           case None     =>
             // this can only happen if we have unnamed Wild/AnyElem

--- a/core/src/test/scala/org/bykn/bosatsu/pattern/StrPartTest.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/pattern/StrPartTest.scala
@@ -1,0 +1,86 @@
+package org.bykn.bosatsu.pattern
+
+import org.bykn.bosatsu.Generators.{genStrPat, genValidUtf}
+import org.bykn.bosatsu.StringUtil
+import org.scalacheck.Prop.forAll
+import org.scalacheck.Gen
+
+class StrPartTest extends munit.ScalaCheckSuite {
+  override def scalaCheckTestParameters =
+    super.scalaCheckTestParameters
+      .withMinSuccessfulTests(20000)
+      .withMaxDiscardRatio(10)
+
+  val nonUnicode: Gen[String] =
+    Gen.oneOf(
+      Gen.asciiStr,
+      Gen.identifier,
+    )
+
+  val genStr: Gen[String] =
+    Gen.oneOf(
+      Gen.asciiStr,
+      Gen.identifier,
+      genValidUtf
+    )
+
+  property("StringUtil codePoints work (used internally by matching)") {
+    forAll(genStr) { str =>
+      val cp = StringUtil.codePoints(str)  
+      val s1 = StringUtil.fromCodePoints(cp)
+      assertEquals(s1, str, s"codepoints = $cp")
+    }
+  }
+
+  property("pat.matcher works for non-unicode strings") {
+    forAll(nonUnicode, genStrPat) { (str, pat) =>
+      val sp = pat.toSeqPattern
+      StrPart.matchPattern(str, pat) match {
+        case Some(binds) =>
+          val justNames = binds.map(_._1)
+          assertEquals(justNames.distinct, justNames)
+          assertEquals(pat.names, justNames)
+          // this should agree with the matches method
+          assert(pat.matcher(str).isDefined, s"seqPattern = $sp, named = ${pat.toNamedSeqPattern}")
+        case None =>
+          assert(pat.matcher(str).isEmpty, s"seqPattern = $sp, named = ${pat.toNamedSeqPattern}")
+      } 
+    }
+  }
+  property("matches finds all the bindings in order (unicode)") {
+    forAll(genStr, genStrPat) { (str, pat) =>
+      StrPart.matchPattern(str, pat) match {
+        case Some(binds) =>
+          val justNames = binds.map(_._1)
+          assertEquals(justNames.distinct, justNames)
+          assertEquals(pat.names, justNames)
+          // this should agree with the matches method
+          assert(pat.matches(str))
+        case None =>
+          assert(!pat.matches(str))
+      } 
+    }
+  }
+
+  property("matches agrees with toRegex") {
+    forAll(genStr, genStrPat) { (str, pat) =>
+      val re = pat.toRegex
+      val matcher = re.matcher(str)
+
+      StrPart.matchPattern(str, pat) match {
+        case Some(binds) =>
+          assert(matcher.matches(), s"binds = $binds, re = $re")
+          val reMatches = (1 to matcher.groupCount)
+            .map { idx =>
+              matcher.group(idx)  
+            }
+            .toList
+
+          // TODO: this fails
+          assertEquals(pat.names.zip(reMatches), binds.map { case (k, v) => (k, v.asStr)})
+        case None =>
+          assert(!matcher.matches())
+      }
+    }
+  }
+}

--- a/core/src/test/scala/org/bykn/bosatsu/pattern/StringSeqPatternSetLaws.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/pattern/StringSeqPatternSetLaws.scala
@@ -6,12 +6,14 @@ import cats.Eq
 import org.scalacheck.Gen
 
 import SeqPattern.{Cat, Empty}
-import SeqPart.{AnyElem, Lit, Wildcard}
+import SeqPart.{AnyElem, Wildcard}
 
 import cats.implicits._
 
-class StringSeqPatternSetLaws extends SetOpsLaws[SeqPattern[Char]] {
-  type Pattern = SeqPattern[Char]
+import StringSeqPatternGen.lit
+
+class StringSeqPatternSetLaws extends SetOpsLaws[SeqPattern[Int]] {
+  type Pattern = SeqPattern[Int]
   val Pattern = SeqPattern
 
   override def scalaCheckTestParameters =
@@ -66,21 +68,20 @@ class StringSeqPatternSetLaws extends SetOpsLaws[SeqPattern[Char]] {
         }
       }
 
-  implicit val setOpsChar: SetOps[Char] = SetOps.distinct[Char]
-  val setOps: SetOps[Pattern] = Pattern.seqPatternSetOps[Char]
+  implicit val setOpsChar: SetOps[Int] = SetOps.distinct[Int]
+  val setOps: SetOps[Pattern] = Pattern.seqPatternSetOps[Int]
 
   test("subsetConsistencyLaw regressions") {
     import SeqPattern.{Cat, Empty}
-    import SeqPart.Lit
 
-    val regressions: List[(SeqPattern[Char], SeqPattern[Char])] =
+    val regressions: List[(SeqPattern[Int], SeqPattern[Int])] =
       (
-        Cat(Lit('1'), Cat(Lit('1'), Cat(Lit('1'), Cat(Lit('1'), Empty)))),
-        Cat(Lit('0'), Cat(Lit('1'), Cat(Lit('1'), Empty)))
+        Cat(lit('1'), Cat(lit('1'), Cat(lit('1'), Cat(lit('1'), Empty)))),
+        Cat(lit('0'), Cat(lit('1'), Cat(lit('1'), Empty)))
       ) ::
         (
-          Cat(Lit('1'), Cat(Lit('0'), Cat(Lit('1'), Cat(Lit('0'), Empty)))),
-          Cat(Lit('0'), Cat(Lit('1'), Empty))
+          Cat(lit('1'), Cat(lit('0'), Cat(lit('1'), Cat(lit('0'), Empty)))),
+          Cat(lit('0'), Cat(lit('1'), Empty))
         ) ::
         Nil
 
@@ -91,14 +92,14 @@ class StringSeqPatternSetLaws extends SetOpsLaws[SeqPattern[Char]] {
 
   test("*x* problems") {
     import SeqPattern.{Cat, Empty}
-    import SeqPart.{Lit, Wildcard}
+    import SeqPart.Wildcard
 
     val x = Cat(
       Wildcard,
-      Cat(Lit('q'), Cat(Wildcard, Cat(Lit('p'), Cat(Wildcard, Empty))))
+      Cat(lit('q'), Cat(Wildcard, Cat(lit('p'), Cat(Wildcard, Empty))))
     )
-    val y = Cat(Wildcard, Cat(Lit('p'), Cat(Wildcard, Empty)))
-    val z = Cat(Wildcard, Cat(Lit('q'), Cat(Wildcard, Empty)))
+    val y = Cat(Wildcard, Cat(lit('p'), Cat(Wildcard, Empty)))
+    val z = Cat(Wildcard, Cat(lit('q'), Cat(Wildcard, Empty)))
     // note y and z are clearly bigger than x because they are prefix/suffix that end/start with
     // Wildcard
     assert(setOps.difference(x, y).isEmpty)
@@ -107,29 +108,29 @@ class StringSeqPatternSetLaws extends SetOpsLaws[SeqPattern[Char]] {
 
   test("(a - b) n c = (a n c) - (b n c) regressions") {
     val regressions
-        : List[(SeqPattern[Char], SeqPattern[Char], SeqPattern[Char])] =
+        : List[(SeqPattern[Int], SeqPattern[Int], SeqPattern[Int])] =
       (
         Cat(Wildcard, Empty),
-        Cat(AnyElem, Cat(Lit('1'), Cat(AnyElem, Empty))),
-        Cat(AnyElem, Cat(Lit('1'), Cat(Lit('0'), Empty)))
+        Cat(AnyElem, Cat(lit('1'), Cat(AnyElem, Empty))),
+        Cat(AnyElem, Cat(lit('1'), Cat(lit('0'), Empty)))
       ) ::
         (
-          Cat(Wildcard, Cat(Lit('0'), Empty)),
-          Cat(AnyElem, Cat(Lit('1'), Cat(AnyElem, Cat(Lit('0'), Empty)))),
-          Cat(AnyElem, Cat(Lit('1'), Cat(Lit('0'), Cat(Lit('0'), Empty))))
+          Cat(Wildcard, Cat(lit('0'), Empty)),
+          Cat(AnyElem, Cat(lit('1'), Cat(AnyElem, Cat(lit('0'), Empty)))),
+          Cat(AnyElem, Cat(lit('1'), Cat(lit('0'), Cat(lit('0'), Empty))))
         ) ::
         (
-          Cat(Wildcard, Cat(Lit('q'), Cat(Wildcard, Empty))),
+          Cat(Wildcard, Cat(lit('q'), Cat(Wildcard, Empty))),
           Cat(Wildcard, Empty),
-          Cat(Wildcard, Cat(Lit('p'), Cat(Wildcard, Empty)))
+          Cat(Wildcard, Cat(lit('p'), Cat(Wildcard, Empty)))
         ) ::
         /*
          * This fails currently
          * see: https://github.com/johnynek/bosatsu/issues/486
       {
-        val p1 = Cat(Wildcard,Cat(Lit('1'),Cat(Lit('0'),Cat(Lit('0'),Empty))))
-        val p2  = Cat(AnyElem,Cat(Lit('1'),Cat(Wildcard,Cat(Lit('0'),Empty))))
-        val p3 = Cat(Lit('1'),Cat(Lit('1'),Cat(Wildcard,Cat(Lit('0'),Empty))))
+        val p1 = Cat(Wildcard,Cat(lit('1'),Cat(lit('0'),Cat(lit('0'),Empty))))
+        val p2  = Cat(AnyElem,Cat(lit('1'),Cat(Wildcard,Cat(lit('0'),Empty))))
+        val p3 = Cat(lit('1'),Cat(lit('1'),Cat(Wildcard,Cat(lit('0'),Empty))))
         (p1, p2, p3)
       } ::
          */
@@ -139,8 +140,8 @@ class StringSeqPatternSetLaws extends SetOpsLaws[SeqPattern[Char]] {
   }
 
   test("intersection regression") {
-    val p1 = Cat(Wildcard, Cat(Lit('0'), Cat(Lit('1'), Empty)))
-    val p2 = Cat(Lit('0'), Cat(Lit('0'), Cat(Lit('0'), Cat(Wildcard, Empty))))
+    val p1 = Cat(Wildcard, Cat(lit('0'), Cat(lit('1'), Empty)))
+    val p2 = Cat(lit('0'), Cat(lit('0'), Cat(lit('0'), Cat(Wildcard, Empty))))
 
     assert(setOps.relate(p1, p2) == Rel.Intersects)
     assert(setOps.relate(p2, p1) == Rel.Intersects)


### PR DESCRIPTION
I noticed we are generating code for static string matches that could be done in advance.

This refactors to use the existing string matching code statically.