### PR TITLE
More improvements to MatchString codegen on Python

### DIFF
--- a/core/src/main/scala/org/bykn/bosatsu/codegen/python/PythonGen.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/codegen/python/PythonGen.scala
@@ -1296,9 +1296,6 @@ object PythonGen {
         val bindArray = binds.toArray
         // return a value like expression that contains the boolean result
         // and assigns all the bindings along the way
-        // TODO: we could keep track of exactOffset: Option[Int]
-        // and in some cases we know the offset we are at
-        // also, we could use pa
         def loop(
             knownPos: Option[Int],
             offsetIdent: Code.Ident,

--- a/test_workspace/Char.bosatsu
+++ b/test_workspace/Char.bosatsu
@@ -58,11 +58,31 @@ match_tests = TestSuite("match tests",
     Assertion("abc👋👋👋" matches "${_}👋", "test matching 6"),
   ])
 
+def starts_with_foo(s): s matches "foo${_}"
+def ends_with_foo(s): s matches "${_}foo"
+def contains_foo(s): s matches "${_}foo${_}"
+def contains_foo_bar(s): s matches "${_}foo${_}bar${_}"
+
+glob_match_tests = TestSuite("glob_match_suites",
+  [
+    Assertion(starts_with_foo("foobar"), "starts_with_foo(foobar)"),
+    Assertion(starts_with_foo("barfoo") matches False, "starts_with_foo(foobar)"),
+    Assertion(ends_with_foo("foobar") matches False, "ends_with_foo(foobar)"),
+    Assertion(ends_with_foo("barfoo"), "ends_with_foo(foobar)"),
+    Assertion(contains_foo("barfoo"), "contains_foo(foobar)"),
+    Assertion(contains_foo("barbar") matches False, "contains_foo(barbar)"),
+    Assertion(contains_foo_bar("there is foo and bar"), "there is foo and bar"),
+    Assertion(contains_foo_bar("there is foobar"), "there is foobar"),
+    Assertion(contains_foo_bar("there is foo but not the other") matches False,
+      "there is foo but not the other"),
+  ])
+
 tests = TestSuite("Char tests",
   [
     str_to_char_tests,
     len_test,
     last_tests,
     match_tests,
+    glob_match_tests,
   ]
 )


### PR DESCRIPTION
I am mostly doing this to just practice improving code generation on an easier target than C. Since I can run the tests under python I have good confidence the changes make sense. Also, the generated code is fairly easy to read.

With this PR, these examples:
```
def starts_with_foo(s): s matches "foo${_}"
def ends_with_foo(s): s matches "${_}foo"
def contains_foo(s): s matches "${_}foo${_}"
def contains_foo_bar(s): s matches "${_}foo${_}bar${_}"
```

compile to:
```python
def starts_with_foo(s):
    ___t14 = 0
    return s.startswith("foo", 0)

def ends_with_foo(s):
    ___t15 = 0
    return s.endswith("foo")

def contains_foo(s):
    ___t16 = 0
    return "foo" in s

def contains_foo_bar(s):
    ___t17 = 0
    ___t18 = 0
    ___t19 = False
    ___t20 = s.find("foo", ___t18)
    if ___t20 > -1:
        ___t21 = ___t20 + 3
        if s.find("bar", ___t21) > -1:
            ___t19 = True
            ___t18 = -1
        else:
            ___t18 = ___t20 + 1
    else:
        ___t18 = -1
    return ___t19
```
