### PR TITLE
Fix bug with shifts and recursive closures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -127,7 +127,7 @@ jobs:
       - name: "build assembly"
         run: "sbt \"++${{matrix.scala}}; cli/assembly\""
       - name: "generate c code"
-        run: "./bosatsuj transpile --input_dir test_workspace/ --package_root test_workspace/ --outdir c_out c --test --filter Bosatsu/List --filter IntTest --filter Bosatsu/BinNat --filter Bosatsu/Char --filter PredefTests"
+        run: "./bosatsuj transpile --input_dir test_workspace/ --package_root test_workspace/ --outdir c_out c --test"
       - name: "compile generated c code"
         run: |
           cp c_runtime/*.h c_out

--- a/c_runtime/bosatsu_runtime.c
+++ b/c_runtime/bosatsu_runtime.c
@@ -85,6 +85,16 @@ size_t closure_data_size(size_t slot_len) {
 BValue* closure_data_of(Closure1Data* s) {
   return (BValue*)((uintptr_t)s + sizeof(Closure1Data));
 }
+
+// Given the slots variable return the closure fn value
+// TODO: this may interact badly with static ptr tagging trick
+// since we have lost track if the original was tagged static or not
+BValue bsts_closure_from_slots(BValue* slots) {
+  uintptr_t s = (uintptr_t)slots;
+  uintptr_t pointer_to_closure = s - sizeof(Closure1Data);
+  return (BValue)pointer_to_closure;
+}
+
 void free_closure(Closure1Data* s) {
   size_t slots = s->slot_len;
   BValue* items = closure_data_of(s);

--- a/c_runtime/bosatsu_runtime.h
+++ b/c_runtime/bosatsu_runtime.h
@@ -113,6 +113,9 @@ BValue bsts_integer_div_mod(BValue l, BValue r);
 BValue alloc_external(void* eval, FreeFn free_fn);
 void* get_external(BValue v);
 
+// Given the slots variable return the closure fn value
+BValue bsts_closure_from_slots(BValue*);
+
 // should be called in main before accessing any BValue top level functions
 void init_statics();
 

--- a/cli/src/test/scala/org/bykn/bosatsu/codegen/clang/ClangGenTest.scala
+++ b/cli/src/test/scala/org/bykn/bosatsu/codegen/clang/ClangGenTest.scala
@@ -45,7 +45,7 @@ class ClangGenTest extends munit.FunSuite {
       To inspect the code, change the hash, and it will print the code out
      */
     testFilesCompilesToHash("test_workspace/Ackermann.bosatsu")(
-      "c4e556fd42f149731c0f31256db8a0b3"
+      "90c04307399ba4cda55601ee86951c20"
     )
   }
 }

--- a/core/src/main/scala/org/bykn/bosatsu/codegen/clang/ClangGen.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/codegen/clang/ClangGen.scala
@@ -1033,12 +1033,8 @@ object ClangGen {
                     pv(boxFn(nm, arity))
                   }
                   else {
-                    // we need to allocate another wrapper
-                    pv(Code.Ident(s"alloc_closure${arity}")(
-                      Code.IntLiteral(BigInt(arity)),
-                      slotsArgName,
-                      nm
-                    ))
+                    // recover the pointer to this closure from the slots argument
+                    pv(Code.Ident("bsts_closure_from_slots")(slotsArgName))
                   }
                 case None =>
                   getBinding(arg).widen

--- a/core/src/test/scala/org/bykn/bosatsu/codegen/clang/ClangGenTest.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/codegen/clang/ClangGenTest.scala
@@ -62,7 +62,7 @@ BValue ___bsts_g_Bosatsu_l_Predef_l_build__List(BValue __bsts_b_fn0) {
   test("check foldr_List") {
     assertPredefFns("foldr_List")("""#include "bosatsu_runtime.h"
 
-BValue __bsts_t_closure0(BValue* __bstsi_slot, BValue __bsts_b_list1) {
+BValue __bsts_t_closure__loop0(BValue* __bstsi_slot, BValue __bsts_b_list1) {
     if (get_variant(__bsts_b_list1) == (0)) {
         return __bstsi_slot[0];
     }
@@ -71,7 +71,7 @@ BValue __bsts_t_closure0(BValue* __bstsi_slot, BValue __bsts_b_list1) {
         BValue __bsts_b_t0 = get_enum_index(__bsts_b_list1, 1);
         return call_fn2(__bstsi_slot[1],
             __bsts_b_h0,
-            __bsts_t_closure0(__bstsi_slot, __bsts_b_t0));
+            __bsts_t_closure__loop0(__bstsi_slot, __bsts_b_t0));
     }
 }
 
@@ -81,7 +81,7 @@ BValue ___bsts_g_Bosatsu_l_Predef_l_foldr__List(BValue __bsts_b_list0,
     BValue __bsts_l_captures1[2] = { __bsts_b_acc0, __bsts_b_fn0 };
     BValue __bsts_b_loop0 = alloc_closure1(2,
         __bsts_l_captures1,
-        __bsts_t_closure0);
+        __bsts_t_closure__loop0);
     return call_fn1(__bsts_b_loop0, __bsts_b_list0);
 }""")
   }
@@ -89,7 +89,7 @@ BValue ___bsts_g_Bosatsu_l_Predef_l_foldr__List(BValue __bsts_b_list0,
   test("check foldLeft and reverse_concat") {
     assertPredefFns("foldLeft", "reverse_concat")("""#include "bosatsu_runtime.h"
 
-BValue __bsts_t_closure0(BValue* __bstsi_slot,
+BValue __bsts_t_closure__loop0(BValue* __bstsi_slot,
     BValue __bsts_b_lst1,
     BValue __bsts_b_item1) {
     BValue __bsts_l_loop__temp3;
@@ -121,7 +121,7 @@ BValue ___bsts_g_Bosatsu_l_Predef_l_foldLeft(BValue __bsts_b_lst0,
     BValue __bsts_l_captures5[1] = { __bsts_b_fn0 };
     BValue __bsts_b_loop0 = alloc_closure2(1,
         __bsts_l_captures5,
-        __bsts_t_closure0);
+        __bsts_t_closure__loop0);
     return call_fn2(__bsts_b_loop0, __bsts_b_lst0, __bsts_b_item0);
 }
 

--- a/test_workspace/IntTest.bosatsu
+++ b/test_workspace/IntTest.bosatsu
@@ -7,6 +7,8 @@ def operator ==(a, b): a.eq_Int(b)
 def operator &(a, b): a.and_Int(b)
 def operator |(a, b): a.or_Int(b)
 def operator ^(a, b): a.xor_Int(b)
+def operator <<(a, b): a.shift_left_Int(b)
+def operator >>(a, b): a.shift_right_Int(b)
 
 def assert_eq(got, expect, message):
   Assertion(got == expect, "${message}: got = ${int_to_String(got)}, expected = ${int_to_String(expect)}")
@@ -146,10 +148,25 @@ string_tests = TestSuite("string tests", [
   ]
 )
 
+shifts = TestSuite("shift tests", [
+  Assertion(((-23 << 1) >> 1) matches -23, "(-23 << 1) >> 1 returned ${int_to_String((-23 << 1) >> 1)}"),
+  Assertion((-23 << 1) matches -46, "(-23 << 1) returned ${int_to_String(-23 << 1)}"),
+  Assertion(((23 << 1) >> 1) matches 23, "(23 << 1) >> 1 returned ${int_to_String((23 << 1) >> 1)}"),
+  Assertion(((-8034984067920789066 << 1) >> 1) matches -8034984067920789066, "(-8034984067920789066 << 1) >> 1 returned ${int_to_String((-8034984067920789066 << 1) >> 1)}"),
+  Assertion(((16470527259447964275 << 20) >> 20) matches 16470527259447964275,
+    "(16470527259447964275 << 20) >> 20) got ${int_to_String((16470527259447964275 << 20) >> 20)}"),
+  Assertion((16470527259447964275 << 20) matches 17270599591602908587622400,
+    "(16470527259447964275 << 20) returned ${int_to_String((16470527259447964275 << 20))}"),
+  Assertion((17270599591602908587622400 >> 20) matches 16470527259447964275,
+    "17270599591602908587622400 >> 20 returned ${int_to_String(17270599591602908587622400 >> 20)}"
+  ),
+])
+
 tests = TestSuite("integer tests", [
   add_sub,
   string_tests,
   and_tests,
   or_tests,
   xor_tests,
+  shifts,
 ])

--- a/test_workspace/Properties.bosatsu
+++ b/test_workspace/Properties.bosatsu
@@ -49,7 +49,8 @@ shift_unshift_law = forall_Prop(
   ((i, k)) -> (
     istr = int_to_String(i)
     kstr = int_to_String(k)
-    Assertion((i << k) >> k == i, "(${istr} << ${kstr}) >> ${kstr} == ${istr}")
+    result = (i << k) >> k
+    Assertion(result == i, "(${istr} << ${kstr}) >> ${kstr} == ${istr}, got: ${int_to_String(result)}")
   ))
 
 def gtez(x): x.cmp_Int(0) matches (GT | EQ)


### PR DESCRIPTION
There are two bugs fixed here (sorry)...

1. the shifting code wasn't using twos compliment (I am having second thoughts about using a sign + magnitude representation, but as long as it is here, for negative numbers we need to convert to twos compliment for bitwise ops).
2. if a closure is used in a nested recursive position, we were incorrectly allocating the value for it. This can happen rarely when the optimizer rewrites a function call to being nested. This seems to be due to an optimization that we push down calls as low as we need them, which can result in pushing them into nested calls. Maybe we don't want to push values down since it can also wind up multiplying work and de-optimizing calls (e.g. imagine `let x = expensive(y) in z.map(w -> (w, x))` here we don't want to push x down since we would wind up computing it on every call. That substitution should probably only be done when we can be sure it will be called 0 or 1 times, (e.g. into a match or lets).