### PR TITLE
Cache function declaration to avoid generating duplicate functions

### DIFF
--- a/cli/src/test/scala/org/bykn/bosatsu/codegen/clang/ClangGenTest.scala
+++ b/cli/src/test/scala/org/bykn/bosatsu/codegen/clang/ClangGenTest.scala
@@ -45,7 +45,7 @@ class ClangGenTest extends munit.FunSuite {
       To inspect the code, change the hash, and it will print the code out
      */
     testFilesCompilesToHash("test_workspace/Ackermann.bosatsu")(
-      "90c04307399ba4cda55601ee86951c20"
+      "e7bf005ddf95ce8e62e45c6985c09e51"
     )
   }
 }


### PR DESCRIPTION
since we lift MakeStruct, MakeEnum, NatSucc into lambdas when they are not directly applied, we can generate duplicate functions that are equivalent if those items appear more than once in generated code.

This avoids that to simplify code generation when inspecting the output, I assume any C compiler would be good enough to optimize this from a performance perspective.