### PR TITLE
 add while to matchless

### DIFF
--- a/cli/src/test/scala/org/bykn/bosatsu/PathModuleTest.scala
+++ b/cli/src/test/scala/org/bykn/bosatsu/PathModuleTest.scala
@@ -22,6 +22,7 @@ class PathModuleTest extends AnyFunSuite {
       Gen.listOf(str).map(parts => Paths.get(parts.mkString("/")))
     }
 
+    /*
   test("test some hand written examples") {
     def pn(roots: List[String], file: String): Option[PackageName] =
       PathModule.pathPackage(roots.map(Paths.get(_)), Paths.get(file))
@@ -100,6 +101,7 @@ class PathModuleTest extends AnyFunSuite {
       if (noPrefix) assert(pack == None)
     }
   }
+    */
 
   def run(args: String*): PathModule.Output =
     PathModule.run(args.toList) match {
@@ -134,6 +136,7 @@ class PathModuleTest extends AnyFunSuite {
     }
   }
 
+  /*
   test("test search run of a file") {
     val out = run(
       "test --package_root test_workspace --search --test_file test_workspace/Bar.bosatsu"
@@ -293,4 +296,5 @@ class PathModuleTest extends AnyFunSuite {
     }
   }
 
+  */
 }

--- a/cli/src/test/scala/org/bykn/bosatsu/PathModuleTest.scala
+++ b/cli/src/test/scala/org/bykn/bosatsu/PathModuleTest.scala
@@ -22,7 +22,6 @@ class PathModuleTest extends AnyFunSuite {
       Gen.listOf(str).map(parts => Paths.get(parts.mkString("/")))
     }
 
-    /*
   test("test some hand written examples") {
     def pn(roots: List[String], file: String): Option[PackageName] =
       PathModule.pathPackage(roots.map(Paths.get(_)), Paths.get(file))
@@ -101,7 +100,6 @@ class PathModuleTest extends AnyFunSuite {
       if (noPrefix) assert(pack == None)
     }
   }
-    */
 
   def run(args: String*): PathModule.Output =
     PathModule.run(args.toList) match {
@@ -136,7 +134,6 @@ class PathModuleTest extends AnyFunSuite {
     }
   }
 
-  /*
   test("test search run of a file") {
     val out = run(
       "test --package_root test_workspace --search --test_file test_workspace/Bar.bosatsu"
@@ -295,6 +292,4 @@ class PathModuleTest extends AnyFunSuite {
       case other => fail(s"unexpeced: $other")
     }
   }
-
-  */
 }

--- a/cli/src/test/scala/org/bykn/bosatsu/codegen/clang/ClangGenTest.scala
+++ b/cli/src/test/scala/org/bykn/bosatsu/codegen/clang/ClangGenTest.scala
@@ -45,7 +45,7 @@ class ClangGenTest extends munit.FunSuite {
       To inspect the code, change the hash, and it will print the code out
      */
     testFilesCompilesToHash("test_workspace/Ackermann.bosatsu")(
-      "e7bf005ddf95ce8e62e45c6985c09e51"
+      "f881ad7b7bda633aae1ad1c061f1d3bd"
     )
   }
 }

--- a/core/src/main/scala/org/bykn/bosatsu/MatchlessToValue.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/MatchlessToValue.scala
@@ -350,10 +350,7 @@ object MatchlessToValue {
             val resFn = loop(res)
             val capScoped = caps.map(loop).toVector
             Dynamic { scope =>
-              val initMutKeys = scope.muts.keySet
               val valuesInScope = capScoped.map(scoped => scoped(scope))
-              // these can't change the keyset
-              require(initMutKeys == scope.muts.keySet)
               // now we ignore the scope after reading from it
               val scope1 = Scope.capture(valuesInScope, scope.extra)
 
@@ -368,10 +365,7 @@ object MatchlessToValue {
             val resFn = loop(res)
             val capScoped = caps.map(loop).toVector
             Dynamic { scope =>
-              val initMutKeys = scope.muts.keySet
               val valuesInScope = capScoped.map(scoped => scoped(scope))
-              // these can't change the keyset
-              require(initMutKeys == scope.muts.keySet)
 
               lazy val scope1: Scope = Scope
                 .capture(valuesInScope)
@@ -395,20 +389,10 @@ object MatchlessToValue {
             // has failed
             Dynamic { (scope: Scope) =>
               var c = condF(scope)
-              def printOnFail[A](a: => A, msg: => String): A = {
-                try a
-                catch {
-                  case t: Throwable =>
-                    println(msg)
-                    throw t
-                }
-              }
               while(c) {
-                //println(s"loop iteration: ${scope.debugString}")
-                printOnFail(effectF(scope), s"failed in effect:\n\n$effect\n\n${scope.debugString}")
-                c = printOnFail(condF(scope), "failed in check")
+                effectF(scope)
+                c = condF(scope)
               }
-
               scope.muts(result.ident).get()
             }
           case Global(p, n) =>

--- a/core/src/main/scala/org/bykn/bosatsu/MatchlessToValue.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/MatchlessToValue.scala
@@ -334,97 +334,6 @@ object MatchlessToValue {
             }
         }
 
-        /*
-      def buildLoop(
-          caps: Vector[Scoped[Value]],
-          fnName: Bindable,
-          args: NonEmptyList[Bindable],
-          body: Scoped[Value]
-      ): Scoped[Value] = {
-        val argCount = args.length
-        val argNames: Array[Bindable] = args.toList.toArray
-        if (caps.isEmpty) {
-          // We only capture ourself and we put that in below
-          val scope1 = Scope.empty()
-          val fn = FnValue { allArgs =>
-            var registers: NonEmptyList[Value] = allArgs
-
-            // the registers are set up
-            // when we recur, that is a continue on the loop,
-            // we just update the registers and return null
-            val continueFn = FnValue { continueArgs =>
-              registers = continueArgs
-              null
-            }
-
-            val scope2 = scope1.let(fnName, Eval.now(continueFn))
-
-            var res: Value = null
-
-            while (res eq null) {
-              // read the registers into the environment
-              var idx = 0
-              var reg: List[Value] = registers.toList
-              var s: Scope = scope2
-              while (idx < argCount) {
-                val b = argNames(idx)
-                val v = reg.head
-                reg = reg.tail
-                s = s.let(b, Eval.now(v))
-                idx = idx + 1
-              }
-              res = body(s)
-            }
-
-            res
-          }
-
-          Static(fn)
-        } else {
-          Dynamic { scope =>
-            // TODO this maybe isn't helpful
-            // it doesn't matter if the scope
-            // is too broad for correctness.
-            // It may make things go faster
-            // if the caps are really small
-            // or if we can GC things sooner.
-            val scope1 = scope.capture(caps.map(s => s(scope)))
-
-            FnValue { allArgs =>
-              var registers: NonEmptyList[Value] = allArgs
-
-              // the registers are set up
-              // when we recur, that is a continue on the loop,
-              // we just update the registers and return null
-              val continueFn = FnValue { continueArgs =>
-                registers = continueArgs
-                null
-              }
-
-              val scope2 = scope1.let(fnName, Eval.now(continueFn))
-
-              var res: Value = null
-
-              while (res eq null) {
-                // read the registers into the environment
-                var idx = 0
-                var reg: List[Value] = registers.toList
-                var s: Scope = scope2
-                while (idx < argCount) {
-                  val b = argNames(idx)
-                  val v = reg.head
-                  reg = reg.tail
-                  s = s.let(b, Eval.now(v))
-                  idx = idx + 1
-                }
-                res = body(s)
-              }
-
-              res
-            }
-          }
-        }
-      }*/
       // the locals can be recusive, so we box into Eval for laziness
       def loop(me: Expr): Scoped[Value] =
         me match {
@@ -434,9 +343,6 @@ object MatchlessToValue {
             val scope1 = Scope.empty()
             val fn = FnValue { argV =>
               val scope2 = scope1.letAll(args, argV)
-              if (args.exists(_ == Identifier.Name("rands"))) {
-                //println(s"calling lambda($argV) with ${scope2.debugString}")
-              }
               resFn(scope2)
             }
             Static(fn)

--- a/core/src/main/scala/org/bykn/bosatsu/codegen/clang/ClangGen.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/codegen/clang/ClangGen.scala
@@ -1007,6 +1007,17 @@ object ClangGen {
               .flatMapN { (c, thenC, elseC) =>
                 Code.ValueLike.ifThenElseV(c, thenC, elseC)(newLocalName)
               }
+          case Always.SetChain(setmuts, result) =>
+            (
+              setmuts.traverse { case (LocalAnonMut(mut), v) =>
+                for {
+                  name <- getAnon(mut)
+                  vl <- innerToValue(v)
+                } yield (name := vl)
+              }, innerToValue(result)
+            ).mapN { (assigns, result) =>
+              Code.Statements(assigns) +: result
+            }
           case Always(cond, thenExpr) =>
             boolToValue(cond).flatMap { bv =>
               bv.discardValue match {

--- a/core/src/main/scala/org/bykn/bosatsu/codegen/clang/ClangGen.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/codegen/clang/ClangGen.scala
@@ -244,69 +244,6 @@ object ClangGen {
       // This name has to be impossible to give out for any other purpose
       val slotsArgName: Code.Ident = Code.Ident("__bstsi_slot")
 
-      // assign any results to result and set the condition to false
-      // and replace any tail calls to nm(args) with assigning args to those values
-      def toWhileBody(fnName: Code.Ident, argTemp: NonEmptyList[(Code.Param, Code.Ident)], isClosure: Boolean, cond: Code.Ident, result: Code.Ident, body: Code.ValueLike): Code.Block = {
-      
-        import Code._
-
-        def returnValue(vl: ValueLike): Statement =
-          (cond := FalseLit) +
-            (result := vl)
-
-        def loop(vl: ValueLike): Option[Statement] =
-          vl match {
-            case Apply(fn, appArgs) if fn == fnName =>
-              // this is a tail call
-              val newArgsList =
-                if (isClosure) appArgs.tail
-                else appArgs
-              // we know the length of appArgs must match args or the code wouldn't have compiled
-              // we have to first assign to the temp variables, and then assign the temp variables
-              // to the results to make sure we don't have any data dependency issues with the values;
-              val tmpAssigns = argTemp
-                .iterator
-                .zip(newArgsList.iterator)
-                .flatMap { case ((Param(_, name), tmp), value) =>
-                  if (name != value)
-                    // don't create self assignments
-                    Iterator.single((Assignment(tmp, value), Assignment(name, tmp)))
-                  else
-                    Iterator.empty
-                }
-                .toList
-
-              // there must be at least one assignment
-              val assignNEL = NonEmptyList.fromListUnsafe(
-                tmpAssigns.map(_._1) ::: tmpAssigns.map(_._2)
-              )
-              Some(Statements(assignNEL))
-            case IfElseValue(c, t, f) =>
-              // this can possible have tail calls inside the branches
-              (loop(t), loop(f)) match {
-                case (Some(t), Some(f)) =>
-                  Some(ifThenElse(c, t, f))
-                case (None, Some(f)) =>
-                  Some(ifThenElse(c, returnValue(t), f))
-                case (Some(t), None) =>
-                  Some(ifThenElse(c, t, returnValue(f)))
-                case (None, None) => None
-              }
-            case Ternary(c, t, f) => loop(IfElseValue(c, t, f))
-            case WithValue(s, vl) => loop(vl).map(s + _)
-            case Apply(_, _) | Cast(_, _) | BinExpr(_, _, _) | Bracket(_, _) | Ident(_) |
-              IntLiteral(_) | PostfixExpr(_, _) | PrefixExpr(_, _) | Select(_, _) |
-              StrLiteral(_) => None
-          }
-
-        loop(body) match {
-          case Some(stmt) => block(stmt)
-          case None =>
-            sys.error("invariant violation: could not find tail calls in:" +
-              s"toWhileBody(fnName = $fnName, body = $body)")
-        }
-      }
-
       def bindAll[A](nel: NonEmptyList[Bindable])(in: T[A]): T[A] =
         bind(nel.head) {
           NonEmptyList.fromList(nel.tail) match {
@@ -1133,6 +1070,24 @@ object ClangGen {
                 NonEmptyList.one(argVL)
               )(newLocalName)
             }
+          case WhileExpr(cond, effect, res) =>
+            (boolToValue(cond), innerToValue(effect), innerToValue(res), newLocalName("cond"))
+              .mapN { (cond, effect, res, condVar) =>
+                Code.Statements(
+                  Code.DeclareVar(Nil, Code.TypeIdent.Bool, condVar, None),
+                  condVar := cond,
+                  Code.While(condVar,
+                    Code.Block(
+                      NonEmptyList.one(
+                        condVar := cond,
+                      )
+                      .prependList(
+                        effect.discardValue.toList
+                      )
+                    )
+                  )
+                ) +: res
+              }
         }
 
       def fnStatement(fnName: Code.Ident, fn: FnExpr): T[Code.Statement] =
@@ -1157,40 +1112,6 @@ object ClangGen {
                   }
               } yield Code.DeclareFn(Nil, Code.TypeIdent.BValue, fnName, allArgs.toList, Some(Code.block(fnBody)))
             }
-            /*
-          case LoopFn(captures, nm, args, body) =>
-            recursiveName(fnName, nm, isClosure = captures.nonEmpty, arity = fn.arity) {
-              bindAll(args) {
-                for {
-                  cond <- newLocalName("cond")
-                  res <- newLocalName("res")
-                  bodyVL <- innerToValue(body)
-                  argParamsTemps <- args.traverse { b =>
-                    (getBinding(b), newLocalName("loop_temp")).mapN { (i, t) => (Code.Param(Code.TypeIdent.BValue, i), t) }
-                  }
-                  whileBody = toWhileBody(fnName, argParamsTemps, isClosure = captures.nonEmpty, cond = cond, result = res, body = bodyVL)
-                  declTmps = Code.Statements(
-                    argParamsTemps.map { case (_, tmp) =>
-                      Code.DeclareVar(Nil, Code.TypeIdent.BValue, tmp, None)
-                    }
-                  )
-                  fnBody = Code.block(
-                    declTmps,
-                    Code.DeclareVar(Nil, Code.TypeIdent.Bool, cond, Some(Code.TrueLit)),
-                    Code.DeclareVar(Nil, Code.TypeIdent.BValue, res, None),
-                    Code.While(cond, whileBody),
-                    Code.Return(Some(res))
-                  )
-                  argParams = argParamsTemps.map(_._1)
-                  allArgs =
-                    if (captures.isEmpty) argParams
-                    else {
-                      Code.Param(Code.TypeIdent.BValue.ptr, slotsArgName) :: argParams
-                    }
-                } yield Code.DeclareFn(Nil, Code.TypeIdent.BValue, fnName, allArgs.toList, Some(fnBody))
-              }
-            }
-            */
         }
 
       def renderTop(p: PackageName, b: Bindable, expr: Expr): T[Unit] =

--- a/core/src/main/scala/org/bykn/bosatsu/codegen/clang/ClangGen.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/codegen/clang/ClangGen.scala
@@ -1157,6 +1157,7 @@ object ClangGen {
                   }
               } yield Code.DeclareFn(Nil, Code.TypeIdent.BValue, fnName, allArgs.toList, Some(Code.block(fnBody)))
             }
+            /*
           case LoopFn(captures, nm, args, body) =>
             recursiveName(fnName, nm, isClosure = captures.nonEmpty, arity = fn.arity) {
               bindAll(args) {
@@ -1189,6 +1190,7 @@ object ClangGen {
                 } yield Code.DeclareFn(Nil, Code.TypeIdent.BValue, fnName, allArgs.toList, Some(fnBody))
               }
             }
+            */
         }
 
       def renderTop(p: PackageName, b: Bindable, expr: Expr): T[Unit] =

--- a/core/src/main/scala/org/bykn/bosatsu/codegen/clang/Code.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/codegen/clang/Code.scala
@@ -498,7 +498,7 @@ object Code {
     // These are the highest priority, so safe to not use a parens
     def unapply(e: Expression): Option[Expression] =
       e match {
-        case noPar @ (Ident(_) | Apply(_, _) | Select(_, _) | Bracket(_, _)) => Some(noPar)
+        case noPar @ (Ident(_) | Apply(_, _) | Select(_, _) | Bracket(_, _) | IntLiteral(_)) => Some(noPar)
         case _ => None
       }
   }

--- a/core/src/main/scala/org/bykn/bosatsu/codegen/python/PythonGen.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/codegen/python/PythonGen.scala
@@ -421,63 +421,6 @@ object PythonGen {
 
       loop(initBody)
     }
-
-    // these are always recursive so we can use def to define them
-    /*
-    def buildLoop(
-        selfName: Ident,
-        fnMutArgs: NonEmptyList[(Ident, Ident)],
-        body: ValueLike
-    ): Env[Statement] = {
-      /*
-       * bodyUpdate = body except App(foo, args) is replaced with
-       * reseting the inputs, and setting cont to True and having
-       * the value ()
-       *
-       * def foo(a)(b)(c):
-       *   cont = True
-       *   res = ()
-       *   while cont:
-       *     cont = False
-       *     res = bodyUpdate
-       *   return res
-       */
-      val fnArgs = fnMutArgs.map(_._1)
-      val mutArgs = fnMutArgs.map(_._2)
-
-      def assignMut(cont: Code.Ident)(args: List[Expression]): Statement = {
-        // do the replacement in one atomic go. otherwise
-        // we could mutate a variable a later expression depends on
-        // some times we generate code that does x = x, remove those cases
-        val (left, right) =
-          mutArgs.toList.zip(args).filter { case (x, y) => x != y }.unzip
-
-        Code.block(
-          cont := Const.True,
-          if (left.isEmpty) Pass
-          else if (left.lengthCompare(1) == 0) {
-            left.head := right.head
-          } else {
-            (MakeTuple(left) := MakeTuple(right))
-          }
-        )
-      }
-
-      for {
-        cont <- Env.newAssignableVar
-        ac = assignMut(cont)(fnArgs.toList)
-        res <- Env.newAssignableVar
-        ar = (res := Code.Const.Unit)
-        body1 <- replaceTailCallWithAssign(selfName, mutArgs.length, body)(
-          assignMut(cont)
-        )
-        setRes = res := body1
-        loop = While(cont, (cont := false) +: setRes)
-        newBody = (ac +: ar +: loop).withValue(res)
-      } yield makeDef(selfName, fnArgs, newBody)
-    }
-    */
-
   }
 
   // we escape by prefixing by three underscores, ___ and n (for name)
@@ -1710,36 +1653,13 @@ object PythonGen {
               .withValue(res)
           }
 
-      // if expr is a LoopFn or Lambda handle it
+      // if expr is a Lambda handle it
       def topFn(
           name: Code.Ident,
           expr: FnExpr,
           slotName: Option[Code.Ident]
       ): Env[Statement] =
         expr match {
-          /*
-          case LoopFn(captures, _, args, b) =>
-            // note, name is already bound
-            // args can use topFn
-            val boundA = args.traverse(Env.topLevelName)
-            val subsA = args.traverse { a =>
-              for {
-                mut <- Env.newAssignableVar
-                _ <- Env.subs(a, mut)
-              } yield (a, mut)
-            }
-
-            for {
-              as <- boundA
-              subs <- subsA
-              subs1 = as.zipWith(subs) { case (b, (_, m)) => (b, m) }
-              (binds, body) <- makeSlots(captures, slotName)(loop(b, _))
-              loopRes <- Env.buildLoop(name, subs1, body)
-              // we have bound this name twice, once for the top and once for substitution
-              _ <- subs.traverse_ { case (a, _) => Env.unbind(a) }
-            } yield Code.blockFromList(binds.toList ::: loopRes :: Nil)
-
-            */
           case Lambda(captures, _, args, body) =>
             // we can ignore name because python already allows recursion
             // we can use topLevelName on makeDefs since they are already
@@ -1748,13 +1668,13 @@ object PythonGen {
               args.traverse(Env.topLevelName(_)),
               makeSlots(captures, slotName)(loop(body, _))
             )
-              .mapN { case (as, (slots, body)) =>
-                Code.blockFromList(
-                  slots.toList :::
-                    Env.makeDef(name, as, body) ::
-                    Nil
-                )
-              }
+            .mapN { case (as, (slots, body)) =>
+              Code.blockFromList(
+                slots.toList :::
+                  Env.makeDef(name, as, body) ::
+                  Nil
+              )
+            }
         }
 
       def makeSlots[A](captures: List[Expr], slotName: Option[Code.Ident])(
@@ -1807,35 +1727,6 @@ object PythonGen {
                   ).withValue(res)  
                 }
               }
-              /*
-          case LoopFn(captures, thisName, args, body) =>
-            // note, thisName is already bound because LoopFn
-            // is a lambda, not a def
-
-            // we can use topLeft for arg names
-            val boundA = args.traverse(Env.topLevelName)
-            val subsA = args.traverse { a =>
-              for {
-                mut <- Env.newAssignableVar
-                _ <- Env.subs(a, mut)
-              } yield (a, mut)
-            }
-
-            for {
-              nameI <- Env.bind(thisName)
-              as <- boundA
-              subs <- subsA
-              (prefix, body) <- makeSlots(captures, slotName)(loop(body, _))
-              subs1 = as.zipWith(subs) { case (b, (_, m)) => (b, m) }
-              loopRes <- Env.buildLoop(nameI, subs1, body)
-              // we have bound the args twice: once as args, once as interal muts
-              _ <- subs.traverse_ { case (a, _) => Env.unbind(a) }
-              _ <- Env.unbind(thisName)
-            } yield Code
-              .blockFromList(prefix.toList :+ loopRes)
-              .withValue(nameI)
-              */
-
           case PredefExternal((fn, arity)) =>
             // make a lambda
             PredefExternal.makeLambda(arity)(fn)

--- a/core/src/main/scala/org/bykn/bosatsu/codegen/python/PythonGen.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/codegen/python/PythonGen.scala
@@ -423,6 +423,7 @@ object PythonGen {
     }
 
     // these are always recursive so we can use def to define them
+    /*
     def buildLoop(
         selfName: Ident,
         fnMutArgs: NonEmptyList[(Ident, Ident)],
@@ -475,6 +476,7 @@ object PythonGen {
         newBody = (ac +: ar +: loop).withValue(res)
       } yield makeDef(selfName, fnArgs, newBody)
     }
+    */
 
   }
 
@@ -1789,6 +1791,15 @@ object PythonGen {
                     defn = Env.makeDef(defName, args, v)
                     block = Code.blockFromList(prefix.toList ::: defn :: Nil)
                   } yield block.withValue(defName)
+              }
+          case WhileExpr(cond, effect, res) =>
+            (boolExpr(cond, slotName), loop(effect, slotName), loop(res, slotName))
+              .flatMapN { (cond, effect, res) =>
+                Env.onLastM(cond) { condX =>
+                  Env.onLast(effect) { effectX =>
+                    Code.WithValue(Code.While(condX, Code.always(effectX)), res)
+                  }
+                }
               }
               /*
           case LoopFn(captures, thisName, args, body) =>

--- a/core/src/main/scala/org/bykn/bosatsu/codegen/python/PythonGen.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/codegen/python/PythonGen.scala
@@ -1715,6 +1715,7 @@ object PythonGen {
           slotName: Option[Code.Ident]
       ): Env[Statement] =
         expr match {
+          /*
           case LoopFn(captures, _, args, b) =>
             // note, name is already bound
             // args can use topFn
@@ -1736,6 +1737,7 @@ object PythonGen {
               _ <- subs.traverse_ { case (a, _) => Env.unbind(a) }
             } yield Code.blockFromList(binds.toList ::: loopRes :: Nil)
 
+            */
           case Lambda(captures, _, args, body) =>
             // we can ignore name because python already allows recursion
             // we can use topLevelName on makeDefs since they are already
@@ -1788,6 +1790,7 @@ object PythonGen {
                     block = Code.blockFromList(prefix.toList ::: defn :: Nil)
                   } yield block.withValue(defName)
               }
+              /*
           case LoopFn(captures, thisName, args, body) =>
             // note, thisName is already bound because LoopFn
             // is a lambda, not a def
@@ -1814,6 +1817,7 @@ object PythonGen {
             } yield Code
               .blockFromList(prefix.toList :+ loopRes)
               .withValue(nameI)
+              */
 
           case PredefExternal((fn, arity)) =>
             // make a lambda

--- a/core/src/test/scala/org/bykn/bosatsu/codegen/clang/ClangGenTest.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/codegen/clang/ClangGenTest.scala
@@ -63,7 +63,7 @@ BValue ___bsts_g_Bosatsu_l_Predef_l_build__List(BValue __bsts_b_fn0) {
     assertPredefFns("foldr_List")("""#include "bosatsu_runtime.h"
 
 BValue __bsts_t_closure__loop0(BValue* __bstsi_slot, BValue __bsts_b_list1) {
-    if (get_variant(__bsts_b_list1) == (0)) {
+    if (get_variant(__bsts_b_list1) == 0) {
         return __bstsi_slot[0];
     }
     else {
@@ -89,43 +89,49 @@ BValue ___bsts_g_Bosatsu_l_Predef_l_foldr__List(BValue __bsts_b_list0,
   test("check foldLeft and reverse_concat") {
     assertPredefFns("foldLeft", "reverse_concat")("""#include "bosatsu_runtime.h"
 
-BValue __bsts_t_closure__loop0(BValue* __bstsi_slot,
+BValue __bsts_t_closure0(BValue* __bstsi_slot,
     BValue __bsts_b_lst1,
     BValue __bsts_b_item1) {
-    BValue __bsts_l_loop__temp3;
-    BValue __bsts_l_loop__temp4;
-    _Bool __bsts_l_cond1 = 1;
-    BValue __bsts_l_res2;
+    BValue __bsts_a_0;
+    BValue __bsts_a_1;
+    BValue __bsts_a_3;
+    BValue __bsts_a_5;
+    __bsts_a_3 = __bsts_b_lst1;
+    __bsts_a_5 = __bsts_b_item1;
+    __bsts_a_0 = alloc_enum0(1);
+    _Bool __bsts_l_cond1;
+    __bsts_l_cond1 = get_variant(__bsts_a_0) == 1;
     while (__bsts_l_cond1) {
-        if (get_variant(__bsts_b_lst1) == (0)) {
-            __bsts_l_cond1 = 0;
-            __bsts_l_res2 = __bsts_b_item1;
+        if (get_variant(__bsts_a_3) == 0) {
+            __bsts_a_0 = alloc_enum0(0);
+            __bsts_a_1 = __bsts_a_5;
         }
         else {
-            BValue __bsts_b_head0 = get_enum_index(__bsts_b_lst1, 0);
-            BValue __bsts_b_tail0 = get_enum_index(__bsts_b_lst1, 1);
-            __bsts_l_loop__temp3 = __bsts_b_tail0;
-            __bsts_l_loop__temp4 = call_fn2(__bstsi_slot[0],
-                __bsts_b_item1,
+            BValue __bsts_b_head0 = get_enum_index(__bsts_a_3, 0);
+            BValue __bsts_b_tail0 = get_enum_index(__bsts_a_3, 1);
+            BValue __bsts_a_2 = __bsts_b_tail0;
+            BValue __bsts_a_4 = call_fn2(__bstsi_slot[0],
+                __bsts_a_5,
                 __bsts_b_head0);
-            __bsts_b_lst1 = __bsts_l_loop__temp3;
-            __bsts_b_item1 = __bsts_l_loop__temp4;
+            __bsts_a_3 = __bsts_a_2;
+            __bsts_a_5 = __bsts_a_4;
         }
+        __bsts_l_cond1 = get_variant(__bsts_a_0) == 1;
     }
-    return __bsts_l_res2;
+    return __bsts_a_1;
 }
 
 BValue ___bsts_g_Bosatsu_l_Predef_l_foldLeft(BValue __bsts_b_lst0,
     BValue __bsts_b_item0,
     BValue __bsts_b_fn0) {
-    BValue __bsts_l_captures5[1] = { __bsts_b_fn0 };
+    BValue __bsts_l_captures2[1] = { __bsts_b_fn0 };
     BValue __bsts_b_loop0 = alloc_closure2(1,
-        __bsts_l_captures5,
-        __bsts_t_closure__loop0);
+        __bsts_l_captures2,
+        __bsts_t_closure0);
     return call_fn2(__bsts_b_loop0, __bsts_b_lst0, __bsts_b_item0);
 }
 
-BValue __bsts_t_lambda6(BValue __bsts_b_tail0, BValue __bsts_b_h0) {
+BValue __bsts_t_lambda3(BValue __bsts_b_tail0, BValue __bsts_b_h0) {
     return alloc_enum2(1, __bsts_b_h0, __bsts_b_tail0);
 }
 
@@ -133,7 +139,7 @@ BValue ___bsts_g_Bosatsu_l_Predef_l_reverse__concat(BValue __bsts_b_front0,
     BValue __bsts_b_back0) {
     return ___bsts_g_Bosatsu_l_Predef_l_foldLeft(__bsts_b_front0,
         __bsts_b_back0,
-        alloc_boxed_pure_fn2(__bsts_t_lambda6));
+        alloc_boxed_pure_fn2(__bsts_t_lambda3));
 }""")
   }
 


### PR DESCRIPTION
this closes #770 by moving a lot of the logic of while construction into a single place, then generate while loops after. This unifies 3 implementations (MatchlessToValue, python, c).

It also opens the door to possibly remove the SearchList node since I think that can be rewritten as a while loop.