### PR TITLE
try boehm gc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,4 @@ jsui/bosatsu_ui.js
 c_runtime/*.o
 c_runtime/test_exe
 c_runtime/test_out
+c_runtime/boehm_example

--- a/c_runtime/Makefile
+++ b/c_runtime/Makefile
@@ -22,11 +22,11 @@ bosatsu_decls_generated.h: typegen.py
 	python3 typegen.py headers > bosatsu_decls_generated.h
 
 bosatsu_runtime.o: bosatsu_runtime.h bosatsu_runtime.c bosatsu_decls_generated.h bosatsu_generated.h
-	gcc -c -Wall -Werror bosatsu_runtime.c
+	gcc -c $(CFLAGS) -Wall -Werror bosatsu_runtime.c
 
 # this will eventually have test code for the runtime and predef
 test_exe: test.c bosatsu_runtime.o
-	gcc -O3 -Wall -o test_exe test.c bosatsu_runtime.o
+	gcc -O3 $(CFLAGS) -Wall -o test_exe test.c bosatsu_runtime.o $(LIBS)
 
 test_out: test_exe
 	./test_exe > output.log 2>&1 || { cat output.log; rm -f output.log; false; }

--- a/c_runtime/Makefile.test
+++ b/c_runtime/Makefile.test
@@ -1,10 +1,25 @@
+OS := $(shell uname)
+
+# Platform-specific settings
+ifneq ($(wildcard /opt/homebrew/Cellar/bdw-gc),)  # Check if the directory exists
+    LATEST_VERSION := $(shell ls -v /opt/homebrew/Cellar/bdw-gc | tail -n 1)
+    BOEHM_GC := /opt/homebrew/Cellar/bdw-gc/$(LATEST_VERSION)
+endif
+
+ifeq ($(OS), Darwin)
+    CFLAGS += -I$(BOEHM_GC)/include
+    LIBS += "$(BOEHM_GC)/lib/libgc.a"
+else ifeq ($(OS), Linux)
+    LIBS += -lgc
+endif
+
 FLAGS = -flto -O3
 //FLAGS = -g
 
 all: bosatsu_runtime.o test_out bosatsu_ext_Bosatsu_l_Predef.o bosatsu_ext_Bosatsu_l_Prog.o
 
 bosatsu_runtime.o: bosatsu_runtime.h bosatsu_runtime.c bosatsu_decls_generated.h bosatsu_generated.h
-	gcc $(FLAGS) -c -Wall -Werror bosatsu_runtime.c
+	gcc $(FLAGS) $(CFLAGS) -c -Wall -Werror bosatsu_runtime.c
 
 bosatsu_ext_Bosatsu_l_Predef.o: bosatsu_ext_Bosatsu_l_Predef.c bosatsu_runtime.o
 	gcc $(FLAGS) -Wall -Werror -c bosatsu_ext_Bosatsu_l_Predef.c
@@ -13,7 +28,7 @@ bosatsu_ext_Bosatsu_l_Prog.o: bosatsu_ext_Bosatsu_l_Prog.c bosatsu_runtime.o
 	gcc $(FLAGS) -Wall -Werror -c bosatsu_ext_Bosatsu_l_Prog.c
 
 test_exe: output.c bosatsu_runtime.o bosatsu_ext_Bosatsu_l_Prog.o bosatsu_ext_Bosatsu_l_Predef.o
-	gcc $(FLAGS) -o test_exe output.c bosatsu_runtime.o bosatsu_ext_Bosatsu_l_Prog.o bosatsu_ext_Bosatsu_l_Predef.o
+	gcc $(FLAGS) $(CFLAGS) -o test_exe output.c bosatsu_runtime.o bosatsu_ext_Bosatsu_l_Prog.o bosatsu_ext_Bosatsu_l_Predef.o $(LIBS)
 
 test_out: test_exe
 	./test_exe > output.log 2>&1 || { cat output.log; rm -f output.log; false; }

--- a/c_runtime/bosatsu_generated.h
+++ b/c_runtime/bosatsu_generated.h
@@ -1,54 +1,27 @@
 // STRUCTS
-DEFINE_RC_STRUCT(Struct2,BValue _0;BValue _1;);
+DEFINE_BSTS_OBJ(Struct2,BValue _0;BValue _1;);
 
-void free_struct2(Struct2* s) {
-    release_value(s->_0);
-    release_value(s->_1);
-    free(s);
-}
 BValue alloc_struct2(BValue b0, BValue b1) {
-    Struct2* rc = malloc(sizeof(Struct2));
-    // this is safe to do outside atomic because no other thread can see this yet
-    rc->ref_count = 1;
-    rc->free = (FreeFn)free_struct2;
+    Struct2* rc = GC_malloc(sizeof(Struct2));
     rc->_0 = b0;
     rc->_1 = b1;
     return (BValue)rc;
 }
 
-DEFINE_RC_STRUCT(Struct3,BValue _0;BValue _1;BValue _2;);
+DEFINE_BSTS_OBJ(Struct3,BValue _0;BValue _1;BValue _2;);
 
-void free_struct3(Struct3* s) {
-    release_value(s->_0);
-    release_value(s->_1);
-    release_value(s->_2);
-    free(s);
-}
 BValue alloc_struct3(BValue b0, BValue b1, BValue b2) {
-    Struct3* rc = malloc(sizeof(Struct3));
-    // this is safe to do outside atomic because no other thread can see this yet
-    rc->ref_count = 1;
-    rc->free = (FreeFn)free_struct3;
+    Struct3* rc = GC_malloc(sizeof(Struct3));
     rc->_0 = b0;
     rc->_1 = b1;
     rc->_2 = b2;
     return (BValue)rc;
 }
 
-DEFINE_RC_STRUCT(Struct4,BValue _0;BValue _1;BValue _2;BValue _3;);
+DEFINE_BSTS_OBJ(Struct4,BValue _0;BValue _1;BValue _2;BValue _3;);
 
-void free_struct4(Struct4* s) {
-    release_value(s->_0);
-    release_value(s->_1);
-    release_value(s->_2);
-    release_value(s->_3);
-    free(s);
-}
 BValue alloc_struct4(BValue b0, BValue b1, BValue b2, BValue b3) {
-    Struct4* rc = malloc(sizeof(Struct4));
-    // this is safe to do outside atomic because no other thread can see this yet
-    rc->ref_count = 1;
-    rc->free = (FreeFn)free_struct4;
+    Struct4* rc = GC_malloc(sizeof(Struct4));
     rc->_0 = b0;
     rc->_1 = b1;
     rc->_2 = b2;
@@ -56,21 +29,10 @@ BValue alloc_struct4(BValue b0, BValue b1, BValue b2, BValue b3) {
     return (BValue)rc;
 }
 
-DEFINE_RC_STRUCT(Struct5,BValue _0;BValue _1;BValue _2;BValue _3;BValue _4;);
+DEFINE_BSTS_OBJ(Struct5,BValue _0;BValue _1;BValue _2;BValue _3;BValue _4;);
 
-void free_struct5(Struct5* s) {
-    release_value(s->_0);
-    release_value(s->_1);
-    release_value(s->_2);
-    release_value(s->_3);
-    release_value(s->_4);
-    free(s);
-}
 BValue alloc_struct5(BValue b0, BValue b1, BValue b2, BValue b3, BValue b4) {
-    Struct5* rc = malloc(sizeof(Struct5));
-    // this is safe to do outside atomic because no other thread can see this yet
-    rc->ref_count = 1;
-    rc->free = (FreeFn)free_struct5;
+    Struct5* rc = GC_malloc(sizeof(Struct5));
     rc->_0 = b0;
     rc->_1 = b1;
     rc->_2 = b2;
@@ -79,22 +41,10 @@ BValue alloc_struct5(BValue b0, BValue b1, BValue b2, BValue b3, BValue b4) {
     return (BValue)rc;
 }
 
-DEFINE_RC_STRUCT(Struct6,BValue _0;BValue _1;BValue _2;BValue _3;BValue _4;BValue _5;);
+DEFINE_BSTS_OBJ(Struct6,BValue _0;BValue _1;BValue _2;BValue _3;BValue _4;BValue _5;);
 
-void free_struct6(Struct6* s) {
-    release_value(s->_0);
-    release_value(s->_1);
-    release_value(s->_2);
-    release_value(s->_3);
-    release_value(s->_4);
-    release_value(s->_5);
-    free(s);
-}
 BValue alloc_struct6(BValue b0, BValue b1, BValue b2, BValue b3, BValue b4, BValue b5) {
-    Struct6* rc = malloc(sizeof(Struct6));
-    // this is safe to do outside atomic because no other thread can see this yet
-    rc->ref_count = 1;
-    rc->free = (FreeFn)free_struct6;
+    Struct6* rc = GC_malloc(sizeof(Struct6));
     rc->_0 = b0;
     rc->_1 = b1;
     rc->_2 = b2;
@@ -104,23 +54,10 @@ BValue alloc_struct6(BValue b0, BValue b1, BValue b2, BValue b3, BValue b4, BVal
     return (BValue)rc;
 }
 
-DEFINE_RC_STRUCT(Struct7,BValue _0;BValue _1;BValue _2;BValue _3;BValue _4;BValue _5;BValue _6;);
+DEFINE_BSTS_OBJ(Struct7,BValue _0;BValue _1;BValue _2;BValue _3;BValue _4;BValue _5;BValue _6;);
 
-void free_struct7(Struct7* s) {
-    release_value(s->_0);
-    release_value(s->_1);
-    release_value(s->_2);
-    release_value(s->_3);
-    release_value(s->_4);
-    release_value(s->_5);
-    release_value(s->_6);
-    free(s);
-}
 BValue alloc_struct7(BValue b0, BValue b1, BValue b2, BValue b3, BValue b4, BValue b5, BValue b6) {
-    Struct7* rc = malloc(sizeof(Struct7));
-    // this is safe to do outside atomic because no other thread can see this yet
-    rc->ref_count = 1;
-    rc->free = (FreeFn)free_struct7;
+    Struct7* rc = GC_malloc(sizeof(Struct7));
     rc->_0 = b0;
     rc->_1 = b1;
     rc->_2 = b2;
@@ -131,24 +68,10 @@ BValue alloc_struct7(BValue b0, BValue b1, BValue b2, BValue b3, BValue b4, BVal
     return (BValue)rc;
 }
 
-DEFINE_RC_STRUCT(Struct8,BValue _0;BValue _1;BValue _2;BValue _3;BValue _4;BValue _5;BValue _6;BValue _7;);
+DEFINE_BSTS_OBJ(Struct8,BValue _0;BValue _1;BValue _2;BValue _3;BValue _4;BValue _5;BValue _6;BValue _7;);
 
-void free_struct8(Struct8* s) {
-    release_value(s->_0);
-    release_value(s->_1);
-    release_value(s->_2);
-    release_value(s->_3);
-    release_value(s->_4);
-    release_value(s->_5);
-    release_value(s->_6);
-    release_value(s->_7);
-    free(s);
-}
 BValue alloc_struct8(BValue b0, BValue b1, BValue b2, BValue b3, BValue b4, BValue b5, BValue b6, BValue b7) {
-    Struct8* rc = malloc(sizeof(Struct8));
-    // this is safe to do outside atomic because no other thread can see this yet
-    rc->ref_count = 1;
-    rc->free = (FreeFn)free_struct8;
+    Struct8* rc = GC_malloc(sizeof(Struct8));
     rc->_0 = b0;
     rc->_1 = b1;
     rc->_2 = b2;
@@ -160,25 +83,10 @@ BValue alloc_struct8(BValue b0, BValue b1, BValue b2, BValue b3, BValue b4, BVal
     return (BValue)rc;
 }
 
-DEFINE_RC_STRUCT(Struct9,BValue _0;BValue _1;BValue _2;BValue _3;BValue _4;BValue _5;BValue _6;BValue _7;BValue _8;);
+DEFINE_BSTS_OBJ(Struct9,BValue _0;BValue _1;BValue _2;BValue _3;BValue _4;BValue _5;BValue _6;BValue _7;BValue _8;);
 
-void free_struct9(Struct9* s) {
-    release_value(s->_0);
-    release_value(s->_1);
-    release_value(s->_2);
-    release_value(s->_3);
-    release_value(s->_4);
-    release_value(s->_5);
-    release_value(s->_6);
-    release_value(s->_7);
-    release_value(s->_8);
-    free(s);
-}
 BValue alloc_struct9(BValue b0, BValue b1, BValue b2, BValue b3, BValue b4, BValue b5, BValue b6, BValue b7, BValue b8) {
-    Struct9* rc = malloc(sizeof(Struct9));
-    // this is safe to do outside atomic because no other thread can see this yet
-    rc->ref_count = 1;
-    rc->free = (FreeFn)free_struct9;
+    Struct9* rc = GC_malloc(sizeof(Struct9));
     rc->_0 = b0;
     rc->_1 = b1;
     rc->_2 = b2;
@@ -191,26 +99,10 @@ BValue alloc_struct9(BValue b0, BValue b1, BValue b2, BValue b3, BValue b4, BVal
     return (BValue)rc;
 }
 
-DEFINE_RC_STRUCT(Struct10,BValue _0;BValue _1;BValue _2;BValue _3;BValue _4;BValue _5;BValue _6;BValue _7;BValue _8;BValue _9;);
+DEFINE_BSTS_OBJ(Struct10,BValue _0;BValue _1;BValue _2;BValue _3;BValue _4;BValue _5;BValue _6;BValue _7;BValue _8;BValue _9;);
 
-void free_struct10(Struct10* s) {
-    release_value(s->_0);
-    release_value(s->_1);
-    release_value(s->_2);
-    release_value(s->_3);
-    release_value(s->_4);
-    release_value(s->_5);
-    release_value(s->_6);
-    release_value(s->_7);
-    release_value(s->_8);
-    release_value(s->_9);
-    free(s);
-}
 BValue alloc_struct10(BValue b0, BValue b1, BValue b2, BValue b3, BValue b4, BValue b5, BValue b6, BValue b7, BValue b8, BValue b9) {
-    Struct10* rc = malloc(sizeof(Struct10));
-    // this is safe to do outside atomic because no other thread can see this yet
-    rc->ref_count = 1;
-    rc->free = (FreeFn)free_struct10;
+    Struct10* rc = GC_malloc(sizeof(Struct10));
     rc->_0 = b0;
     rc->_1 = b1;
     rc->_2 = b2;
@@ -224,27 +116,10 @@ BValue alloc_struct10(BValue b0, BValue b1, BValue b2, BValue b3, BValue b4, BVa
     return (BValue)rc;
 }
 
-DEFINE_RC_STRUCT(Struct11,BValue _0;BValue _1;BValue _2;BValue _3;BValue _4;BValue _5;BValue _6;BValue _7;BValue _8;BValue _9;BValue _10;);
+DEFINE_BSTS_OBJ(Struct11,BValue _0;BValue _1;BValue _2;BValue _3;BValue _4;BValue _5;BValue _6;BValue _7;BValue _8;BValue _9;BValue _10;);
 
-void free_struct11(Struct11* s) {
-    release_value(s->_0);
-    release_value(s->_1);
-    release_value(s->_2);
-    release_value(s->_3);
-    release_value(s->_4);
-    release_value(s->_5);
-    release_value(s->_6);
-    release_value(s->_7);
-    release_value(s->_8);
-    release_value(s->_9);
-    release_value(s->_10);
-    free(s);
-}
 BValue alloc_struct11(BValue b0, BValue b1, BValue b2, BValue b3, BValue b4, BValue b5, BValue b6, BValue b7, BValue b8, BValue b9, BValue b10) {
-    Struct11* rc = malloc(sizeof(Struct11));
-    // this is safe to do outside atomic because no other thread can see this yet
-    rc->ref_count = 1;
-    rc->free = (FreeFn)free_struct11;
+    Struct11* rc = GC_malloc(sizeof(Struct11));
     rc->_0 = b0;
     rc->_1 = b1;
     rc->_2 = b2;
@@ -259,28 +134,10 @@ BValue alloc_struct11(BValue b0, BValue b1, BValue b2, BValue b3, BValue b4, BVa
     return (BValue)rc;
 }
 
-DEFINE_RC_STRUCT(Struct12,BValue _0;BValue _1;BValue _2;BValue _3;BValue _4;BValue _5;BValue _6;BValue _7;BValue _8;BValue _9;BValue _10;BValue _11;);
+DEFINE_BSTS_OBJ(Struct12,BValue _0;BValue _1;BValue _2;BValue _3;BValue _4;BValue _5;BValue _6;BValue _7;BValue _8;BValue _9;BValue _10;BValue _11;);
 
-void free_struct12(Struct12* s) {
-    release_value(s->_0);
-    release_value(s->_1);
-    release_value(s->_2);
-    release_value(s->_3);
-    release_value(s->_4);
-    release_value(s->_5);
-    release_value(s->_6);
-    release_value(s->_7);
-    release_value(s->_8);
-    release_value(s->_9);
-    release_value(s->_10);
-    release_value(s->_11);
-    free(s);
-}
 BValue alloc_struct12(BValue b0, BValue b1, BValue b2, BValue b3, BValue b4, BValue b5, BValue b6, BValue b7, BValue b8, BValue b9, BValue b10, BValue b11) {
-    Struct12* rc = malloc(sizeof(Struct12));
-    // this is safe to do outside atomic because no other thread can see this yet
-    rc->ref_count = 1;
-    rc->free = (FreeFn)free_struct12;
+    Struct12* rc = GC_malloc(sizeof(Struct12));
     rc->_0 = b0;
     rc->_1 = b1;
     rc->_2 = b2;
@@ -296,29 +153,10 @@ BValue alloc_struct12(BValue b0, BValue b1, BValue b2, BValue b3, BValue b4, BVa
     return (BValue)rc;
 }
 
-DEFINE_RC_STRUCT(Struct13,BValue _0;BValue _1;BValue _2;BValue _3;BValue _4;BValue _5;BValue _6;BValue _7;BValue _8;BValue _9;BValue _10;BValue _11;BValue _12;);
+DEFINE_BSTS_OBJ(Struct13,BValue _0;BValue _1;BValue _2;BValue _3;BValue _4;BValue _5;BValue _6;BValue _7;BValue _8;BValue _9;BValue _10;BValue _11;BValue _12;);
 
-void free_struct13(Struct13* s) {
-    release_value(s->_0);
-    release_value(s->_1);
-    release_value(s->_2);
-    release_value(s->_3);
-    release_value(s->_4);
-    release_value(s->_5);
-    release_value(s->_6);
-    release_value(s->_7);
-    release_value(s->_8);
-    release_value(s->_9);
-    release_value(s->_10);
-    release_value(s->_11);
-    release_value(s->_12);
-    free(s);
-}
 BValue alloc_struct13(BValue b0, BValue b1, BValue b2, BValue b3, BValue b4, BValue b5, BValue b6, BValue b7, BValue b8, BValue b9, BValue b10, BValue b11, BValue b12) {
-    Struct13* rc = malloc(sizeof(Struct13));
-    // this is safe to do outside atomic because no other thread can see this yet
-    rc->ref_count = 1;
-    rc->free = (FreeFn)free_struct13;
+    Struct13* rc = GC_malloc(sizeof(Struct13));
     rc->_0 = b0;
     rc->_1 = b1;
     rc->_2 = b2;
@@ -335,30 +173,10 @@ BValue alloc_struct13(BValue b0, BValue b1, BValue b2, BValue b3, BValue b4, BVa
     return (BValue)rc;
 }
 
-DEFINE_RC_STRUCT(Struct14,BValue _0;BValue _1;BValue _2;BValue _3;BValue _4;BValue _5;BValue _6;BValue _7;BValue _8;BValue _9;BValue _10;BValue _11;BValue _12;BValue _13;);
+DEFINE_BSTS_OBJ(Struct14,BValue _0;BValue _1;BValue _2;BValue _3;BValue _4;BValue _5;BValue _6;BValue _7;BValue _8;BValue _9;BValue _10;BValue _11;BValue _12;BValue _13;);
 
-void free_struct14(Struct14* s) {
-    release_value(s->_0);
-    release_value(s->_1);
-    release_value(s->_2);
-    release_value(s->_3);
-    release_value(s->_4);
-    release_value(s->_5);
-    release_value(s->_6);
-    release_value(s->_7);
-    release_value(s->_8);
-    release_value(s->_9);
-    release_value(s->_10);
-    release_value(s->_11);
-    release_value(s->_12);
-    release_value(s->_13);
-    free(s);
-}
 BValue alloc_struct14(BValue b0, BValue b1, BValue b2, BValue b3, BValue b4, BValue b5, BValue b6, BValue b7, BValue b8, BValue b9, BValue b10, BValue b11, BValue b12, BValue b13) {
-    Struct14* rc = malloc(sizeof(Struct14));
-    // this is safe to do outside atomic because no other thread can see this yet
-    rc->ref_count = 1;
-    rc->free = (FreeFn)free_struct14;
+    Struct14* rc = GC_malloc(sizeof(Struct14));
     rc->_0 = b0;
     rc->_1 = b1;
     rc->_2 = b2;
@@ -376,31 +194,10 @@ BValue alloc_struct14(BValue b0, BValue b1, BValue b2, BValue b3, BValue b4, BVa
     return (BValue)rc;
 }
 
-DEFINE_RC_STRUCT(Struct15,BValue _0;BValue _1;BValue _2;BValue _3;BValue _4;BValue _5;BValue _6;BValue _7;BValue _8;BValue _9;BValue _10;BValue _11;BValue _12;BValue _13;BValue _14;);
+DEFINE_BSTS_OBJ(Struct15,BValue _0;BValue _1;BValue _2;BValue _3;BValue _4;BValue _5;BValue _6;BValue _7;BValue _8;BValue _9;BValue _10;BValue _11;BValue _12;BValue _13;BValue _14;);
 
-void free_struct15(Struct15* s) {
-    release_value(s->_0);
-    release_value(s->_1);
-    release_value(s->_2);
-    release_value(s->_3);
-    release_value(s->_4);
-    release_value(s->_5);
-    release_value(s->_6);
-    release_value(s->_7);
-    release_value(s->_8);
-    release_value(s->_9);
-    release_value(s->_10);
-    release_value(s->_11);
-    release_value(s->_12);
-    release_value(s->_13);
-    release_value(s->_14);
-    free(s);
-}
 BValue alloc_struct15(BValue b0, BValue b1, BValue b2, BValue b3, BValue b4, BValue b5, BValue b6, BValue b7, BValue b8, BValue b9, BValue b10, BValue b11, BValue b12, BValue b13, BValue b14) {
-    Struct15* rc = malloc(sizeof(Struct15));
-    // this is safe to do outside atomic because no other thread can see this yet
-    rc->ref_count = 1;
-    rc->free = (FreeFn)free_struct15;
+    Struct15* rc = GC_malloc(sizeof(Struct15));
     rc->_0 = b0;
     rc->_1 = b1;
     rc->_2 = b2;
@@ -419,32 +216,10 @@ BValue alloc_struct15(BValue b0, BValue b1, BValue b2, BValue b3, BValue b4, BVa
     return (BValue)rc;
 }
 
-DEFINE_RC_STRUCT(Struct16,BValue _0;BValue _1;BValue _2;BValue _3;BValue _4;BValue _5;BValue _6;BValue _7;BValue _8;BValue _9;BValue _10;BValue _11;BValue _12;BValue _13;BValue _14;BValue _15;);
+DEFINE_BSTS_OBJ(Struct16,BValue _0;BValue _1;BValue _2;BValue _3;BValue _4;BValue _5;BValue _6;BValue _7;BValue _8;BValue _9;BValue _10;BValue _11;BValue _12;BValue _13;BValue _14;BValue _15;);
 
-void free_struct16(Struct16* s) {
-    release_value(s->_0);
-    release_value(s->_1);
-    release_value(s->_2);
-    release_value(s->_3);
-    release_value(s->_4);
-    release_value(s->_5);
-    release_value(s->_6);
-    release_value(s->_7);
-    release_value(s->_8);
-    release_value(s->_9);
-    release_value(s->_10);
-    release_value(s->_11);
-    release_value(s->_12);
-    release_value(s->_13);
-    release_value(s->_14);
-    release_value(s->_15);
-    free(s);
-}
 BValue alloc_struct16(BValue b0, BValue b1, BValue b2, BValue b3, BValue b4, BValue b5, BValue b6, BValue b7, BValue b8, BValue b9, BValue b10, BValue b11, BValue b12, BValue b13, BValue b14, BValue b15) {
-    Struct16* rc = malloc(sizeof(Struct16));
-    // this is safe to do outside atomic because no other thread can see this yet
-    rc->ref_count = 1;
-    rc->free = (FreeFn)free_struct16;
+    Struct16* rc = GC_malloc(sizeof(Struct16));
     rc->_0 = b0;
     rc->_1 = b1;
     rc->_2 = b2;
@@ -464,33 +239,10 @@ BValue alloc_struct16(BValue b0, BValue b1, BValue b2, BValue b3, BValue b4, BVa
     return (BValue)rc;
 }
 
-DEFINE_RC_STRUCT(Struct17,BValue _0;BValue _1;BValue _2;BValue _3;BValue _4;BValue _5;BValue _6;BValue _7;BValue _8;BValue _9;BValue _10;BValue _11;BValue _12;BValue _13;BValue _14;BValue _15;BValue _16;);
+DEFINE_BSTS_OBJ(Struct17,BValue _0;BValue _1;BValue _2;BValue _3;BValue _4;BValue _5;BValue _6;BValue _7;BValue _8;BValue _9;BValue _10;BValue _11;BValue _12;BValue _13;BValue _14;BValue _15;BValue _16;);
 
-void free_struct17(Struct17* s) {
-    release_value(s->_0);
-    release_value(s->_1);
-    release_value(s->_2);
-    release_value(s->_3);
-    release_value(s->_4);
-    release_value(s->_5);
-    release_value(s->_6);
-    release_value(s->_7);
-    release_value(s->_8);
-    release_value(s->_9);
-    release_value(s->_10);
-    release_value(s->_11);
-    release_value(s->_12);
-    release_value(s->_13);
-    release_value(s->_14);
-    release_value(s->_15);
-    release_value(s->_16);
-    free(s);
-}
 BValue alloc_struct17(BValue b0, BValue b1, BValue b2, BValue b3, BValue b4, BValue b5, BValue b6, BValue b7, BValue b8, BValue b9, BValue b10, BValue b11, BValue b12, BValue b13, BValue b14, BValue b15, BValue b16) {
-    Struct17* rc = malloc(sizeof(Struct17));
-    // this is safe to do outside atomic because no other thread can see this yet
-    rc->ref_count = 1;
-    rc->free = (FreeFn)free_struct17;
+    Struct17* rc = GC_malloc(sizeof(Struct17));
     rc->_0 = b0;
     rc->_1 = b1;
     rc->_2 = b2;
@@ -511,34 +263,10 @@ BValue alloc_struct17(BValue b0, BValue b1, BValue b2, BValue b3, BValue b4, BVa
     return (BValue)rc;
 }
 
-DEFINE_RC_STRUCT(Struct18,BValue _0;BValue _1;BValue _2;BValue _3;BValue _4;BValue _5;BValue _6;BValue _7;BValue _8;BValue _9;BValue _10;BValue _11;BValue _12;BValue _13;BValue _14;BValue _15;BValue _16;BValue _17;);
+DEFINE_BSTS_OBJ(Struct18,BValue _0;BValue _1;BValue _2;BValue _3;BValue _4;BValue _5;BValue _6;BValue _7;BValue _8;BValue _9;BValue _10;BValue _11;BValue _12;BValue _13;BValue _14;BValue _15;BValue _16;BValue _17;);
 
-void free_struct18(Struct18* s) {
-    release_value(s->_0);
-    release_value(s->_1);
-    release_value(s->_2);
-    release_value(s->_3);
-    release_value(s->_4);
-    release_value(s->_5);
-    release_value(s->_6);
-    release_value(s->_7);
-    release_value(s->_8);
-    release_value(s->_9);
-    release_value(s->_10);
-    release_value(s->_11);
-    release_value(s->_12);
-    release_value(s->_13);
-    release_value(s->_14);
-    release_value(s->_15);
-    release_value(s->_16);
-    release_value(s->_17);
-    free(s);
-}
 BValue alloc_struct18(BValue b0, BValue b1, BValue b2, BValue b3, BValue b4, BValue b5, BValue b6, BValue b7, BValue b8, BValue b9, BValue b10, BValue b11, BValue b12, BValue b13, BValue b14, BValue b15, BValue b16, BValue b17) {
-    Struct18* rc = malloc(sizeof(Struct18));
-    // this is safe to do outside atomic because no other thread can see this yet
-    rc->ref_count = 1;
-    rc->free = (FreeFn)free_struct18;
+    Struct18* rc = GC_malloc(sizeof(Struct18));
     rc->_0 = b0;
     rc->_1 = b1;
     rc->_2 = b2;
@@ -560,35 +288,10 @@ BValue alloc_struct18(BValue b0, BValue b1, BValue b2, BValue b3, BValue b4, BVa
     return (BValue)rc;
 }
 
-DEFINE_RC_STRUCT(Struct19,BValue _0;BValue _1;BValue _2;BValue _3;BValue _4;BValue _5;BValue _6;BValue _7;BValue _8;BValue _9;BValue _10;BValue _11;BValue _12;BValue _13;BValue _14;BValue _15;BValue _16;BValue _17;BValue _18;);
+DEFINE_BSTS_OBJ(Struct19,BValue _0;BValue _1;BValue _2;BValue _3;BValue _4;BValue _5;BValue _6;BValue _7;BValue _8;BValue _9;BValue _10;BValue _11;BValue _12;BValue _13;BValue _14;BValue _15;BValue _16;BValue _17;BValue _18;);
 
-void free_struct19(Struct19* s) {
-    release_value(s->_0);
-    release_value(s->_1);
-    release_value(s->_2);
-    release_value(s->_3);
-    release_value(s->_4);
-    release_value(s->_5);
-    release_value(s->_6);
-    release_value(s->_7);
-    release_value(s->_8);
-    release_value(s->_9);
-    release_value(s->_10);
-    release_value(s->_11);
-    release_value(s->_12);
-    release_value(s->_13);
-    release_value(s->_14);
-    release_value(s->_15);
-    release_value(s->_16);
-    release_value(s->_17);
-    release_value(s->_18);
-    free(s);
-}
 BValue alloc_struct19(BValue b0, BValue b1, BValue b2, BValue b3, BValue b4, BValue b5, BValue b6, BValue b7, BValue b8, BValue b9, BValue b10, BValue b11, BValue b12, BValue b13, BValue b14, BValue b15, BValue b16, BValue b17, BValue b18) {
-    Struct19* rc = malloc(sizeof(Struct19));
-    // this is safe to do outside atomic because no other thread can see this yet
-    rc->ref_count = 1;
-    rc->free = (FreeFn)free_struct19;
+    Struct19* rc = GC_malloc(sizeof(Struct19));
     rc->_0 = b0;
     rc->_1 = b1;
     rc->_2 = b2;
@@ -611,36 +314,10 @@ BValue alloc_struct19(BValue b0, BValue b1, BValue b2, BValue b3, BValue b4, BVa
     return (BValue)rc;
 }
 
-DEFINE_RC_STRUCT(Struct20,BValue _0;BValue _1;BValue _2;BValue _3;BValue _4;BValue _5;BValue _6;BValue _7;BValue _8;BValue _9;BValue _10;BValue _11;BValue _12;BValue _13;BValue _14;BValue _15;BValue _16;BValue _17;BValue _18;BValue _19;);
+DEFINE_BSTS_OBJ(Struct20,BValue _0;BValue _1;BValue _2;BValue _3;BValue _4;BValue _5;BValue _6;BValue _7;BValue _8;BValue _9;BValue _10;BValue _11;BValue _12;BValue _13;BValue _14;BValue _15;BValue _16;BValue _17;BValue _18;BValue _19;);
 
-void free_struct20(Struct20* s) {
-    release_value(s->_0);
-    release_value(s->_1);
-    release_value(s->_2);
-    release_value(s->_3);
-    release_value(s->_4);
-    release_value(s->_5);
-    release_value(s->_6);
-    release_value(s->_7);
-    release_value(s->_8);
-    release_value(s->_9);
-    release_value(s->_10);
-    release_value(s->_11);
-    release_value(s->_12);
-    release_value(s->_13);
-    release_value(s->_14);
-    release_value(s->_15);
-    release_value(s->_16);
-    release_value(s->_17);
-    release_value(s->_18);
-    release_value(s->_19);
-    free(s);
-}
 BValue alloc_struct20(BValue b0, BValue b1, BValue b2, BValue b3, BValue b4, BValue b5, BValue b6, BValue b7, BValue b8, BValue b9, BValue b10, BValue b11, BValue b12, BValue b13, BValue b14, BValue b15, BValue b16, BValue b17, BValue b18, BValue b19) {
-    Struct20* rc = malloc(sizeof(Struct20));
-    // this is safe to do outside atomic because no other thread can see this yet
-    rc->ref_count = 1;
-    rc->free = (FreeFn)free_struct20;
+    Struct20* rc = GC_malloc(sizeof(Struct20));
     rc->_0 = b0;
     rc->_1 = b1;
     rc->_2 = b2;
@@ -664,37 +341,10 @@ BValue alloc_struct20(BValue b0, BValue b1, BValue b2, BValue b3, BValue b4, BVa
     return (BValue)rc;
 }
 
-DEFINE_RC_STRUCT(Struct21,BValue _0;BValue _1;BValue _2;BValue _3;BValue _4;BValue _5;BValue _6;BValue _7;BValue _8;BValue _9;BValue _10;BValue _11;BValue _12;BValue _13;BValue _14;BValue _15;BValue _16;BValue _17;BValue _18;BValue _19;BValue _20;);
+DEFINE_BSTS_OBJ(Struct21,BValue _0;BValue _1;BValue _2;BValue _3;BValue _4;BValue _5;BValue _6;BValue _7;BValue _8;BValue _9;BValue _10;BValue _11;BValue _12;BValue _13;BValue _14;BValue _15;BValue _16;BValue _17;BValue _18;BValue _19;BValue _20;);
 
-void free_struct21(Struct21* s) {
-    release_value(s->_0);
-    release_value(s->_1);
-    release_value(s->_2);
-    release_value(s->_3);
-    release_value(s->_4);
-    release_value(s->_5);
-    release_value(s->_6);
-    release_value(s->_7);
-    release_value(s->_8);
-    release_value(s->_9);
-    release_value(s->_10);
-    release_value(s->_11);
-    release_value(s->_12);
-    release_value(s->_13);
-    release_value(s->_14);
-    release_value(s->_15);
-    release_value(s->_16);
-    release_value(s->_17);
-    release_value(s->_18);
-    release_value(s->_19);
-    release_value(s->_20);
-    free(s);
-}
 BValue alloc_struct21(BValue b0, BValue b1, BValue b2, BValue b3, BValue b4, BValue b5, BValue b6, BValue b7, BValue b8, BValue b9, BValue b10, BValue b11, BValue b12, BValue b13, BValue b14, BValue b15, BValue b16, BValue b17, BValue b18, BValue b19, BValue b20) {
-    Struct21* rc = malloc(sizeof(Struct21));
-    // this is safe to do outside atomic because no other thread can see this yet
-    rc->ref_count = 1;
-    rc->free = (FreeFn)free_struct21;
+    Struct21* rc = GC_malloc(sizeof(Struct21));
     rc->_0 = b0;
     rc->_1 = b1;
     rc->_2 = b2;
@@ -719,38 +369,10 @@ BValue alloc_struct21(BValue b0, BValue b1, BValue b2, BValue b3, BValue b4, BVa
     return (BValue)rc;
 }
 
-DEFINE_RC_STRUCT(Struct22,BValue _0;BValue _1;BValue _2;BValue _3;BValue _4;BValue _5;BValue _6;BValue _7;BValue _8;BValue _9;BValue _10;BValue _11;BValue _12;BValue _13;BValue _14;BValue _15;BValue _16;BValue _17;BValue _18;BValue _19;BValue _20;BValue _21;);
+DEFINE_BSTS_OBJ(Struct22,BValue _0;BValue _1;BValue _2;BValue _3;BValue _4;BValue _5;BValue _6;BValue _7;BValue _8;BValue _9;BValue _10;BValue _11;BValue _12;BValue _13;BValue _14;BValue _15;BValue _16;BValue _17;BValue _18;BValue _19;BValue _20;BValue _21;);
 
-void free_struct22(Struct22* s) {
-    release_value(s->_0);
-    release_value(s->_1);
-    release_value(s->_2);
-    release_value(s->_3);
-    release_value(s->_4);
-    release_value(s->_5);
-    release_value(s->_6);
-    release_value(s->_7);
-    release_value(s->_8);
-    release_value(s->_9);
-    release_value(s->_10);
-    release_value(s->_11);
-    release_value(s->_12);
-    release_value(s->_13);
-    release_value(s->_14);
-    release_value(s->_15);
-    release_value(s->_16);
-    release_value(s->_17);
-    release_value(s->_18);
-    release_value(s->_19);
-    release_value(s->_20);
-    release_value(s->_21);
-    free(s);
-}
 BValue alloc_struct22(BValue b0, BValue b1, BValue b2, BValue b3, BValue b4, BValue b5, BValue b6, BValue b7, BValue b8, BValue b9, BValue b10, BValue b11, BValue b12, BValue b13, BValue b14, BValue b15, BValue b16, BValue b17, BValue b18, BValue b19, BValue b20, BValue b21) {
-    Struct22* rc = malloc(sizeof(Struct22));
-    // this is safe to do outside atomic because no other thread can see this yet
-    rc->ref_count = 1;
-    rc->free = (FreeFn)free_struct22;
+    Struct22* rc = GC_malloc(sizeof(Struct22));
     rc->_0 = b0;
     rc->_1 = b1;
     rc->_2 = b2;
@@ -776,39 +398,10 @@ BValue alloc_struct22(BValue b0, BValue b1, BValue b2, BValue b3, BValue b4, BVa
     return (BValue)rc;
 }
 
-DEFINE_RC_STRUCT(Struct23,BValue _0;BValue _1;BValue _2;BValue _3;BValue _4;BValue _5;BValue _6;BValue _7;BValue _8;BValue _9;BValue _10;BValue _11;BValue _12;BValue _13;BValue _14;BValue _15;BValue _16;BValue _17;BValue _18;BValue _19;BValue _20;BValue _21;BValue _22;);
+DEFINE_BSTS_OBJ(Struct23,BValue _0;BValue _1;BValue _2;BValue _3;BValue _4;BValue _5;BValue _6;BValue _7;BValue _8;BValue _9;BValue _10;BValue _11;BValue _12;BValue _13;BValue _14;BValue _15;BValue _16;BValue _17;BValue _18;BValue _19;BValue _20;BValue _21;BValue _22;);
 
-void free_struct23(Struct23* s) {
-    release_value(s->_0);
-    release_value(s->_1);
-    release_value(s->_2);
-    release_value(s->_3);
-    release_value(s->_4);
-    release_value(s->_5);
-    release_value(s->_6);
-    release_value(s->_7);
-    release_value(s->_8);
-    release_value(s->_9);
-    release_value(s->_10);
-    release_value(s->_11);
-    release_value(s->_12);
-    release_value(s->_13);
-    release_value(s->_14);
-    release_value(s->_15);
-    release_value(s->_16);
-    release_value(s->_17);
-    release_value(s->_18);
-    release_value(s->_19);
-    release_value(s->_20);
-    release_value(s->_21);
-    release_value(s->_22);
-    free(s);
-}
 BValue alloc_struct23(BValue b0, BValue b1, BValue b2, BValue b3, BValue b4, BValue b5, BValue b6, BValue b7, BValue b8, BValue b9, BValue b10, BValue b11, BValue b12, BValue b13, BValue b14, BValue b15, BValue b16, BValue b17, BValue b18, BValue b19, BValue b20, BValue b21, BValue b22) {
-    Struct23* rc = malloc(sizeof(Struct23));
-    // this is safe to do outside atomic because no other thread can see this yet
-    rc->ref_count = 1;
-    rc->free = (FreeFn)free_struct23;
+    Struct23* rc = GC_malloc(sizeof(Struct23));
     rc->_0 = b0;
     rc->_1 = b1;
     rc->_2 = b2;
@@ -835,40 +428,10 @@ BValue alloc_struct23(BValue b0, BValue b1, BValue b2, BValue b3, BValue b4, BVa
     return (BValue)rc;
 }
 
-DEFINE_RC_STRUCT(Struct24,BValue _0;BValue _1;BValue _2;BValue _3;BValue _4;BValue _5;BValue _6;BValue _7;BValue _8;BValue _9;BValue _10;BValue _11;BValue _12;BValue _13;BValue _14;BValue _15;BValue _16;BValue _17;BValue _18;BValue _19;BValue _20;BValue _21;BValue _22;BValue _23;);
+DEFINE_BSTS_OBJ(Struct24,BValue _0;BValue _1;BValue _2;BValue _3;BValue _4;BValue _5;BValue _6;BValue _7;BValue _8;BValue _9;BValue _10;BValue _11;BValue _12;BValue _13;BValue _14;BValue _15;BValue _16;BValue _17;BValue _18;BValue _19;BValue _20;BValue _21;BValue _22;BValue _23;);
 
-void free_struct24(Struct24* s) {
-    release_value(s->_0);
-    release_value(s->_1);
-    release_value(s->_2);
-    release_value(s->_3);
-    release_value(s->_4);
-    release_value(s->_5);
-    release_value(s->_6);
-    release_value(s->_7);
-    release_value(s->_8);
-    release_value(s->_9);
-    release_value(s->_10);
-    release_value(s->_11);
-    release_value(s->_12);
-    release_value(s->_13);
-    release_value(s->_14);
-    release_value(s->_15);
-    release_value(s->_16);
-    release_value(s->_17);
-    release_value(s->_18);
-    release_value(s->_19);
-    release_value(s->_20);
-    release_value(s->_21);
-    release_value(s->_22);
-    release_value(s->_23);
-    free(s);
-}
 BValue alloc_struct24(BValue b0, BValue b1, BValue b2, BValue b3, BValue b4, BValue b5, BValue b6, BValue b7, BValue b8, BValue b9, BValue b10, BValue b11, BValue b12, BValue b13, BValue b14, BValue b15, BValue b16, BValue b17, BValue b18, BValue b19, BValue b20, BValue b21, BValue b22, BValue b23) {
-    Struct24* rc = malloc(sizeof(Struct24));
-    // this is safe to do outside atomic because no other thread can see this yet
-    rc->ref_count = 1;
-    rc->free = (FreeFn)free_struct24;
+    Struct24* rc = GC_malloc(sizeof(Struct24));
     rc->_0 = b0;
     rc->_1 = b1;
     rc->_2 = b2;
@@ -896,41 +459,10 @@ BValue alloc_struct24(BValue b0, BValue b1, BValue b2, BValue b3, BValue b4, BVa
     return (BValue)rc;
 }
 
-DEFINE_RC_STRUCT(Struct25,BValue _0;BValue _1;BValue _2;BValue _3;BValue _4;BValue _5;BValue _6;BValue _7;BValue _8;BValue _9;BValue _10;BValue _11;BValue _12;BValue _13;BValue _14;BValue _15;BValue _16;BValue _17;BValue _18;BValue _19;BValue _20;BValue _21;BValue _22;BValue _23;BValue _24;);
+DEFINE_BSTS_OBJ(Struct25,BValue _0;BValue _1;BValue _2;BValue _3;BValue _4;BValue _5;BValue _6;BValue _7;BValue _8;BValue _9;BValue _10;BValue _11;BValue _12;BValue _13;BValue _14;BValue _15;BValue _16;BValue _17;BValue _18;BValue _19;BValue _20;BValue _21;BValue _22;BValue _23;BValue _24;);
 
-void free_struct25(Struct25* s) {
-    release_value(s->_0);
-    release_value(s->_1);
-    release_value(s->_2);
-    release_value(s->_3);
-    release_value(s->_4);
-    release_value(s->_5);
-    release_value(s->_6);
-    release_value(s->_7);
-    release_value(s->_8);
-    release_value(s->_9);
-    release_value(s->_10);
-    release_value(s->_11);
-    release_value(s->_12);
-    release_value(s->_13);
-    release_value(s->_14);
-    release_value(s->_15);
-    release_value(s->_16);
-    release_value(s->_17);
-    release_value(s->_18);
-    release_value(s->_19);
-    release_value(s->_20);
-    release_value(s->_21);
-    release_value(s->_22);
-    release_value(s->_23);
-    release_value(s->_24);
-    free(s);
-}
 BValue alloc_struct25(BValue b0, BValue b1, BValue b2, BValue b3, BValue b4, BValue b5, BValue b6, BValue b7, BValue b8, BValue b9, BValue b10, BValue b11, BValue b12, BValue b13, BValue b14, BValue b15, BValue b16, BValue b17, BValue b18, BValue b19, BValue b20, BValue b21, BValue b22, BValue b23, BValue b24) {
-    Struct25* rc = malloc(sizeof(Struct25));
-    // this is safe to do outside atomic because no other thread can see this yet
-    rc->ref_count = 1;
-    rc->free = (FreeFn)free_struct25;
+    Struct25* rc = GC_malloc(sizeof(Struct25));
     rc->_0 = b0;
     rc->_1 = b1;
     rc->_2 = b2;
@@ -959,42 +491,10 @@ BValue alloc_struct25(BValue b0, BValue b1, BValue b2, BValue b3, BValue b4, BVa
     return (BValue)rc;
 }
 
-DEFINE_RC_STRUCT(Struct26,BValue _0;BValue _1;BValue _2;BValue _3;BValue _4;BValue _5;BValue _6;BValue _7;BValue _8;BValue _9;BValue _10;BValue _11;BValue _12;BValue _13;BValue _14;BValue _15;BValue _16;BValue _17;BValue _18;BValue _19;BValue _20;BValue _21;BValue _22;BValue _23;BValue _24;BValue _25;);
+DEFINE_BSTS_OBJ(Struct26,BValue _0;BValue _1;BValue _2;BValue _3;BValue _4;BValue _5;BValue _6;BValue _7;BValue _8;BValue _9;BValue _10;BValue _11;BValue _12;BValue _13;BValue _14;BValue _15;BValue _16;BValue _17;BValue _18;BValue _19;BValue _20;BValue _21;BValue _22;BValue _23;BValue _24;BValue _25;);
 
-void free_struct26(Struct26* s) {
-    release_value(s->_0);
-    release_value(s->_1);
-    release_value(s->_2);
-    release_value(s->_3);
-    release_value(s->_4);
-    release_value(s->_5);
-    release_value(s->_6);
-    release_value(s->_7);
-    release_value(s->_8);
-    release_value(s->_9);
-    release_value(s->_10);
-    release_value(s->_11);
-    release_value(s->_12);
-    release_value(s->_13);
-    release_value(s->_14);
-    release_value(s->_15);
-    release_value(s->_16);
-    release_value(s->_17);
-    release_value(s->_18);
-    release_value(s->_19);
-    release_value(s->_20);
-    release_value(s->_21);
-    release_value(s->_22);
-    release_value(s->_23);
-    release_value(s->_24);
-    release_value(s->_25);
-    free(s);
-}
 BValue alloc_struct26(BValue b0, BValue b1, BValue b2, BValue b3, BValue b4, BValue b5, BValue b6, BValue b7, BValue b8, BValue b9, BValue b10, BValue b11, BValue b12, BValue b13, BValue b14, BValue b15, BValue b16, BValue b17, BValue b18, BValue b19, BValue b20, BValue b21, BValue b22, BValue b23, BValue b24, BValue b25) {
-    Struct26* rc = malloc(sizeof(Struct26));
-    // this is safe to do outside atomic because no other thread can see this yet
-    rc->ref_count = 1;
-    rc->free = (FreeFn)free_struct26;
+    Struct26* rc = GC_malloc(sizeof(Struct26));
     rc->_0 = b0;
     rc->_1 = b1;
     rc->_2 = b2;
@@ -1024,43 +524,10 @@ BValue alloc_struct26(BValue b0, BValue b1, BValue b2, BValue b3, BValue b4, BVa
     return (BValue)rc;
 }
 
-DEFINE_RC_STRUCT(Struct27,BValue _0;BValue _1;BValue _2;BValue _3;BValue _4;BValue _5;BValue _6;BValue _7;BValue _8;BValue _9;BValue _10;BValue _11;BValue _12;BValue _13;BValue _14;BValue _15;BValue _16;BValue _17;BValue _18;BValue _19;BValue _20;BValue _21;BValue _22;BValue _23;BValue _24;BValue _25;BValue _26;);
+DEFINE_BSTS_OBJ(Struct27,BValue _0;BValue _1;BValue _2;BValue _3;BValue _4;BValue _5;BValue _6;BValue _7;BValue _8;BValue _9;BValue _10;BValue _11;BValue _12;BValue _13;BValue _14;BValue _15;BValue _16;BValue _17;BValue _18;BValue _19;BValue _20;BValue _21;BValue _22;BValue _23;BValue _24;BValue _25;BValue _26;);
 
-void free_struct27(Struct27* s) {
-    release_value(s->_0);
-    release_value(s->_1);
-    release_value(s->_2);
-    release_value(s->_3);
-    release_value(s->_4);
-    release_value(s->_5);
-    release_value(s->_6);
-    release_value(s->_7);
-    release_value(s->_8);
-    release_value(s->_9);
-    release_value(s->_10);
-    release_value(s->_11);
-    release_value(s->_12);
-    release_value(s->_13);
-    release_value(s->_14);
-    release_value(s->_15);
-    release_value(s->_16);
-    release_value(s->_17);
-    release_value(s->_18);
-    release_value(s->_19);
-    release_value(s->_20);
-    release_value(s->_21);
-    release_value(s->_22);
-    release_value(s->_23);
-    release_value(s->_24);
-    release_value(s->_25);
-    release_value(s->_26);
-    free(s);
-}
 BValue alloc_struct27(BValue b0, BValue b1, BValue b2, BValue b3, BValue b4, BValue b5, BValue b6, BValue b7, BValue b8, BValue b9, BValue b10, BValue b11, BValue b12, BValue b13, BValue b14, BValue b15, BValue b16, BValue b17, BValue b18, BValue b19, BValue b20, BValue b21, BValue b22, BValue b23, BValue b24, BValue b25, BValue b26) {
-    Struct27* rc = malloc(sizeof(Struct27));
-    // this is safe to do outside atomic because no other thread can see this yet
-    rc->ref_count = 1;
-    rc->free = (FreeFn)free_struct27;
+    Struct27* rc = GC_malloc(sizeof(Struct27));
     rc->_0 = b0;
     rc->_1 = b1;
     rc->_2 = b2;
@@ -1091,44 +558,10 @@ BValue alloc_struct27(BValue b0, BValue b1, BValue b2, BValue b3, BValue b4, BVa
     return (BValue)rc;
 }
 
-DEFINE_RC_STRUCT(Struct28,BValue _0;BValue _1;BValue _2;BValue _3;BValue _4;BValue _5;BValue _6;BValue _7;BValue _8;BValue _9;BValue _10;BValue _11;BValue _12;BValue _13;BValue _14;BValue _15;BValue _16;BValue _17;BValue _18;BValue _19;BValue _20;BValue _21;BValue _22;BValue _23;BValue _24;BValue _25;BValue _26;BValue _27;);
+DEFINE_BSTS_OBJ(Struct28,BValue _0;BValue _1;BValue _2;BValue _3;BValue _4;BValue _5;BValue _6;BValue _7;BValue _8;BValue _9;BValue _10;BValue _11;BValue _12;BValue _13;BValue _14;BValue _15;BValue _16;BValue _17;BValue _18;BValue _19;BValue _20;BValue _21;BValue _22;BValue _23;BValue _24;BValue _25;BValue _26;BValue _27;);
 
-void free_struct28(Struct28* s) {
-    release_value(s->_0);
-    release_value(s->_1);
-    release_value(s->_2);
-    release_value(s->_3);
-    release_value(s->_4);
-    release_value(s->_5);
-    release_value(s->_6);
-    release_value(s->_7);
-    release_value(s->_8);
-    release_value(s->_9);
-    release_value(s->_10);
-    release_value(s->_11);
-    release_value(s->_12);
-    release_value(s->_13);
-    release_value(s->_14);
-    release_value(s->_15);
-    release_value(s->_16);
-    release_value(s->_17);
-    release_value(s->_18);
-    release_value(s->_19);
-    release_value(s->_20);
-    release_value(s->_21);
-    release_value(s->_22);
-    release_value(s->_23);
-    release_value(s->_24);
-    release_value(s->_25);
-    release_value(s->_26);
-    release_value(s->_27);
-    free(s);
-}
 BValue alloc_struct28(BValue b0, BValue b1, BValue b2, BValue b3, BValue b4, BValue b5, BValue b6, BValue b7, BValue b8, BValue b9, BValue b10, BValue b11, BValue b12, BValue b13, BValue b14, BValue b15, BValue b16, BValue b17, BValue b18, BValue b19, BValue b20, BValue b21, BValue b22, BValue b23, BValue b24, BValue b25, BValue b26, BValue b27) {
-    Struct28* rc = malloc(sizeof(Struct28));
-    // this is safe to do outside atomic because no other thread can see this yet
-    rc->ref_count = 1;
-    rc->free = (FreeFn)free_struct28;
+    Struct28* rc = GC_malloc(sizeof(Struct28));
     rc->_0 = b0;
     rc->_1 = b1;
     rc->_2 = b2;
@@ -1160,45 +593,10 @@ BValue alloc_struct28(BValue b0, BValue b1, BValue b2, BValue b3, BValue b4, BVa
     return (BValue)rc;
 }
 
-DEFINE_RC_STRUCT(Struct29,BValue _0;BValue _1;BValue _2;BValue _3;BValue _4;BValue _5;BValue _6;BValue _7;BValue _8;BValue _9;BValue _10;BValue _11;BValue _12;BValue _13;BValue _14;BValue _15;BValue _16;BValue _17;BValue _18;BValue _19;BValue _20;BValue _21;BValue _22;BValue _23;BValue _24;BValue _25;BValue _26;BValue _27;BValue _28;);
+DEFINE_BSTS_OBJ(Struct29,BValue _0;BValue _1;BValue _2;BValue _3;BValue _4;BValue _5;BValue _6;BValue _7;BValue _8;BValue _9;BValue _10;BValue _11;BValue _12;BValue _13;BValue _14;BValue _15;BValue _16;BValue _17;BValue _18;BValue _19;BValue _20;BValue _21;BValue _22;BValue _23;BValue _24;BValue _25;BValue _26;BValue _27;BValue _28;);
 
-void free_struct29(Struct29* s) {
-    release_value(s->_0);
-    release_value(s->_1);
-    release_value(s->_2);
-    release_value(s->_3);
-    release_value(s->_4);
-    release_value(s->_5);
-    release_value(s->_6);
-    release_value(s->_7);
-    release_value(s->_8);
-    release_value(s->_9);
-    release_value(s->_10);
-    release_value(s->_11);
-    release_value(s->_12);
-    release_value(s->_13);
-    release_value(s->_14);
-    release_value(s->_15);
-    release_value(s->_16);
-    release_value(s->_17);
-    release_value(s->_18);
-    release_value(s->_19);
-    release_value(s->_20);
-    release_value(s->_21);
-    release_value(s->_22);
-    release_value(s->_23);
-    release_value(s->_24);
-    release_value(s->_25);
-    release_value(s->_26);
-    release_value(s->_27);
-    release_value(s->_28);
-    free(s);
-}
 BValue alloc_struct29(BValue b0, BValue b1, BValue b2, BValue b3, BValue b4, BValue b5, BValue b6, BValue b7, BValue b8, BValue b9, BValue b10, BValue b11, BValue b12, BValue b13, BValue b14, BValue b15, BValue b16, BValue b17, BValue b18, BValue b19, BValue b20, BValue b21, BValue b22, BValue b23, BValue b24, BValue b25, BValue b26, BValue b27, BValue b28) {
-    Struct29* rc = malloc(sizeof(Struct29));
-    // this is safe to do outside atomic because no other thread can see this yet
-    rc->ref_count = 1;
-    rc->free = (FreeFn)free_struct29;
+    Struct29* rc = GC_malloc(sizeof(Struct29));
     rc->_0 = b0;
     rc->_1 = b1;
     rc->_2 = b2;
@@ -1231,46 +629,10 @@ BValue alloc_struct29(BValue b0, BValue b1, BValue b2, BValue b3, BValue b4, BVa
     return (BValue)rc;
 }
 
-DEFINE_RC_STRUCT(Struct30,BValue _0;BValue _1;BValue _2;BValue _3;BValue _4;BValue _5;BValue _6;BValue _7;BValue _8;BValue _9;BValue _10;BValue _11;BValue _12;BValue _13;BValue _14;BValue _15;BValue _16;BValue _17;BValue _18;BValue _19;BValue _20;BValue _21;BValue _22;BValue _23;BValue _24;BValue _25;BValue _26;BValue _27;BValue _28;BValue _29;);
+DEFINE_BSTS_OBJ(Struct30,BValue _0;BValue _1;BValue _2;BValue _3;BValue _4;BValue _5;BValue _6;BValue _7;BValue _8;BValue _9;BValue _10;BValue _11;BValue _12;BValue _13;BValue _14;BValue _15;BValue _16;BValue _17;BValue _18;BValue _19;BValue _20;BValue _21;BValue _22;BValue _23;BValue _24;BValue _25;BValue _26;BValue _27;BValue _28;BValue _29;);
 
-void free_struct30(Struct30* s) {
-    release_value(s->_0);
-    release_value(s->_1);
-    release_value(s->_2);
-    release_value(s->_3);
-    release_value(s->_4);
-    release_value(s->_5);
-    release_value(s->_6);
-    release_value(s->_7);
-    release_value(s->_8);
-    release_value(s->_9);
-    release_value(s->_10);
-    release_value(s->_11);
-    release_value(s->_12);
-    release_value(s->_13);
-    release_value(s->_14);
-    release_value(s->_15);
-    release_value(s->_16);
-    release_value(s->_17);
-    release_value(s->_18);
-    release_value(s->_19);
-    release_value(s->_20);
-    release_value(s->_21);
-    release_value(s->_22);
-    release_value(s->_23);
-    release_value(s->_24);
-    release_value(s->_25);
-    release_value(s->_26);
-    release_value(s->_27);
-    release_value(s->_28);
-    release_value(s->_29);
-    free(s);
-}
 BValue alloc_struct30(BValue b0, BValue b1, BValue b2, BValue b3, BValue b4, BValue b5, BValue b6, BValue b7, BValue b8, BValue b9, BValue b10, BValue b11, BValue b12, BValue b13, BValue b14, BValue b15, BValue b16, BValue b17, BValue b18, BValue b19, BValue b20, BValue b21, BValue b22, BValue b23, BValue b24, BValue b25, BValue b26, BValue b27, BValue b28, BValue b29) {
-    Struct30* rc = malloc(sizeof(Struct30));
-    // this is safe to do outside atomic because no other thread can see this yet
-    rc->ref_count = 1;
-    rc->free = (FreeFn)free_struct30;
+    Struct30* rc = GC_malloc(sizeof(Struct30));
     rc->_0 = b0;
     rc->_1 = b1;
     rc->_2 = b2;
@@ -1304,47 +666,10 @@ BValue alloc_struct30(BValue b0, BValue b1, BValue b2, BValue b3, BValue b4, BVa
     return (BValue)rc;
 }
 
-DEFINE_RC_STRUCT(Struct31,BValue _0;BValue _1;BValue _2;BValue _3;BValue _4;BValue _5;BValue _6;BValue _7;BValue _8;BValue _9;BValue _10;BValue _11;BValue _12;BValue _13;BValue _14;BValue _15;BValue _16;BValue _17;BValue _18;BValue _19;BValue _20;BValue _21;BValue _22;BValue _23;BValue _24;BValue _25;BValue _26;BValue _27;BValue _28;BValue _29;BValue _30;);
+DEFINE_BSTS_OBJ(Struct31,BValue _0;BValue _1;BValue _2;BValue _3;BValue _4;BValue _5;BValue _6;BValue _7;BValue _8;BValue _9;BValue _10;BValue _11;BValue _12;BValue _13;BValue _14;BValue _15;BValue _16;BValue _17;BValue _18;BValue _19;BValue _20;BValue _21;BValue _22;BValue _23;BValue _24;BValue _25;BValue _26;BValue _27;BValue _28;BValue _29;BValue _30;);
 
-void free_struct31(Struct31* s) {
-    release_value(s->_0);
-    release_value(s->_1);
-    release_value(s->_2);
-    release_value(s->_3);
-    release_value(s->_4);
-    release_value(s->_5);
-    release_value(s->_6);
-    release_value(s->_7);
-    release_value(s->_8);
-    release_value(s->_9);
-    release_value(s->_10);
-    release_value(s->_11);
-    release_value(s->_12);
-    release_value(s->_13);
-    release_value(s->_14);
-    release_value(s->_15);
-    release_value(s->_16);
-    release_value(s->_17);
-    release_value(s->_18);
-    release_value(s->_19);
-    release_value(s->_20);
-    release_value(s->_21);
-    release_value(s->_22);
-    release_value(s->_23);
-    release_value(s->_24);
-    release_value(s->_25);
-    release_value(s->_26);
-    release_value(s->_27);
-    release_value(s->_28);
-    release_value(s->_29);
-    release_value(s->_30);
-    free(s);
-}
 BValue alloc_struct31(BValue b0, BValue b1, BValue b2, BValue b3, BValue b4, BValue b5, BValue b6, BValue b7, BValue b8, BValue b9, BValue b10, BValue b11, BValue b12, BValue b13, BValue b14, BValue b15, BValue b16, BValue b17, BValue b18, BValue b19, BValue b20, BValue b21, BValue b22, BValue b23, BValue b24, BValue b25, BValue b26, BValue b27, BValue b28, BValue b29, BValue b30) {
-    Struct31* rc = malloc(sizeof(Struct31));
-    // this is safe to do outside atomic because no other thread can see this yet
-    rc->ref_count = 1;
-    rc->free = (FreeFn)free_struct31;
+    Struct31* rc = GC_malloc(sizeof(Struct31));
     rc->_0 = b0;
     rc->_1 = b1;
     rc->_2 = b2;
@@ -1379,48 +704,10 @@ BValue alloc_struct31(BValue b0, BValue b1, BValue b2, BValue b3, BValue b4, BVa
     return (BValue)rc;
 }
 
-DEFINE_RC_STRUCT(Struct32,BValue _0;BValue _1;BValue _2;BValue _3;BValue _4;BValue _5;BValue _6;BValue _7;BValue _8;BValue _9;BValue _10;BValue _11;BValue _12;BValue _13;BValue _14;BValue _15;BValue _16;BValue _17;BValue _18;BValue _19;BValue _20;BValue _21;BValue _22;BValue _23;BValue _24;BValue _25;BValue _26;BValue _27;BValue _28;BValue _29;BValue _30;BValue _31;);
+DEFINE_BSTS_OBJ(Struct32,BValue _0;BValue _1;BValue _2;BValue _3;BValue _4;BValue _5;BValue _6;BValue _7;BValue _8;BValue _9;BValue _10;BValue _11;BValue _12;BValue _13;BValue _14;BValue _15;BValue _16;BValue _17;BValue _18;BValue _19;BValue _20;BValue _21;BValue _22;BValue _23;BValue _24;BValue _25;BValue _26;BValue _27;BValue _28;BValue _29;BValue _30;BValue _31;);
 
-void free_struct32(Struct32* s) {
-    release_value(s->_0);
-    release_value(s->_1);
-    release_value(s->_2);
-    release_value(s->_3);
-    release_value(s->_4);
-    release_value(s->_5);
-    release_value(s->_6);
-    release_value(s->_7);
-    release_value(s->_8);
-    release_value(s->_9);
-    release_value(s->_10);
-    release_value(s->_11);
-    release_value(s->_12);
-    release_value(s->_13);
-    release_value(s->_14);
-    release_value(s->_15);
-    release_value(s->_16);
-    release_value(s->_17);
-    release_value(s->_18);
-    release_value(s->_19);
-    release_value(s->_20);
-    release_value(s->_21);
-    release_value(s->_22);
-    release_value(s->_23);
-    release_value(s->_24);
-    release_value(s->_25);
-    release_value(s->_26);
-    release_value(s->_27);
-    release_value(s->_28);
-    release_value(s->_29);
-    release_value(s->_30);
-    release_value(s->_31);
-    free(s);
-}
 BValue alloc_struct32(BValue b0, BValue b1, BValue b2, BValue b3, BValue b4, BValue b5, BValue b6, BValue b7, BValue b8, BValue b9, BValue b10, BValue b11, BValue b12, BValue b13, BValue b14, BValue b15, BValue b16, BValue b17, BValue b18, BValue b19, BValue b20, BValue b21, BValue b22, BValue b23, BValue b24, BValue b25, BValue b26, BValue b27, BValue b28, BValue b29, BValue b30, BValue b31) {
-    Struct32* rc = malloc(sizeof(Struct32));
-    // this is safe to do outside atomic because no other thread can see this yet
-    rc->ref_count = 1;
-    rc->free = (FreeFn)free_struct32;
+    Struct32* rc = GC_malloc(sizeof(Struct32));
     rc->_0 = b0;
     rc->_1 = b1;
     rc->_2 = b2;
@@ -1457,53 +744,29 @@ BValue alloc_struct32(BValue b0, BValue b1, BValue b2, BValue b3, BValue b4, BVa
 }
 
 // ENUMS
-DEFINE_RC_ENUM(Enum1,BValue _0;);
+DEFINE_BSTS_ENUM(Enum1,BValue _0;);
 
-void free_enum1(Enum1* s) {
-    release_value(s->_0);
-    free(s);
-}
 BValue alloc_enum1(ENUM_TAG tag, BValue b0) {
-    Enum1* rc = malloc(sizeof(Enum1));
-    // this is safe to do outside atomic because no other thread can see this yet
-    rc->ref_count = 1;
-    rc->free = (FreeFn)free_enum1;
+    Enum1* rc = GC_malloc(sizeof(Enum1));
     rc->tag = tag;
     rc->_0 = b0;
     return (BValue)rc;
 }
 
-DEFINE_RC_ENUM(Enum2,BValue _0;BValue _1;);
+DEFINE_BSTS_ENUM(Enum2,BValue _0;BValue _1;);
 
-void free_enum2(Enum2* s) {
-    release_value(s->_0);
-    release_value(s->_1);
-    free(s);
-}
 BValue alloc_enum2(ENUM_TAG tag, BValue b0, BValue b1) {
-    Enum2* rc = malloc(sizeof(Enum2));
-    // this is safe to do outside atomic because no other thread can see this yet
-    rc->ref_count = 1;
-    rc->free = (FreeFn)free_enum2;
+    Enum2* rc = GC_malloc(sizeof(Enum2));
     rc->tag = tag;
     rc->_0 = b0;
     rc->_1 = b1;
     return (BValue)rc;
 }
 
-DEFINE_RC_ENUM(Enum3,BValue _0;BValue _1;BValue _2;);
+DEFINE_BSTS_ENUM(Enum3,BValue _0;BValue _1;BValue _2;);
 
-void free_enum3(Enum3* s) {
-    release_value(s->_0);
-    release_value(s->_1);
-    release_value(s->_2);
-    free(s);
-}
 BValue alloc_enum3(ENUM_TAG tag, BValue b0, BValue b1, BValue b2) {
-    Enum3* rc = malloc(sizeof(Enum3));
-    // this is safe to do outside atomic because no other thread can see this yet
-    rc->ref_count = 1;
-    rc->free = (FreeFn)free_enum3;
+    Enum3* rc = GC_malloc(sizeof(Enum3));
     rc->tag = tag;
     rc->_0 = b0;
     rc->_1 = b1;
@@ -1511,20 +774,10 @@ BValue alloc_enum3(ENUM_TAG tag, BValue b0, BValue b1, BValue b2) {
     return (BValue)rc;
 }
 
-DEFINE_RC_ENUM(Enum4,BValue _0;BValue _1;BValue _2;BValue _3;);
+DEFINE_BSTS_ENUM(Enum4,BValue _0;BValue _1;BValue _2;BValue _3;);
 
-void free_enum4(Enum4* s) {
-    release_value(s->_0);
-    release_value(s->_1);
-    release_value(s->_2);
-    release_value(s->_3);
-    free(s);
-}
 BValue alloc_enum4(ENUM_TAG tag, BValue b0, BValue b1, BValue b2, BValue b3) {
-    Enum4* rc = malloc(sizeof(Enum4));
-    // this is safe to do outside atomic because no other thread can see this yet
-    rc->ref_count = 1;
-    rc->free = (FreeFn)free_enum4;
+    Enum4* rc = GC_malloc(sizeof(Enum4));
     rc->tag = tag;
     rc->_0 = b0;
     rc->_1 = b1;
@@ -1533,21 +786,10 @@ BValue alloc_enum4(ENUM_TAG tag, BValue b0, BValue b1, BValue b2, BValue b3) {
     return (BValue)rc;
 }
 
-DEFINE_RC_ENUM(Enum5,BValue _0;BValue _1;BValue _2;BValue _3;BValue _4;);
+DEFINE_BSTS_ENUM(Enum5,BValue _0;BValue _1;BValue _2;BValue _3;BValue _4;);
 
-void free_enum5(Enum5* s) {
-    release_value(s->_0);
-    release_value(s->_1);
-    release_value(s->_2);
-    release_value(s->_3);
-    release_value(s->_4);
-    free(s);
-}
 BValue alloc_enum5(ENUM_TAG tag, BValue b0, BValue b1, BValue b2, BValue b3, BValue b4) {
-    Enum5* rc = malloc(sizeof(Enum5));
-    // this is safe to do outside atomic because no other thread can see this yet
-    rc->ref_count = 1;
-    rc->free = (FreeFn)free_enum5;
+    Enum5* rc = GC_malloc(sizeof(Enum5));
     rc->tag = tag;
     rc->_0 = b0;
     rc->_1 = b1;
@@ -1557,22 +799,10 @@ BValue alloc_enum5(ENUM_TAG tag, BValue b0, BValue b1, BValue b2, BValue b3, BVa
     return (BValue)rc;
 }
 
-DEFINE_RC_ENUM(Enum6,BValue _0;BValue _1;BValue _2;BValue _3;BValue _4;BValue _5;);
+DEFINE_BSTS_ENUM(Enum6,BValue _0;BValue _1;BValue _2;BValue _3;BValue _4;BValue _5;);
 
-void free_enum6(Enum6* s) {
-    release_value(s->_0);
-    release_value(s->_1);
-    release_value(s->_2);
-    release_value(s->_3);
-    release_value(s->_4);
-    release_value(s->_5);
-    free(s);
-}
 BValue alloc_enum6(ENUM_TAG tag, BValue b0, BValue b1, BValue b2, BValue b3, BValue b4, BValue b5) {
-    Enum6* rc = malloc(sizeof(Enum6));
-    // this is safe to do outside atomic because no other thread can see this yet
-    rc->ref_count = 1;
-    rc->free = (FreeFn)free_enum6;
+    Enum6* rc = GC_malloc(sizeof(Enum6));
     rc->tag = tag;
     rc->_0 = b0;
     rc->_1 = b1;
@@ -1583,23 +813,10 @@ BValue alloc_enum6(ENUM_TAG tag, BValue b0, BValue b1, BValue b2, BValue b3, BVa
     return (BValue)rc;
 }
 
-DEFINE_RC_ENUM(Enum7,BValue _0;BValue _1;BValue _2;BValue _3;BValue _4;BValue _5;BValue _6;);
+DEFINE_BSTS_ENUM(Enum7,BValue _0;BValue _1;BValue _2;BValue _3;BValue _4;BValue _5;BValue _6;);
 
-void free_enum7(Enum7* s) {
-    release_value(s->_0);
-    release_value(s->_1);
-    release_value(s->_2);
-    release_value(s->_3);
-    release_value(s->_4);
-    release_value(s->_5);
-    release_value(s->_6);
-    free(s);
-}
 BValue alloc_enum7(ENUM_TAG tag, BValue b0, BValue b1, BValue b2, BValue b3, BValue b4, BValue b5, BValue b6) {
-    Enum7* rc = malloc(sizeof(Enum7));
-    // this is safe to do outside atomic because no other thread can see this yet
-    rc->ref_count = 1;
-    rc->free = (FreeFn)free_enum7;
+    Enum7* rc = GC_malloc(sizeof(Enum7));
     rc->tag = tag;
     rc->_0 = b0;
     rc->_1 = b1;
@@ -1611,24 +828,10 @@ BValue alloc_enum7(ENUM_TAG tag, BValue b0, BValue b1, BValue b2, BValue b3, BVa
     return (BValue)rc;
 }
 
-DEFINE_RC_ENUM(Enum8,BValue _0;BValue _1;BValue _2;BValue _3;BValue _4;BValue _5;BValue _6;BValue _7;);
+DEFINE_BSTS_ENUM(Enum8,BValue _0;BValue _1;BValue _2;BValue _3;BValue _4;BValue _5;BValue _6;BValue _7;);
 
-void free_enum8(Enum8* s) {
-    release_value(s->_0);
-    release_value(s->_1);
-    release_value(s->_2);
-    release_value(s->_3);
-    release_value(s->_4);
-    release_value(s->_5);
-    release_value(s->_6);
-    release_value(s->_7);
-    free(s);
-}
 BValue alloc_enum8(ENUM_TAG tag, BValue b0, BValue b1, BValue b2, BValue b3, BValue b4, BValue b5, BValue b6, BValue b7) {
-    Enum8* rc = malloc(sizeof(Enum8));
-    // this is safe to do outside atomic because no other thread can see this yet
-    rc->ref_count = 1;
-    rc->free = (FreeFn)free_enum8;
+    Enum8* rc = GC_malloc(sizeof(Enum8));
     rc->tag = tag;
     rc->_0 = b0;
     rc->_1 = b1;
@@ -1641,25 +844,10 @@ BValue alloc_enum8(ENUM_TAG tag, BValue b0, BValue b1, BValue b2, BValue b3, BVa
     return (BValue)rc;
 }
 
-DEFINE_RC_ENUM(Enum9,BValue _0;BValue _1;BValue _2;BValue _3;BValue _4;BValue _5;BValue _6;BValue _7;BValue _8;);
+DEFINE_BSTS_ENUM(Enum9,BValue _0;BValue _1;BValue _2;BValue _3;BValue _4;BValue _5;BValue _6;BValue _7;BValue _8;);
 
-void free_enum9(Enum9* s) {
-    release_value(s->_0);
-    release_value(s->_1);
-    release_value(s->_2);
-    release_value(s->_3);
-    release_value(s->_4);
-    release_value(s->_5);
-    release_value(s->_6);
-    release_value(s->_7);
-    release_value(s->_8);
-    free(s);
-}
 BValue alloc_enum9(ENUM_TAG tag, BValue b0, BValue b1, BValue b2, BValue b3, BValue b4, BValue b5, BValue b6, BValue b7, BValue b8) {
-    Enum9* rc = malloc(sizeof(Enum9));
-    // this is safe to do outside atomic because no other thread can see this yet
-    rc->ref_count = 1;
-    rc->free = (FreeFn)free_enum9;
+    Enum9* rc = GC_malloc(sizeof(Enum9));
     rc->tag = tag;
     rc->_0 = b0;
     rc->_1 = b1;
@@ -1673,26 +861,10 @@ BValue alloc_enum9(ENUM_TAG tag, BValue b0, BValue b1, BValue b2, BValue b3, BVa
     return (BValue)rc;
 }
 
-DEFINE_RC_ENUM(Enum10,BValue _0;BValue _1;BValue _2;BValue _3;BValue _4;BValue _5;BValue _6;BValue _7;BValue _8;BValue _9;);
+DEFINE_BSTS_ENUM(Enum10,BValue _0;BValue _1;BValue _2;BValue _3;BValue _4;BValue _5;BValue _6;BValue _7;BValue _8;BValue _9;);
 
-void free_enum10(Enum10* s) {
-    release_value(s->_0);
-    release_value(s->_1);
-    release_value(s->_2);
-    release_value(s->_3);
-    release_value(s->_4);
-    release_value(s->_5);
-    release_value(s->_6);
-    release_value(s->_7);
-    release_value(s->_8);
-    release_value(s->_9);
-    free(s);
-}
 BValue alloc_enum10(ENUM_TAG tag, BValue b0, BValue b1, BValue b2, BValue b3, BValue b4, BValue b5, BValue b6, BValue b7, BValue b8, BValue b9) {
-    Enum10* rc = malloc(sizeof(Enum10));
-    // this is safe to do outside atomic because no other thread can see this yet
-    rc->ref_count = 1;
-    rc->free = (FreeFn)free_enum10;
+    Enum10* rc = GC_malloc(sizeof(Enum10));
     rc->tag = tag;
     rc->_0 = b0;
     rc->_1 = b1;
@@ -1707,27 +879,10 @@ BValue alloc_enum10(ENUM_TAG tag, BValue b0, BValue b1, BValue b2, BValue b3, BV
     return (BValue)rc;
 }
 
-DEFINE_RC_ENUM(Enum11,BValue _0;BValue _1;BValue _2;BValue _3;BValue _4;BValue _5;BValue _6;BValue _7;BValue _8;BValue _9;BValue _10;);
+DEFINE_BSTS_ENUM(Enum11,BValue _0;BValue _1;BValue _2;BValue _3;BValue _4;BValue _5;BValue _6;BValue _7;BValue _8;BValue _9;BValue _10;);
 
-void free_enum11(Enum11* s) {
-    release_value(s->_0);
-    release_value(s->_1);
-    release_value(s->_2);
-    release_value(s->_3);
-    release_value(s->_4);
-    release_value(s->_5);
-    release_value(s->_6);
-    release_value(s->_7);
-    release_value(s->_8);
-    release_value(s->_9);
-    release_value(s->_10);
-    free(s);
-}
 BValue alloc_enum11(ENUM_TAG tag, BValue b0, BValue b1, BValue b2, BValue b3, BValue b4, BValue b5, BValue b6, BValue b7, BValue b8, BValue b9, BValue b10) {
-    Enum11* rc = malloc(sizeof(Enum11));
-    // this is safe to do outside atomic because no other thread can see this yet
-    rc->ref_count = 1;
-    rc->free = (FreeFn)free_enum11;
+    Enum11* rc = GC_malloc(sizeof(Enum11));
     rc->tag = tag;
     rc->_0 = b0;
     rc->_1 = b1;
@@ -1743,28 +898,10 @@ BValue alloc_enum11(ENUM_TAG tag, BValue b0, BValue b1, BValue b2, BValue b3, BV
     return (BValue)rc;
 }
 
-DEFINE_RC_ENUM(Enum12,BValue _0;BValue _1;BValue _2;BValue _3;BValue _4;BValue _5;BValue _6;BValue _7;BValue _8;BValue _9;BValue _10;BValue _11;);
+DEFINE_BSTS_ENUM(Enum12,BValue _0;BValue _1;BValue _2;BValue _3;BValue _4;BValue _5;BValue _6;BValue _7;BValue _8;BValue _9;BValue _10;BValue _11;);
 
-void free_enum12(Enum12* s) {
-    release_value(s->_0);
-    release_value(s->_1);
-    release_value(s->_2);
-    release_value(s->_3);
-    release_value(s->_4);
-    release_value(s->_5);
-    release_value(s->_6);
-    release_value(s->_7);
-    release_value(s->_8);
-    release_value(s->_9);
-    release_value(s->_10);
-    release_value(s->_11);
-    free(s);
-}
 BValue alloc_enum12(ENUM_TAG tag, BValue b0, BValue b1, BValue b2, BValue b3, BValue b4, BValue b5, BValue b6, BValue b7, BValue b8, BValue b9, BValue b10, BValue b11) {
-    Enum12* rc = malloc(sizeof(Enum12));
-    // this is safe to do outside atomic because no other thread can see this yet
-    rc->ref_count = 1;
-    rc->free = (FreeFn)free_enum12;
+    Enum12* rc = GC_malloc(sizeof(Enum12));
     rc->tag = tag;
     rc->_0 = b0;
     rc->_1 = b1;
@@ -1781,29 +918,10 @@ BValue alloc_enum12(ENUM_TAG tag, BValue b0, BValue b1, BValue b2, BValue b3, BV
     return (BValue)rc;
 }
 
-DEFINE_RC_ENUM(Enum13,BValue _0;BValue _1;BValue _2;BValue _3;BValue _4;BValue _5;BValue _6;BValue _7;BValue _8;BValue _9;BValue _10;BValue _11;BValue _12;);
+DEFINE_BSTS_ENUM(Enum13,BValue _0;BValue _1;BValue _2;BValue _3;BValue _4;BValue _5;BValue _6;BValue _7;BValue _8;BValue _9;BValue _10;BValue _11;BValue _12;);
 
-void free_enum13(Enum13* s) {
-    release_value(s->_0);
-    release_value(s->_1);
-    release_value(s->_2);
-    release_value(s->_3);
-    release_value(s->_4);
-    release_value(s->_5);
-    release_value(s->_6);
-    release_value(s->_7);
-    release_value(s->_8);
-    release_value(s->_9);
-    release_value(s->_10);
-    release_value(s->_11);
-    release_value(s->_12);
-    free(s);
-}
 BValue alloc_enum13(ENUM_TAG tag, BValue b0, BValue b1, BValue b2, BValue b3, BValue b4, BValue b5, BValue b6, BValue b7, BValue b8, BValue b9, BValue b10, BValue b11, BValue b12) {
-    Enum13* rc = malloc(sizeof(Enum13));
-    // this is safe to do outside atomic because no other thread can see this yet
-    rc->ref_count = 1;
-    rc->free = (FreeFn)free_enum13;
+    Enum13* rc = GC_malloc(sizeof(Enum13));
     rc->tag = tag;
     rc->_0 = b0;
     rc->_1 = b1;
@@ -1821,30 +939,10 @@ BValue alloc_enum13(ENUM_TAG tag, BValue b0, BValue b1, BValue b2, BValue b3, BV
     return (BValue)rc;
 }
 
-DEFINE_RC_ENUM(Enum14,BValue _0;BValue _1;BValue _2;BValue _3;BValue _4;BValue _5;BValue _6;BValue _7;BValue _8;BValue _9;BValue _10;BValue _11;BValue _12;BValue _13;);
+DEFINE_BSTS_ENUM(Enum14,BValue _0;BValue _1;BValue _2;BValue _3;BValue _4;BValue _5;BValue _6;BValue _7;BValue _8;BValue _9;BValue _10;BValue _11;BValue _12;BValue _13;);
 
-void free_enum14(Enum14* s) {
-    release_value(s->_0);
-    release_value(s->_1);
-    release_value(s->_2);
-    release_value(s->_3);
-    release_value(s->_4);
-    release_value(s->_5);
-    release_value(s->_6);
-    release_value(s->_7);
-    release_value(s->_8);
-    release_value(s->_9);
-    release_value(s->_10);
-    release_value(s->_11);
-    release_value(s->_12);
-    release_value(s->_13);
-    free(s);
-}
 BValue alloc_enum14(ENUM_TAG tag, BValue b0, BValue b1, BValue b2, BValue b3, BValue b4, BValue b5, BValue b6, BValue b7, BValue b8, BValue b9, BValue b10, BValue b11, BValue b12, BValue b13) {
-    Enum14* rc = malloc(sizeof(Enum14));
-    // this is safe to do outside atomic because no other thread can see this yet
-    rc->ref_count = 1;
-    rc->free = (FreeFn)free_enum14;
+    Enum14* rc = GC_malloc(sizeof(Enum14));
     rc->tag = tag;
     rc->_0 = b0;
     rc->_1 = b1;
@@ -1863,31 +961,10 @@ BValue alloc_enum14(ENUM_TAG tag, BValue b0, BValue b1, BValue b2, BValue b3, BV
     return (BValue)rc;
 }
 
-DEFINE_RC_ENUM(Enum15,BValue _0;BValue _1;BValue _2;BValue _3;BValue _4;BValue _5;BValue _6;BValue _7;BValue _8;BValue _9;BValue _10;BValue _11;BValue _12;BValue _13;BValue _14;);
+DEFINE_BSTS_ENUM(Enum15,BValue _0;BValue _1;BValue _2;BValue _3;BValue _4;BValue _5;BValue _6;BValue _7;BValue _8;BValue _9;BValue _10;BValue _11;BValue _12;BValue _13;BValue _14;);
 
-void free_enum15(Enum15* s) {
-    release_value(s->_0);
-    release_value(s->_1);
-    release_value(s->_2);
-    release_value(s->_3);
-    release_value(s->_4);
-    release_value(s->_5);
-    release_value(s->_6);
-    release_value(s->_7);
-    release_value(s->_8);
-    release_value(s->_9);
-    release_value(s->_10);
-    release_value(s->_11);
-    release_value(s->_12);
-    release_value(s->_13);
-    release_value(s->_14);
-    free(s);
-}
 BValue alloc_enum15(ENUM_TAG tag, BValue b0, BValue b1, BValue b2, BValue b3, BValue b4, BValue b5, BValue b6, BValue b7, BValue b8, BValue b9, BValue b10, BValue b11, BValue b12, BValue b13, BValue b14) {
-    Enum15* rc = malloc(sizeof(Enum15));
-    // this is safe to do outside atomic because no other thread can see this yet
-    rc->ref_count = 1;
-    rc->free = (FreeFn)free_enum15;
+    Enum15* rc = GC_malloc(sizeof(Enum15));
     rc->tag = tag;
     rc->_0 = b0;
     rc->_1 = b1;
@@ -1907,32 +984,10 @@ BValue alloc_enum15(ENUM_TAG tag, BValue b0, BValue b1, BValue b2, BValue b3, BV
     return (BValue)rc;
 }
 
-DEFINE_RC_ENUM(Enum16,BValue _0;BValue _1;BValue _2;BValue _3;BValue _4;BValue _5;BValue _6;BValue _7;BValue _8;BValue _9;BValue _10;BValue _11;BValue _12;BValue _13;BValue _14;BValue _15;);
+DEFINE_BSTS_ENUM(Enum16,BValue _0;BValue _1;BValue _2;BValue _3;BValue _4;BValue _5;BValue _6;BValue _7;BValue _8;BValue _9;BValue _10;BValue _11;BValue _12;BValue _13;BValue _14;BValue _15;);
 
-void free_enum16(Enum16* s) {
-    release_value(s->_0);
-    release_value(s->_1);
-    release_value(s->_2);
-    release_value(s->_3);
-    release_value(s->_4);
-    release_value(s->_5);
-    release_value(s->_6);
-    release_value(s->_7);
-    release_value(s->_8);
-    release_value(s->_9);
-    release_value(s->_10);
-    release_value(s->_11);
-    release_value(s->_12);
-    release_value(s->_13);
-    release_value(s->_14);
-    release_value(s->_15);
-    free(s);
-}
 BValue alloc_enum16(ENUM_TAG tag, BValue b0, BValue b1, BValue b2, BValue b3, BValue b4, BValue b5, BValue b6, BValue b7, BValue b8, BValue b9, BValue b10, BValue b11, BValue b12, BValue b13, BValue b14, BValue b15) {
-    Enum16* rc = malloc(sizeof(Enum16));
-    // this is safe to do outside atomic because no other thread can see this yet
-    rc->ref_count = 1;
-    rc->free = (FreeFn)free_enum16;
+    Enum16* rc = GC_malloc(sizeof(Enum16));
     rc->tag = tag;
     rc->_0 = b0;
     rc->_1 = b1;
@@ -1953,33 +1008,10 @@ BValue alloc_enum16(ENUM_TAG tag, BValue b0, BValue b1, BValue b2, BValue b3, BV
     return (BValue)rc;
 }
 
-DEFINE_RC_ENUM(Enum17,BValue _0;BValue _1;BValue _2;BValue _3;BValue _4;BValue _5;BValue _6;BValue _7;BValue _8;BValue _9;BValue _10;BValue _11;BValue _12;BValue _13;BValue _14;BValue _15;BValue _16;);
+DEFINE_BSTS_ENUM(Enum17,BValue _0;BValue _1;BValue _2;BValue _3;BValue _4;BValue _5;BValue _6;BValue _7;BValue _8;BValue _9;BValue _10;BValue _11;BValue _12;BValue _13;BValue _14;BValue _15;BValue _16;);
 
-void free_enum17(Enum17* s) {
-    release_value(s->_0);
-    release_value(s->_1);
-    release_value(s->_2);
-    release_value(s->_3);
-    release_value(s->_4);
-    release_value(s->_5);
-    release_value(s->_6);
-    release_value(s->_7);
-    release_value(s->_8);
-    release_value(s->_9);
-    release_value(s->_10);
-    release_value(s->_11);
-    release_value(s->_12);
-    release_value(s->_13);
-    release_value(s->_14);
-    release_value(s->_15);
-    release_value(s->_16);
-    free(s);
-}
 BValue alloc_enum17(ENUM_TAG tag, BValue b0, BValue b1, BValue b2, BValue b3, BValue b4, BValue b5, BValue b6, BValue b7, BValue b8, BValue b9, BValue b10, BValue b11, BValue b12, BValue b13, BValue b14, BValue b15, BValue b16) {
-    Enum17* rc = malloc(sizeof(Enum17));
-    // this is safe to do outside atomic because no other thread can see this yet
-    rc->ref_count = 1;
-    rc->free = (FreeFn)free_enum17;
+    Enum17* rc = GC_malloc(sizeof(Enum17));
     rc->tag = tag;
     rc->_0 = b0;
     rc->_1 = b1;
@@ -2001,34 +1033,10 @@ BValue alloc_enum17(ENUM_TAG tag, BValue b0, BValue b1, BValue b2, BValue b3, BV
     return (BValue)rc;
 }
 
-DEFINE_RC_ENUM(Enum18,BValue _0;BValue _1;BValue _2;BValue _3;BValue _4;BValue _5;BValue _6;BValue _7;BValue _8;BValue _9;BValue _10;BValue _11;BValue _12;BValue _13;BValue _14;BValue _15;BValue _16;BValue _17;);
+DEFINE_BSTS_ENUM(Enum18,BValue _0;BValue _1;BValue _2;BValue _3;BValue _4;BValue _5;BValue _6;BValue _7;BValue _8;BValue _9;BValue _10;BValue _11;BValue _12;BValue _13;BValue _14;BValue _15;BValue _16;BValue _17;);
 
-void free_enum18(Enum18* s) {
-    release_value(s->_0);
-    release_value(s->_1);
-    release_value(s->_2);
-    release_value(s->_3);
-    release_value(s->_4);
-    release_value(s->_5);
-    release_value(s->_6);
-    release_value(s->_7);
-    release_value(s->_8);
-    release_value(s->_9);
-    release_value(s->_10);
-    release_value(s->_11);
-    release_value(s->_12);
-    release_value(s->_13);
-    release_value(s->_14);
-    release_value(s->_15);
-    release_value(s->_16);
-    release_value(s->_17);
-    free(s);
-}
 BValue alloc_enum18(ENUM_TAG tag, BValue b0, BValue b1, BValue b2, BValue b3, BValue b4, BValue b5, BValue b6, BValue b7, BValue b8, BValue b9, BValue b10, BValue b11, BValue b12, BValue b13, BValue b14, BValue b15, BValue b16, BValue b17) {
-    Enum18* rc = malloc(sizeof(Enum18));
-    // this is safe to do outside atomic because no other thread can see this yet
-    rc->ref_count = 1;
-    rc->free = (FreeFn)free_enum18;
+    Enum18* rc = GC_malloc(sizeof(Enum18));
     rc->tag = tag;
     rc->_0 = b0;
     rc->_1 = b1;
@@ -2051,35 +1059,10 @@ BValue alloc_enum18(ENUM_TAG tag, BValue b0, BValue b1, BValue b2, BValue b3, BV
     return (BValue)rc;
 }
 
-DEFINE_RC_ENUM(Enum19,BValue _0;BValue _1;BValue _2;BValue _3;BValue _4;BValue _5;BValue _6;BValue _7;BValue _8;BValue _9;BValue _10;BValue _11;BValue _12;BValue _13;BValue _14;BValue _15;BValue _16;BValue _17;BValue _18;);
+DEFINE_BSTS_ENUM(Enum19,BValue _0;BValue _1;BValue _2;BValue _3;BValue _4;BValue _5;BValue _6;BValue _7;BValue _8;BValue _9;BValue _10;BValue _11;BValue _12;BValue _13;BValue _14;BValue _15;BValue _16;BValue _17;BValue _18;);
 
-void free_enum19(Enum19* s) {
-    release_value(s->_0);
-    release_value(s->_1);
-    release_value(s->_2);
-    release_value(s->_3);
-    release_value(s->_4);
-    release_value(s->_5);
-    release_value(s->_6);
-    release_value(s->_7);
-    release_value(s->_8);
-    release_value(s->_9);
-    release_value(s->_10);
-    release_value(s->_11);
-    release_value(s->_12);
-    release_value(s->_13);
-    release_value(s->_14);
-    release_value(s->_15);
-    release_value(s->_16);
-    release_value(s->_17);
-    release_value(s->_18);
-    free(s);
-}
 BValue alloc_enum19(ENUM_TAG tag, BValue b0, BValue b1, BValue b2, BValue b3, BValue b4, BValue b5, BValue b6, BValue b7, BValue b8, BValue b9, BValue b10, BValue b11, BValue b12, BValue b13, BValue b14, BValue b15, BValue b16, BValue b17, BValue b18) {
-    Enum19* rc = malloc(sizeof(Enum19));
-    // this is safe to do outside atomic because no other thread can see this yet
-    rc->ref_count = 1;
-    rc->free = (FreeFn)free_enum19;
+    Enum19* rc = GC_malloc(sizeof(Enum19));
     rc->tag = tag;
     rc->_0 = b0;
     rc->_1 = b1;
@@ -2103,36 +1086,10 @@ BValue alloc_enum19(ENUM_TAG tag, BValue b0, BValue b1, BValue b2, BValue b3, BV
     return (BValue)rc;
 }
 
-DEFINE_RC_ENUM(Enum20,BValue _0;BValue _1;BValue _2;BValue _3;BValue _4;BValue _5;BValue _6;BValue _7;BValue _8;BValue _9;BValue _10;BValue _11;BValue _12;BValue _13;BValue _14;BValue _15;BValue _16;BValue _17;BValue _18;BValue _19;);
+DEFINE_BSTS_ENUM(Enum20,BValue _0;BValue _1;BValue _2;BValue _3;BValue _4;BValue _5;BValue _6;BValue _7;BValue _8;BValue _9;BValue _10;BValue _11;BValue _12;BValue _13;BValue _14;BValue _15;BValue _16;BValue _17;BValue _18;BValue _19;);
 
-void free_enum20(Enum20* s) {
-    release_value(s->_0);
-    release_value(s->_1);
-    release_value(s->_2);
-    release_value(s->_3);
-    release_value(s->_4);
-    release_value(s->_5);
-    release_value(s->_6);
-    release_value(s->_7);
-    release_value(s->_8);
-    release_value(s->_9);
-    release_value(s->_10);
-    release_value(s->_11);
-    release_value(s->_12);
-    release_value(s->_13);
-    release_value(s->_14);
-    release_value(s->_15);
-    release_value(s->_16);
-    release_value(s->_17);
-    release_value(s->_18);
-    release_value(s->_19);
-    free(s);
-}
 BValue alloc_enum20(ENUM_TAG tag, BValue b0, BValue b1, BValue b2, BValue b3, BValue b4, BValue b5, BValue b6, BValue b7, BValue b8, BValue b9, BValue b10, BValue b11, BValue b12, BValue b13, BValue b14, BValue b15, BValue b16, BValue b17, BValue b18, BValue b19) {
-    Enum20* rc = malloc(sizeof(Enum20));
-    // this is safe to do outside atomic because no other thread can see this yet
-    rc->ref_count = 1;
-    rc->free = (FreeFn)free_enum20;
+    Enum20* rc = GC_malloc(sizeof(Enum20));
     rc->tag = tag;
     rc->_0 = b0;
     rc->_1 = b1;
@@ -2157,37 +1114,10 @@ BValue alloc_enum20(ENUM_TAG tag, BValue b0, BValue b1, BValue b2, BValue b3, BV
     return (BValue)rc;
 }
 
-DEFINE_RC_ENUM(Enum21,BValue _0;BValue _1;BValue _2;BValue _3;BValue _4;BValue _5;BValue _6;BValue _7;BValue _8;BValue _9;BValue _10;BValue _11;BValue _12;BValue _13;BValue _14;BValue _15;BValue _16;BValue _17;BValue _18;BValue _19;BValue _20;);
+DEFINE_BSTS_ENUM(Enum21,BValue _0;BValue _1;BValue _2;BValue _3;BValue _4;BValue _5;BValue _6;BValue _7;BValue _8;BValue _9;BValue _10;BValue _11;BValue _12;BValue _13;BValue _14;BValue _15;BValue _16;BValue _17;BValue _18;BValue _19;BValue _20;);
 
-void free_enum21(Enum21* s) {
-    release_value(s->_0);
-    release_value(s->_1);
-    release_value(s->_2);
-    release_value(s->_3);
-    release_value(s->_4);
-    release_value(s->_5);
-    release_value(s->_6);
-    release_value(s->_7);
-    release_value(s->_8);
-    release_value(s->_9);
-    release_value(s->_10);
-    release_value(s->_11);
-    release_value(s->_12);
-    release_value(s->_13);
-    release_value(s->_14);
-    release_value(s->_15);
-    release_value(s->_16);
-    release_value(s->_17);
-    release_value(s->_18);
-    release_value(s->_19);
-    release_value(s->_20);
-    free(s);
-}
 BValue alloc_enum21(ENUM_TAG tag, BValue b0, BValue b1, BValue b2, BValue b3, BValue b4, BValue b5, BValue b6, BValue b7, BValue b8, BValue b9, BValue b10, BValue b11, BValue b12, BValue b13, BValue b14, BValue b15, BValue b16, BValue b17, BValue b18, BValue b19, BValue b20) {
-    Enum21* rc = malloc(sizeof(Enum21));
-    // this is safe to do outside atomic because no other thread can see this yet
-    rc->ref_count = 1;
-    rc->free = (FreeFn)free_enum21;
+    Enum21* rc = GC_malloc(sizeof(Enum21));
     rc->tag = tag;
     rc->_0 = b0;
     rc->_1 = b1;
@@ -2213,38 +1143,10 @@ BValue alloc_enum21(ENUM_TAG tag, BValue b0, BValue b1, BValue b2, BValue b3, BV
     return (BValue)rc;
 }
 
-DEFINE_RC_ENUM(Enum22,BValue _0;BValue _1;BValue _2;BValue _3;BValue _4;BValue _5;BValue _6;BValue _7;BValue _8;BValue _9;BValue _10;BValue _11;BValue _12;BValue _13;BValue _14;BValue _15;BValue _16;BValue _17;BValue _18;BValue _19;BValue _20;BValue _21;);
+DEFINE_BSTS_ENUM(Enum22,BValue _0;BValue _1;BValue _2;BValue _3;BValue _4;BValue _5;BValue _6;BValue _7;BValue _8;BValue _9;BValue _10;BValue _11;BValue _12;BValue _13;BValue _14;BValue _15;BValue _16;BValue _17;BValue _18;BValue _19;BValue _20;BValue _21;);
 
-void free_enum22(Enum22* s) {
-    release_value(s->_0);
-    release_value(s->_1);
-    release_value(s->_2);
-    release_value(s->_3);
-    release_value(s->_4);
-    release_value(s->_5);
-    release_value(s->_6);
-    release_value(s->_7);
-    release_value(s->_8);
-    release_value(s->_9);
-    release_value(s->_10);
-    release_value(s->_11);
-    release_value(s->_12);
-    release_value(s->_13);
-    release_value(s->_14);
-    release_value(s->_15);
-    release_value(s->_16);
-    release_value(s->_17);
-    release_value(s->_18);
-    release_value(s->_19);
-    release_value(s->_20);
-    release_value(s->_21);
-    free(s);
-}
 BValue alloc_enum22(ENUM_TAG tag, BValue b0, BValue b1, BValue b2, BValue b3, BValue b4, BValue b5, BValue b6, BValue b7, BValue b8, BValue b9, BValue b10, BValue b11, BValue b12, BValue b13, BValue b14, BValue b15, BValue b16, BValue b17, BValue b18, BValue b19, BValue b20, BValue b21) {
-    Enum22* rc = malloc(sizeof(Enum22));
-    // this is safe to do outside atomic because no other thread can see this yet
-    rc->ref_count = 1;
-    rc->free = (FreeFn)free_enum22;
+    Enum22* rc = GC_malloc(sizeof(Enum22));
     rc->tag = tag;
     rc->_0 = b0;
     rc->_1 = b1;
@@ -2271,39 +1173,10 @@ BValue alloc_enum22(ENUM_TAG tag, BValue b0, BValue b1, BValue b2, BValue b3, BV
     return (BValue)rc;
 }
 
-DEFINE_RC_ENUM(Enum23,BValue _0;BValue _1;BValue _2;BValue _3;BValue _4;BValue _5;BValue _6;BValue _7;BValue _8;BValue _9;BValue _10;BValue _11;BValue _12;BValue _13;BValue _14;BValue _15;BValue _16;BValue _17;BValue _18;BValue _19;BValue _20;BValue _21;BValue _22;);
+DEFINE_BSTS_ENUM(Enum23,BValue _0;BValue _1;BValue _2;BValue _3;BValue _4;BValue _5;BValue _6;BValue _7;BValue _8;BValue _9;BValue _10;BValue _11;BValue _12;BValue _13;BValue _14;BValue _15;BValue _16;BValue _17;BValue _18;BValue _19;BValue _20;BValue _21;BValue _22;);
 
-void free_enum23(Enum23* s) {
-    release_value(s->_0);
-    release_value(s->_1);
-    release_value(s->_2);
-    release_value(s->_3);
-    release_value(s->_4);
-    release_value(s->_5);
-    release_value(s->_6);
-    release_value(s->_7);
-    release_value(s->_8);
-    release_value(s->_9);
-    release_value(s->_10);
-    release_value(s->_11);
-    release_value(s->_12);
-    release_value(s->_13);
-    release_value(s->_14);
-    release_value(s->_15);
-    release_value(s->_16);
-    release_value(s->_17);
-    release_value(s->_18);
-    release_value(s->_19);
-    release_value(s->_20);
-    release_value(s->_21);
-    release_value(s->_22);
-    free(s);
-}
 BValue alloc_enum23(ENUM_TAG tag, BValue b0, BValue b1, BValue b2, BValue b3, BValue b4, BValue b5, BValue b6, BValue b7, BValue b8, BValue b9, BValue b10, BValue b11, BValue b12, BValue b13, BValue b14, BValue b15, BValue b16, BValue b17, BValue b18, BValue b19, BValue b20, BValue b21, BValue b22) {
-    Enum23* rc = malloc(sizeof(Enum23));
-    // this is safe to do outside atomic because no other thread can see this yet
-    rc->ref_count = 1;
-    rc->free = (FreeFn)free_enum23;
+    Enum23* rc = GC_malloc(sizeof(Enum23));
     rc->tag = tag;
     rc->_0 = b0;
     rc->_1 = b1;
@@ -2331,40 +1204,10 @@ BValue alloc_enum23(ENUM_TAG tag, BValue b0, BValue b1, BValue b2, BValue b3, BV
     return (BValue)rc;
 }
 
-DEFINE_RC_ENUM(Enum24,BValue _0;BValue _1;BValue _2;BValue _3;BValue _4;BValue _5;BValue _6;BValue _7;BValue _8;BValue _9;BValue _10;BValue _11;BValue _12;BValue _13;BValue _14;BValue _15;BValue _16;BValue _17;BValue _18;BValue _19;BValue _20;BValue _21;BValue _22;BValue _23;);
+DEFINE_BSTS_ENUM(Enum24,BValue _0;BValue _1;BValue _2;BValue _3;BValue _4;BValue _5;BValue _6;BValue _7;BValue _8;BValue _9;BValue _10;BValue _11;BValue _12;BValue _13;BValue _14;BValue _15;BValue _16;BValue _17;BValue _18;BValue _19;BValue _20;BValue _21;BValue _22;BValue _23;);
 
-void free_enum24(Enum24* s) {
-    release_value(s->_0);
-    release_value(s->_1);
-    release_value(s->_2);
-    release_value(s->_3);
-    release_value(s->_4);
-    release_value(s->_5);
-    release_value(s->_6);
-    release_value(s->_7);
-    release_value(s->_8);
-    release_value(s->_9);
-    release_value(s->_10);
-    release_value(s->_11);
-    release_value(s->_12);
-    release_value(s->_13);
-    release_value(s->_14);
-    release_value(s->_15);
-    release_value(s->_16);
-    release_value(s->_17);
-    release_value(s->_18);
-    release_value(s->_19);
-    release_value(s->_20);
-    release_value(s->_21);
-    release_value(s->_22);
-    release_value(s->_23);
-    free(s);
-}
 BValue alloc_enum24(ENUM_TAG tag, BValue b0, BValue b1, BValue b2, BValue b3, BValue b4, BValue b5, BValue b6, BValue b7, BValue b8, BValue b9, BValue b10, BValue b11, BValue b12, BValue b13, BValue b14, BValue b15, BValue b16, BValue b17, BValue b18, BValue b19, BValue b20, BValue b21, BValue b22, BValue b23) {
-    Enum24* rc = malloc(sizeof(Enum24));
-    // this is safe to do outside atomic because no other thread can see this yet
-    rc->ref_count = 1;
-    rc->free = (FreeFn)free_enum24;
+    Enum24* rc = GC_malloc(sizeof(Enum24));
     rc->tag = tag;
     rc->_0 = b0;
     rc->_1 = b1;
@@ -2393,41 +1236,10 @@ BValue alloc_enum24(ENUM_TAG tag, BValue b0, BValue b1, BValue b2, BValue b3, BV
     return (BValue)rc;
 }
 
-DEFINE_RC_ENUM(Enum25,BValue _0;BValue _1;BValue _2;BValue _3;BValue _4;BValue _5;BValue _6;BValue _7;BValue _8;BValue _9;BValue _10;BValue _11;BValue _12;BValue _13;BValue _14;BValue _15;BValue _16;BValue _17;BValue _18;BValue _19;BValue _20;BValue _21;BValue _22;BValue _23;BValue _24;);
+DEFINE_BSTS_ENUM(Enum25,BValue _0;BValue _1;BValue _2;BValue _3;BValue _4;BValue _5;BValue _6;BValue _7;BValue _8;BValue _9;BValue _10;BValue _11;BValue _12;BValue _13;BValue _14;BValue _15;BValue _16;BValue _17;BValue _18;BValue _19;BValue _20;BValue _21;BValue _22;BValue _23;BValue _24;);
 
-void free_enum25(Enum25* s) {
-    release_value(s->_0);
-    release_value(s->_1);
-    release_value(s->_2);
-    release_value(s->_3);
-    release_value(s->_4);
-    release_value(s->_5);
-    release_value(s->_6);
-    release_value(s->_7);
-    release_value(s->_8);
-    release_value(s->_9);
-    release_value(s->_10);
-    release_value(s->_11);
-    release_value(s->_12);
-    release_value(s->_13);
-    release_value(s->_14);
-    release_value(s->_15);
-    release_value(s->_16);
-    release_value(s->_17);
-    release_value(s->_18);
-    release_value(s->_19);
-    release_value(s->_20);
-    release_value(s->_21);
-    release_value(s->_22);
-    release_value(s->_23);
-    release_value(s->_24);
-    free(s);
-}
 BValue alloc_enum25(ENUM_TAG tag, BValue b0, BValue b1, BValue b2, BValue b3, BValue b4, BValue b5, BValue b6, BValue b7, BValue b8, BValue b9, BValue b10, BValue b11, BValue b12, BValue b13, BValue b14, BValue b15, BValue b16, BValue b17, BValue b18, BValue b19, BValue b20, BValue b21, BValue b22, BValue b23, BValue b24) {
-    Enum25* rc = malloc(sizeof(Enum25));
-    // this is safe to do outside atomic because no other thread can see this yet
-    rc->ref_count = 1;
-    rc->free = (FreeFn)free_enum25;
+    Enum25* rc = GC_malloc(sizeof(Enum25));
     rc->tag = tag;
     rc->_0 = b0;
     rc->_1 = b1;
@@ -2457,42 +1269,10 @@ BValue alloc_enum25(ENUM_TAG tag, BValue b0, BValue b1, BValue b2, BValue b3, BV
     return (BValue)rc;
 }
 
-DEFINE_RC_ENUM(Enum26,BValue _0;BValue _1;BValue _2;BValue _3;BValue _4;BValue _5;BValue _6;BValue _7;BValue _8;BValue _9;BValue _10;BValue _11;BValue _12;BValue _13;BValue _14;BValue _15;BValue _16;BValue _17;BValue _18;BValue _19;BValue _20;BValue _21;BValue _22;BValue _23;BValue _24;BValue _25;);
+DEFINE_BSTS_ENUM(Enum26,BValue _0;BValue _1;BValue _2;BValue _3;BValue _4;BValue _5;BValue _6;BValue _7;BValue _8;BValue _9;BValue _10;BValue _11;BValue _12;BValue _13;BValue _14;BValue _15;BValue _16;BValue _17;BValue _18;BValue _19;BValue _20;BValue _21;BValue _22;BValue _23;BValue _24;BValue _25;);
 
-void free_enum26(Enum26* s) {
-    release_value(s->_0);
-    release_value(s->_1);
-    release_value(s->_2);
-    release_value(s->_3);
-    release_value(s->_4);
-    release_value(s->_5);
-    release_value(s->_6);
-    release_value(s->_7);
-    release_value(s->_8);
-    release_value(s->_9);
-    release_value(s->_10);
-    release_value(s->_11);
-    release_value(s->_12);
-    release_value(s->_13);
-    release_value(s->_14);
-    release_value(s->_15);
-    release_value(s->_16);
-    release_value(s->_17);
-    release_value(s->_18);
-    release_value(s->_19);
-    release_value(s->_20);
-    release_value(s->_21);
-    release_value(s->_22);
-    release_value(s->_23);
-    release_value(s->_24);
-    release_value(s->_25);
-    free(s);
-}
 BValue alloc_enum26(ENUM_TAG tag, BValue b0, BValue b1, BValue b2, BValue b3, BValue b4, BValue b5, BValue b6, BValue b7, BValue b8, BValue b9, BValue b10, BValue b11, BValue b12, BValue b13, BValue b14, BValue b15, BValue b16, BValue b17, BValue b18, BValue b19, BValue b20, BValue b21, BValue b22, BValue b23, BValue b24, BValue b25) {
-    Enum26* rc = malloc(sizeof(Enum26));
-    // this is safe to do outside atomic because no other thread can see this yet
-    rc->ref_count = 1;
-    rc->free = (FreeFn)free_enum26;
+    Enum26* rc = GC_malloc(sizeof(Enum26));
     rc->tag = tag;
     rc->_0 = b0;
     rc->_1 = b1;
@@ -2523,43 +1303,10 @@ BValue alloc_enum26(ENUM_TAG tag, BValue b0, BValue b1, BValue b2, BValue b3, BV
     return (BValue)rc;
 }
 
-DEFINE_RC_ENUM(Enum27,BValue _0;BValue _1;BValue _2;BValue _3;BValue _4;BValue _5;BValue _6;BValue _7;BValue _8;BValue _9;BValue _10;BValue _11;BValue _12;BValue _13;BValue _14;BValue _15;BValue _16;BValue _17;BValue _18;BValue _19;BValue _20;BValue _21;BValue _22;BValue _23;BValue _24;BValue _25;BValue _26;);
+DEFINE_BSTS_ENUM(Enum27,BValue _0;BValue _1;BValue _2;BValue _3;BValue _4;BValue _5;BValue _6;BValue _7;BValue _8;BValue _9;BValue _10;BValue _11;BValue _12;BValue _13;BValue _14;BValue _15;BValue _16;BValue _17;BValue _18;BValue _19;BValue _20;BValue _21;BValue _22;BValue _23;BValue _24;BValue _25;BValue _26;);
 
-void free_enum27(Enum27* s) {
-    release_value(s->_0);
-    release_value(s->_1);
-    release_value(s->_2);
-    release_value(s->_3);
-    release_value(s->_4);
-    release_value(s->_5);
-    release_value(s->_6);
-    release_value(s->_7);
-    release_value(s->_8);
-    release_value(s->_9);
-    release_value(s->_10);
-    release_value(s->_11);
-    release_value(s->_12);
-    release_value(s->_13);
-    release_value(s->_14);
-    release_value(s->_15);
-    release_value(s->_16);
-    release_value(s->_17);
-    release_value(s->_18);
-    release_value(s->_19);
-    release_value(s->_20);
-    release_value(s->_21);
-    release_value(s->_22);
-    release_value(s->_23);
-    release_value(s->_24);
-    release_value(s->_25);
-    release_value(s->_26);
-    free(s);
-}
 BValue alloc_enum27(ENUM_TAG tag, BValue b0, BValue b1, BValue b2, BValue b3, BValue b4, BValue b5, BValue b6, BValue b7, BValue b8, BValue b9, BValue b10, BValue b11, BValue b12, BValue b13, BValue b14, BValue b15, BValue b16, BValue b17, BValue b18, BValue b19, BValue b20, BValue b21, BValue b22, BValue b23, BValue b24, BValue b25, BValue b26) {
-    Enum27* rc = malloc(sizeof(Enum27));
-    // this is safe to do outside atomic because no other thread can see this yet
-    rc->ref_count = 1;
-    rc->free = (FreeFn)free_enum27;
+    Enum27* rc = GC_malloc(sizeof(Enum27));
     rc->tag = tag;
     rc->_0 = b0;
     rc->_1 = b1;
@@ -2591,44 +1338,10 @@ BValue alloc_enum27(ENUM_TAG tag, BValue b0, BValue b1, BValue b2, BValue b3, BV
     return (BValue)rc;
 }
 
-DEFINE_RC_ENUM(Enum28,BValue _0;BValue _1;BValue _2;BValue _3;BValue _4;BValue _5;BValue _6;BValue _7;BValue _8;BValue _9;BValue _10;BValue _11;BValue _12;BValue _13;BValue _14;BValue _15;BValue _16;BValue _17;BValue _18;BValue _19;BValue _20;BValue _21;BValue _22;BValue _23;BValue _24;BValue _25;BValue _26;BValue _27;);
+DEFINE_BSTS_ENUM(Enum28,BValue _0;BValue _1;BValue _2;BValue _3;BValue _4;BValue _5;BValue _6;BValue _7;BValue _8;BValue _9;BValue _10;BValue _11;BValue _12;BValue _13;BValue _14;BValue _15;BValue _16;BValue _17;BValue _18;BValue _19;BValue _20;BValue _21;BValue _22;BValue _23;BValue _24;BValue _25;BValue _26;BValue _27;);
 
-void free_enum28(Enum28* s) {
-    release_value(s->_0);
-    release_value(s->_1);
-    release_value(s->_2);
-    release_value(s->_3);
-    release_value(s->_4);
-    release_value(s->_5);
-    release_value(s->_6);
-    release_value(s->_7);
-    release_value(s->_8);
-    release_value(s->_9);
-    release_value(s->_10);
-    release_value(s->_11);
-    release_value(s->_12);
-    release_value(s->_13);
-    release_value(s->_14);
-    release_value(s->_15);
-    release_value(s->_16);
-    release_value(s->_17);
-    release_value(s->_18);
-    release_value(s->_19);
-    release_value(s->_20);
-    release_value(s->_21);
-    release_value(s->_22);
-    release_value(s->_23);
-    release_value(s->_24);
-    release_value(s->_25);
-    release_value(s->_26);
-    release_value(s->_27);
-    free(s);
-}
 BValue alloc_enum28(ENUM_TAG tag, BValue b0, BValue b1, BValue b2, BValue b3, BValue b4, BValue b5, BValue b6, BValue b7, BValue b8, BValue b9, BValue b10, BValue b11, BValue b12, BValue b13, BValue b14, BValue b15, BValue b16, BValue b17, BValue b18, BValue b19, BValue b20, BValue b21, BValue b22, BValue b23, BValue b24, BValue b25, BValue b26, BValue b27) {
-    Enum28* rc = malloc(sizeof(Enum28));
-    // this is safe to do outside atomic because no other thread can see this yet
-    rc->ref_count = 1;
-    rc->free = (FreeFn)free_enum28;
+    Enum28* rc = GC_malloc(sizeof(Enum28));
     rc->tag = tag;
     rc->_0 = b0;
     rc->_1 = b1;
@@ -2661,45 +1374,10 @@ BValue alloc_enum28(ENUM_TAG tag, BValue b0, BValue b1, BValue b2, BValue b3, BV
     return (BValue)rc;
 }
 
-DEFINE_RC_ENUM(Enum29,BValue _0;BValue _1;BValue _2;BValue _3;BValue _4;BValue _5;BValue _6;BValue _7;BValue _8;BValue _9;BValue _10;BValue _11;BValue _12;BValue _13;BValue _14;BValue _15;BValue _16;BValue _17;BValue _18;BValue _19;BValue _20;BValue _21;BValue _22;BValue _23;BValue _24;BValue _25;BValue _26;BValue _27;BValue _28;);
+DEFINE_BSTS_ENUM(Enum29,BValue _0;BValue _1;BValue _2;BValue _3;BValue _4;BValue _5;BValue _6;BValue _7;BValue _8;BValue _9;BValue _10;BValue _11;BValue _12;BValue _13;BValue _14;BValue _15;BValue _16;BValue _17;BValue _18;BValue _19;BValue _20;BValue _21;BValue _22;BValue _23;BValue _24;BValue _25;BValue _26;BValue _27;BValue _28;);
 
-void free_enum29(Enum29* s) {
-    release_value(s->_0);
-    release_value(s->_1);
-    release_value(s->_2);
-    release_value(s->_3);
-    release_value(s->_4);
-    release_value(s->_5);
-    release_value(s->_6);
-    release_value(s->_7);
-    release_value(s->_8);
-    release_value(s->_9);
-    release_value(s->_10);
-    release_value(s->_11);
-    release_value(s->_12);
-    release_value(s->_13);
-    release_value(s->_14);
-    release_value(s->_15);
-    release_value(s->_16);
-    release_value(s->_17);
-    release_value(s->_18);
-    release_value(s->_19);
-    release_value(s->_20);
-    release_value(s->_21);
-    release_value(s->_22);
-    release_value(s->_23);
-    release_value(s->_24);
-    release_value(s->_25);
-    release_value(s->_26);
-    release_value(s->_27);
-    release_value(s->_28);
-    free(s);
-}
 BValue alloc_enum29(ENUM_TAG tag, BValue b0, BValue b1, BValue b2, BValue b3, BValue b4, BValue b5, BValue b6, BValue b7, BValue b8, BValue b9, BValue b10, BValue b11, BValue b12, BValue b13, BValue b14, BValue b15, BValue b16, BValue b17, BValue b18, BValue b19, BValue b20, BValue b21, BValue b22, BValue b23, BValue b24, BValue b25, BValue b26, BValue b27, BValue b28) {
-    Enum29* rc = malloc(sizeof(Enum29));
-    // this is safe to do outside atomic because no other thread can see this yet
-    rc->ref_count = 1;
-    rc->free = (FreeFn)free_enum29;
+    Enum29* rc = GC_malloc(sizeof(Enum29));
     rc->tag = tag;
     rc->_0 = b0;
     rc->_1 = b1;
@@ -2733,46 +1411,10 @@ BValue alloc_enum29(ENUM_TAG tag, BValue b0, BValue b1, BValue b2, BValue b3, BV
     return (BValue)rc;
 }
 
-DEFINE_RC_ENUM(Enum30,BValue _0;BValue _1;BValue _2;BValue _3;BValue _4;BValue _5;BValue _6;BValue _7;BValue _8;BValue _9;BValue _10;BValue _11;BValue _12;BValue _13;BValue _14;BValue _15;BValue _16;BValue _17;BValue _18;BValue _19;BValue _20;BValue _21;BValue _22;BValue _23;BValue _24;BValue _25;BValue _26;BValue _27;BValue _28;BValue _29;);
+DEFINE_BSTS_ENUM(Enum30,BValue _0;BValue _1;BValue _2;BValue _3;BValue _4;BValue _5;BValue _6;BValue _7;BValue _8;BValue _9;BValue _10;BValue _11;BValue _12;BValue _13;BValue _14;BValue _15;BValue _16;BValue _17;BValue _18;BValue _19;BValue _20;BValue _21;BValue _22;BValue _23;BValue _24;BValue _25;BValue _26;BValue _27;BValue _28;BValue _29;);
 
-void free_enum30(Enum30* s) {
-    release_value(s->_0);
-    release_value(s->_1);
-    release_value(s->_2);
-    release_value(s->_3);
-    release_value(s->_4);
-    release_value(s->_5);
-    release_value(s->_6);
-    release_value(s->_7);
-    release_value(s->_8);
-    release_value(s->_9);
-    release_value(s->_10);
-    release_value(s->_11);
-    release_value(s->_12);
-    release_value(s->_13);
-    release_value(s->_14);
-    release_value(s->_15);
-    release_value(s->_16);
-    release_value(s->_17);
-    release_value(s->_18);
-    release_value(s->_19);
-    release_value(s->_20);
-    release_value(s->_21);
-    release_value(s->_22);
-    release_value(s->_23);
-    release_value(s->_24);
-    release_value(s->_25);
-    release_value(s->_26);
-    release_value(s->_27);
-    release_value(s->_28);
-    release_value(s->_29);
-    free(s);
-}
 BValue alloc_enum30(ENUM_TAG tag, BValue b0, BValue b1, BValue b2, BValue b3, BValue b4, BValue b5, BValue b6, BValue b7, BValue b8, BValue b9, BValue b10, BValue b11, BValue b12, BValue b13, BValue b14, BValue b15, BValue b16, BValue b17, BValue b18, BValue b19, BValue b20, BValue b21, BValue b22, BValue b23, BValue b24, BValue b25, BValue b26, BValue b27, BValue b28, BValue b29) {
-    Enum30* rc = malloc(sizeof(Enum30));
-    // this is safe to do outside atomic because no other thread can see this yet
-    rc->ref_count = 1;
-    rc->free = (FreeFn)free_enum30;
+    Enum30* rc = GC_malloc(sizeof(Enum30));
     rc->tag = tag;
     rc->_0 = b0;
     rc->_1 = b1;
@@ -2807,47 +1449,10 @@ BValue alloc_enum30(ENUM_TAG tag, BValue b0, BValue b1, BValue b2, BValue b3, BV
     return (BValue)rc;
 }
 
-DEFINE_RC_ENUM(Enum31,BValue _0;BValue _1;BValue _2;BValue _3;BValue _4;BValue _5;BValue _6;BValue _7;BValue _8;BValue _9;BValue _10;BValue _11;BValue _12;BValue _13;BValue _14;BValue _15;BValue _16;BValue _17;BValue _18;BValue _19;BValue _20;BValue _21;BValue _22;BValue _23;BValue _24;BValue _25;BValue _26;BValue _27;BValue _28;BValue _29;BValue _30;);
+DEFINE_BSTS_ENUM(Enum31,BValue _0;BValue _1;BValue _2;BValue _3;BValue _4;BValue _5;BValue _6;BValue _7;BValue _8;BValue _9;BValue _10;BValue _11;BValue _12;BValue _13;BValue _14;BValue _15;BValue _16;BValue _17;BValue _18;BValue _19;BValue _20;BValue _21;BValue _22;BValue _23;BValue _24;BValue _25;BValue _26;BValue _27;BValue _28;BValue _29;BValue _30;);
 
-void free_enum31(Enum31* s) {
-    release_value(s->_0);
-    release_value(s->_1);
-    release_value(s->_2);
-    release_value(s->_3);
-    release_value(s->_4);
-    release_value(s->_5);
-    release_value(s->_6);
-    release_value(s->_7);
-    release_value(s->_8);
-    release_value(s->_9);
-    release_value(s->_10);
-    release_value(s->_11);
-    release_value(s->_12);
-    release_value(s->_13);
-    release_value(s->_14);
-    release_value(s->_15);
-    release_value(s->_16);
-    release_value(s->_17);
-    release_value(s->_18);
-    release_value(s->_19);
-    release_value(s->_20);
-    release_value(s->_21);
-    release_value(s->_22);
-    release_value(s->_23);
-    release_value(s->_24);
-    release_value(s->_25);
-    release_value(s->_26);
-    release_value(s->_27);
-    release_value(s->_28);
-    release_value(s->_29);
-    release_value(s->_30);
-    free(s);
-}
 BValue alloc_enum31(ENUM_TAG tag, BValue b0, BValue b1, BValue b2, BValue b3, BValue b4, BValue b5, BValue b6, BValue b7, BValue b8, BValue b9, BValue b10, BValue b11, BValue b12, BValue b13, BValue b14, BValue b15, BValue b16, BValue b17, BValue b18, BValue b19, BValue b20, BValue b21, BValue b22, BValue b23, BValue b24, BValue b25, BValue b26, BValue b27, BValue b28, BValue b29, BValue b30) {
-    Enum31* rc = malloc(sizeof(Enum31));
-    // this is safe to do outside atomic because no other thread can see this yet
-    rc->ref_count = 1;
-    rc->free = (FreeFn)free_enum31;
+    Enum31* rc = GC_malloc(sizeof(Enum31));
     rc->tag = tag;
     rc->_0 = b0;
     rc->_1 = b1;
@@ -2883,48 +1488,10 @@ BValue alloc_enum31(ENUM_TAG tag, BValue b0, BValue b1, BValue b2, BValue b3, BV
     return (BValue)rc;
 }
 
-DEFINE_RC_ENUM(Enum32,BValue _0;BValue _1;BValue _2;BValue _3;BValue _4;BValue _5;BValue _6;BValue _7;BValue _8;BValue _9;BValue _10;BValue _11;BValue _12;BValue _13;BValue _14;BValue _15;BValue _16;BValue _17;BValue _18;BValue _19;BValue _20;BValue _21;BValue _22;BValue _23;BValue _24;BValue _25;BValue _26;BValue _27;BValue _28;BValue _29;BValue _30;BValue _31;);
+DEFINE_BSTS_ENUM(Enum32,BValue _0;BValue _1;BValue _2;BValue _3;BValue _4;BValue _5;BValue _6;BValue _7;BValue _8;BValue _9;BValue _10;BValue _11;BValue _12;BValue _13;BValue _14;BValue _15;BValue _16;BValue _17;BValue _18;BValue _19;BValue _20;BValue _21;BValue _22;BValue _23;BValue _24;BValue _25;BValue _26;BValue _27;BValue _28;BValue _29;BValue _30;BValue _31;);
 
-void free_enum32(Enum32* s) {
-    release_value(s->_0);
-    release_value(s->_1);
-    release_value(s->_2);
-    release_value(s->_3);
-    release_value(s->_4);
-    release_value(s->_5);
-    release_value(s->_6);
-    release_value(s->_7);
-    release_value(s->_8);
-    release_value(s->_9);
-    release_value(s->_10);
-    release_value(s->_11);
-    release_value(s->_12);
-    release_value(s->_13);
-    release_value(s->_14);
-    release_value(s->_15);
-    release_value(s->_16);
-    release_value(s->_17);
-    release_value(s->_18);
-    release_value(s->_19);
-    release_value(s->_20);
-    release_value(s->_21);
-    release_value(s->_22);
-    release_value(s->_23);
-    release_value(s->_24);
-    release_value(s->_25);
-    release_value(s->_26);
-    release_value(s->_27);
-    release_value(s->_28);
-    release_value(s->_29);
-    release_value(s->_30);
-    release_value(s->_31);
-    free(s);
-}
 BValue alloc_enum32(ENUM_TAG tag, BValue b0, BValue b1, BValue b2, BValue b3, BValue b4, BValue b5, BValue b6, BValue b7, BValue b8, BValue b9, BValue b10, BValue b11, BValue b12, BValue b13, BValue b14, BValue b15, BValue b16, BValue b17, BValue b18, BValue b19, BValue b20, BValue b21, BValue b22, BValue b23, BValue b24, BValue b25, BValue b26, BValue b27, BValue b28, BValue b29, BValue b30, BValue b31) {
-    Enum32* rc = malloc(sizeof(Enum32));
-    // this is safe to do outside atomic because no other thread can see this yet
-    rc->ref_count = 1;
-    rc->free = (FreeFn)free_enum32;
+    Enum32* rc = GC_malloc(sizeof(Enum32));
     rc->tag = tag;
     rc->_0 = b0;
     rc->_1 = b1;
@@ -2963,13 +1530,10 @@ BValue alloc_enum32(ENUM_TAG tag, BValue b0, BValue b1, BValue b2, BValue b3, BV
 
 // FUNCTIONS
 
-DEFINE_RC_STRUCT(BoxedPureFn1, BPureFn1 fn; size_t slot_len;);
+DEFINE_BSTS_OBJ(BoxedPureFn1, BPureFn1 fn; size_t slot_len;);
 
 BValue alloc_closure1(size_t size, BValue* data, BClosure1 fn) {
-    Closure1Data* rc = malloc(closure_data_size(size));
-    // this is safe to do outside atomic because no other thread can see this yet
-    rc->ref_count = 1;
-    rc->free = (FreeFn)free_closure;
+    Closure1Data* rc = GC_malloc(closure_data_size(size));
     rc->fn = fn;
     rc->slot_len = size;
     BValue* closure_data = closure_data_of(rc);
@@ -2986,10 +1550,7 @@ BValue alloc_boxed_pure_fn1(BPureFn1 fn) {
       // can pack into a pure value
       return (BValue)(TO_PURE_VALUE(fn));
     }
-    BoxedPureFn1* rc = (BoxedPureFn1*)malloc(sizeof(BoxedPureFn1));
-    // this is safe to do outside atomic because no other thread can see this yet
-    rc->ref_count = 1;
-    rc->free = free;
+    BoxedPureFn1* rc = (BoxedPureFn1*)GC_malloc(sizeof(BoxedPureFn1));
     rc->fn = fn;
     rc->slot_len = 0;
     return (BValue)rc;
@@ -3015,14 +1576,11 @@ BValue call_fn1(BValue fn, BValue arg0) {
 }
 
 
-DEFINE_RC_STRUCT(Closure2Data, BClosure2 fn; size_t slot_len;);
-DEFINE_RC_STRUCT(BoxedPureFn2, BPureFn2 fn; size_t slot_len;);
+DEFINE_BSTS_OBJ(Closure2Data, BClosure2 fn; size_t slot_len;);
+DEFINE_BSTS_OBJ(BoxedPureFn2, BPureFn2 fn; size_t slot_len;);
 
 BValue alloc_closure2(size_t size, BValue* data, BClosure2 fn) {
-    Closure2Data* rc = malloc(closure_data_size(size));
-    // this is safe to do outside atomic because no other thread can see this yet
-    rc->ref_count = 1;
-    rc->free = (FreeFn)free_closure;
+    Closure2Data* rc = GC_malloc(closure_data_size(size));
     rc->fn = fn;
     rc->slot_len = size;
     BValue* closure_data = closure_data_of((Closure1Data*)rc);
@@ -3039,10 +1597,7 @@ BValue alloc_boxed_pure_fn2(BPureFn2 fn) {
       // can pack into a pure value
       return (BValue)(TO_PURE_VALUE(fn));
     }
-    BoxedPureFn2* rc = (BoxedPureFn2*)malloc(sizeof(BoxedPureFn2));
-    // this is safe to do outside atomic because no other thread can see this yet
-    rc->ref_count = 1;
-    rc->free = free;
+    BoxedPureFn2* rc = (BoxedPureFn2*)GC_malloc(sizeof(BoxedPureFn2));
     rc->fn = fn;
     rc->slot_len = 0;
     return (BValue)rc;
@@ -3068,14 +1623,11 @@ BValue call_fn2(BValue fn, BValue arg0, BValue arg1) {
 }
 
 
-DEFINE_RC_STRUCT(Closure3Data, BClosure3 fn; size_t slot_len;);
-DEFINE_RC_STRUCT(BoxedPureFn3, BPureFn3 fn; size_t slot_len;);
+DEFINE_BSTS_OBJ(Closure3Data, BClosure3 fn; size_t slot_len;);
+DEFINE_BSTS_OBJ(BoxedPureFn3, BPureFn3 fn; size_t slot_len;);
 
 BValue alloc_closure3(size_t size, BValue* data, BClosure3 fn) {
-    Closure3Data* rc = malloc(closure_data_size(size));
-    // this is safe to do outside atomic because no other thread can see this yet
-    rc->ref_count = 1;
-    rc->free = (FreeFn)free_closure;
+    Closure3Data* rc = GC_malloc(closure_data_size(size));
     rc->fn = fn;
     rc->slot_len = size;
     BValue* closure_data = closure_data_of((Closure1Data*)rc);
@@ -3092,10 +1644,7 @@ BValue alloc_boxed_pure_fn3(BPureFn3 fn) {
       // can pack into a pure value
       return (BValue)(TO_PURE_VALUE(fn));
     }
-    BoxedPureFn3* rc = (BoxedPureFn3*)malloc(sizeof(BoxedPureFn3));
-    // this is safe to do outside atomic because no other thread can see this yet
-    rc->ref_count = 1;
-    rc->free = free;
+    BoxedPureFn3* rc = (BoxedPureFn3*)GC_malloc(sizeof(BoxedPureFn3));
     rc->fn = fn;
     rc->slot_len = 0;
     return (BValue)rc;
@@ -3121,14 +1670,11 @@ BValue call_fn3(BValue fn, BValue arg0, BValue arg1, BValue arg2) {
 }
 
 
-DEFINE_RC_STRUCT(Closure4Data, BClosure4 fn; size_t slot_len;);
-DEFINE_RC_STRUCT(BoxedPureFn4, BPureFn4 fn; size_t slot_len;);
+DEFINE_BSTS_OBJ(Closure4Data, BClosure4 fn; size_t slot_len;);
+DEFINE_BSTS_OBJ(BoxedPureFn4, BPureFn4 fn; size_t slot_len;);
 
 BValue alloc_closure4(size_t size, BValue* data, BClosure4 fn) {
-    Closure4Data* rc = malloc(closure_data_size(size));
-    // this is safe to do outside atomic because no other thread can see this yet
-    rc->ref_count = 1;
-    rc->free = (FreeFn)free_closure;
+    Closure4Data* rc = GC_malloc(closure_data_size(size));
     rc->fn = fn;
     rc->slot_len = size;
     BValue* closure_data = closure_data_of((Closure1Data*)rc);
@@ -3145,10 +1691,7 @@ BValue alloc_boxed_pure_fn4(BPureFn4 fn) {
       // can pack into a pure value
       return (BValue)(TO_PURE_VALUE(fn));
     }
-    BoxedPureFn4* rc = (BoxedPureFn4*)malloc(sizeof(BoxedPureFn4));
-    // this is safe to do outside atomic because no other thread can see this yet
-    rc->ref_count = 1;
-    rc->free = free;
+    BoxedPureFn4* rc = (BoxedPureFn4*)GC_malloc(sizeof(BoxedPureFn4));
     rc->fn = fn;
     rc->slot_len = 0;
     return (BValue)rc;
@@ -3174,14 +1717,11 @@ BValue call_fn4(BValue fn, BValue arg0, BValue arg1, BValue arg2, BValue arg3) {
 }
 
 
-DEFINE_RC_STRUCT(Closure5Data, BClosure5 fn; size_t slot_len;);
-DEFINE_RC_STRUCT(BoxedPureFn5, BPureFn5 fn; size_t slot_len;);
+DEFINE_BSTS_OBJ(Closure5Data, BClosure5 fn; size_t slot_len;);
+DEFINE_BSTS_OBJ(BoxedPureFn5, BPureFn5 fn; size_t slot_len;);
 
 BValue alloc_closure5(size_t size, BValue* data, BClosure5 fn) {
-    Closure5Data* rc = malloc(closure_data_size(size));
-    // this is safe to do outside atomic because no other thread can see this yet
-    rc->ref_count = 1;
-    rc->free = (FreeFn)free_closure;
+    Closure5Data* rc = GC_malloc(closure_data_size(size));
     rc->fn = fn;
     rc->slot_len = size;
     BValue* closure_data = closure_data_of((Closure1Data*)rc);
@@ -3198,10 +1738,7 @@ BValue alloc_boxed_pure_fn5(BPureFn5 fn) {
       // can pack into a pure value
       return (BValue)(TO_PURE_VALUE(fn));
     }
-    BoxedPureFn5* rc = (BoxedPureFn5*)malloc(sizeof(BoxedPureFn5));
-    // this is safe to do outside atomic because no other thread can see this yet
-    rc->ref_count = 1;
-    rc->free = free;
+    BoxedPureFn5* rc = (BoxedPureFn5*)GC_malloc(sizeof(BoxedPureFn5));
     rc->fn = fn;
     rc->slot_len = 0;
     return (BValue)rc;
@@ -3227,14 +1764,11 @@ BValue call_fn5(BValue fn, BValue arg0, BValue arg1, BValue arg2, BValue arg3, B
 }
 
 
-DEFINE_RC_STRUCT(Closure6Data, BClosure6 fn; size_t slot_len;);
-DEFINE_RC_STRUCT(BoxedPureFn6, BPureFn6 fn; size_t slot_len;);
+DEFINE_BSTS_OBJ(Closure6Data, BClosure6 fn; size_t slot_len;);
+DEFINE_BSTS_OBJ(BoxedPureFn6, BPureFn6 fn; size_t slot_len;);
 
 BValue alloc_closure6(size_t size, BValue* data, BClosure6 fn) {
-    Closure6Data* rc = malloc(closure_data_size(size));
-    // this is safe to do outside atomic because no other thread can see this yet
-    rc->ref_count = 1;
-    rc->free = (FreeFn)free_closure;
+    Closure6Data* rc = GC_malloc(closure_data_size(size));
     rc->fn = fn;
     rc->slot_len = size;
     BValue* closure_data = closure_data_of((Closure1Data*)rc);
@@ -3251,10 +1785,7 @@ BValue alloc_boxed_pure_fn6(BPureFn6 fn) {
       // can pack into a pure value
       return (BValue)(TO_PURE_VALUE(fn));
     }
-    BoxedPureFn6* rc = (BoxedPureFn6*)malloc(sizeof(BoxedPureFn6));
-    // this is safe to do outside atomic because no other thread can see this yet
-    rc->ref_count = 1;
-    rc->free = free;
+    BoxedPureFn6* rc = (BoxedPureFn6*)GC_malloc(sizeof(BoxedPureFn6));
     rc->fn = fn;
     rc->slot_len = 0;
     return (BValue)rc;
@@ -3280,14 +1811,11 @@ BValue call_fn6(BValue fn, BValue arg0, BValue arg1, BValue arg2, BValue arg3, B
 }
 
 
-DEFINE_RC_STRUCT(Closure7Data, BClosure7 fn; size_t slot_len;);
-DEFINE_RC_STRUCT(BoxedPureFn7, BPureFn7 fn; size_t slot_len;);
+DEFINE_BSTS_OBJ(Closure7Data, BClosure7 fn; size_t slot_len;);
+DEFINE_BSTS_OBJ(BoxedPureFn7, BPureFn7 fn; size_t slot_len;);
 
 BValue alloc_closure7(size_t size, BValue* data, BClosure7 fn) {
-    Closure7Data* rc = malloc(closure_data_size(size));
-    // this is safe to do outside atomic because no other thread can see this yet
-    rc->ref_count = 1;
-    rc->free = (FreeFn)free_closure;
+    Closure7Data* rc = GC_malloc(closure_data_size(size));
     rc->fn = fn;
     rc->slot_len = size;
     BValue* closure_data = closure_data_of((Closure1Data*)rc);
@@ -3304,10 +1832,7 @@ BValue alloc_boxed_pure_fn7(BPureFn7 fn) {
       // can pack into a pure value
       return (BValue)(TO_PURE_VALUE(fn));
     }
-    BoxedPureFn7* rc = (BoxedPureFn7*)malloc(sizeof(BoxedPureFn7));
-    // this is safe to do outside atomic because no other thread can see this yet
-    rc->ref_count = 1;
-    rc->free = free;
+    BoxedPureFn7* rc = (BoxedPureFn7*)GC_malloc(sizeof(BoxedPureFn7));
     rc->fn = fn;
     rc->slot_len = 0;
     return (BValue)rc;
@@ -3333,14 +1858,11 @@ BValue call_fn7(BValue fn, BValue arg0, BValue arg1, BValue arg2, BValue arg3, B
 }
 
 
-DEFINE_RC_STRUCT(Closure8Data, BClosure8 fn; size_t slot_len;);
-DEFINE_RC_STRUCT(BoxedPureFn8, BPureFn8 fn; size_t slot_len;);
+DEFINE_BSTS_OBJ(Closure8Data, BClosure8 fn; size_t slot_len;);
+DEFINE_BSTS_OBJ(BoxedPureFn8, BPureFn8 fn; size_t slot_len;);
 
 BValue alloc_closure8(size_t size, BValue* data, BClosure8 fn) {
-    Closure8Data* rc = malloc(closure_data_size(size));
-    // this is safe to do outside atomic because no other thread can see this yet
-    rc->ref_count = 1;
-    rc->free = (FreeFn)free_closure;
+    Closure8Data* rc = GC_malloc(closure_data_size(size));
     rc->fn = fn;
     rc->slot_len = size;
     BValue* closure_data = closure_data_of((Closure1Data*)rc);
@@ -3357,10 +1879,7 @@ BValue alloc_boxed_pure_fn8(BPureFn8 fn) {
       // can pack into a pure value
       return (BValue)(TO_PURE_VALUE(fn));
     }
-    BoxedPureFn8* rc = (BoxedPureFn8*)malloc(sizeof(BoxedPureFn8));
-    // this is safe to do outside atomic because no other thread can see this yet
-    rc->ref_count = 1;
-    rc->free = free;
+    BoxedPureFn8* rc = (BoxedPureFn8*)GC_malloc(sizeof(BoxedPureFn8));
     rc->fn = fn;
     rc->slot_len = 0;
     return (BValue)rc;
@@ -3386,14 +1905,11 @@ BValue call_fn8(BValue fn, BValue arg0, BValue arg1, BValue arg2, BValue arg3, B
 }
 
 
-DEFINE_RC_STRUCT(Closure9Data, BClosure9 fn; size_t slot_len;);
-DEFINE_RC_STRUCT(BoxedPureFn9, BPureFn9 fn; size_t slot_len;);
+DEFINE_BSTS_OBJ(Closure9Data, BClosure9 fn; size_t slot_len;);
+DEFINE_BSTS_OBJ(BoxedPureFn9, BPureFn9 fn; size_t slot_len;);
 
 BValue alloc_closure9(size_t size, BValue* data, BClosure9 fn) {
-    Closure9Data* rc = malloc(closure_data_size(size));
-    // this is safe to do outside atomic because no other thread can see this yet
-    rc->ref_count = 1;
-    rc->free = (FreeFn)free_closure;
+    Closure9Data* rc = GC_malloc(closure_data_size(size));
     rc->fn = fn;
     rc->slot_len = size;
     BValue* closure_data = closure_data_of((Closure1Data*)rc);
@@ -3410,10 +1926,7 @@ BValue alloc_boxed_pure_fn9(BPureFn9 fn) {
       // can pack into a pure value
       return (BValue)(TO_PURE_VALUE(fn));
     }
-    BoxedPureFn9* rc = (BoxedPureFn9*)malloc(sizeof(BoxedPureFn9));
-    // this is safe to do outside atomic because no other thread can see this yet
-    rc->ref_count = 1;
-    rc->free = free;
+    BoxedPureFn9* rc = (BoxedPureFn9*)GC_malloc(sizeof(BoxedPureFn9));
     rc->fn = fn;
     rc->slot_len = 0;
     return (BValue)rc;
@@ -3439,14 +1952,11 @@ BValue call_fn9(BValue fn, BValue arg0, BValue arg1, BValue arg2, BValue arg3, B
 }
 
 
-DEFINE_RC_STRUCT(Closure10Data, BClosure10 fn; size_t slot_len;);
-DEFINE_RC_STRUCT(BoxedPureFn10, BPureFn10 fn; size_t slot_len;);
+DEFINE_BSTS_OBJ(Closure10Data, BClosure10 fn; size_t slot_len;);
+DEFINE_BSTS_OBJ(BoxedPureFn10, BPureFn10 fn; size_t slot_len;);
 
 BValue alloc_closure10(size_t size, BValue* data, BClosure10 fn) {
-    Closure10Data* rc = malloc(closure_data_size(size));
-    // this is safe to do outside atomic because no other thread can see this yet
-    rc->ref_count = 1;
-    rc->free = (FreeFn)free_closure;
+    Closure10Data* rc = GC_malloc(closure_data_size(size));
     rc->fn = fn;
     rc->slot_len = size;
     BValue* closure_data = closure_data_of((Closure1Data*)rc);
@@ -3463,10 +1973,7 @@ BValue alloc_boxed_pure_fn10(BPureFn10 fn) {
       // can pack into a pure value
       return (BValue)(TO_PURE_VALUE(fn));
     }
-    BoxedPureFn10* rc = (BoxedPureFn10*)malloc(sizeof(BoxedPureFn10));
-    // this is safe to do outside atomic because no other thread can see this yet
-    rc->ref_count = 1;
-    rc->free = free;
+    BoxedPureFn10* rc = (BoxedPureFn10*)GC_malloc(sizeof(BoxedPureFn10));
     rc->fn = fn;
     rc->slot_len = 0;
     return (BValue)rc;
@@ -3492,14 +1999,11 @@ BValue call_fn10(BValue fn, BValue arg0, BValue arg1, BValue arg2, BValue arg3, 
 }
 
 
-DEFINE_RC_STRUCT(Closure11Data, BClosure11 fn; size_t slot_len;);
-DEFINE_RC_STRUCT(BoxedPureFn11, BPureFn11 fn; size_t slot_len;);
+DEFINE_BSTS_OBJ(Closure11Data, BClosure11 fn; size_t slot_len;);
+DEFINE_BSTS_OBJ(BoxedPureFn11, BPureFn11 fn; size_t slot_len;);
 
 BValue alloc_closure11(size_t size, BValue* data, BClosure11 fn) {
-    Closure11Data* rc = malloc(closure_data_size(size));
-    // this is safe to do outside atomic because no other thread can see this yet
-    rc->ref_count = 1;
-    rc->free = (FreeFn)free_closure;
+    Closure11Data* rc = GC_malloc(closure_data_size(size));
     rc->fn = fn;
     rc->slot_len = size;
     BValue* closure_data = closure_data_of((Closure1Data*)rc);
@@ -3516,10 +2020,7 @@ BValue alloc_boxed_pure_fn11(BPureFn11 fn) {
       // can pack into a pure value
       return (BValue)(TO_PURE_VALUE(fn));
     }
-    BoxedPureFn11* rc = (BoxedPureFn11*)malloc(sizeof(BoxedPureFn11));
-    // this is safe to do outside atomic because no other thread can see this yet
-    rc->ref_count = 1;
-    rc->free = free;
+    BoxedPureFn11* rc = (BoxedPureFn11*)GC_malloc(sizeof(BoxedPureFn11));
     rc->fn = fn;
     rc->slot_len = 0;
     return (BValue)rc;
@@ -3545,14 +2046,11 @@ BValue call_fn11(BValue fn, BValue arg0, BValue arg1, BValue arg2, BValue arg3, 
 }
 
 
-DEFINE_RC_STRUCT(Closure12Data, BClosure12 fn; size_t slot_len;);
-DEFINE_RC_STRUCT(BoxedPureFn12, BPureFn12 fn; size_t slot_len;);
+DEFINE_BSTS_OBJ(Closure12Data, BClosure12 fn; size_t slot_len;);
+DEFINE_BSTS_OBJ(BoxedPureFn12, BPureFn12 fn; size_t slot_len;);
 
 BValue alloc_closure12(size_t size, BValue* data, BClosure12 fn) {
-    Closure12Data* rc = malloc(closure_data_size(size));
-    // this is safe to do outside atomic because no other thread can see this yet
-    rc->ref_count = 1;
-    rc->free = (FreeFn)free_closure;
+    Closure12Data* rc = GC_malloc(closure_data_size(size));
     rc->fn = fn;
     rc->slot_len = size;
     BValue* closure_data = closure_data_of((Closure1Data*)rc);
@@ -3569,10 +2067,7 @@ BValue alloc_boxed_pure_fn12(BPureFn12 fn) {
       // can pack into a pure value
       return (BValue)(TO_PURE_VALUE(fn));
     }
-    BoxedPureFn12* rc = (BoxedPureFn12*)malloc(sizeof(BoxedPureFn12));
-    // this is safe to do outside atomic because no other thread can see this yet
-    rc->ref_count = 1;
-    rc->free = free;
+    BoxedPureFn12* rc = (BoxedPureFn12*)GC_malloc(sizeof(BoxedPureFn12));
     rc->fn = fn;
     rc->slot_len = 0;
     return (BValue)rc;
@@ -3598,14 +2093,11 @@ BValue call_fn12(BValue fn, BValue arg0, BValue arg1, BValue arg2, BValue arg3, 
 }
 
 
-DEFINE_RC_STRUCT(Closure13Data, BClosure13 fn; size_t slot_len;);
-DEFINE_RC_STRUCT(BoxedPureFn13, BPureFn13 fn; size_t slot_len;);
+DEFINE_BSTS_OBJ(Closure13Data, BClosure13 fn; size_t slot_len;);
+DEFINE_BSTS_OBJ(BoxedPureFn13, BPureFn13 fn; size_t slot_len;);
 
 BValue alloc_closure13(size_t size, BValue* data, BClosure13 fn) {
-    Closure13Data* rc = malloc(closure_data_size(size));
-    // this is safe to do outside atomic because no other thread can see this yet
-    rc->ref_count = 1;
-    rc->free = (FreeFn)free_closure;
+    Closure13Data* rc = GC_malloc(closure_data_size(size));
     rc->fn = fn;
     rc->slot_len = size;
     BValue* closure_data = closure_data_of((Closure1Data*)rc);
@@ -3622,10 +2114,7 @@ BValue alloc_boxed_pure_fn13(BPureFn13 fn) {
       // can pack into a pure value
       return (BValue)(TO_PURE_VALUE(fn));
     }
-    BoxedPureFn13* rc = (BoxedPureFn13*)malloc(sizeof(BoxedPureFn13));
-    // this is safe to do outside atomic because no other thread can see this yet
-    rc->ref_count = 1;
-    rc->free = free;
+    BoxedPureFn13* rc = (BoxedPureFn13*)GC_malloc(sizeof(BoxedPureFn13));
     rc->fn = fn;
     rc->slot_len = 0;
     return (BValue)rc;
@@ -3651,14 +2140,11 @@ BValue call_fn13(BValue fn, BValue arg0, BValue arg1, BValue arg2, BValue arg3, 
 }
 
 
-DEFINE_RC_STRUCT(Closure14Data, BClosure14 fn; size_t slot_len;);
-DEFINE_RC_STRUCT(BoxedPureFn14, BPureFn14 fn; size_t slot_len;);
+DEFINE_BSTS_OBJ(Closure14Data, BClosure14 fn; size_t slot_len;);
+DEFINE_BSTS_OBJ(BoxedPureFn14, BPureFn14 fn; size_t slot_len;);
 
 BValue alloc_closure14(size_t size, BValue* data, BClosure14 fn) {
-    Closure14Data* rc = malloc(closure_data_size(size));
-    // this is safe to do outside atomic because no other thread can see this yet
-    rc->ref_count = 1;
-    rc->free = (FreeFn)free_closure;
+    Closure14Data* rc = GC_malloc(closure_data_size(size));
     rc->fn = fn;
     rc->slot_len = size;
     BValue* closure_data = closure_data_of((Closure1Data*)rc);
@@ -3675,10 +2161,7 @@ BValue alloc_boxed_pure_fn14(BPureFn14 fn) {
       // can pack into a pure value
       return (BValue)(TO_PURE_VALUE(fn));
     }
-    BoxedPureFn14* rc = (BoxedPureFn14*)malloc(sizeof(BoxedPureFn14));
-    // this is safe to do outside atomic because no other thread can see this yet
-    rc->ref_count = 1;
-    rc->free = free;
+    BoxedPureFn14* rc = (BoxedPureFn14*)GC_malloc(sizeof(BoxedPureFn14));
     rc->fn = fn;
     rc->slot_len = 0;
     return (BValue)rc;
@@ -3704,14 +2187,11 @@ BValue call_fn14(BValue fn, BValue arg0, BValue arg1, BValue arg2, BValue arg3, 
 }
 
 
-DEFINE_RC_STRUCT(Closure15Data, BClosure15 fn; size_t slot_len;);
-DEFINE_RC_STRUCT(BoxedPureFn15, BPureFn15 fn; size_t slot_len;);
+DEFINE_BSTS_OBJ(Closure15Data, BClosure15 fn; size_t slot_len;);
+DEFINE_BSTS_OBJ(BoxedPureFn15, BPureFn15 fn; size_t slot_len;);
 
 BValue alloc_closure15(size_t size, BValue* data, BClosure15 fn) {
-    Closure15Data* rc = malloc(closure_data_size(size));
-    // this is safe to do outside atomic because no other thread can see this yet
-    rc->ref_count = 1;
-    rc->free = (FreeFn)free_closure;
+    Closure15Data* rc = GC_malloc(closure_data_size(size));
     rc->fn = fn;
     rc->slot_len = size;
     BValue* closure_data = closure_data_of((Closure1Data*)rc);
@@ -3728,10 +2208,7 @@ BValue alloc_boxed_pure_fn15(BPureFn15 fn) {
       // can pack into a pure value
       return (BValue)(TO_PURE_VALUE(fn));
     }
-    BoxedPureFn15* rc = (BoxedPureFn15*)malloc(sizeof(BoxedPureFn15));
-    // this is safe to do outside atomic because no other thread can see this yet
-    rc->ref_count = 1;
-    rc->free = free;
+    BoxedPureFn15* rc = (BoxedPureFn15*)GC_malloc(sizeof(BoxedPureFn15));
     rc->fn = fn;
     rc->slot_len = 0;
     return (BValue)rc;
@@ -3757,14 +2234,11 @@ BValue call_fn15(BValue fn, BValue arg0, BValue arg1, BValue arg2, BValue arg3, 
 }
 
 
-DEFINE_RC_STRUCT(Closure16Data, BClosure16 fn; size_t slot_len;);
-DEFINE_RC_STRUCT(BoxedPureFn16, BPureFn16 fn; size_t slot_len;);
+DEFINE_BSTS_OBJ(Closure16Data, BClosure16 fn; size_t slot_len;);
+DEFINE_BSTS_OBJ(BoxedPureFn16, BPureFn16 fn; size_t slot_len;);
 
 BValue alloc_closure16(size_t size, BValue* data, BClosure16 fn) {
-    Closure16Data* rc = malloc(closure_data_size(size));
-    // this is safe to do outside atomic because no other thread can see this yet
-    rc->ref_count = 1;
-    rc->free = (FreeFn)free_closure;
+    Closure16Data* rc = GC_malloc(closure_data_size(size));
     rc->fn = fn;
     rc->slot_len = size;
     BValue* closure_data = closure_data_of((Closure1Data*)rc);
@@ -3781,10 +2255,7 @@ BValue alloc_boxed_pure_fn16(BPureFn16 fn) {
       // can pack into a pure value
       return (BValue)(TO_PURE_VALUE(fn));
     }
-    BoxedPureFn16* rc = (BoxedPureFn16*)malloc(sizeof(BoxedPureFn16));
-    // this is safe to do outside atomic because no other thread can see this yet
-    rc->ref_count = 1;
-    rc->free = free;
+    BoxedPureFn16* rc = (BoxedPureFn16*)GC_malloc(sizeof(BoxedPureFn16));
     rc->fn = fn;
     rc->slot_len = 0;
     return (BValue)rc;
@@ -3810,14 +2281,11 @@ BValue call_fn16(BValue fn, BValue arg0, BValue arg1, BValue arg2, BValue arg3, 
 }
 
 
-DEFINE_RC_STRUCT(Closure17Data, BClosure17 fn; size_t slot_len;);
-DEFINE_RC_STRUCT(BoxedPureFn17, BPureFn17 fn; size_t slot_len;);
+DEFINE_BSTS_OBJ(Closure17Data, BClosure17 fn; size_t slot_len;);
+DEFINE_BSTS_OBJ(BoxedPureFn17, BPureFn17 fn; size_t slot_len;);
 
 BValue alloc_closure17(size_t size, BValue* data, BClosure17 fn) {
-    Closure17Data* rc = malloc(closure_data_size(size));
-    // this is safe to do outside atomic because no other thread can see this yet
-    rc->ref_count = 1;
-    rc->free = (FreeFn)free_closure;
+    Closure17Data* rc = GC_malloc(closure_data_size(size));
     rc->fn = fn;
     rc->slot_len = size;
     BValue* closure_data = closure_data_of((Closure1Data*)rc);
@@ -3834,10 +2302,7 @@ BValue alloc_boxed_pure_fn17(BPureFn17 fn) {
       // can pack into a pure value
       return (BValue)(TO_PURE_VALUE(fn));
     }
-    BoxedPureFn17* rc = (BoxedPureFn17*)malloc(sizeof(BoxedPureFn17));
-    // this is safe to do outside atomic because no other thread can see this yet
-    rc->ref_count = 1;
-    rc->free = free;
+    BoxedPureFn17* rc = (BoxedPureFn17*)GC_malloc(sizeof(BoxedPureFn17));
     rc->fn = fn;
     rc->slot_len = 0;
     return (BValue)rc;
@@ -3863,14 +2328,11 @@ BValue call_fn17(BValue fn, BValue arg0, BValue arg1, BValue arg2, BValue arg3, 
 }
 
 
-DEFINE_RC_STRUCT(Closure18Data, BClosure18 fn; size_t slot_len;);
-DEFINE_RC_STRUCT(BoxedPureFn18, BPureFn18 fn; size_t slot_len;);
+DEFINE_BSTS_OBJ(Closure18Data, BClosure18 fn; size_t slot_len;);
+DEFINE_BSTS_OBJ(BoxedPureFn18, BPureFn18 fn; size_t slot_len;);
 
 BValue alloc_closure18(size_t size, BValue* data, BClosure18 fn) {
-    Closure18Data* rc = malloc(closure_data_size(size));
-    // this is safe to do outside atomic because no other thread can see this yet
-    rc->ref_count = 1;
-    rc->free = (FreeFn)free_closure;
+    Closure18Data* rc = GC_malloc(closure_data_size(size));
     rc->fn = fn;
     rc->slot_len = size;
     BValue* closure_data = closure_data_of((Closure1Data*)rc);
@@ -3887,10 +2349,7 @@ BValue alloc_boxed_pure_fn18(BPureFn18 fn) {
       // can pack into a pure value
       return (BValue)(TO_PURE_VALUE(fn));
     }
-    BoxedPureFn18* rc = (BoxedPureFn18*)malloc(sizeof(BoxedPureFn18));
-    // this is safe to do outside atomic because no other thread can see this yet
-    rc->ref_count = 1;
-    rc->free = free;
+    BoxedPureFn18* rc = (BoxedPureFn18*)GC_malloc(sizeof(BoxedPureFn18));
     rc->fn = fn;
     rc->slot_len = 0;
     return (BValue)rc;
@@ -3916,14 +2375,11 @@ BValue call_fn18(BValue fn, BValue arg0, BValue arg1, BValue arg2, BValue arg3, 
 }
 
 
-DEFINE_RC_STRUCT(Closure19Data, BClosure19 fn; size_t slot_len;);
-DEFINE_RC_STRUCT(BoxedPureFn19, BPureFn19 fn; size_t slot_len;);
+DEFINE_BSTS_OBJ(Closure19Data, BClosure19 fn; size_t slot_len;);
+DEFINE_BSTS_OBJ(BoxedPureFn19, BPureFn19 fn; size_t slot_len;);
 
 BValue alloc_closure19(size_t size, BValue* data, BClosure19 fn) {
-    Closure19Data* rc = malloc(closure_data_size(size));
-    // this is safe to do outside atomic because no other thread can see this yet
-    rc->ref_count = 1;
-    rc->free = (FreeFn)free_closure;
+    Closure19Data* rc = GC_malloc(closure_data_size(size));
     rc->fn = fn;
     rc->slot_len = size;
     BValue* closure_data = closure_data_of((Closure1Data*)rc);
@@ -3940,10 +2396,7 @@ BValue alloc_boxed_pure_fn19(BPureFn19 fn) {
       // can pack into a pure value
       return (BValue)(TO_PURE_VALUE(fn));
     }
-    BoxedPureFn19* rc = (BoxedPureFn19*)malloc(sizeof(BoxedPureFn19));
-    // this is safe to do outside atomic because no other thread can see this yet
-    rc->ref_count = 1;
-    rc->free = free;
+    BoxedPureFn19* rc = (BoxedPureFn19*)GC_malloc(sizeof(BoxedPureFn19));
     rc->fn = fn;
     rc->slot_len = 0;
     return (BValue)rc;
@@ -3969,14 +2422,11 @@ BValue call_fn19(BValue fn, BValue arg0, BValue arg1, BValue arg2, BValue arg3, 
 }
 
 
-DEFINE_RC_STRUCT(Closure20Data, BClosure20 fn; size_t slot_len;);
-DEFINE_RC_STRUCT(BoxedPureFn20, BPureFn20 fn; size_t slot_len;);
+DEFINE_BSTS_OBJ(Closure20Data, BClosure20 fn; size_t slot_len;);
+DEFINE_BSTS_OBJ(BoxedPureFn20, BPureFn20 fn; size_t slot_len;);
 
 BValue alloc_closure20(size_t size, BValue* data, BClosure20 fn) {
-    Closure20Data* rc = malloc(closure_data_size(size));
-    // this is safe to do outside atomic because no other thread can see this yet
-    rc->ref_count = 1;
-    rc->free = (FreeFn)free_closure;
+    Closure20Data* rc = GC_malloc(closure_data_size(size));
     rc->fn = fn;
     rc->slot_len = size;
     BValue* closure_data = closure_data_of((Closure1Data*)rc);
@@ -3993,10 +2443,7 @@ BValue alloc_boxed_pure_fn20(BPureFn20 fn) {
       // can pack into a pure value
       return (BValue)(TO_PURE_VALUE(fn));
     }
-    BoxedPureFn20* rc = (BoxedPureFn20*)malloc(sizeof(BoxedPureFn20));
-    // this is safe to do outside atomic because no other thread can see this yet
-    rc->ref_count = 1;
-    rc->free = free;
+    BoxedPureFn20* rc = (BoxedPureFn20*)GC_malloc(sizeof(BoxedPureFn20));
     rc->fn = fn;
     rc->slot_len = 0;
     return (BValue)rc;
@@ -4022,14 +2469,11 @@ BValue call_fn20(BValue fn, BValue arg0, BValue arg1, BValue arg2, BValue arg3, 
 }
 
 
-DEFINE_RC_STRUCT(Closure21Data, BClosure21 fn; size_t slot_len;);
-DEFINE_RC_STRUCT(BoxedPureFn21, BPureFn21 fn; size_t slot_len;);
+DEFINE_BSTS_OBJ(Closure21Data, BClosure21 fn; size_t slot_len;);
+DEFINE_BSTS_OBJ(BoxedPureFn21, BPureFn21 fn; size_t slot_len;);
 
 BValue alloc_closure21(size_t size, BValue* data, BClosure21 fn) {
-    Closure21Data* rc = malloc(closure_data_size(size));
-    // this is safe to do outside atomic because no other thread can see this yet
-    rc->ref_count = 1;
-    rc->free = (FreeFn)free_closure;
+    Closure21Data* rc = GC_malloc(closure_data_size(size));
     rc->fn = fn;
     rc->slot_len = size;
     BValue* closure_data = closure_data_of((Closure1Data*)rc);
@@ -4046,10 +2490,7 @@ BValue alloc_boxed_pure_fn21(BPureFn21 fn) {
       // can pack into a pure value
       return (BValue)(TO_PURE_VALUE(fn));
     }
-    BoxedPureFn21* rc = (BoxedPureFn21*)malloc(sizeof(BoxedPureFn21));
-    // this is safe to do outside atomic because no other thread can see this yet
-    rc->ref_count = 1;
-    rc->free = free;
+    BoxedPureFn21* rc = (BoxedPureFn21*)GC_malloc(sizeof(BoxedPureFn21));
     rc->fn = fn;
     rc->slot_len = 0;
     return (BValue)rc;
@@ -4075,14 +2516,11 @@ BValue call_fn21(BValue fn, BValue arg0, BValue arg1, BValue arg2, BValue arg3, 
 }
 
 
-DEFINE_RC_STRUCT(Closure22Data, BClosure22 fn; size_t slot_len;);
-DEFINE_RC_STRUCT(BoxedPureFn22, BPureFn22 fn; size_t slot_len;);
+DEFINE_BSTS_OBJ(Closure22Data, BClosure22 fn; size_t slot_len;);
+DEFINE_BSTS_OBJ(BoxedPureFn22, BPureFn22 fn; size_t slot_len;);
 
 BValue alloc_closure22(size_t size, BValue* data, BClosure22 fn) {
-    Closure22Data* rc = malloc(closure_data_size(size));
-    // this is safe to do outside atomic because no other thread can see this yet
-    rc->ref_count = 1;
-    rc->free = (FreeFn)free_closure;
+    Closure22Data* rc = GC_malloc(closure_data_size(size));
     rc->fn = fn;
     rc->slot_len = size;
     BValue* closure_data = closure_data_of((Closure1Data*)rc);
@@ -4099,10 +2537,7 @@ BValue alloc_boxed_pure_fn22(BPureFn22 fn) {
       // can pack into a pure value
       return (BValue)(TO_PURE_VALUE(fn));
     }
-    BoxedPureFn22* rc = (BoxedPureFn22*)malloc(sizeof(BoxedPureFn22));
-    // this is safe to do outside atomic because no other thread can see this yet
-    rc->ref_count = 1;
-    rc->free = free;
+    BoxedPureFn22* rc = (BoxedPureFn22*)GC_malloc(sizeof(BoxedPureFn22));
     rc->fn = fn;
     rc->slot_len = 0;
     return (BValue)rc;
@@ -4128,14 +2563,11 @@ BValue call_fn22(BValue fn, BValue arg0, BValue arg1, BValue arg2, BValue arg3, 
 }
 
 
-DEFINE_RC_STRUCT(Closure23Data, BClosure23 fn; size_t slot_len;);
-DEFINE_RC_STRUCT(BoxedPureFn23, BPureFn23 fn; size_t slot_len;);
+DEFINE_BSTS_OBJ(Closure23Data, BClosure23 fn; size_t slot_len;);
+DEFINE_BSTS_OBJ(BoxedPureFn23, BPureFn23 fn; size_t slot_len;);
 
 BValue alloc_closure23(size_t size, BValue* data, BClosure23 fn) {
-    Closure23Data* rc = malloc(closure_data_size(size));
-    // this is safe to do outside atomic because no other thread can see this yet
-    rc->ref_count = 1;
-    rc->free = (FreeFn)free_closure;
+    Closure23Data* rc = GC_malloc(closure_data_size(size));
     rc->fn = fn;
     rc->slot_len = size;
     BValue* closure_data = closure_data_of((Closure1Data*)rc);
@@ -4152,10 +2584,7 @@ BValue alloc_boxed_pure_fn23(BPureFn23 fn) {
       // can pack into a pure value
       return (BValue)(TO_PURE_VALUE(fn));
     }
-    BoxedPureFn23* rc = (BoxedPureFn23*)malloc(sizeof(BoxedPureFn23));
-    // this is safe to do outside atomic because no other thread can see this yet
-    rc->ref_count = 1;
-    rc->free = free;
+    BoxedPureFn23* rc = (BoxedPureFn23*)GC_malloc(sizeof(BoxedPureFn23));
     rc->fn = fn;
     rc->slot_len = 0;
     return (BValue)rc;
@@ -4181,14 +2610,11 @@ BValue call_fn23(BValue fn, BValue arg0, BValue arg1, BValue arg2, BValue arg3, 
 }
 
 
-DEFINE_RC_STRUCT(Closure24Data, BClosure24 fn; size_t slot_len;);
-DEFINE_RC_STRUCT(BoxedPureFn24, BPureFn24 fn; size_t slot_len;);
+DEFINE_BSTS_OBJ(Closure24Data, BClosure24 fn; size_t slot_len;);
+DEFINE_BSTS_OBJ(BoxedPureFn24, BPureFn24 fn; size_t slot_len;);
 
 BValue alloc_closure24(size_t size, BValue* data, BClosure24 fn) {
-    Closure24Data* rc = malloc(closure_data_size(size));
-    // this is safe to do outside atomic because no other thread can see this yet
-    rc->ref_count = 1;
-    rc->free = (FreeFn)free_closure;
+    Closure24Data* rc = GC_malloc(closure_data_size(size));
     rc->fn = fn;
     rc->slot_len = size;
     BValue* closure_data = closure_data_of((Closure1Data*)rc);
@@ -4205,10 +2631,7 @@ BValue alloc_boxed_pure_fn24(BPureFn24 fn) {
       // can pack into a pure value
       return (BValue)(TO_PURE_VALUE(fn));
     }
-    BoxedPureFn24* rc = (BoxedPureFn24*)malloc(sizeof(BoxedPureFn24));
-    // this is safe to do outside atomic because no other thread can see this yet
-    rc->ref_count = 1;
-    rc->free = free;
+    BoxedPureFn24* rc = (BoxedPureFn24*)GC_malloc(sizeof(BoxedPureFn24));
     rc->fn = fn;
     rc->slot_len = 0;
     return (BValue)rc;
@@ -4234,14 +2657,11 @@ BValue call_fn24(BValue fn, BValue arg0, BValue arg1, BValue arg2, BValue arg3, 
 }
 
 
-DEFINE_RC_STRUCT(Closure25Data, BClosure25 fn; size_t slot_len;);
-DEFINE_RC_STRUCT(BoxedPureFn25, BPureFn25 fn; size_t slot_len;);
+DEFINE_BSTS_OBJ(Closure25Data, BClosure25 fn; size_t slot_len;);
+DEFINE_BSTS_OBJ(BoxedPureFn25, BPureFn25 fn; size_t slot_len;);
 
 BValue alloc_closure25(size_t size, BValue* data, BClosure25 fn) {
-    Closure25Data* rc = malloc(closure_data_size(size));
-    // this is safe to do outside atomic because no other thread can see this yet
-    rc->ref_count = 1;
-    rc->free = (FreeFn)free_closure;
+    Closure25Data* rc = GC_malloc(closure_data_size(size));
     rc->fn = fn;
     rc->slot_len = size;
     BValue* closure_data = closure_data_of((Closure1Data*)rc);
@@ -4258,10 +2678,7 @@ BValue alloc_boxed_pure_fn25(BPureFn25 fn) {
       // can pack into a pure value
       return (BValue)(TO_PURE_VALUE(fn));
     }
-    BoxedPureFn25* rc = (BoxedPureFn25*)malloc(sizeof(BoxedPureFn25));
-    // this is safe to do outside atomic because no other thread can see this yet
-    rc->ref_count = 1;
-    rc->free = free;
+    BoxedPureFn25* rc = (BoxedPureFn25*)GC_malloc(sizeof(BoxedPureFn25));
     rc->fn = fn;
     rc->slot_len = 0;
     return (BValue)rc;
@@ -4287,14 +2704,11 @@ BValue call_fn25(BValue fn, BValue arg0, BValue arg1, BValue arg2, BValue arg3, 
 }
 
 
-DEFINE_RC_STRUCT(Closure26Data, BClosure26 fn; size_t slot_len;);
-DEFINE_RC_STRUCT(BoxedPureFn26, BPureFn26 fn; size_t slot_len;);
+DEFINE_BSTS_OBJ(Closure26Data, BClosure26 fn; size_t slot_len;);
+DEFINE_BSTS_OBJ(BoxedPureFn26, BPureFn26 fn; size_t slot_len;);
 
 BValue alloc_closure26(size_t size, BValue* data, BClosure26 fn) {
-    Closure26Data* rc = malloc(closure_data_size(size));
-    // this is safe to do outside atomic because no other thread can see this yet
-    rc->ref_count = 1;
-    rc->free = (FreeFn)free_closure;
+    Closure26Data* rc = GC_malloc(closure_data_size(size));
     rc->fn = fn;
     rc->slot_len = size;
     BValue* closure_data = closure_data_of((Closure1Data*)rc);
@@ -4311,10 +2725,7 @@ BValue alloc_boxed_pure_fn26(BPureFn26 fn) {
       // can pack into a pure value
       return (BValue)(TO_PURE_VALUE(fn));
     }
-    BoxedPureFn26* rc = (BoxedPureFn26*)malloc(sizeof(BoxedPureFn26));
-    // this is safe to do outside atomic because no other thread can see this yet
-    rc->ref_count = 1;
-    rc->free = free;
+    BoxedPureFn26* rc = (BoxedPureFn26*)GC_malloc(sizeof(BoxedPureFn26));
     rc->fn = fn;
     rc->slot_len = 0;
     return (BValue)rc;
@@ -4340,14 +2751,11 @@ BValue call_fn26(BValue fn, BValue arg0, BValue arg1, BValue arg2, BValue arg3, 
 }
 
 
-DEFINE_RC_STRUCT(Closure27Data, BClosure27 fn; size_t slot_len;);
-DEFINE_RC_STRUCT(BoxedPureFn27, BPureFn27 fn; size_t slot_len;);
+DEFINE_BSTS_OBJ(Closure27Data, BClosure27 fn; size_t slot_len;);
+DEFINE_BSTS_OBJ(BoxedPureFn27, BPureFn27 fn; size_t slot_len;);
 
 BValue alloc_closure27(size_t size, BValue* data, BClosure27 fn) {
-    Closure27Data* rc = malloc(closure_data_size(size));
-    // this is safe to do outside atomic because no other thread can see this yet
-    rc->ref_count = 1;
-    rc->free = (FreeFn)free_closure;
+    Closure27Data* rc = GC_malloc(closure_data_size(size));
     rc->fn = fn;
     rc->slot_len = size;
     BValue* closure_data = closure_data_of((Closure1Data*)rc);
@@ -4364,10 +2772,7 @@ BValue alloc_boxed_pure_fn27(BPureFn27 fn) {
       // can pack into a pure value
       return (BValue)(TO_PURE_VALUE(fn));
     }
-    BoxedPureFn27* rc = (BoxedPureFn27*)malloc(sizeof(BoxedPureFn27));
-    // this is safe to do outside atomic because no other thread can see this yet
-    rc->ref_count = 1;
-    rc->free = free;
+    BoxedPureFn27* rc = (BoxedPureFn27*)GC_malloc(sizeof(BoxedPureFn27));
     rc->fn = fn;
     rc->slot_len = 0;
     return (BValue)rc;
@@ -4393,14 +2798,11 @@ BValue call_fn27(BValue fn, BValue arg0, BValue arg1, BValue arg2, BValue arg3, 
 }
 
 
-DEFINE_RC_STRUCT(Closure28Data, BClosure28 fn; size_t slot_len;);
-DEFINE_RC_STRUCT(BoxedPureFn28, BPureFn28 fn; size_t slot_len;);
+DEFINE_BSTS_OBJ(Closure28Data, BClosure28 fn; size_t slot_len;);
+DEFINE_BSTS_OBJ(BoxedPureFn28, BPureFn28 fn; size_t slot_len;);
 
 BValue alloc_closure28(size_t size, BValue* data, BClosure28 fn) {
-    Closure28Data* rc = malloc(closure_data_size(size));
-    // this is safe to do outside atomic because no other thread can see this yet
-    rc->ref_count = 1;
-    rc->free = (FreeFn)free_closure;
+    Closure28Data* rc = GC_malloc(closure_data_size(size));
     rc->fn = fn;
     rc->slot_len = size;
     BValue* closure_data = closure_data_of((Closure1Data*)rc);
@@ -4417,10 +2819,7 @@ BValue alloc_boxed_pure_fn28(BPureFn28 fn) {
       // can pack into a pure value
       return (BValue)(TO_PURE_VALUE(fn));
     }
-    BoxedPureFn28* rc = (BoxedPureFn28*)malloc(sizeof(BoxedPureFn28));
-    // this is safe to do outside atomic because no other thread can see this yet
-    rc->ref_count = 1;
-    rc->free = free;
+    BoxedPureFn28* rc = (BoxedPureFn28*)GC_malloc(sizeof(BoxedPureFn28));
     rc->fn = fn;
     rc->slot_len = 0;
     return (BValue)rc;
@@ -4446,14 +2845,11 @@ BValue call_fn28(BValue fn, BValue arg0, BValue arg1, BValue arg2, BValue arg3, 
 }
 
 
-DEFINE_RC_STRUCT(Closure29Data, BClosure29 fn; size_t slot_len;);
-DEFINE_RC_STRUCT(BoxedPureFn29, BPureFn29 fn; size_t slot_len;);
+DEFINE_BSTS_OBJ(Closure29Data, BClosure29 fn; size_t slot_len;);
+DEFINE_BSTS_OBJ(BoxedPureFn29, BPureFn29 fn; size_t slot_len;);
 
 BValue alloc_closure29(size_t size, BValue* data, BClosure29 fn) {
-    Closure29Data* rc = malloc(closure_data_size(size));
-    // this is safe to do outside atomic because no other thread can see this yet
-    rc->ref_count = 1;
-    rc->free = (FreeFn)free_closure;
+    Closure29Data* rc = GC_malloc(closure_data_size(size));
     rc->fn = fn;
     rc->slot_len = size;
     BValue* closure_data = closure_data_of((Closure1Data*)rc);
@@ -4470,10 +2866,7 @@ BValue alloc_boxed_pure_fn29(BPureFn29 fn) {
       // can pack into a pure value
       return (BValue)(TO_PURE_VALUE(fn));
     }
-    BoxedPureFn29* rc = (BoxedPureFn29*)malloc(sizeof(BoxedPureFn29));
-    // this is safe to do outside atomic because no other thread can see this yet
-    rc->ref_count = 1;
-    rc->free = free;
+    BoxedPureFn29* rc = (BoxedPureFn29*)GC_malloc(sizeof(BoxedPureFn29));
     rc->fn = fn;
     rc->slot_len = 0;
     return (BValue)rc;
@@ -4499,14 +2892,11 @@ BValue call_fn29(BValue fn, BValue arg0, BValue arg1, BValue arg2, BValue arg3, 
 }
 
 
-DEFINE_RC_STRUCT(Closure30Data, BClosure30 fn; size_t slot_len;);
-DEFINE_RC_STRUCT(BoxedPureFn30, BPureFn30 fn; size_t slot_len;);
+DEFINE_BSTS_OBJ(Closure30Data, BClosure30 fn; size_t slot_len;);
+DEFINE_BSTS_OBJ(BoxedPureFn30, BPureFn30 fn; size_t slot_len;);
 
 BValue alloc_closure30(size_t size, BValue* data, BClosure30 fn) {
-    Closure30Data* rc = malloc(closure_data_size(size));
-    // this is safe to do outside atomic because no other thread can see this yet
-    rc->ref_count = 1;
-    rc->free = (FreeFn)free_closure;
+    Closure30Data* rc = GC_malloc(closure_data_size(size));
     rc->fn = fn;
     rc->slot_len = size;
     BValue* closure_data = closure_data_of((Closure1Data*)rc);
@@ -4523,10 +2913,7 @@ BValue alloc_boxed_pure_fn30(BPureFn30 fn) {
       // can pack into a pure value
       return (BValue)(TO_PURE_VALUE(fn));
     }
-    BoxedPureFn30* rc = (BoxedPureFn30*)malloc(sizeof(BoxedPureFn30));
-    // this is safe to do outside atomic because no other thread can see this yet
-    rc->ref_count = 1;
-    rc->free = free;
+    BoxedPureFn30* rc = (BoxedPureFn30*)GC_malloc(sizeof(BoxedPureFn30));
     rc->fn = fn;
     rc->slot_len = 0;
     return (BValue)rc;
@@ -4552,14 +2939,11 @@ BValue call_fn30(BValue fn, BValue arg0, BValue arg1, BValue arg2, BValue arg3, 
 }
 
 
-DEFINE_RC_STRUCT(Closure31Data, BClosure31 fn; size_t slot_len;);
-DEFINE_RC_STRUCT(BoxedPureFn31, BPureFn31 fn; size_t slot_len;);
+DEFINE_BSTS_OBJ(Closure31Data, BClosure31 fn; size_t slot_len;);
+DEFINE_BSTS_OBJ(BoxedPureFn31, BPureFn31 fn; size_t slot_len;);
 
 BValue alloc_closure31(size_t size, BValue* data, BClosure31 fn) {
-    Closure31Data* rc = malloc(closure_data_size(size));
-    // this is safe to do outside atomic because no other thread can see this yet
-    rc->ref_count = 1;
-    rc->free = (FreeFn)free_closure;
+    Closure31Data* rc = GC_malloc(closure_data_size(size));
     rc->fn = fn;
     rc->slot_len = size;
     BValue* closure_data = closure_data_of((Closure1Data*)rc);
@@ -4576,10 +2960,7 @@ BValue alloc_boxed_pure_fn31(BPureFn31 fn) {
       // can pack into a pure value
       return (BValue)(TO_PURE_VALUE(fn));
     }
-    BoxedPureFn31* rc = (BoxedPureFn31*)malloc(sizeof(BoxedPureFn31));
-    // this is safe to do outside atomic because no other thread can see this yet
-    rc->ref_count = 1;
-    rc->free = free;
+    BoxedPureFn31* rc = (BoxedPureFn31*)GC_malloc(sizeof(BoxedPureFn31));
     rc->fn = fn;
     rc->slot_len = 0;
     return (BValue)rc;
@@ -4605,14 +2986,11 @@ BValue call_fn31(BValue fn, BValue arg0, BValue arg1, BValue arg2, BValue arg3, 
 }
 
 
-DEFINE_RC_STRUCT(Closure32Data, BClosure32 fn; size_t slot_len;);
-DEFINE_RC_STRUCT(BoxedPureFn32, BPureFn32 fn; size_t slot_len;);
+DEFINE_BSTS_OBJ(Closure32Data, BClosure32 fn; size_t slot_len;);
+DEFINE_BSTS_OBJ(BoxedPureFn32, BPureFn32 fn; size_t slot_len;);
 
 BValue alloc_closure32(size_t size, BValue* data, BClosure32 fn) {
-    Closure32Data* rc = malloc(closure_data_size(size));
-    // this is safe to do outside atomic because no other thread can see this yet
-    rc->ref_count = 1;
-    rc->free = (FreeFn)free_closure;
+    Closure32Data* rc = GC_malloc(closure_data_size(size));
     rc->fn = fn;
     rc->slot_len = size;
     BValue* closure_data = closure_data_of((Closure1Data*)rc);
@@ -4629,10 +3007,7 @@ BValue alloc_boxed_pure_fn32(BPureFn32 fn) {
       // can pack into a pure value
       return (BValue)(TO_PURE_VALUE(fn));
     }
-    BoxedPureFn32* rc = (BoxedPureFn32*)malloc(sizeof(BoxedPureFn32));
-    // this is safe to do outside atomic because no other thread can see this yet
-    rc->ref_count = 1;
-    rc->free = free;
+    BoxedPureFn32* rc = (BoxedPureFn32*)GC_malloc(sizeof(BoxedPureFn32));
     rc->fn = fn;
     rc->slot_len = 0;
     return (BValue)rc;

--- a/c_runtime/bosatsu_generated.h
+++ b/c_runtime/bosatsu_generated.h
@@ -1537,9 +1537,7 @@ BValue alloc_closure1(size_t size, BValue* data, BClosure1 fn) {
     rc->fn = fn;
     rc->slot_len = size;
     BValue* closure_data = closure_data_of(rc);
-    for (size_t i = 0; i < size; i++) {
-      closure_data[i] = data[i];
-    }
+    memcpy(closure_data, data, sizeof(BValue*) * size);
     return (BValue)rc;
 }
 
@@ -1584,9 +1582,7 @@ BValue alloc_closure2(size_t size, BValue* data, BClosure2 fn) {
     rc->fn = fn;
     rc->slot_len = size;
     BValue* closure_data = closure_data_of((Closure1Data*)rc);
-    for (size_t i = 0; i < size; i++) {
-      closure_data[i] = data[i];
-    }
+    memcpy(closure_data, data, sizeof(BValue*) * size);
     return (BValue)rc;
 }
 
@@ -1631,9 +1627,7 @@ BValue alloc_closure3(size_t size, BValue* data, BClosure3 fn) {
     rc->fn = fn;
     rc->slot_len = size;
     BValue* closure_data = closure_data_of((Closure1Data*)rc);
-    for (size_t i = 0; i < size; i++) {
-      closure_data[i] = data[i];
-    }
+    memcpy(closure_data, data, sizeof(BValue*) * size);
     return (BValue)rc;
 }
 
@@ -1678,9 +1672,7 @@ BValue alloc_closure4(size_t size, BValue* data, BClosure4 fn) {
     rc->fn = fn;
     rc->slot_len = size;
     BValue* closure_data = closure_data_of((Closure1Data*)rc);
-    for (size_t i = 0; i < size; i++) {
-      closure_data[i] = data[i];
-    }
+    memcpy(closure_data, data, sizeof(BValue*) * size);
     return (BValue)rc;
 }
 
@@ -1725,9 +1717,7 @@ BValue alloc_closure5(size_t size, BValue* data, BClosure5 fn) {
     rc->fn = fn;
     rc->slot_len = size;
     BValue* closure_data = closure_data_of((Closure1Data*)rc);
-    for (size_t i = 0; i < size; i++) {
-      closure_data[i] = data[i];
-    }
+    memcpy(closure_data, data, sizeof(BValue*) * size);
     return (BValue)rc;
 }
 
@@ -1772,9 +1762,7 @@ BValue alloc_closure6(size_t size, BValue* data, BClosure6 fn) {
     rc->fn = fn;
     rc->slot_len = size;
     BValue* closure_data = closure_data_of((Closure1Data*)rc);
-    for (size_t i = 0; i < size; i++) {
-      closure_data[i] = data[i];
-    }
+    memcpy(closure_data, data, sizeof(BValue*) * size);
     return (BValue)rc;
 }
 
@@ -1819,9 +1807,7 @@ BValue alloc_closure7(size_t size, BValue* data, BClosure7 fn) {
     rc->fn = fn;
     rc->slot_len = size;
     BValue* closure_data = closure_data_of((Closure1Data*)rc);
-    for (size_t i = 0; i < size; i++) {
-      closure_data[i] = data[i];
-    }
+    memcpy(closure_data, data, sizeof(BValue*) * size);
     return (BValue)rc;
 }
 
@@ -1866,9 +1852,7 @@ BValue alloc_closure8(size_t size, BValue* data, BClosure8 fn) {
     rc->fn = fn;
     rc->slot_len = size;
     BValue* closure_data = closure_data_of((Closure1Data*)rc);
-    for (size_t i = 0; i < size; i++) {
-      closure_data[i] = data[i];
-    }
+    memcpy(closure_data, data, sizeof(BValue*) * size);
     return (BValue)rc;
 }
 
@@ -1913,9 +1897,7 @@ BValue alloc_closure9(size_t size, BValue* data, BClosure9 fn) {
     rc->fn = fn;
     rc->slot_len = size;
     BValue* closure_data = closure_data_of((Closure1Data*)rc);
-    for (size_t i = 0; i < size; i++) {
-      closure_data[i] = data[i];
-    }
+    memcpy(closure_data, data, sizeof(BValue*) * size);
     return (BValue)rc;
 }
 
@@ -1960,9 +1942,7 @@ BValue alloc_closure10(size_t size, BValue* data, BClosure10 fn) {
     rc->fn = fn;
     rc->slot_len = size;
     BValue* closure_data = closure_data_of((Closure1Data*)rc);
-    for (size_t i = 0; i < size; i++) {
-      closure_data[i] = data[i];
-    }
+    memcpy(closure_data, data, sizeof(BValue*) * size);
     return (BValue)rc;
 }
 
@@ -2007,9 +1987,7 @@ BValue alloc_closure11(size_t size, BValue* data, BClosure11 fn) {
     rc->fn = fn;
     rc->slot_len = size;
     BValue* closure_data = closure_data_of((Closure1Data*)rc);
-    for (size_t i = 0; i < size; i++) {
-      closure_data[i] = data[i];
-    }
+    memcpy(closure_data, data, sizeof(BValue*) * size);
     return (BValue)rc;
 }
 
@@ -2054,9 +2032,7 @@ BValue alloc_closure12(size_t size, BValue* data, BClosure12 fn) {
     rc->fn = fn;
     rc->slot_len = size;
     BValue* closure_data = closure_data_of((Closure1Data*)rc);
-    for (size_t i = 0; i < size; i++) {
-      closure_data[i] = data[i];
-    }
+    memcpy(closure_data, data, sizeof(BValue*) * size);
     return (BValue)rc;
 }
 
@@ -2101,9 +2077,7 @@ BValue alloc_closure13(size_t size, BValue* data, BClosure13 fn) {
     rc->fn = fn;
     rc->slot_len = size;
     BValue* closure_data = closure_data_of((Closure1Data*)rc);
-    for (size_t i = 0; i < size; i++) {
-      closure_data[i] = data[i];
-    }
+    memcpy(closure_data, data, sizeof(BValue*) * size);
     return (BValue)rc;
 }
 
@@ -2148,9 +2122,7 @@ BValue alloc_closure14(size_t size, BValue* data, BClosure14 fn) {
     rc->fn = fn;
     rc->slot_len = size;
     BValue* closure_data = closure_data_of((Closure1Data*)rc);
-    for (size_t i = 0; i < size; i++) {
-      closure_data[i] = data[i];
-    }
+    memcpy(closure_data, data, sizeof(BValue*) * size);
     return (BValue)rc;
 }
 
@@ -2195,9 +2167,7 @@ BValue alloc_closure15(size_t size, BValue* data, BClosure15 fn) {
     rc->fn = fn;
     rc->slot_len = size;
     BValue* closure_data = closure_data_of((Closure1Data*)rc);
-    for (size_t i = 0; i < size; i++) {
-      closure_data[i] = data[i];
-    }
+    memcpy(closure_data, data, sizeof(BValue*) * size);
     return (BValue)rc;
 }
 
@@ -2242,9 +2212,7 @@ BValue alloc_closure16(size_t size, BValue* data, BClosure16 fn) {
     rc->fn = fn;
     rc->slot_len = size;
     BValue* closure_data = closure_data_of((Closure1Data*)rc);
-    for (size_t i = 0; i < size; i++) {
-      closure_data[i] = data[i];
-    }
+    memcpy(closure_data, data, sizeof(BValue*) * size);
     return (BValue)rc;
 }
 
@@ -2289,9 +2257,7 @@ BValue alloc_closure17(size_t size, BValue* data, BClosure17 fn) {
     rc->fn = fn;
     rc->slot_len = size;
     BValue* closure_data = closure_data_of((Closure1Data*)rc);
-    for (size_t i = 0; i < size; i++) {
-      closure_data[i] = data[i];
-    }
+    memcpy(closure_data, data, sizeof(BValue*) * size);
     return (BValue)rc;
 }
 
@@ -2336,9 +2302,7 @@ BValue alloc_closure18(size_t size, BValue* data, BClosure18 fn) {
     rc->fn = fn;
     rc->slot_len = size;
     BValue* closure_data = closure_data_of((Closure1Data*)rc);
-    for (size_t i = 0; i < size; i++) {
-      closure_data[i] = data[i];
-    }
+    memcpy(closure_data, data, sizeof(BValue*) * size);
     return (BValue)rc;
 }
 
@@ -2383,9 +2347,7 @@ BValue alloc_closure19(size_t size, BValue* data, BClosure19 fn) {
     rc->fn = fn;
     rc->slot_len = size;
     BValue* closure_data = closure_data_of((Closure1Data*)rc);
-    for (size_t i = 0; i < size; i++) {
-      closure_data[i] = data[i];
-    }
+    memcpy(closure_data, data, sizeof(BValue*) * size);
     return (BValue)rc;
 }
 
@@ -2430,9 +2392,7 @@ BValue alloc_closure20(size_t size, BValue* data, BClosure20 fn) {
     rc->fn = fn;
     rc->slot_len = size;
     BValue* closure_data = closure_data_of((Closure1Data*)rc);
-    for (size_t i = 0; i < size; i++) {
-      closure_data[i] = data[i];
-    }
+    memcpy(closure_data, data, sizeof(BValue*) * size);
     return (BValue)rc;
 }
 
@@ -2477,9 +2437,7 @@ BValue alloc_closure21(size_t size, BValue* data, BClosure21 fn) {
     rc->fn = fn;
     rc->slot_len = size;
     BValue* closure_data = closure_data_of((Closure1Data*)rc);
-    for (size_t i = 0; i < size; i++) {
-      closure_data[i] = data[i];
-    }
+    memcpy(closure_data, data, sizeof(BValue*) * size);
     return (BValue)rc;
 }
 
@@ -2524,9 +2482,7 @@ BValue alloc_closure22(size_t size, BValue* data, BClosure22 fn) {
     rc->fn = fn;
     rc->slot_len = size;
     BValue* closure_data = closure_data_of((Closure1Data*)rc);
-    for (size_t i = 0; i < size; i++) {
-      closure_data[i] = data[i];
-    }
+    memcpy(closure_data, data, sizeof(BValue*) * size);
     return (BValue)rc;
 }
 
@@ -2571,9 +2527,7 @@ BValue alloc_closure23(size_t size, BValue* data, BClosure23 fn) {
     rc->fn = fn;
     rc->slot_len = size;
     BValue* closure_data = closure_data_of((Closure1Data*)rc);
-    for (size_t i = 0; i < size; i++) {
-      closure_data[i] = data[i];
-    }
+    memcpy(closure_data, data, sizeof(BValue*) * size);
     return (BValue)rc;
 }
 
@@ -2618,9 +2572,7 @@ BValue alloc_closure24(size_t size, BValue* data, BClosure24 fn) {
     rc->fn = fn;
     rc->slot_len = size;
     BValue* closure_data = closure_data_of((Closure1Data*)rc);
-    for (size_t i = 0; i < size; i++) {
-      closure_data[i] = data[i];
-    }
+    memcpy(closure_data, data, sizeof(BValue*) * size);
     return (BValue)rc;
 }
 
@@ -2665,9 +2617,7 @@ BValue alloc_closure25(size_t size, BValue* data, BClosure25 fn) {
     rc->fn = fn;
     rc->slot_len = size;
     BValue* closure_data = closure_data_of((Closure1Data*)rc);
-    for (size_t i = 0; i < size; i++) {
-      closure_data[i] = data[i];
-    }
+    memcpy(closure_data, data, sizeof(BValue*) * size);
     return (BValue)rc;
 }
 
@@ -2712,9 +2662,7 @@ BValue alloc_closure26(size_t size, BValue* data, BClosure26 fn) {
     rc->fn = fn;
     rc->slot_len = size;
     BValue* closure_data = closure_data_of((Closure1Data*)rc);
-    for (size_t i = 0; i < size; i++) {
-      closure_data[i] = data[i];
-    }
+    memcpy(closure_data, data, sizeof(BValue*) * size);
     return (BValue)rc;
 }
 
@@ -2759,9 +2707,7 @@ BValue alloc_closure27(size_t size, BValue* data, BClosure27 fn) {
     rc->fn = fn;
     rc->slot_len = size;
     BValue* closure_data = closure_data_of((Closure1Data*)rc);
-    for (size_t i = 0; i < size; i++) {
-      closure_data[i] = data[i];
-    }
+    memcpy(closure_data, data, sizeof(BValue*) * size);
     return (BValue)rc;
 }
 
@@ -2806,9 +2752,7 @@ BValue alloc_closure28(size_t size, BValue* data, BClosure28 fn) {
     rc->fn = fn;
     rc->slot_len = size;
     BValue* closure_data = closure_data_of((Closure1Data*)rc);
-    for (size_t i = 0; i < size; i++) {
-      closure_data[i] = data[i];
-    }
+    memcpy(closure_data, data, sizeof(BValue*) * size);
     return (BValue)rc;
 }
 
@@ -2853,9 +2797,7 @@ BValue alloc_closure29(size_t size, BValue* data, BClosure29 fn) {
     rc->fn = fn;
     rc->slot_len = size;
     BValue* closure_data = closure_data_of((Closure1Data*)rc);
-    for (size_t i = 0; i < size; i++) {
-      closure_data[i] = data[i];
-    }
+    memcpy(closure_data, data, sizeof(BValue*) * size);
     return (BValue)rc;
 }
 
@@ -2900,9 +2842,7 @@ BValue alloc_closure30(size_t size, BValue* data, BClosure30 fn) {
     rc->fn = fn;
     rc->slot_len = size;
     BValue* closure_data = closure_data_of((Closure1Data*)rc);
-    for (size_t i = 0; i < size; i++) {
-      closure_data[i] = data[i];
-    }
+    memcpy(closure_data, data, sizeof(BValue*) * size);
     return (BValue)rc;
 }
 
@@ -2947,9 +2887,7 @@ BValue alloc_closure31(size_t size, BValue* data, BClosure31 fn) {
     rc->fn = fn;
     rc->slot_len = size;
     BValue* closure_data = closure_data_of((Closure1Data*)rc);
-    for (size_t i = 0; i < size; i++) {
-      closure_data[i] = data[i];
-    }
+    memcpy(closure_data, data, sizeof(BValue*) * size);
     return (BValue)rc;
 }
 
@@ -2994,9 +2932,7 @@ BValue alloc_closure32(size_t size, BValue* data, BClosure32 fn) {
     rc->fn = fn;
     rc->slot_len = size;
     BValue* closure_data = closure_data_of((Closure1Data*)rc);
-    for (size_t i = 0; i < size; i++) {
-      closure_data[i] = data[i];
-    }
+    memcpy(closure_data, data, sizeof(BValue*) * size);
     return (BValue)rc;
 }
 

--- a/c_runtime/bosatsu_generated.h
+++ b/c_runtime/bosatsu_generated.h
@@ -1560,7 +1560,7 @@ BValue call_fn1(BValue fn, BValue arg0) {
     BPureFn1 pure = (BPureFn1)PURE_VALUE(fn);
     return pure(arg0);
   }
-  BValue ptr = (BValue)TO_POINTER(fn);
+  BValue ptr = (BValue)(fn);
   BoxedPureFn1* purefn = (BoxedPureFn1*)ptr;
   if (purefn->slot_len == 0) {
     return purefn->fn(arg0);
@@ -1605,7 +1605,7 @@ BValue call_fn2(BValue fn, BValue arg0, BValue arg1) {
     BPureFn2 pure = (BPureFn2)PURE_VALUE(fn);
     return pure(arg0, arg1);
   }
-  BValue ptr = (BValue)TO_POINTER(fn);
+  BValue ptr = (BValue)(fn);
   BoxedPureFn2* purefn = (BoxedPureFn2*)ptr;
   if (purefn->slot_len == 0) {
     return purefn->fn(arg0, arg1);
@@ -1650,7 +1650,7 @@ BValue call_fn3(BValue fn, BValue arg0, BValue arg1, BValue arg2) {
     BPureFn3 pure = (BPureFn3)PURE_VALUE(fn);
     return pure(arg0, arg1, arg2);
   }
-  BValue ptr = (BValue)TO_POINTER(fn);
+  BValue ptr = (BValue)(fn);
   BoxedPureFn3* purefn = (BoxedPureFn3*)ptr;
   if (purefn->slot_len == 0) {
     return purefn->fn(arg0, arg1, arg2);
@@ -1695,7 +1695,7 @@ BValue call_fn4(BValue fn, BValue arg0, BValue arg1, BValue arg2, BValue arg3) {
     BPureFn4 pure = (BPureFn4)PURE_VALUE(fn);
     return pure(arg0, arg1, arg2, arg3);
   }
-  BValue ptr = (BValue)TO_POINTER(fn);
+  BValue ptr = (BValue)(fn);
   BoxedPureFn4* purefn = (BoxedPureFn4*)ptr;
   if (purefn->slot_len == 0) {
     return purefn->fn(arg0, arg1, arg2, arg3);
@@ -1740,7 +1740,7 @@ BValue call_fn5(BValue fn, BValue arg0, BValue arg1, BValue arg2, BValue arg3, B
     BPureFn5 pure = (BPureFn5)PURE_VALUE(fn);
     return pure(arg0, arg1, arg2, arg3, arg4);
   }
-  BValue ptr = (BValue)TO_POINTER(fn);
+  BValue ptr = (BValue)(fn);
   BoxedPureFn5* purefn = (BoxedPureFn5*)ptr;
   if (purefn->slot_len == 0) {
     return purefn->fn(arg0, arg1, arg2, arg3, arg4);
@@ -1785,7 +1785,7 @@ BValue call_fn6(BValue fn, BValue arg0, BValue arg1, BValue arg2, BValue arg3, B
     BPureFn6 pure = (BPureFn6)PURE_VALUE(fn);
     return pure(arg0, arg1, arg2, arg3, arg4, arg5);
   }
-  BValue ptr = (BValue)TO_POINTER(fn);
+  BValue ptr = (BValue)(fn);
   BoxedPureFn6* purefn = (BoxedPureFn6*)ptr;
   if (purefn->slot_len == 0) {
     return purefn->fn(arg0, arg1, arg2, arg3, arg4, arg5);
@@ -1830,7 +1830,7 @@ BValue call_fn7(BValue fn, BValue arg0, BValue arg1, BValue arg2, BValue arg3, B
     BPureFn7 pure = (BPureFn7)PURE_VALUE(fn);
     return pure(arg0, arg1, arg2, arg3, arg4, arg5, arg6);
   }
-  BValue ptr = (BValue)TO_POINTER(fn);
+  BValue ptr = (BValue)(fn);
   BoxedPureFn7* purefn = (BoxedPureFn7*)ptr;
   if (purefn->slot_len == 0) {
     return purefn->fn(arg0, arg1, arg2, arg3, arg4, arg5, arg6);
@@ -1875,7 +1875,7 @@ BValue call_fn8(BValue fn, BValue arg0, BValue arg1, BValue arg2, BValue arg3, B
     BPureFn8 pure = (BPureFn8)PURE_VALUE(fn);
     return pure(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7);
   }
-  BValue ptr = (BValue)TO_POINTER(fn);
+  BValue ptr = (BValue)(fn);
   BoxedPureFn8* purefn = (BoxedPureFn8*)ptr;
   if (purefn->slot_len == 0) {
     return purefn->fn(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7);
@@ -1920,7 +1920,7 @@ BValue call_fn9(BValue fn, BValue arg0, BValue arg1, BValue arg2, BValue arg3, B
     BPureFn9 pure = (BPureFn9)PURE_VALUE(fn);
     return pure(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8);
   }
-  BValue ptr = (BValue)TO_POINTER(fn);
+  BValue ptr = (BValue)(fn);
   BoxedPureFn9* purefn = (BoxedPureFn9*)ptr;
   if (purefn->slot_len == 0) {
     return purefn->fn(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8);
@@ -1965,7 +1965,7 @@ BValue call_fn10(BValue fn, BValue arg0, BValue arg1, BValue arg2, BValue arg3, 
     BPureFn10 pure = (BPureFn10)PURE_VALUE(fn);
     return pure(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9);
   }
-  BValue ptr = (BValue)TO_POINTER(fn);
+  BValue ptr = (BValue)(fn);
   BoxedPureFn10* purefn = (BoxedPureFn10*)ptr;
   if (purefn->slot_len == 0) {
     return purefn->fn(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9);
@@ -2010,7 +2010,7 @@ BValue call_fn11(BValue fn, BValue arg0, BValue arg1, BValue arg2, BValue arg3, 
     BPureFn11 pure = (BPureFn11)PURE_VALUE(fn);
     return pure(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10);
   }
-  BValue ptr = (BValue)TO_POINTER(fn);
+  BValue ptr = (BValue)(fn);
   BoxedPureFn11* purefn = (BoxedPureFn11*)ptr;
   if (purefn->slot_len == 0) {
     return purefn->fn(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10);
@@ -2055,7 +2055,7 @@ BValue call_fn12(BValue fn, BValue arg0, BValue arg1, BValue arg2, BValue arg3, 
     BPureFn12 pure = (BPureFn12)PURE_VALUE(fn);
     return pure(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11);
   }
-  BValue ptr = (BValue)TO_POINTER(fn);
+  BValue ptr = (BValue)(fn);
   BoxedPureFn12* purefn = (BoxedPureFn12*)ptr;
   if (purefn->slot_len == 0) {
     return purefn->fn(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11);
@@ -2100,7 +2100,7 @@ BValue call_fn13(BValue fn, BValue arg0, BValue arg1, BValue arg2, BValue arg3, 
     BPureFn13 pure = (BPureFn13)PURE_VALUE(fn);
     return pure(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12);
   }
-  BValue ptr = (BValue)TO_POINTER(fn);
+  BValue ptr = (BValue)(fn);
   BoxedPureFn13* purefn = (BoxedPureFn13*)ptr;
   if (purefn->slot_len == 0) {
     return purefn->fn(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12);
@@ -2145,7 +2145,7 @@ BValue call_fn14(BValue fn, BValue arg0, BValue arg1, BValue arg2, BValue arg3, 
     BPureFn14 pure = (BPureFn14)PURE_VALUE(fn);
     return pure(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13);
   }
-  BValue ptr = (BValue)TO_POINTER(fn);
+  BValue ptr = (BValue)(fn);
   BoxedPureFn14* purefn = (BoxedPureFn14*)ptr;
   if (purefn->slot_len == 0) {
     return purefn->fn(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13);
@@ -2190,7 +2190,7 @@ BValue call_fn15(BValue fn, BValue arg0, BValue arg1, BValue arg2, BValue arg3, 
     BPureFn15 pure = (BPureFn15)PURE_VALUE(fn);
     return pure(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14);
   }
-  BValue ptr = (BValue)TO_POINTER(fn);
+  BValue ptr = (BValue)(fn);
   BoxedPureFn15* purefn = (BoxedPureFn15*)ptr;
   if (purefn->slot_len == 0) {
     return purefn->fn(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14);
@@ -2235,7 +2235,7 @@ BValue call_fn16(BValue fn, BValue arg0, BValue arg1, BValue arg2, BValue arg3, 
     BPureFn16 pure = (BPureFn16)PURE_VALUE(fn);
     return pure(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15);
   }
-  BValue ptr = (BValue)TO_POINTER(fn);
+  BValue ptr = (BValue)(fn);
   BoxedPureFn16* purefn = (BoxedPureFn16*)ptr;
   if (purefn->slot_len == 0) {
     return purefn->fn(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15);
@@ -2280,7 +2280,7 @@ BValue call_fn17(BValue fn, BValue arg0, BValue arg1, BValue arg2, BValue arg3, 
     BPureFn17 pure = (BPureFn17)PURE_VALUE(fn);
     return pure(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16);
   }
-  BValue ptr = (BValue)TO_POINTER(fn);
+  BValue ptr = (BValue)(fn);
   BoxedPureFn17* purefn = (BoxedPureFn17*)ptr;
   if (purefn->slot_len == 0) {
     return purefn->fn(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16);
@@ -2325,7 +2325,7 @@ BValue call_fn18(BValue fn, BValue arg0, BValue arg1, BValue arg2, BValue arg3, 
     BPureFn18 pure = (BPureFn18)PURE_VALUE(fn);
     return pure(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16, arg17);
   }
-  BValue ptr = (BValue)TO_POINTER(fn);
+  BValue ptr = (BValue)(fn);
   BoxedPureFn18* purefn = (BoxedPureFn18*)ptr;
   if (purefn->slot_len == 0) {
     return purefn->fn(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16, arg17);
@@ -2370,7 +2370,7 @@ BValue call_fn19(BValue fn, BValue arg0, BValue arg1, BValue arg2, BValue arg3, 
     BPureFn19 pure = (BPureFn19)PURE_VALUE(fn);
     return pure(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16, arg17, arg18);
   }
-  BValue ptr = (BValue)TO_POINTER(fn);
+  BValue ptr = (BValue)(fn);
   BoxedPureFn19* purefn = (BoxedPureFn19*)ptr;
   if (purefn->slot_len == 0) {
     return purefn->fn(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16, arg17, arg18);
@@ -2415,7 +2415,7 @@ BValue call_fn20(BValue fn, BValue arg0, BValue arg1, BValue arg2, BValue arg3, 
     BPureFn20 pure = (BPureFn20)PURE_VALUE(fn);
     return pure(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16, arg17, arg18, arg19);
   }
-  BValue ptr = (BValue)TO_POINTER(fn);
+  BValue ptr = (BValue)(fn);
   BoxedPureFn20* purefn = (BoxedPureFn20*)ptr;
   if (purefn->slot_len == 0) {
     return purefn->fn(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16, arg17, arg18, arg19);
@@ -2460,7 +2460,7 @@ BValue call_fn21(BValue fn, BValue arg0, BValue arg1, BValue arg2, BValue arg3, 
     BPureFn21 pure = (BPureFn21)PURE_VALUE(fn);
     return pure(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16, arg17, arg18, arg19, arg20);
   }
-  BValue ptr = (BValue)TO_POINTER(fn);
+  BValue ptr = (BValue)(fn);
   BoxedPureFn21* purefn = (BoxedPureFn21*)ptr;
   if (purefn->slot_len == 0) {
     return purefn->fn(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16, arg17, arg18, arg19, arg20);
@@ -2505,7 +2505,7 @@ BValue call_fn22(BValue fn, BValue arg0, BValue arg1, BValue arg2, BValue arg3, 
     BPureFn22 pure = (BPureFn22)PURE_VALUE(fn);
     return pure(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16, arg17, arg18, arg19, arg20, arg21);
   }
-  BValue ptr = (BValue)TO_POINTER(fn);
+  BValue ptr = (BValue)(fn);
   BoxedPureFn22* purefn = (BoxedPureFn22*)ptr;
   if (purefn->slot_len == 0) {
     return purefn->fn(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16, arg17, arg18, arg19, arg20, arg21);
@@ -2550,7 +2550,7 @@ BValue call_fn23(BValue fn, BValue arg0, BValue arg1, BValue arg2, BValue arg3, 
     BPureFn23 pure = (BPureFn23)PURE_VALUE(fn);
     return pure(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16, arg17, arg18, arg19, arg20, arg21, arg22);
   }
-  BValue ptr = (BValue)TO_POINTER(fn);
+  BValue ptr = (BValue)(fn);
   BoxedPureFn23* purefn = (BoxedPureFn23*)ptr;
   if (purefn->slot_len == 0) {
     return purefn->fn(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16, arg17, arg18, arg19, arg20, arg21, arg22);
@@ -2595,7 +2595,7 @@ BValue call_fn24(BValue fn, BValue arg0, BValue arg1, BValue arg2, BValue arg3, 
     BPureFn24 pure = (BPureFn24)PURE_VALUE(fn);
     return pure(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16, arg17, arg18, arg19, arg20, arg21, arg22, arg23);
   }
-  BValue ptr = (BValue)TO_POINTER(fn);
+  BValue ptr = (BValue)(fn);
   BoxedPureFn24* purefn = (BoxedPureFn24*)ptr;
   if (purefn->slot_len == 0) {
     return purefn->fn(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16, arg17, arg18, arg19, arg20, arg21, arg22, arg23);
@@ -2640,7 +2640,7 @@ BValue call_fn25(BValue fn, BValue arg0, BValue arg1, BValue arg2, BValue arg3, 
     BPureFn25 pure = (BPureFn25)PURE_VALUE(fn);
     return pure(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16, arg17, arg18, arg19, arg20, arg21, arg22, arg23, arg24);
   }
-  BValue ptr = (BValue)TO_POINTER(fn);
+  BValue ptr = (BValue)(fn);
   BoxedPureFn25* purefn = (BoxedPureFn25*)ptr;
   if (purefn->slot_len == 0) {
     return purefn->fn(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16, arg17, arg18, arg19, arg20, arg21, arg22, arg23, arg24);
@@ -2685,7 +2685,7 @@ BValue call_fn26(BValue fn, BValue arg0, BValue arg1, BValue arg2, BValue arg3, 
     BPureFn26 pure = (BPureFn26)PURE_VALUE(fn);
     return pure(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16, arg17, arg18, arg19, arg20, arg21, arg22, arg23, arg24, arg25);
   }
-  BValue ptr = (BValue)TO_POINTER(fn);
+  BValue ptr = (BValue)(fn);
   BoxedPureFn26* purefn = (BoxedPureFn26*)ptr;
   if (purefn->slot_len == 0) {
     return purefn->fn(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16, arg17, arg18, arg19, arg20, arg21, arg22, arg23, arg24, arg25);
@@ -2730,7 +2730,7 @@ BValue call_fn27(BValue fn, BValue arg0, BValue arg1, BValue arg2, BValue arg3, 
     BPureFn27 pure = (BPureFn27)PURE_VALUE(fn);
     return pure(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16, arg17, arg18, arg19, arg20, arg21, arg22, arg23, arg24, arg25, arg26);
   }
-  BValue ptr = (BValue)TO_POINTER(fn);
+  BValue ptr = (BValue)(fn);
   BoxedPureFn27* purefn = (BoxedPureFn27*)ptr;
   if (purefn->slot_len == 0) {
     return purefn->fn(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16, arg17, arg18, arg19, arg20, arg21, arg22, arg23, arg24, arg25, arg26);
@@ -2775,7 +2775,7 @@ BValue call_fn28(BValue fn, BValue arg0, BValue arg1, BValue arg2, BValue arg3, 
     BPureFn28 pure = (BPureFn28)PURE_VALUE(fn);
     return pure(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16, arg17, arg18, arg19, arg20, arg21, arg22, arg23, arg24, arg25, arg26, arg27);
   }
-  BValue ptr = (BValue)TO_POINTER(fn);
+  BValue ptr = (BValue)(fn);
   BoxedPureFn28* purefn = (BoxedPureFn28*)ptr;
   if (purefn->slot_len == 0) {
     return purefn->fn(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16, arg17, arg18, arg19, arg20, arg21, arg22, arg23, arg24, arg25, arg26, arg27);
@@ -2820,7 +2820,7 @@ BValue call_fn29(BValue fn, BValue arg0, BValue arg1, BValue arg2, BValue arg3, 
     BPureFn29 pure = (BPureFn29)PURE_VALUE(fn);
     return pure(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16, arg17, arg18, arg19, arg20, arg21, arg22, arg23, arg24, arg25, arg26, arg27, arg28);
   }
-  BValue ptr = (BValue)TO_POINTER(fn);
+  BValue ptr = (BValue)(fn);
   BoxedPureFn29* purefn = (BoxedPureFn29*)ptr;
   if (purefn->slot_len == 0) {
     return purefn->fn(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16, arg17, arg18, arg19, arg20, arg21, arg22, arg23, arg24, arg25, arg26, arg27, arg28);
@@ -2865,7 +2865,7 @@ BValue call_fn30(BValue fn, BValue arg0, BValue arg1, BValue arg2, BValue arg3, 
     BPureFn30 pure = (BPureFn30)PURE_VALUE(fn);
     return pure(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16, arg17, arg18, arg19, arg20, arg21, arg22, arg23, arg24, arg25, arg26, arg27, arg28, arg29);
   }
-  BValue ptr = (BValue)TO_POINTER(fn);
+  BValue ptr = (BValue)(fn);
   BoxedPureFn30* purefn = (BoxedPureFn30*)ptr;
   if (purefn->slot_len == 0) {
     return purefn->fn(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16, arg17, arg18, arg19, arg20, arg21, arg22, arg23, arg24, arg25, arg26, arg27, arg28, arg29);
@@ -2910,7 +2910,7 @@ BValue call_fn31(BValue fn, BValue arg0, BValue arg1, BValue arg2, BValue arg3, 
     BPureFn31 pure = (BPureFn31)PURE_VALUE(fn);
     return pure(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16, arg17, arg18, arg19, arg20, arg21, arg22, arg23, arg24, arg25, arg26, arg27, arg28, arg29, arg30);
   }
-  BValue ptr = (BValue)TO_POINTER(fn);
+  BValue ptr = (BValue)(fn);
   BoxedPureFn31* purefn = (BoxedPureFn31*)ptr;
   if (purefn->slot_len == 0) {
     return purefn->fn(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16, arg17, arg18, arg19, arg20, arg21, arg22, arg23, arg24, arg25, arg26, arg27, arg28, arg29, arg30);
@@ -2955,7 +2955,7 @@ BValue call_fn32(BValue fn, BValue arg0, BValue arg1, BValue arg2, BValue arg3, 
     BPureFn32 pure = (BPureFn32)PURE_VALUE(fn);
     return pure(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16, arg17, arg18, arg19, arg20, arg21, arg22, arg23, arg24, arg25, arg26, arg27, arg28, arg29, arg30, arg31);
   }
-  BValue ptr = (BValue)TO_POINTER(fn);
+  BValue ptr = (BValue)(fn);
   BoxedPureFn32* purefn = (BoxedPureFn32*)ptr;
   if (purefn->slot_len == 0) {
     return purefn->fn(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16, arg17, arg18, arg19, arg20, arg21, arg22, arg23, arg24, arg25, arg26, arg27, arg28, arg29, arg30, arg31);

--- a/c_runtime/bosatsu_runtime.c
+++ b/c_runtime/bosatsu_runtime.c
@@ -5,19 +5,18 @@
 #include <string.h>
 #include <stdio.h>
 #include <limits.h>
+#include "gc.h"
 
 /*
 There are a few kinds of values:
 
 1. pure values: small ints, characters, small strings that can fit into 63 bits.
-2. pointers to referenced counted values
-3. pointers to static values stack allocated at startup
+2. pointers to gc'ed values
 
 to distinguish these cases we allocate pointers such that they are aligned to at least 4 byte
 boundaries:
   a. ends with 01: pure value
-  b. ends with 11: static pointer (allocated once and deleteds at the end of the world)
-  c. ends with 00: refcount pointer.
+  b. ends with 00: gc pointer.
 
 when it comes to functions there are two types, PureFn and closures. We have to box
   pointers to them, but when we know we have a global PureFn we can directly call it.
@@ -34,35 +33,28 @@ a length and char* holding the utf-8 bytes. We could also potentially optimize
 short strings by packing them literally into 63 bits with a length.
 
 Integer values are either pure values (signed values packed into 63 bits),
-or ref-counted big integers
-
-We need to know which case we are in because in generic context we need to know
-how to clone values.
+or gced big integers
 */
 #define TAG_MASK 0x3
 #define PURE_VALUE_TAG 0x1
-#define STATIC_VALUE_TAG 0x3
 #define POINTER_TAG 0x0
 
 // Utility macros to check the tag of a value
 #define IS_PURE_VALUE(ptr) (((uintptr_t)(ptr) & TAG_MASK) == PURE_VALUE_TAG)
 #define TO_PURE_VALUE(v) ((BValue)((((uintptr_t)v) << 2) | PURE_VALUE_TAG))
 #define PURE_VALUE(ptr) ((uintptr_t)(ptr) >> 2)
-#define IS_STATIC_VALUE(ptr) (((uintptr_t)(ptr) & TAG_MASK) == STATIC_VALUE_TAG)
 #define IS_POINTER(ptr) (((uintptr_t)(ptr) & TAG_MASK) == POINTER_TAG)
 #define TO_POINTER(ptr) ((uintptr_t)(ptr) & ~TAG_MASK)
 
-#define DEFINE_RC_STRUCT(name, fields) \
+#define DEFINE_BSTS_OBJ(name, fields) \
     struct name { \
-      atomic_int ref_count; \
-      FreeFn free; \
       fields \
     }; \
     typedef struct name name
 
-#define DEFINE_RC_ENUM(name, fields) DEFINE_RC_STRUCT(name, ENUM_TAG tag; fields)
+#define DEFINE_BSTS_ENUM(name, fields) DEFINE_BSTS_OBJ(name, ENUM_TAG tag; fields)
 
-DEFINE_RC_STRUCT(RefCounted,);
+DEFINE_BSTS_OBJ(BSTS_OBJ,);
 
 BValue bsts_unit_value() {
   return (BValue)PURE_VALUE_TAG;
@@ -77,7 +69,7 @@ int bsts_char_code_point_from_value(BValue ch) {
 }
 
 // Closures:
-DEFINE_RC_STRUCT(Closure1Data, BClosure1 fn; size_t slot_len;);
+DEFINE_BSTS_OBJ(Closure1Data, BClosure1 fn; size_t slot_len;);
 
 size_t closure_data_size(size_t slot_len) {
   return sizeof(Closure1Data) + slot_len * sizeof(BValue);
@@ -95,26 +87,15 @@ BValue bsts_closure_from_slots(BValue* slots) {
   return (BValue)pointer_to_closure;
 }
 
-void free_closure(Closure1Data* s) {
-  size_t slots = s->slot_len;
-  BValue* items = closure_data_of(s);
-  while (slots > 0) {
-    release_value(items);
-    items = items + 1;
-    slots = slots - 1;
-  }
-  free(s);
-}
-
 #include "bosatsu_generated.h"
 
 // ENUM0 can always be encoded into a BValue, but we define it to
 // be able to get sizeof() to skip the header
-DEFINE_RC_ENUM(Enum0,);
+DEFINE_BSTS_ENUM(Enum0,);
 
-DEFINE_RC_STRUCT(External, void* external; FreeFn ex_free;);
-DEFINE_RC_STRUCT(BSTS_String, size_t len; char* bytes;);
-DEFINE_RC_STRUCT(BSTS_Integer, size_t len; _Bool sign; uint32_t* words;);
+DEFINE_BSTS_OBJ(External, void* external;);
+DEFINE_BSTS_OBJ(BSTS_String, size_t len; char* bytes;);
+DEFINE_BSTS_OBJ(BSTS_Integer, size_t len; _Bool sign; uint32_t* words;);
 
 typedef struct {
     size_t len;
@@ -161,7 +142,7 @@ void bsts_integer_load_op(BValue v, uint32_t* buffer, BSTS_Int_Operand* operand)
 // A general structure for a reference counted memory block
 // it is always allocated with len BValue array immediately after
 typedef struct _Node {
-  RefCounted* value;
+  BSTS_OBJ* value;
   struct _Node* next;
 } Node;
 
@@ -173,9 +154,9 @@ static _Atomic Stack statics;
 
 // for now, we only push refcounted values on here while they are still valid
 // then we | STATIC_VALUE_TAG to avoid bothering with ref-counting during operation
-static void push(RefCounted* static_value) {
+static void push(BSTS_OBJ* static_value) {
   // TODO what if this malloc fails
-  Node* node = malloc(sizeof(Node));
+  Node* node = GC_malloc(sizeof(Node));
   node->value = static_value;
 
   Stack current;
@@ -194,7 +175,7 @@ void free_on_close(BValue v) {
 }
 
 // Returns NULl when there is nothing to pop
-static RefCounted* pop() {
+static BSTS_OBJ* pop() {
   Stack next;
   Stack current;
   do {
@@ -204,8 +185,8 @@ static RefCounted* pop() {
     }
     next.head = current.head->next; //set the head to the next node
   } while(!atomic_compare_exchange_weak(&statics, &current, next));
-  RefCounted* rc = current.head->value;
-  free(current.head);
+  BSTS_OBJ* rc = current.head->value;
+  GC_free(current.head);
   return rc;
 }
 
@@ -217,7 +198,7 @@ void init_statics() {
 
 BValue get_struct_index(BValue v, int idx) {
   uintptr_t rc = TO_POINTER(v);
-  BValue* ptr = (BValue*)(rc + sizeof(RefCounted) + idx * sizeof(BValue));
+  BValue* ptr = (BValue*)(rc + sizeof(BSTS_OBJ) + idx * sizeof(BValue));
   return *ptr;
 }
 
@@ -242,69 +223,43 @@ BValue alloc_enum0(ENUM_TAG tag) {
 }
 
 // Externals:
-void free_external(External* ex) {
-  ex->ex_free(ex->external);
-  free(ex);
-}
-
-void bsts_init_rc(RefCounted* rc, FreeFn free) {
-    // this is safe to do because before initialization there can't be race on allocated values
-    rc->ref_count = 1;
-    rc->free = free;
+void free_external(void* ex, void* data) {
+  FreeFn ex_free = (FreeFn)data;
+  ex_free(ex);
 }
 
 BValue alloc_external(void* data, FreeFn free) {
-    External* rc = malloc(sizeof(External));
-    bsts_init_rc((RefCounted*)rc, free);
-    rc->external = data;
-    rc->ex_free = free;
-    return (BValue)rc;
+    External* ext = GC_malloc(sizeof(External));
+    ext->external = data;
+    GC_register_finalizer(ext, free_external, free, NULL, NULL);
+    return (BValue)ext;
 }
 
 void* get_external(BValue v) {
   // Externals can be static also, top level external values
-  External* rc = (External*)TO_POINTER(v);
-  return rc->external;
+  External* ext = (External*)TO_POINTER(v);
+  return ext->external;
 }
 
-void free_string(void* str) {
-  BSTS_String* casted = (BSTS_String*)str;
-  free(casted->bytes);
-  free(str);
-}
-
-void free_static_string(void* str) {
-  free(str);
+BValue bsts_string_mut(size_t len) {
+  BSTS_String* str = GC_malloc(sizeof(BSTS_String));
+  str->len = len;
+  str->bytes = GC_malloc_atomic(sizeof(char) * len);
+  return (BValue)str;
 }
 
 // this copies the bytes in, it does not take ownership
 BValue bsts_string_from_utf8_bytes_copy(size_t len, char* bytes) {
-  BSTS_String* str = malloc(sizeof(BSTS_String));
-  // TODO we could allocate just once and make sure this is the tail of BSTS_String
-  char* bytes_copy = malloc(sizeof(char) * len);
-  memcpy(bytes_copy, bytes, len);
-  str->len = len;
-  str->bytes = bytes_copy;
-  bsts_init_rc((RefCounted*)str, free_string);
-
+  BSTS_String* str = (BSTS_String*)bsts_string_mut(len);
+  memcpy(str->bytes, bytes, len);
   return (BValue)str;
 }
 
-BValue bsts_string_from_utf8_bytes_owned(size_t len, char* bytes) {
-  BSTS_String* str = malloc(sizeof(BSTS_String));
-  str->len = len;
-  str->bytes = bytes;
-  bsts_init_rc((RefCounted*)str, free_string);
-
-  return (BValue)str;
-}
 
 BValue bsts_string_from_utf8_bytes_static(size_t len, char* bytes) {
-  BSTS_String* str = malloc(sizeof(BSTS_String));
+  BSTS_String* str = GC_malloc_atomic(sizeof(BSTS_String));
   str->len = len;
   str->bytes = bytes;
-  bsts_init_rc((RefCounted*)str, free_static_string);
-
   return (BValue)str;
 }
 
@@ -507,10 +462,6 @@ BValue bsts_string_char_at(BValue value, int offset) {
     return bsts_char_from_code_point(code_point);
 }
 
-_Bool bsts_rc_value_is_unique(RefCounted* value) {
-  return atomic_load(&(value->ref_count)) == 1;
-}
-
 // (&string, int, int) -> string
 BValue bsts_string_substring(BValue value, int start, int end) {
   BSTS_String* str = GET_STRING(value);
@@ -524,11 +475,7 @@ BValue bsts_string_substring(BValue value, int start, int end) {
     // empty string, should probably be a constant
     return bsts_string_from_utf8_bytes_static(0, "");
   }
-  else if (str->free == free_static_string) {
-    return bsts_string_from_utf8_bytes_static(new_len, str->bytes + start);
-  }
   else {
-    // ref-counted bytes
     // TODO: we could keep track of an offset into the string to optimize
     // this case when refcount == 1, which may matter for tail recursion
     // taking substrings....
@@ -640,29 +587,21 @@ BValue bsts_integer_from_int(int32_t small_int) {
     return TO_PURE_VALUE(small_int);
 }
 
-void free_integer(void* integer) {
-  BSTS_Integer* bint = GET_BIG_INT(integer);
-  free(bint->words);
-  free(integer);
-}
-
 BSTS_Integer* bsts_integer_alloc(size_t size) {
     // chatgpt authored this
-    BSTS_Integer* integer = (BSTS_Integer*)malloc(sizeof(BSTS_Integer));
+    BSTS_Integer* integer = (BSTS_Integer*)GC_malloc(sizeof(BSTS_Integer));
     if (integer == NULL) {
         // Handle allocation failure
         return NULL;
     }
 
     // TODO we could allocate just once and make sure this is the tail of BSTS_Integer
-    integer->words = (uint32_t*)malloc(size * sizeof(uint32_t));
+    integer->words = (uint32_t*)GC_malloc_atomic(size * sizeof(uint32_t));
     if (integer->words == NULL) {
         // Handle allocation failure
-        free(integer);
         return NULL;
     }
     integer->len = size;
-    bsts_init_rc((RefCounted*)integer, free_integer);
     return integer; // Low bit is 0 since it's a pointer
 }
 
@@ -684,7 +623,7 @@ BValue bsts_integer_from_words_copy(_Bool is_pos, size_t size, uint32_t* words) 
 
 BValue bsts_integer_from_words_owned(_Bool is_pos, size_t size, uint32_t* words) {
     // TODO: use bsts_integer_alloc
-    BSTS_Integer* integer = (BSTS_Integer*)malloc(sizeof(BSTS_Integer));
+    BSTS_Integer* integer = (BSTS_Integer*)GC_malloc(sizeof(BSTS_Integer));
     if (integer == NULL) {
         // Handle allocation failure
         return NULL;
@@ -697,7 +636,6 @@ BValue bsts_integer_from_words_owned(_Bool is_pos, size_t size, uint32_t* words)
     }
     integer->len = size;
     integer->words = words;
-    bsts_init_rc((RefCounted*)integer, free_integer);
     return (BValue)integer; // Low bit is 0 since it's a pointer
 }
 
@@ -1015,12 +953,6 @@ BValue bsts_integer_negate(BValue v) {
             // Zero remains zero when negated
             return bsts_integer_from_int(0);
         }
-        if (bsts_rc_value_is_unique((RefCounted*)integer)) {
-          // we can reuse the data
-          _Bool sign = integer->sign;
-          integer->sign = !sign;
-          return v;
-        }
         // Create a new big integer with flipped sign
 
         // recall the sign is (-1)^sign, so to negate, pos = sign
@@ -1029,7 +961,6 @@ BValue bsts_integer_negate(BValue v) {
         if (result == NULL) {
             return NULL;
         }
-        release_value(v);
         return result;
     }
 }
@@ -1147,8 +1078,8 @@ BValue bsts_integer_to_string(BValue v) {
         }
 
         // Now, reverse the digits to get the correct order
-        char* data = (char*)malloc(digit_count);
-        if (data == NULL) {
+        BSTS_String* res = (BSTS_String*)bsts_string_mut(digit_count);
+        if (res == NULL) {
             // Memory allocation error
             free(digits);
             free(words_copy);
@@ -1157,42 +1088,14 @@ BValue bsts_integer_to_string(BValue v) {
 
         // reverse the data
         for (size_t i = 0; i < digit_count; i++) {
-            data[i] = digits[digit_count - i - 1];
+            res->bytes[i] = digits[digit_count - i - 1];
         }
 
         // Free temporary allocations
         free(digits);
         free(words_copy);
 
-        return bsts_string_from_utf8_bytes_owned(digit_count, data);
-    }
-}
-
-// Function to determine the type of the given value pointer and clone if necessary
-BValue clone_value(BValue value) {
-    if (IS_POINTER(value)) {
-        // It's a pointer to a reference counted value
-        RefCounted* original = (RefCounted *)value;
-        // Increase reference count atomically using atomic_fetch_add
-        atomic_fetch_add_explicit(&original->ref_count, 1, memory_order_seq_cst);
-        return value;
-    } else {
-        // must be a pure or static value
-        // else if (IS_PURE_VALUE(value) || IS_STATIC_VALUE(value)) {
-        // Pure values and static values are immutable, return them directly
-        return value;
-    }
-}
-
-// Function to safely decrement the reference count and free memory if needed
-static void release_ref_counted(RefCounted *block) {
-    if (block == NULL) return;
-
-    // Decrement the reference count atomically using atomic_fetch_sub
-    if (atomic_fetch_sub_explicit(&block->ref_count, 1, memory_order_seq_cst) == 1) {
-        // If reference count drops to 0, free the memory
-        // TODO actually free
-        //block->free(block);
+        return res;
     }
 }
 
@@ -1765,11 +1668,6 @@ BValue bsts_integer_diff_prod(BSTS_Int_Operand left, uint64_t prod, BSTS_Int_Ope
 
     BValue v1 = bsts_integer_negate(bsts_integer_times(p, ri));
     BValue result = bsts_integer_add(li, v1);
-
-    release_value(li);
-    release_value(ri);
-    release_value(p);
-    release_value(v1);
     return result;
 }
 
@@ -1784,7 +1682,6 @@ BSTS_Int_Div_Mod bsts_integer_search_div_mod(BSTS_Int_Operand left, BSTS_Int_Ope
       //println(s"with l = $l, r = $r search($low, $high) gives mid = $mid, c = $c")
       if (bsts_integer_lt_zero(mod)) {
         // mid is too big
-        release_value(mod);
         high = mid;
       }
       else {
@@ -1794,7 +1691,6 @@ BSTS_Int_Div_Mod bsts_integer_search_div_mod(BSTS_Int_Operand left, BSTS_Int_Ope
         int cmp_mod_r = compare_abs(mod_op.len, mod_op.words, right.len, right.words);
         if (cmp_mod_r >= 0) {
           // mid is too small
-          release_value(mod);
           low = mid;
         }
         else {
@@ -1875,7 +1771,6 @@ BSTS_Int_Div_Mod bsts_integer_divmod_pos(BSTS_Int_Operand l_op, BSTS_Int_Operand
     BValue m1 = div_mod_1.mod;
     // this must be a big integer if it isn't zero
     BValue m1_shift = bsts_integer_shift_left(m1, bsts_integer_from_int(32));
-    release_value(m1);
     // next_left = (m1 << 32) | l0
     uint32_t next_left_temp[2];
     BSTS_Int_Operand next_left_operand;
@@ -1884,19 +1779,14 @@ BSTS_Int_Div_Mod bsts_integer_divmod_pos(BSTS_Int_Operand l_op, BSTS_Int_Operand
     next_left_operand.words[0] = l_op.words[0];
 
     BSTS_Int_Div_Mod div_mod_next = bsts_integer_divmod_pos(next_left_operand, r_op);
-    release_value(m1_shift);
     // we are done
     // m1 * b + l0 == md1 * r + mm1
     // l = d1 * r * b + md1 * r + mm1 = (d1 * b + md1) * r + mm1
     // TODO this is next_div += (d1 << 32), and we own d1 and next_div
     // to we could reuse the memory if we are careful
     BValue div_shift = bsts_integer_shift_left(d1, bsts_integer_from_int(32));
-    release_value(d1);
     BValue div = bsts_integer_add(div_shift, div_mod_next.div);
     // we are done with div_shift and div_mod_next.div now
-    release_value(div_shift);
-    release_value(div_mod_next.div);
-    // 
     div_mod_next.div = div;
     // but we don't need to do this
     // div_mod_next.mod = div_mod_next.mod;
@@ -1932,16 +1822,14 @@ BValue bsts_integer_div_mod(BValue l, BValue r) {
       int32_t rs = GET_SMALL_INT(r);
       if (rs == 0) {
         // we define division by zero as (0, l)
-        return alloc_struct2(bsts_integer_from_int(0), clone_value(l));
+        return alloc_struct2(bsts_integer_from_int(0), l);
       }
       if (rs == 1) {
-        return alloc_struct2(
-          clone_value(l),
-          bsts_integer_from_int(0));
+        return alloc_struct2(l, bsts_integer_from_int(0));
       }
       if (rs == -1) {
         return alloc_struct2(
-          bsts_integer_negate(clone_value(l)),
+          bsts_integer_negate(l),
           bsts_integer_from_int(0));
       }
       if (IS_SMALL(l)) {
@@ -1994,10 +1882,8 @@ BValue bsts_integer_div_mod(BValue l, BValue r) {
           // l = (-d)(-r) + m - r + r
           // l = -(d + 1) (-r) + (m + (-r))
           BValue div1 = bsts_integer_negate(bsts_integer_add(div, bsts_integer_from_int(1))); 
-          release_value(div);
           div = div1;
           BValue mod1 = bsts_integer_add(mod, r);
-          release_value(mod);
           mod = mod1;
         }
       }
@@ -2005,11 +1891,9 @@ BValue bsts_integer_div_mod(BValue l, BValue r) {
         if (!right_neg) {
           // -l = (-d - 1) r + (r - m)
           BValue div1 = bsts_integer_negate(bsts_integer_add(div, bsts_integer_from_int(1))); 
-          release_value(div);
           div = div1;
           BValue neg_mod = bsts_integer_negate(mod);
           BValue mod1 = bsts_integer_add(r, neg_mod);
-          release_value(neg_mod);
           mod = mod1;
         }
         else {
@@ -2029,42 +1913,26 @@ BValue bsts_integer_div_mod(BValue l, BValue r) {
 }
 
 void free_statics() {
-  RefCounted* rc;
+  BSTS_OBJ* rc;
   do {
     rc = pop();
     if (rc == NULL) return;
-    release_ref_counted(rc);
+    GC_free(rc);
   } while(1);
-}
-
-void release_value(BValue value) {
-    if (IS_POINTER(value)) {
-        // It's a pointer to a reference counted value
-        return release_ref_counted((RefCounted *)value);
-    }
-}
-
-BValue make_static(BValue v) {
-  if (IS_POINTER(v)) {
-    return (BValue)(((uintptr_t)v) | STATIC_VALUE_TAG);
-  }
-  return v;
 }
 
 BValue read_or_build(_Atomic BValue* target, BConstruct cons) {
     BValue result = atomic_load(target);
     if (result == NULL) {
         result = cons();
-        BValue static_version = make_static(result);
         BValue expected = NULL;
         do {
-            if (atomic_compare_exchange_weak(target, &expected, static_version)) {
+            if (atomic_compare_exchange_weak(target, &expected, result)) {
                 free_on_close(result);
                 break;
             } else {
                 expected = atomic_load(target);
                 if (expected != NULL) {
-                    release_value(result);
                     result = expected;
                     break;
                 }

--- a/c_runtime/bosatsu_runtime.c
+++ b/c_runtime/bosatsu_runtime.c
@@ -44,7 +44,6 @@ or gced big integers
 #define TO_PURE_VALUE(v) ((BValue)((((uintptr_t)v) << 2) | PURE_VALUE_TAG))
 #define PURE_VALUE(ptr) ((uintptr_t)(ptr) >> 2)
 #define IS_POINTER(ptr) (((uintptr_t)(ptr) & TAG_MASK) == POINTER_TAG)
-#define TO_POINTER(ptr) ((uintptr_t)(ptr) & ~TAG_MASK)
 
 #define DEFINE_BSTS_OBJ(name, fields) \
     struct name { \
@@ -106,7 +105,7 @@ typedef struct {
 // Helper macros and functions
 #define IS_SMALL(v) IS_PURE_VALUE(v)
 #define GET_SMALL_INT(v) (int32_t)(PURE_VALUE(v))
-#define GET_BIG_INT(v) ((BSTS_Integer*)(TO_POINTER(v)))
+#define GET_BIG_INT(v) ((BSTS_Integer*)(v))
 
 void bsts_load_op_from_small(int32_t value, uint32_t* words, BSTS_Int_Operand* op) {
     op->sign = value < 0;
@@ -197,7 +196,7 @@ void init_statics() {
 }
 
 BValue get_struct_index(BValue v, int idx) {
-  uintptr_t rc = TO_POINTER(v);
+  uintptr_t rc = (uintptr_t)(v);
   BValue* ptr = (BValue*)(rc + sizeof(BSTS_OBJ) + idx * sizeof(BValue));
   return *ptr;
 }
@@ -207,13 +206,17 @@ ENUM_TAG get_variant(BValue v) {
     return (ENUM_TAG)PURE_VALUE(v);
   }
   else {
-    Enum0* real_v = (Enum0*)TO_POINTER(v);
+    Enum0* real_v = (Enum0*)(v);
     return real_v->tag;
   }
 }
 
+ENUM_TAG get_variant_value(BValue v) {
+  return (ENUM_TAG)PURE_VALUE(v);
+}
+
 BValue get_enum_index(BValue v, int idx) {
-  uintptr_t rc = TO_POINTER(v);
+  uintptr_t rc = (uintptr_t)(v);
   BValue* ptr = (BValue*)(rc + sizeof(Enum0) + idx * sizeof(BValue));
   return *ptr;
 }
@@ -237,7 +240,7 @@ BValue alloc_external(void* data, FreeFn free) {
 
 void* get_external(BValue v) {
   // Externals can be static also, top level external values
-  External* ext = (External*)TO_POINTER(v);
+  External* ext = (External*)(v);
   return ext->external;
 }
 
@@ -299,7 +302,7 @@ int bsts_string_code_point_to_utf8(int code_point, char* output) {
     return -1;
 }
 
-#define GET_STRING(v) (BSTS_String*)(TO_POINTER(v))
+#define GET_STRING(v) (BSTS_String*)(v)
 
 _Bool bsts_string_equals(BValue left, BValue right) {
   if (left == right) {

--- a/c_runtime/bosatsu_runtime.h
+++ b/c_runtime/bosatsu_runtime.h
@@ -29,6 +29,8 @@ BValue get_struct_index(BValue v, int idx);
 
 // &BValue -> Tag
 ENUM_TAG get_variant(BValue v);
+// This is only safe if all enums have zero args
+ENUM_TAG get_variant_value(BValue v);
 // (&BValue, int) -> &BValue
 BValue get_enum_index(BValue v, int idx);
 

--- a/c_runtime/bosatsu_runtime.h
+++ b/c_runtime/bosatsu_runtime.h
@@ -21,11 +21,8 @@ typedef void (*FreeFn)(void*);
 // A function which constructs a BValue
 typedef BValue (*BConstruct)();
 
-// Function to determine the type of the given value pointer and clone if necessary
-// &BValue -> BValue
-BValue clone_value(BValue value);
-// BValue -> ()
-void release_value(BValue value);
+// delta may be negative or positive
+void bsts_increment_value(BValue value, int delta);
 
 // (&BValue, int) -> &BValue
 BValue get_struct_index(BValue v, int idx);
@@ -39,7 +36,8 @@ BValue get_enum_index(BValue v, int idx);
 BValue alloc_enum0(ENUM_TAG tag);
 
 BValue bsts_string_from_utf8_bytes_copy(size_t len, char* bytes);
-BValue bsts_string_from_utf8_bytes_owned(size_t len, char* bytes);
+// This is dangerous, it should not be mutated after returned 
+BValue bsts_string_mut(size_t len);
 BValue bsts_string_from_utf8_bytes_static(size_t len, char* bytes);
 /*
  * write the codepoint into bytes, which must be >= 4 in length
@@ -124,7 +122,6 @@ void free_statics();
 
 // This should only be called immediately on allocated values
 // on top level allocations that are made
-BValue make_static(BValue v);
 void free_on_close(BValue v);
 
 BValue read_or_build(_Atomic BValue* v, BConstruct cons);
@@ -139,29 +136,5 @@ typedef struct BSTS_Test_Result {
 // and print to stdout
 BSTS_Test_Result bsts_test_run(char* package_name, BConstruct test_value);
 int bsts_test_result_print_summary(int count, BSTS_Test_Result* results);
-
-#define CONSTRUCT(target, cons) (\
-{\
-    BValue result = atomic_load(target);\
-    if (result == NULL) {\
-        result = (cons)();\
-        BValue static_version = make_static(result);\
-        BValue expected = NULL;\
-        do {\
-            if (atomic_compare_exchange_weak(target, &expected, static_version)) {\
-                free_on_close(result);\
-                break;\
-            } else {\
-                expected = atomic_load(target);\
-                if (expected != NULL) {\
-                    release_value(result);\
-                    result = expected;\
-                    break;\
-                }\
-            }\
-        } while (1);\
-    }\
-    result;\
-})
 
 #endif

--- a/c_runtime/test.c
+++ b/c_runtime/test.c
@@ -1,6 +1,7 @@
 #include "bosatsu_runtime.h"
 #include <stdlib.h>
 #include <stdio.h>
+#include "gc.h"
 
 void assert(_Bool cond, char* message) {
   if (!cond) {
@@ -13,7 +14,6 @@ void test_runtime_enum_struct() {
   BValue s1 = alloc_struct2(alloc_enum0(0), alloc_enum0(1));
   assert(get_variant(get_struct_index(s1, 0)) == 0, "index0 == alloc_enum0");
   assert(get_variant(get_struct_index(s1, 1)) == 1, "index0 == alloc_enum0(1)");
-  release_value(s1);
 }
 
 void test_integer() {
@@ -25,8 +25,6 @@ void test_integer() {
       bsts_string_println(s1);
       exit(1);
     }
-    release_value(s1);
-    release_value(expects1);
   }
 
   {
@@ -37,8 +35,6 @@ void test_integer() {
       bsts_string_println(s1);
       exit(1);
     }
-    release_value(s1);
-    release_value(expects1);
   }
 
   {
@@ -50,8 +46,6 @@ void test_integer() {
       bsts_string_println(s1);
       exit(1);
     }
-    release_value(s1);
-    release_value(expects1);
   }
 
   {
@@ -88,11 +82,6 @@ void test_runtime_strings() {
   assert(bsts_string_equals(v1tail, v2tail), "v1tail == v2tail");
   assert(bsts_string_equals(v1tail, tail_expected), "v1tail == expected");
 
-  release_value(v1tail);
-  release_value(v2tail);
-  release_value(tail_expected);
-  release_value(v3);
-
   {
     BValue hello_world1 = bsts_string_from_utf8_bytes_static(11, "hello world");
     BValue hello1 = bsts_string_from_utf8_bytes_static(5, "world");
@@ -102,14 +91,13 @@ void test_runtime_strings() {
     assert(find2 == 6, "find2");
     int find3 = bsts_string_find(hello_world1, hello1, 7);
     assert(find3 == -1, "find3");
-    release_value(hello_world1);
-    release_value(hello1);
   }
 
 }
 
 int main(int argc, char** argv) {
 
+  GC_init();
   test_runtime_enum_struct();
   test_runtime_strings();
   test_integer();

--- a/c_runtime/typegen.py
+++ b/c_runtime/typegen.py
@@ -60,9 +60,7 @@ BValue alloc_closure{size}(size_t size, BValue* data, BClosure{size} fn) {{
     rc->fn = fn;
     rc->slot_len = size;
     BValue* closure_data = closure_data_of({cast_to_1}rc);
-    for (size_t i = 0; i < size; i++) {{
-      closure_data[i] = data[i];
-    }}
+    memcpy(closure_data, data, sizeof(BValue*) * size);
     return (BValue)rc;
 }}
 

--- a/c_runtime/typegen.py
+++ b/c_runtime/typegen.py
@@ -83,7 +83,7 @@ BValue call_fn{size}(BValue fn, {arg_params}) {{
     BPureFn{size} pure = (BPureFn{size})PURE_VALUE(fn);
     return pure({just_args});
   }}
-  BValue ptr = (BValue)TO_POINTER(fn);
+  BValue ptr = (BValue)(fn);
   BoxedPureFn{size}* purefn = (BoxedPureFn{size}*)ptr;
   if (purefn->slot_len == 0) {{
     return purefn->fn({just_args});

--- a/cli/src/test/scala/org/bykn/bosatsu/codegen/clang/ClangGenTest.scala
+++ b/cli/src/test/scala/org/bykn/bosatsu/codegen/clang/ClangGenTest.scala
@@ -45,7 +45,7 @@ class ClangGenTest extends munit.FunSuite {
       To inspect the code, change the hash, and it will print the code out
      */
     testFilesCompilesToHash("test_workspace/Ackermann.bosatsu")(
-      "f881ad7b7bda633aae1ad1c061f1d3bd"
+      "66654b8c57c8fcb5d63c48830ffebdab"
     )
   }
 }

--- a/core/src/main/scala/org/bykn/bosatsu/codegen/clang/ClangGen.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/codegen/clang/ClangGen.scala
@@ -358,10 +358,10 @@ object ClangGen {
             (boolToValue(e1), boolToValue(e2))
               .flatMapN { (a, b) => andCode(a, b) }
 
-          case CheckVariant(expr, expect, _, _) =>
+          case CheckVariant(expr, expect, _, famArities) =>
             innerToValue(expr).flatMap { vl =>
-            // this is just get_variant(expr) == expect
-              vl.onExpr { expr => pv(Code.Ident("get_variant")(expr) =:= Code.IntLiteral(expect)) }(newLocalName)
+              val fn = if (famArities.forall(_ == 0)) "get_variant_value" else  "get_variant"
+              vl.onExpr { expr => pv(Code.Ident(fn)(expr) =:= Code.IntLiteral(expect)) }(newLocalName)
             }
           case MatchString(arg, parts, binds, mustMatch) =>
             (

--- a/core/src/test/scala/org/bykn/bosatsu/codegen/clang/ClangGenTest.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/codegen/clang/ClangGenTest.scala
@@ -100,7 +100,7 @@ BValue __bsts_t_closure0(BValue* __bstsi_slot,
     __bsts_a_5 = __bsts_b_item1;
     __bsts_a_0 = alloc_enum0(1);
     _Bool __bsts_l_cond1;
-    __bsts_l_cond1 = get_variant(__bsts_a_0) == 1;
+    __bsts_l_cond1 = get_variant_value(__bsts_a_0) == 1;
     while (__bsts_l_cond1) {
         if (get_variant(__bsts_a_3) == 0) {
             __bsts_a_0 = alloc_enum0(0);
@@ -116,7 +116,7 @@ BValue __bsts_t_closure0(BValue* __bstsi_slot,
             __bsts_a_3 = __bsts_a_2;
             __bsts_a_5 = __bsts_a_4;
         }
-        __bsts_l_cond1 = get_variant(__bsts_a_0) == 1;
+        __bsts_l_cond1 = get_variant_value(__bsts_a_0) == 1;
     }
     return __bsts_a_1;
 }


### PR DESCRIPTION
in #1298 I was trying to leverage the fact that all objects are immutable and form a DAG to justify reference counting.

Doing this correctly is a significant challenge, but also it makes the code much more complex. My reading of the GC literature is that it is actually very hard to make reference counting perform as well as GC and its conceptual simplicity is appealing, but a mirage. I've seen reports the tail GC time of ref counting (which still exists when large dags fall out of scope) is also very large, but since most objects don't get many references and are almost immediately collected, you are doing a lot of extra work (maybe 30-50%) not to mention making the code harder for the c compiler to optimize.

I can always come back to this if I want to continue, but it seems wise to just use boehm like virtually every other project I can find that needs some form of garbage collection.