### PR TITLE
Don't inline Apply across lambdas

### DIFF
--- a/cli/src/test/scala/org/bykn/bosatsu/codegen/clang/ClangGenTest.scala
+++ b/cli/src/test/scala/org/bykn/bosatsu/codegen/clang/ClangGenTest.scala
@@ -45,7 +45,7 @@ class ClangGenTest extends munit.FunSuite {
       To inspect the code, change the hash, and it will print the code out
      */
     testFilesCompilesToHash("test_workspace/Ackermann.bosatsu")(
-      "66654b8c57c8fcb5d63c48830ffebdab"
+      "b31036461ebf3f7474f73e6661e0812f"
     )
   }
 }

--- a/core/src/main/scala/org/bykn/bosatsu/TypedExpr.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/TypedExpr.scala
@@ -1144,7 +1144,8 @@ object TypedExpr {
   def substitute[A](
       ident: Bindable,
       ex: TypedExpr[A],
-      in: TypedExpr[A]
+      in: TypedExpr[A],
+      enterLambda: Boolean = true
   ): Option[TypedExpr[A]] = {
     // if we hit a shadow, we don't need to substitute down
     // that branch
@@ -1164,7 +1165,8 @@ object TypedExpr {
         case Annotation(t, tpe) =>
           loop(t).map(Annotation(_, tpe))
         case AnnotatedLambda(args, res, tag) =>
-          if (args.exists { case (n, _) => masks(n) }) None
+          if (!enterLambda) None
+          else if (args.exists { case (n, _) => masks(n) }) None
           else if (args.exists { case (n, _) => shadows(n) }) Some(in)
           else loop(res).map(AnnotatedLambda(args, _, tag))
         case App(fn, args, tpe, tag) =>

--- a/core/src/main/scala/org/bykn/bosatsu/TypedExprNormalization.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/TypedExprNormalization.scala
@@ -405,11 +405,14 @@ object TypedExprNormalization {
                 val cnt = in1.freeVarsDup.count(_ === arg)
                 if (cnt > 0) {
                   // the arg is needed
+                  val isSimp = Impl.isSimple(ex1, lambdaSimple = true)
                   val shouldInline = (!rec.isRecursive) && {
-                    (cnt == 1) || Impl.isSimple(ex1, lambdaSimple = true)
+                    (cnt == 1) || isSimp
                   }
+                  // we don't want to inline a value that is itself a function call
+                  // inside of lambdas
                   val inlined =
-                    if (shouldInline) substitute(arg, ex1, in1) else None
+                    if (shouldInline) substitute(arg, ex1, in1, enterLambda = isSimp) else None
                   inlined match {
                     case Some(il) =>
                       normalize1(namerec, il, scope, typeEnv)


### PR DESCRIPTION
if we have:
```python

x = f(y)

z -> (x, z)

```
it looks like you could inline `x = f(y)` but the problem is we have no idea how many times the lambda will be called. By moving that in we could massively blow up function run time since a constant may not be un-cached. This also changes what closures close over. Without a good reason to do this, it shouldn't be the default.

I noticed some code being generated that surprised me due to this behavior.