### PR TITLE
Fix tree shaking graph edge code

### DIFF
--- a/core/src/main/scala/org/bykn/bosatsu/PackageMap.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/PackageMap.scala
@@ -126,7 +126,10 @@ object PackageMap {
     def dependency(a: Ident): Iterable[Ident] =
       p.toMap.get(a._1) match {
         case Some(pack) =>
-          pack.lets.flatMap { case (_, _, te) => te.globals }
+          pack.lets.flatMap {
+            case (n, _, te) if a._2 === n => te.globals
+            case _ => Nil
+          }
         case None => Nil
       }
 


### PR DESCRIPTION
The original code was keeping any *package* we depend on, but at final code generation stage we only need to keep the values.

