### PR TITLE
Make a simple fib computing program for naive benchmarks

### DIFF
--- a/test_workspace/FibBench.bosatsu
+++ b/test_workspace/FibBench.bosatsu
@@ -1,0 +1,36 @@
+package Bosatsu/FibBench
+
+from Bosatsu/Prog import Prog, Main, println, read_env, await, ignore_env, pure
+from Bosatsu/Nat import Nat, to_Nat, Zero as NZero, Succ as NSucc
+
+def fib_Nat(n: Nat) -> Int:
+  recur n:
+    case NZero | NSucc(NZero): 1
+    case NSucc(NSucc(p1) as prev):
+      fp = fib_Nat(prev)
+      fp1 = fib_Nat(p1)
+      add(fp, fp1)
+
+def fib(i: Int) -> Int: fib_Nat(to_Nat(i))
+
+def print_fib(str: String):
+  match string_to_Int(str):
+    case Some(i): println("fib(${str}) = ${int_to_String(fib(i))}")
+    case None: println("could not parse ${str}")
+
+def list_len(lst, acc):
+  recur lst:
+    case []: acc
+    case [_, *tail]: list_len(tail, add(acc, 1))
+
+def main(args: List[String]):
+  match args:
+    case [_, n]: print_fib(n)
+    case _: println("expected exactly one arg, got: ${int_to_String(list_len(args, 0))}")
+
+main = Main((
+  args <- read_env.await()
+  _ <- main(args).ignore_env().await()
+  pure(0)
+))
+  

--- a/test_workspace/Prog.bosatsu
+++ b/test_workspace/Prog.bosatsu
@@ -1,8 +1,8 @@
 package Bosatsu/Prog
 
-export (unit, pure, raise_error, read_env, recover, remap_env,
+export (unit, pure, raise_error, read_env, ignore_env, recover, remap_env,
   println, await, recursive, map, map_err,
-  with_env, Prog, Main)
+  with_env, Prog, Main())
 
 external struct Prog[env: -*, err: +*, res: +*]
 


### PR DESCRIPTION
comparing python on 37:
```
took seconds 4.24458909034729
>>> fib(37)
39088169
```

bosatsu C:
```
oscar@patricks-air bosatsu % time c_out/test_exe 37
fib(37) = 39088169
c_out/test_exe 37  0.13s user 0.00s system 98% cpu 0.132 total
```

or 32x faster. Both of these implementations are using naive fib big integers, so this is really a silly benchmark of function call and big int addition.

We can go bigger and overflow int32 (which we use when numbers are small)
```
oscar@patricks-air bosatsu % time c_out/test_exe 47
fib(47) = 4807526976
c_out/test_exe 47  12.56s user 0.03s system 99% cpu 12.615 total
```