### PR TITLE
Improve TypedExpr.substitute issue 1126

### DIFF
--- a/cli/src/test/scala/org/bykn/bosatsu/codegen/clang/ClangGenTest.scala
+++ b/cli/src/test/scala/org/bykn/bosatsu/codegen/clang/ClangGenTest.scala
@@ -45,7 +45,7 @@ class ClangGenTest extends munit.FunSuite {
       To inspect the code, change the hash, and it will print the code out
      */
     testFilesCompilesToHash("test_workspace/Ackermann.bosatsu")(
-      "01b16c11c1597e46371d356111276af5"
+      "ccbf676b90cf04397c908d23f86b6434"
     )
   }
 }

--- a/cli/src/test/scala/org/bykn/bosatsu/codegen/clang/ClangGenTest.scala
+++ b/cli/src/test/scala/org/bykn/bosatsu/codegen/clang/ClangGenTest.scala
@@ -45,7 +45,7 @@ class ClangGenTest extends munit.FunSuite {
       To inspect the code, change the hash, and it will print the code out
      */
     testFilesCompilesToHash("test_workspace/Ackermann.bosatsu")(
-      "260c81bc79b6232a3f174cb9afc04143"
+      "01b16c11c1597e46371d356111276af5"
     )
   }
 }

--- a/core/src/main/scala/org/bykn/bosatsu/TypedExpr.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/TypedExpr.scala
@@ -220,6 +220,7 @@ object TypedExpr {
       tag: T
   ) extends TypedExpr[T] {
 
+    // This makes sure the args don't shadow any of the items in freeSet
     def unshadow(freeSet: Set[Bindable]): AnnotatedLambda[T] = {
       val clashIdent =
         if (freeSet.isEmpty) Set.empty[Bindable]

--- a/core/src/main/scala/org/bykn/bosatsu/TypedExpr.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/TypedExpr.scala
@@ -62,52 +62,54 @@ sealed abstract class TypedExpr[+T] { self: Product =>
   def repr: Doc = {
     def rept(t: Type): Doc = Type.fullyResolvedDocument.document(t)
 
+    def block(d: Doc): Doc = d.nested(4).grouped
+
     def loop(te: TypedExpr[T]): Doc =
       te match {
         case g @ Generic(_, expr) =>
-          (Doc.text("(generic") + Doc.lineOrSpace + rept(
+          block(Doc.text("(generic") + Doc.line + rept(
             g.quantType
-          ) + Doc.lineOrSpace + loop(expr) + Doc.char(')')).nested(4)
+          ) + Doc.line + loop(expr) + Doc.char(')'))
         case Annotation(expr, tpe) =>
-          (Doc.text("(ann") + Doc.lineOrSpace + rept(
+          block(Doc.text("(ann") + Doc.line + rept(
             tpe
-          ) + Doc.lineOrSpace + loop(expr) + Doc.char(')')).nested(4)
+          ) + Doc.line + loop(expr) + Doc.char(')'))
         case AnnotatedLambda(args, res, _) =>
-          (Doc.text("(lambda") + Doc.lineOrSpace + (
-            Doc.char('[') + Doc.intercalate(
-              Doc.lineOrSpace,
+          block(Doc.text("(lambda") + Doc.line + (
+            Doc.char('[') + block(Doc.intercalate(
+              Doc.line,
               args.toList.map { case (arg, tpe) =>
-                Doc.text(arg.sourceCodeRepr) + Doc.lineOrSpace + rept(tpe)
+                Doc.text(arg.sourceCodeRepr) + Doc.line + rept(tpe)
               }
-            ) + Doc.char(']')
-          ) + Doc.lineOrSpace + loop(res) + Doc.char(')')).nested(4)
+            )) + Doc.char(']')
+          ) + Doc.line + loop(res) + Doc.char(')'))
         case Local(v, tpe, _) =>
-          (Doc.text("(var") + Doc.lineOrSpace + Doc.text(
+          block(Doc.text("(var") + Doc.line + Doc.text(
             v.sourceCodeRepr
-          ) + Doc.lineOrSpace + rept(tpe) + Doc.char(')')).nested(4)
+          ) + Doc.line + rept(tpe) + Doc.char(')'))
         case Global(p, v, tpe, _) =>
           val pstr = Doc.text(p.asString + "::" + v.sourceCodeRepr)
-          (Doc.text("(var") + Doc.lineOrSpace + pstr + Doc.lineOrSpace + rept(
+          block(Doc.text("(var") + Doc.line + pstr + Doc.line + rept(
             tpe
-          ) + Doc.char(')')).nested(4)
+          ) + Doc.char(')'))
         case App(fn, args, tpe, _) =>
-          val argsDoc = Doc.intercalate(Doc.lineOrSpace, args.toList.map(loop))
-          (Doc.text("(ap") + Doc.lineOrSpace + loop(
+          val argsDoc = block(Doc.intercalate(Doc.line, args.toList.map(loop)))
+          block(Doc.text("(ap") + Doc.line + loop(
             fn
-          ) + Doc.lineOrSpace + argsDoc + Doc.lineOrSpace + rept(tpe) + Doc
-            .char(')')).nested(4)
+          ) + Doc.line + argsDoc + Doc.line + rept(tpe) + Doc
+            .char(')'))
         case Let(n, b, in, rec, _) =>
           val nm =
             if (rec.isRecursive) Doc.text("(letrec") else Doc.text("(let")
-          (nm + Doc.lineOrSpace + Doc.text(
+          block(nm + Doc.line + Doc.text(
             n.sourceCodeRepr
-          ) + Doc.lineOrSpace + loop(b) + Doc.lineOrSpace + loop(in) + Doc.char(
+          ) + Doc.line + loop(b) + Doc.line + loop(in) + Doc.char(
             ')'
-          )).nested(4)
+          ))
         case Literal(v, tpe, _) =>
-          (Doc.text("(lit") + Doc.lineOrSpace + Doc.text(
+          block(Doc.text("(lit") + Doc.line + Doc.text(
             v.repr
-          ) + Doc.lineOrSpace + rept(tpe) + Doc.char(')')).nested(4)
+          ) + Doc.line + rept(tpe) + Doc.char(')'))
         case Match(arg, branches, _) =>
           implicit val docType: Document[Type] =
             Document.instance(tpe => rept(tpe))
@@ -116,17 +118,16 @@ sealed abstract class TypedExpr[+T] { self: Product =>
             cpat.document(p)
 
           val bstr = branches.toList.map { case (p, t) =>
-            (Doc.char('[') + pat(p) + Doc.comma + Doc.lineOrSpace + loop(
-              t
-            ).grouped + Doc.char(']')).nested(4)
+            block(Doc.char('[') + pat(p) + Doc.comma + Doc.line + loop(t) + Doc.char(']'))
           }
-          (Doc.text("(match") + Doc.lineOrSpace + loop(arg) + (Doc.hardLine +
-            Doc.intercalate(Doc.hardLine, bstr)).nested(4) + Doc.char(')'))
-            .nested(4)
+          block(Doc.text("(match") + Doc.line + loop(arg) + block(Doc.hardLine +
+            Doc.intercalate(Doc.hardLine, bstr)) + Doc.char(')'))
       }
 
     loop(this)
   }
+
+  def reprString: String = repr.render(80)
 
   /** All the free variables in this expression in order encountered and with
     * duplicates (to see how often they appear)
@@ -194,7 +195,7 @@ object TypedExpr {
   type Rho[A] =
     TypedExpr[A] // an expression with a Rho type (no top level forall)
 
-  sealed abstract class Name[A] extends TypedExpr[A] with Product
+  sealed abstract class Name[+A] extends TypedExpr[A] with Product
 
   /** This says that the resulting term is generic on a given param
     *
@@ -213,12 +214,70 @@ object TypedExpr {
       extends TypedExpr[T] {
     def tag: T = term.tag
   }
-  case class AnnotatedLambda[T](
+  case class AnnotatedLambda[+T](
       args: NonEmptyList[(Bindable, Type)],
       expr: TypedExpr[T],
       tag: T
-  ) extends TypedExpr[T]
-  case class Local[T](name: Bindable, tpe: Type, tag: T) extends Name[T]
+  ) extends TypedExpr[T] {
+
+    def unshadow(freeSet: Set[Bindable]): AnnotatedLambda[T] = {
+      val clashIdent =
+        if (freeSet.isEmpty) Set.empty[Bindable]
+        else args.iterator.flatMap {
+          case (n, _) if freeSet(n) => n :: Nil
+          case _ => Nil
+        }.toSet
+
+      if (clashIdent.isEmpty) this
+      else {
+        // we have to allocate new variables
+        type I = Bindable
+        def inc(n: I, idx: Int): I =
+          n match {
+            case Identifier.Name(n) => Identifier.Name(n + idx.toString)
+            case _ => Identifier.Name("a" + idx.toString)
+          }
+
+        def alloc(head: (I, Type), tail: List[(I, Type)], avoid: Set[I]): NonEmptyList[(I, Type)] = {
+          val (ident, tpe) = head
+          val ident1 =
+            if (clashIdent(ident)) {
+              // the following iterator is infinite and distinct, and the avoid
+              // set is finite, so the get here must terminate in at most avoid.size
+              // steps
+              Iterator.from(0)
+                .map { i => inc(ident, i) }
+                .collectFirst { case n if !avoid(n) => n }
+                .get
+
+          }
+          else ident
+
+          tail match {
+            case Nil =>  NonEmptyList.one((ident1, tpe))
+            case h :: t =>
+              (ident1, tpe) :: alloc(h, t, avoid + ident1)
+          }
+        }
+
+        val avoids = freeSet | freeVarsSet(expr :: Nil)
+        val newArgs = alloc(args.head, args.tail, avoids)
+        val resSub = args.iterator.map(_._1)
+          .zip(newArgs.iterator.map { case (n1, _) => 
+
+            { (loc: Local[T]) => Local(n1, loc.tpe, loc.tag) }  
+          })
+          .toMap
+
+        // calling .get is safe when enterLambda = true
+        val expr1 = substituteAll(resSub, expr, enterLambda = true).get
+
+        AnnotatedLambda(newArgs, expr1, tag)
+      }
+    }
+  }
+
+  case class Local[+T](name: Bindable, tpe: Type, tag: T) extends Name[T]
   case class Global[T](pack: PackageName, name: Identifier, tpe: Type, tag: T)
       extends Name[T]
   case class App[T](
@@ -233,7 +292,72 @@ object TypedExpr {
       in: TypedExpr[T],
       recursive: RecursionKind,
       tag: T
-  ) extends TypedExpr[T]
+  ) extends TypedExpr[T] {
+    def unshadowResult(freeSet: Set[Bindable]): Let[T] = {
+      val clashIdent =
+        if (freeSet(arg)) Set(arg)
+        else Set.empty
+
+      if (clashIdent.isEmpty) this
+      else {
+        // we have to allocate new let
+        val avoids = freeSet | freeVarsSet(in :: expr :: Nil)
+        type I = Bindable
+        def inc(n: I, idx: Int): I =
+          n match {
+            case Identifier.Name(n) => Identifier.Name(n + idx.toString)
+            case _ => Identifier.Name("a" + idx.toString)
+          }
+
+        val arg1 = Iterator.from(0)
+              .map { i => inc(arg, i) }
+              .collectFirst { case n if !avoids(n) => n }
+              .get
+
+        val resSub = Map(arg ->
+            { (loc: Local[T]) => Local(arg1, loc.tpe, loc.tag) }  
+          )
+
+        // calling .get is safe when enterLambda = true
+        val in1 = substituteAll(resSub, in, enterLambda = true).get
+
+        copy(arg = arg1, in = in1)
+      }
+    }
+
+    def unshadowBoth(freeSet: Set[Bindable]): Let[T] =  {
+      val clashIdent =
+        if (freeSet(arg)) Set(arg)
+        else Set.empty
+
+      if (clashIdent.isEmpty) this
+      else {
+        // we have to allocate new let
+        val avoids = freeSet | freeVarsSet(in :: expr :: Nil)
+        type I = Bindable
+        def inc(n: I, idx: Int): I =
+          n match {
+            case Identifier.Name(n) => Identifier.Name(n + idx.toString)
+            case _ => Identifier.Name("a" + idx.toString)
+          }
+
+        val arg1 = Iterator.from(0)
+              .map { i => inc(arg, i) }
+              .collectFirst { case n if !avoids(n) => n }
+              .get
+
+        val resSub = Map(arg ->
+            { (loc: Local[T]) => Local(arg1, loc.tpe, loc.tag) }  
+          )
+
+        // calling .get is safe when enterLambda = true
+        val expr1 = substituteAll(resSub, expr, enterLambda = true).get
+        val in1 = substituteAll(resSub, in, enterLambda = true).get
+
+        copy(arg = arg1, expr = expr1, in = in1)
+      }
+    }
+  }
   // TODO, this shouldn't have a type, we know the type from Lit currently
   case class Literal[T](lit: Lit, tpe: Type, tag: T) extends TypedExpr[T]
   case class Match[T](
@@ -637,16 +761,13 @@ object TypedExpr {
            * which has a type forall a. Int which is the same
            * as Int
            */
-          type Branch =
-            (Pattern[(PackageName, Constructor), Type], TypedExpr[A])
-
           val allMatchMetas: F[SortedSet[Type.Meta]] =
             getMetaTyVars(arg.getType :: branches.foldMap { case (p, _) =>
               allPatternTypes(p)
             }.toList)
 
           val env1 = env + te.getType
-          def handleBranch(br: Branch): F[Branch] = {
+          def handleBranch(br: Branch[A]): F[Branch[A]] = {
             val (p, expr) = br
             val branchEnv = env1 ++ Pattern
               .envOf(p, Map.empty)(ident => (None, ident))
@@ -1146,54 +1267,207 @@ object TypedExpr {
       ex: TypedExpr[A],
       in: TypedExpr[A],
       enterLambda: Boolean = true
+  ): Option[TypedExpr[A]] =
+    substituteAll(Map(ident -> { (_: Local[A]) => ex }), in, enterLambda)
+
+  // Invariant, if enterLambda == true, we always return Some
+  def substituteAll[A](
+      table: Map[Bindable, Local[A] => TypedExpr[A]],
+      in: TypedExpr[A],
+      enterLambda: Boolean = true
   ): Option[TypedExpr[A]] = {
-    // if we hit a shadow, we don't need to substitute down
-    // that branch
-    @inline def shadows(i: Bindable): Boolean = i === ident
-
-    // free variables in ex are being rebound,
-    // this causes us to return None
-    lazy val masks: Bindable => Boolean =
-      freeVarsSet(ex :: Nil)
-
-    def loop(in: TypedExpr[A]): Option[TypedExpr[A]] =
+    def loop(table: Map[Bindable, Local[A] => TypedExpr[A]], in: TypedExpr[A]): Option[TypedExpr[A]] =
       in match {
-        case Local(i, _, _) if i === ident                          => Some(ex)
-        case Global(_, _, _, _) | Local(_, _, _) | Literal(_, _, _) => Some(in)
-        case Generic(a, expr) =>
-          loop(expr).map(Generic(a, _))
-        case Annotation(t, tpe) =>
-          loop(t).map(Annotation(_, tpe))
-        case AnnotatedLambda(args, res, tag) =>
-          if (!enterLambda) None
-          else if (args.exists { case (n, _) => masks(n) }) None
-          else if (args.exists { case (n, _) => shadows(n) }) Some(in)
-          else loop(res).map(AnnotatedLambda(args, _, tag))
-        case App(fn, args, tpe, tag) =>
-          (loop(fn), args.traverse(loop(_))).mapN(App(_, _, tpe, tag))
-        case let @ Let(arg, argE, in, rec, tag) =>
-          if (masks(arg)) None
-          else if (shadows(arg)) {
-            // recursive shadow blocks both argE and in
-            if (rec.isRecursive) Some(let)
-            else loop(argE).map(Let(arg, _, in, rec, tag))
-          } else {
-            (loop(argE), loop(in)).mapN(Let(arg, _, _, rec, tag))
+        case local @ Local(i, _, _) =>
+          table.get(i) match {
+            case Some(te) => Some(te(local))
+            case None => Some(in)
           }
+        case Global(_, _, _, _) | Literal(_, _, _) => Some(in)
+        case Generic(a, expr) =>
+          loop(table, expr).map(Generic(a, _))
+        case Annotation(t, tpe) =>
+          loop(table, t).map(Annotation(_, tpe))
+        case lam @ AnnotatedLambda(args, res, tag) =>
+          if (!enterLambda) None
+          else {
+            // this is the same algorithm as python/Code.Expression.substitute
+            //
+            // the args here can shadow, so we have to remove any
+            // items from subMap that have the same Ident
+            val argsSet = args.iterator.map(_._1).toSet
+            val nonShadowed = table.filterNot { case (i, _) => argsSet(i) }
+            // if subFrees is empty, unshadow is a no-op.
+            // but that is efficiently handled by unshadow
+            val subFrees = nonShadowed.iterator
+              .map { case (n, v) =>
+                // TODO this isn't great but we just need to get the free vars from the function
+                // this assumes the replacement free variables is constant over the type
+                // which it should be otherwise we can make ill-typed TypedExpr
+                val dummyTpe = res.getType
+                freeVarsSet(v(Local(n, tpe = dummyTpe, tag)) :: Nil)
+              }
+              .foldLeft(nonShadowed.keySet)(_ | _)
+
+            val AnnotatedLambda(args1, res1, tag1) = lam.unshadow(subFrees)
+            // now we know that none of args1 shadow anything in subFrees
+            // so we can just directly substitute nonShadowed on res1
+            // put another way: unshadow make substitute "commute" with lambda.
+            val subRes = substituteAll(nonShadowed, res1, enterLambda = true).get
+            Some(AnnotatedLambda(args1, subRes , tag1))
+          }
+        case App(fn, args, tpe, tag) =>
+          (loop(table, fn), args.traverse(loop(table, _))).mapN(App(_, _, tpe, tag))
+        case let @ Let(arg, _, _, _, _) =>
+            if (let.recursive.isRecursive) {
+              // arg is in scope for argE and in
+              // the args here can shadow, so we have to remove any
+              // items from subMap that have the same Ident
+              val nonShadowed = table - arg
+              // if subFrees is empty, unshadow is a no-op.
+              // but that is efficiently handled by unshadow
+              val subFrees = nonShadowed.iterator
+                .map { case (n, v) =>
+                  // TODO this isn't great but we just need to get the free vars from the function
+                  // this assumes the replacement free variables is constant over the type
+                  // which it should be otherwise we can make ill-typed TypedExpr
+                  val dummyTpe = in.getType
+                  freeVarsSet(v(Local(n, tpe = dummyTpe, let.tag)) :: Nil)
+                }
+                .foldLeft(nonShadowed.keySet)(_ | _)
+
+              val Let(arg1, argE1, in1, rec1, tag1) = let.unshadowBoth(subFrees)
+              // now we know that none of args1 shadow anything in subFrees
+              // so we can just directly substitute nonShadowed on res1
+              // put another way: unshadow make substitute "commute" with lambda.
+              (substituteAll(nonShadowed, argE1, enterLambda), substituteAll(nonShadowed, in1, enterLambda))
+                .mapN(Let(arg1, _, _, rec1, tag1))
+            }
+            else {
+              // the scopes are different the binding and the result
+              // the args here can shadow, so we have to remove any
+              // items from subMap that have the same Ident
+              val argsSet = Set(arg)
+              val nonShadowed = table.filterNot { case (i, _) => argsSet(i) }
+              // if subFrees is empty, unshadow is a no-op.
+              // but that is efficiently handled by unshadow
+              val subFrees = nonShadowed.iterator
+                .map { case (n, v) =>
+                  // TODO this isn't great but we just need to get the free vars from the function
+                  // this assumes the replacement free variables is constant over the type
+                  // which it should be otherwise we can make ill-typed TypedExpr
+                  val dummyTpe = in.getType
+                  freeVarsSet(v(Local(n, tpe = dummyTpe, let.tag)) :: Nil)
+                }
+                .foldLeft(nonShadowed.keySet)(_ | _)
+
+              val Let(arg1, argE1, in1, rec1, tag1) = let.unshadowResult(subFrees)
+              // now we know that none of args1 shadow anything in subFrees
+              // so we can just directly substitute nonShadowed on res1
+              // put another way: unshadow make substitute "commute" with lambda.
+              (loop(table, argE1), loop(nonShadowed, in1))
+                .mapN(Let(arg1, _, _, rec1, tag1))
+            }
         case Match(arg, branches, tag) =>
           // Maintain the order we encounter things:
-          val arg1 = loop(arg)
+          val arg1 = loop(table, arg)
           val b1 = branches.traverse { case in @ (p, b) =>
             // these are not free variables in this branch
             val ns = p.names
-            if (ns.exists(masks)) None
-            else if (ns.exists(shadows)) Some(in)
-            else loop(b).map((p, _))
+            
+            val (table1, (p1, b1)) = 
+              if (ns.isEmpty) (table, in)
+              else {
+                // the args here can shadow, so we have to remove any
+                // items from subMap that have the same Ident
+                val argsSet = ns.toSet
+                val nonShadowed =
+                  if (argsSet.isEmpty) table
+                  else table.filterNot { case (i, _) => argsSet(i) }
+
+                // if subFrees is empty, unshadow is a no-op.
+                // but that is efficiently handled by unshadow
+                val subFrees = nonShadowed.iterator
+                  .map { case (n, v) =>
+                    // TODO this isn't great but we just need to get the free vars from the function
+                    // this assumes the replacement free variables is constant over the type
+                    // which it should be otherwise we can make ill-typed TypedExpr
+                    val dummyTpe = b.getType
+                    freeVarsSet(v(Local(n, tpe = dummyTpe, tag)) :: Nil)
+                  }
+                  .foldLeft(nonShadowed.keySet)(_ | _)
+
+                (nonShadowed, unshadowBranch[A](subFrees, in))
+              }
+            // now we know that none of args1 shadow anything in subFrees
+            // so we can just directly substitute nonShadowed on res1
+            // put another way: unshadow make substitute "commute" with lambda.
+            loop(table1, b1).map((p1, _))
           }
           (arg1, b1).mapN(Match(_, _, tag))
       }
 
-    loop(in)
+    loop(table, in)
+  }
+
+  private def unshadowBranch[A](freeSet: Set[Bindable], branch: Branch[A]): Branch[A] = {
+    // we only get in here when p has some names
+    val (p, b) = branch
+    val args = NonEmptyList.fromList(p.names) match {
+      case None => return branch
+      case Some(argsNel) => argsNel
+    }
+
+    val clashIdent =
+      if (freeSet.isEmpty) Set.empty[Bindable]
+      else args.iterator.filter(freeSet).toSet
+
+    if (clashIdent.isEmpty) branch
+    else {
+      // we have to allocate new variables
+      type I = Bindable
+      def inc(n: I, idx: Int): I =
+        n match {
+          case Identifier.Name(n) => Identifier.Name(n + idx.toString)
+          case _ => Identifier.Name("a" + idx.toString)
+        }
+
+      def alloc(ident: I, tail: List[I], avoid: Set[I]): NonEmptyList[I] = {
+        val ident1 =
+          if (clashIdent(ident)) {
+            // the following iterator is infinite and distinct, and the avoid
+            // set is finite, so the get here must terminate in at most avoid.size
+            // steps
+            Iterator.from(0)
+              .map { i => inc(ident, i) }
+              .collectFirst { case n if !avoid(n) => n }
+              .get
+
+        }
+        else ident
+
+        tail match {
+          case Nil =>  NonEmptyList.one(ident1)
+          case h :: t =>
+            ident1 :: alloc(h, t, avoid + ident1)
+        }
+      }
+
+      val avoids = freeSet | freeVarsSet(b :: Nil)
+      val newArgs = alloc(args.head, args.tail, avoids)
+      val resSub = args.iterator
+        .zip(newArgs.iterator.map { n1 => 
+
+          { (loc: Local[A]) => Local(n1, loc.tpe, loc.tag) }  
+        })
+        .toMap
+
+      // calling .get is safe when enterLambda = true
+      val b1 = substituteAll(resSub, b, enterLambda = true).get
+      val p1 = p.substitute(args.iterator.zip(newArgs.iterator).toMap)
+
+      (p1, b1)
+    }
   }
 
   def substituteTypeVar[A](
@@ -1465,6 +1739,9 @@ object TypedExpr {
             }
         }
     }
+
+  type Branch[A] =
+    (Pattern[(PackageName, Constructor), Type], TypedExpr[A])
 
   def quantVars[A](
       forallList: List[(Type.Var.Bound, Kind)],

--- a/core/src/main/scala/org/bykn/bosatsu/codegen/clang/ClangGen.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/codegen/clang/ClangGen.scala
@@ -233,6 +233,7 @@ object ClangGen {
       def directFn(p: PackageName, b: Bindable): T[Option[(Code.Ident, Int)]]
       def directFn(b: Bindable): T[Option[(Code.Ident, Boolean, Int)]]
       def inTop[A](p: PackageName, bn: Bindable)(ta: T[A]): T[A]
+      def inFnStatement[A](in: T[A]): T[A]
       def currentTop: T[Option[(PackageName, Bindable)]]
       def staticValueName(p: PackageName, b: Bindable): T[Code.Ident]
       def constructorFn(p: PackageName, b: Bindable): T[Code.Ident]
@@ -1026,7 +1027,7 @@ object ClangGen {
         }
 
       def fnStatement(fnName: Code.Ident, fn: FnExpr): T[Code.Statement] =
-        fn match {
+        inFnStatement(fn match {
           case Lambda(captures, name, args, expr) =>
             val body = innerToValue(expr).map(Code.returnValue(_))
             val body1 = name match {
@@ -1047,7 +1048,7 @@ object ClangGen {
                   }
               } yield Code.DeclareFn(Nil, Code.TypeIdent.BValue, fnName, allArgs.toList, Some(Code.block(fnBody)))
             }
-        }
+        })
 
       def renderTop(p: PackageName, b: Bindable, expr: Expr): T[Unit] =
         inTop(p, b) { expr match {
@@ -1112,6 +1113,31 @@ object ClangGen {
         def catsMonad[S]: Monad[StateT[EitherT[Eval, Error, *], S, *]] = implicitly
 
         new Env {
+          sealed abstract class BindingKind {
+            def ident: Code.Ident
+          }
+          object BindingKind {
+            case class Normal(bn: Bindable, idx: Int) extends BindingKind {
+              val ident = Code.Ident(Idents.escape("__bsts_b_", bn.asString + idx.toString))
+            }
+            case class Recursive(ident: Code.Ident, isClosure: Boolean, arity: Int, idx: Int) extends BindingKind
+          }
+          case class BindState(count: Int, stack: List[BindingKind]) {
+            def pop: BindState =
+              // by invariant this tail should never fail
+              copy(stack = stack.tail)
+
+            def nextBind(bn: Bindable): BindState =
+              copy(count = count + 1, BindingKind.Normal(bn, count) :: stack)
+
+            def nextRecursive(fnName: Code.Ident, isClosure: Boolean, arity: Int): BindState =
+              copy(count = count + 1, BindingKind.Recursive(fnName, isClosure, arity, count) :: stack)
+          }
+
+          object BindState {
+            val empty: BindState = BindState(0, Nil)
+          }
+
           case class State(
             allValues: AllValues,
             externals: ExternalResolver,
@@ -1119,8 +1145,7 @@ object ClangGen {
             includes: Chain[Code.Include],
             stmts: Chain[Code.Statement],
             currentTop: Option[(PackageName, Bindable)],
-            bindCount: Int,
-            binds: Map[Bindable, NonEmptyList[Either[((Code.Ident, Boolean, Int), Int), Int]]],
+            binds: Map[Bindable, BindState],
             counter: Long,
             identCache: Map[Expr, Code.Ident]
           ) {
@@ -1140,7 +1165,7 @@ object ClangGen {
                 List(Code.Include.quote("bosatsu_runtime.h"))
 
               State(allValues, externals, Set.empty ++ defaultIncludes, Chain.fromSeq(defaultIncludes), Chain.empty,
-                None, 0, Map.empty, 0L, Map.empty
+                None, Map.empty, 0L, Map.empty
               )
             }
           }
@@ -1175,6 +1200,9 @@ object ClangGen {
           def tryUpdate[A](fn: State => Either[Error, (State, A)]): T[A] =
             StateT(s => EitherT[Eval, Error, (State, A)](Eval.now(fn(s))))
 
+          def read[A](fn: State => A): T[A] =
+            StateT(s => EitherT[Eval, Error, (State, A)](Eval.now(Right((s, fn(s))))))
+
           def tryRead[A](fn: State => Either[Error, A]): T[A] =
             StateT(s => EitherT[Eval, Error, (State, A)](Eval.now(fn(s).map((s, _)))))
 
@@ -1196,27 +1224,20 @@ object ClangGen {
 
           def bind[A](bn: Bindable)(in: T[A]): T[A] = {
             val init: T[Unit] = update { s =>
-              val cnt = s.bindCount
-              val v = s.binds.get(bn) match {
-                case None => NonEmptyList.one(Right(cnt))
-                case Some(items) =>
-                  Right(cnt) :: items
+              val bs0 = s.binds.get(bn) match {
+                case None => BindState.empty
+                case Some(bs) => bs
               }  
-              (s.copy(bindCount = cnt + 1, binds = s.binds.updated(bn, v)), ())
+              val bs1 = bs0.nextBind(bn)
+              (s.copy(binds = s.binds.updated(bn, bs1)), ())
             }
 
             val uninit: T[Unit] = update { s =>
-              s.binds.get(bn) match {
-                case Some(NonEmptyList(_, tail)) =>
-                  val s1 = NonEmptyList.fromList(tail) match {
-                    case None =>
-                      s.copy(binds = s.binds - bn)
-                    case Some(prior) =>
-                      s.copy(binds = s.binds.updated(bn, prior))
-                  }
-                  (s1, ())
+              val bs1 = s.binds.get(bn) match {
+                case Some(bs) => bs.pop
                 case None => sys.error(s"bindable $bn no longer in $s")
               }  
+              (s.copy(binds = s.binds.updated(bn, bs1)), ())
             }
 
             for {
@@ -1228,15 +1249,7 @@ object ClangGen {
           def getBinding(bn: Bindable): T[Code.Ident] =
             tryRead { s =>
               s.binds.get(bn) match {
-                case Some(stack) =>
-                  stack.head match {
-                    case Right(idx) =>
-                      Right(Code.Ident(Idents.escape("__bsts_b_", bn.asString + idx.toString)))
-                    case Left(((ident, _, _), _)) =>
-                      // TODO: suspicious to ignore isClosure and arity here
-                      // probably need to conv
-                      Right(ident)
-                  }
+                case Some(bs) => Right(bs.stack.head.ident)
                 case None => Left(Error.Unbound(bn, s.currentTop))
               }  
             }
@@ -1250,30 +1263,21 @@ object ClangGen {
 
           // a recursive function needs to remap the Bindable to the top-level mangling
           def recursiveName[A](fnName: Code.Ident, bn: Bindable, isClosure: Boolean, arity: Int)(in: T[A]): T[A] = {
-            val init: T[Unit] = StateT { s =>
-              val entry = (fnName, isClosure, arity)
-              val v = s.binds.get(bn) match {
-                case None => NonEmptyList.one(Left((entry, -1)))
-                case Some(items @ NonEmptyList(Right(idx), _)) =>
-                  Left((entry, idx)) :: items
-                case Some(items @ NonEmptyList(Left((_, idx)), _)) =>
-                  Left((entry, idx)) :: items
-              }  
-              result(s.copy(binds = s.binds.updated(bn, v)), ())
+            val init: T[Unit] = update { s =>
+              val bs0 = s.binds.get(bn) match {
+                case Some(bs) => bs
+                case None => BindState.empty
+              }
+              val bs1 = bs0.nextRecursive(fnName, isClosure, arity)
+              (s.copy(binds = s.binds.updated(bn, bs1)), ())
             }
 
-            val uninit: T[Unit] = StateT { s =>
-              s.binds.get(bn) match {
-                case Some(NonEmptyList(_, tail)) =>
-                  val s1 = NonEmptyList.fromList(tail) match {
-                    case None =>
-                      s.copy(binds = s.binds - bn)
-                    case Some(prior) =>
-                      s.copy(binds = s.binds.updated(bn, prior))
-                  }
-                  result(s1, ())
+            val uninit: T[Unit] = update { s =>
+              val bs1 = s.binds.get(bn) match {
+                case Some(bs) => bs.pop
                 case None => sys.error(s"bindable $bn no longer in $s")
               }  
+              (s.copy(binds = s.binds.updated(bn, bs1)), ())
             }
 
             for {
@@ -1319,20 +1323,28 @@ object ClangGen {
             }
 
           def directFn(b: Bindable): T[Option[(Code.Ident, Boolean, Int)]] =
-            StateT { s =>
+            read { s =>
               s.binds.get(b) match {
-                case Some(NonEmptyList(Left((c, _)), _)) =>
-                  result(s, Some(c))
+                case Some(BindState(_, BindingKind.Recursive(n, c, a, _) :: _)) =>
+                  Some((n, c, a))
                 case _ =>
-                  result(s, None)
+                  None
               } 
             }
 
+          def inFnStatement[A](ta: T[A]): T[A] = {
+            for {
+              bindState <- update { (s: State) => (s.copy(binds = Map.empty), s.binds) }
+              a <- ta
+              _ <- update { (s: State) => (s.copy(binds = bindState), ()) }
+            } yield a
+          }
+
           def inTop[A](p: PackageName, bn: Bindable)(ta: T[A]): T[A] =
             for {
-              initBindCount <- update { (s: State) => (s.copy(bindCount = 0, currentTop = Some((p, bn))), s.bindCount)}
+              bindState <- update { (s: State) => (s.copy(binds = Map.empty, currentTop = Some((p, bn))), s.binds)}
               a <- ta
-              _ <- update { (s: State) => (s.copy(currentTop = None, bindCount = initBindCount), ()) }
+              _ <- update { (s: State) => (s.copy(currentTop = None, binds = bindState), ()) }
             } yield a
 
           val currentTop: T[Option[(PackageName, Bindable)]] =

--- a/core/src/test/scala/org/bykn/bosatsu/PatternTest.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/PatternTest.scala
@@ -152,4 +152,16 @@ class PatternTest extends AnyFunSuite {
       }
     }
   }
+
+  test("substitute identity is identity") {
+    forAll(patGen, Gen.listOf(Generators.bindIdentGen)) { (p, list) =>
+      assert(p.substitute(list.map(b => (b, b)).toMap) == p)
+    }
+  }
+
+  test("substitute names homomorphism") {
+    forAll(patGen, Gen.mapOf(Gen.zip(Generators.bindIdentGen, Generators.bindIdentGen))) { (p, map) =>
+      assert(p.substitute(map).names == p.names.map(n => map.getOrElse(n, n)))
+    }
+  }
 }

--- a/core/src/test/scala/org/bykn/bosatsu/PatternTest.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/PatternTest.scala
@@ -10,7 +10,7 @@ import org.scalatest.funsuite.AnyFunSuite
 
 class PatternTest extends AnyFunSuite {
   implicit val generatorDrivenConfig: PropertyCheckConfiguration =
-    PropertyCheckConfiguration(minSuccessful = 1000)
+    PropertyCheckConfiguration(minSuccessful = 5000)
 
   val patGen = Gen.choose(0, 5).flatMap(Generators.genPattern(_))
 
@@ -160,8 +160,27 @@ class PatternTest extends AnyFunSuite {
   }
 
   test("substitute names homomorphism") {
+    import Identifier._
+
+    def law[A, B](p: Pattern[A, B], map: Map[Bindable, Bindable]) = {
+      val subsP = p.substitute(map)
+      assert(subsP.names.distinct == p.names.map(n => map.getOrElse(n, n)).distinct, s"got $subsP")
+    }
+
+    def b(s: String) = Identifier.Name(s)
+
+    {
+      import Pattern._
+      import StrPart._
+      import Lit.Str
+
+      val p = Union(Var(Name("a")), NonEmptyList(StrPat(NonEmptyList(NamedStr(Name("k")), List(LitStr("wrk"), WildChar))), List(Named(Name("hqZ9aeuAood"), WildCard), Literal(Str("q5VgEdksu")), WildCard)))
+
+      law(p, Map(b("k") -> b("a")))
+    }
+
     forAll(patGen, Gen.mapOf(Gen.zip(Generators.bindIdentGen, Generators.bindIdentGen))) { (p, map) =>
-      assert(p.substitute(map).names == p.names.map(n => map.getOrElse(n, n)))
+      law(p, map)
     }
   }
 }

--- a/core/src/test/scala/org/bykn/bosatsu/TypedExprTest.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/TypedExprTest.scala
@@ -868,8 +868,8 @@ enum L[a]: E, NE(head: a, tail: L[a])
 
 x = (
   def go(y, z):
-    def loop(z):
-      recur z:
+    def loop(z1):
+      recur z1:
         case E: y
         case NE(_, t): loop(t)
 
@@ -879,7 +879,7 @@ x = (
   fn1(NE(1, NE(2, E)))
 )
     """) { te2 =>
-        assert(te1.void == te2.void, s"${te1.repr} != ${te2.repr}")
+        assert(te1.void == te2.void, s"\n${te1.reprString}\n\n!=\n\n${te2.reprString}")
       }
     }
   }

--- a/core/src/test/scala/org/bykn/bosatsu/TypedExprTest.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/TypedExprTest.scala
@@ -416,8 +416,8 @@ foo = _ -> 1
       // substitution in let with a masking
       val let1 = let("y", varTE("x", intTpe), varTE("y", intTpe))
       assert(
-        TypedExpr.substitute(Identifier.Name("x"), varTE("y", intTpe), let1) ==
-          None
+        TypedExpr.substitute(Identifier.Name("x"), varTE("y", intTpe), let1).map(_.reprString) ==
+          Some("(let y0 (var y Bosatsu/Predef::Int) (var y0 Bosatsu/Predef::Int))")
       )
     }
 
@@ -516,37 +516,46 @@ foo = _ -> 1
       )
     )
 
-  test("we can't inline using a shadow: let x = y in let y = z in x(y, y)") {
-    // we can't inline a shadow
+  test("we can inline using a shadow: let x = y in let y = z(43) in x(y)(y)") {
+    // we can inline a shadow by unshadowing y to be y1
     // x = y
     // y = z(43)
     // x(y, y)
-    assert(TypedExprNormalization.normalize(normalLet) == None)
+    val normed = TypedExprNormalization.normalize(normalLet)
+    assert(normed.map(_.repr.render(80)) == Some("""(let
+    y0
+    (ap
+        (var z Bosatsu/Predef::Int)
+        (lit 43 Bosatsu/Predef::Int)
+        Bosatsu/Predef::Int)
+    (ap
+        (ap
+            (var y Bosatsu/Predef::Int)
+            (var y0 Bosatsu/Predef::Int)
+            Bosatsu/Predef::Int)
+        (var y0 Bosatsu/Predef::Int)
+        Bosatsu/Predef::Int))"""))
   }
 
   test("if w doesn't have x free: (app (let x y z) w) == let x y (app z w)") {
     assert(
       TypedExprNormalization.normalize(
         app(normalLet, varTE("w", intTpe), intTpe)
-      ) ==
+      ).map(_.reprString) ==
         Some(
-          let(
-            "x",
-            varTE("y", intTpe),
             let(
-              "y",
+              "y0",
               app(varTE("z", intTpe), int(43), intTpe),
               app(
                 app(
-                  app(varTE("x", intTpe), varTE("y", intTpe), intTpe),
-                  varTE("y", intTpe),
+                  app(varTE("y", intTpe), varTE("y0", intTpe), intTpe),
+                  varTE("y0", intTpe),
                   intTpe
                 ),
                 varTE("w", intTpe),
                 intTpe
               )
-            )
-          )
+          ).reprString
         )
     )
 

--- a/core/src/test/scala/org/bykn/bosatsu/TypedExprTest.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/TypedExprTest.scala
@@ -875,7 +875,7 @@ x = (
 
     loop(z)
 
-  fn1 = z0 -> go(1, z0)
+  fn1 = z -> go(1, z)
   fn1(NE(1, NE(2, E)))
 )
     """) { te2 =>

--- a/core/src/test/scala/org/bykn/bosatsu/codegen/clang/ClangGenTest.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/codegen/clang/ClangGenTest.scala
@@ -51,8 +51,8 @@ x = 1
 #include <stdlib.h>
 #include "gc.h"
 
-BValue __bsts_t_lambda0(BValue __bsts_b_a0, BValue __bsts_b_b0) {
-    return alloc_enum2(1, __bsts_b_a0, __bsts_b_b0);
+BValue __bsts_t_lambda0(BValue __bsts_b_a1, BValue __bsts_b_b2) {
+    return alloc_enum2(1, __bsts_b_a1, __bsts_b_b2);
 }
 
 BValue ___bsts_g_Bosatsu_l_Predef_l_build__List(BValue __bsts_b_fn0) {
@@ -75,27 +75,27 @@ int main(int argc, char** argv) {
 #include <stdlib.h>
 #include "gc.h"
 
-BValue __bsts_t_closure__loop0(BValue* __bstsi_slot, BValue __bsts_b_list1) {
-    if (get_variant(__bsts_b_list1) == 0) {
+BValue __bsts_t_closure__loop0(BValue* __bstsi_slot, BValue __bsts_b_list3) {
+    if (get_variant(__bsts_b_list3) == 0) {
         return __bstsi_slot[0];
     }
     else {
-        BValue __bsts_b_h0 = get_enum_index(__bsts_b_list1, 0);
-        BValue __bsts_b_t0 = get_enum_index(__bsts_b_list1, 1);
+        BValue __bsts_b_h4 = get_enum_index(__bsts_b_list3, 0);
+        BValue __bsts_b_t5 = get_enum_index(__bsts_b_list3, 1);
         return call_fn2(__bstsi_slot[1],
-            __bsts_b_h0,
-            __bsts_t_closure__loop0(__bstsi_slot, __bsts_b_t0));
+            __bsts_b_h4,
+            __bsts_t_closure__loop0(__bstsi_slot, __bsts_b_t5));
     }
 }
 
 BValue ___bsts_g_Bosatsu_l_Predef_l_foldr__List(BValue __bsts_b_list0,
-    BValue __bsts_b_fn0,
-    BValue __bsts_b_acc0) {
-    BValue __bsts_l_captures1[2] = { __bsts_b_acc0, __bsts_b_fn0 };
-    BValue __bsts_b_loop0 = alloc_closure1(2,
+    BValue __bsts_b_fn1,
+    BValue __bsts_b_acc2) {
+    BValue __bsts_l_captures1[2] = { __bsts_b_acc2, __bsts_b_fn1 };
+    BValue __bsts_b_loop6 = alloc_closure1(2,
         __bsts_l_captures1,
         __bsts_t_closure__loop0);
-    return call_fn1(__bsts_b_loop0, __bsts_b_list0);
+    return call_fn1(__bsts_b_loop6, __bsts_b_list0);
 }
 
 int main(int argc, char** argv) {
@@ -113,14 +113,14 @@ int main(int argc, char** argv) {
 #include "gc.h"
 
 BValue __bsts_t_closure0(BValue* __bstsi_slot,
-    BValue __bsts_b_lst1,
-    BValue __bsts_b_item1) {
+    BValue __bsts_b_lst3,
+    BValue __bsts_b_item4) {
     BValue __bsts_a_0;
     BValue __bsts_a_1;
     BValue __bsts_a_3;
     BValue __bsts_a_5;
-    __bsts_a_3 = __bsts_b_lst1;
-    __bsts_a_5 = __bsts_b_item1;
+    __bsts_a_3 = __bsts_b_lst3;
+    __bsts_a_5 = __bsts_b_item4;
     __bsts_a_0 = alloc_enum0(1);
     _Bool __bsts_l_cond1;
     __bsts_l_cond1 = get_variant_value(__bsts_a_0) == 1;
@@ -130,12 +130,12 @@ BValue __bsts_t_closure0(BValue* __bstsi_slot,
             __bsts_a_1 = __bsts_a_5;
         }
         else {
-            BValue __bsts_b_head0 = get_enum_index(__bsts_a_3, 0);
-            BValue __bsts_b_tail0 = get_enum_index(__bsts_a_3, 1);
-            BValue __bsts_a_2 = __bsts_b_tail0;
+            BValue __bsts_b_head5 = get_enum_index(__bsts_a_3, 0);
+            BValue __bsts_b_tail6 = get_enum_index(__bsts_a_3, 1);
+            BValue __bsts_a_2 = __bsts_b_tail6;
             BValue __bsts_a_4 = call_fn2(__bstsi_slot[0],
                 __bsts_a_5,
-                __bsts_b_head0);
+                __bsts_b_head5);
             __bsts_a_3 = __bsts_a_2;
             __bsts_a_5 = __bsts_a_4;
         }
@@ -145,23 +145,23 @@ BValue __bsts_t_closure0(BValue* __bstsi_slot,
 }
 
 BValue ___bsts_g_Bosatsu_l_Predef_l_foldl__List(BValue __bsts_b_lst0,
-    BValue __bsts_b_item0,
-    BValue __bsts_b_fn0) {
-    BValue __bsts_l_captures2[1] = { __bsts_b_fn0 };
-    BValue __bsts_b_loop0 = alloc_closure2(1,
+    BValue __bsts_b_item1,
+    BValue __bsts_b_fn2) {
+    BValue __bsts_l_captures2[1] = { __bsts_b_fn2 };
+    BValue __bsts_b_loop7 = alloc_closure2(1,
         __bsts_l_captures2,
         __bsts_t_closure0);
-    return call_fn2(__bsts_b_loop0, __bsts_b_lst0, __bsts_b_item0);
+    return call_fn2(__bsts_b_loop7, __bsts_b_lst0, __bsts_b_item1);
 }
 
-BValue __bsts_t_lambda3(BValue __bsts_b_tail0, BValue __bsts_b_h0) {
-    return alloc_enum2(1, __bsts_b_h0, __bsts_b_tail0);
+BValue __bsts_t_lambda3(BValue __bsts_b_tail2, BValue __bsts_b_h3) {
+    return alloc_enum2(1, __bsts_b_h3, __bsts_b_tail2);
 }
 
 BValue ___bsts_g_Bosatsu_l_Predef_l_reverse__concat(BValue __bsts_b_front0,
-    BValue __bsts_b_back0) {
+    BValue __bsts_b_back1) {
     return ___bsts_g_Bosatsu_l_Predef_l_foldl__List(__bsts_b_front0,
-        __bsts_b_back0,
+        __bsts_b_back1,
         alloc_boxed_pure_fn2(__bsts_t_lambda3));
 }
 

--- a/core/src/test/scala/org/bykn/bosatsu/codegen/clang/ClangGenTest.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/codegen/clang/ClangGenTest.scala
@@ -51,8 +51,8 @@ x = 1
 #include <stdlib.h>
 #include "gc.h"
 
-BValue __bsts_t_lambda0(BValue __bsts_b_a1, BValue __bsts_b_b2) {
-    return alloc_enum2(1, __bsts_b_a1, __bsts_b_b2);
+BValue __bsts_t_lambda0(BValue __bsts_b_a0, BValue __bsts_b_b0) {
+    return alloc_enum2(1, __bsts_b_a0, __bsts_b_b0);
 }
 
 BValue ___bsts_g_Bosatsu_l_Predef_l_build__List(BValue __bsts_b_fn0) {
@@ -75,27 +75,27 @@ int main(int argc, char** argv) {
 #include <stdlib.h>
 #include "gc.h"
 
-BValue __bsts_t_closure__loop0(BValue* __bstsi_slot, BValue __bsts_b_list3) {
-    if (get_variant(__bsts_b_list3) == 0) {
+BValue __bsts_t_closure__loop0(BValue* __bstsi_slot, BValue __bsts_b_list0) {
+    if (get_variant(__bsts_b_list0) == 0) {
         return __bstsi_slot[0];
     }
     else {
-        BValue __bsts_b_h4 = get_enum_index(__bsts_b_list3, 0);
-        BValue __bsts_b_t5 = get_enum_index(__bsts_b_list3, 1);
+        BValue __bsts_b_h0 = get_enum_index(__bsts_b_list0, 0);
+        BValue __bsts_b_t0 = get_enum_index(__bsts_b_list0, 1);
         return call_fn2(__bstsi_slot[1],
-            __bsts_b_h4,
-            __bsts_t_closure__loop0(__bstsi_slot, __bsts_b_t5));
+            __bsts_b_h0,
+            __bsts_t_closure__loop0(__bstsi_slot, __bsts_b_t0));
     }
 }
 
 BValue ___bsts_g_Bosatsu_l_Predef_l_foldr__List(BValue __bsts_b_list0,
-    BValue __bsts_b_fn1,
-    BValue __bsts_b_acc2) {
-    BValue __bsts_l_captures1[2] = { __bsts_b_acc2, __bsts_b_fn1 };
-    BValue __bsts_b_loop6 = alloc_closure1(2,
+    BValue __bsts_b_fn0,
+    BValue __bsts_b_acc0) {
+    BValue __bsts_l_captures1[2] = { __bsts_b_acc0, __bsts_b_fn0 };
+    BValue __bsts_b_loop0 = alloc_closure1(2,
         __bsts_l_captures1,
         __bsts_t_closure__loop0);
-    return call_fn1(__bsts_b_loop6, __bsts_b_list0);
+    return call_fn1(__bsts_b_loop0, __bsts_b_list0);
 }
 
 int main(int argc, char** argv) {
@@ -113,14 +113,14 @@ int main(int argc, char** argv) {
 #include "gc.h"
 
 BValue __bsts_t_closure0(BValue* __bstsi_slot,
-    BValue __bsts_b_lst3,
-    BValue __bsts_b_item4) {
+    BValue __bsts_b_lst0,
+    BValue __bsts_b_item0) {
     BValue __bsts_a_0;
     BValue __bsts_a_1;
     BValue __bsts_a_3;
     BValue __bsts_a_5;
-    __bsts_a_3 = __bsts_b_lst3;
-    __bsts_a_5 = __bsts_b_item4;
+    __bsts_a_3 = __bsts_b_lst0;
+    __bsts_a_5 = __bsts_b_item0;
     __bsts_a_0 = alloc_enum0(1);
     _Bool __bsts_l_cond1;
     __bsts_l_cond1 = get_variant_value(__bsts_a_0) == 1;
@@ -130,12 +130,12 @@ BValue __bsts_t_closure0(BValue* __bstsi_slot,
             __bsts_a_1 = __bsts_a_5;
         }
         else {
-            BValue __bsts_b_head5 = get_enum_index(__bsts_a_3, 0);
-            BValue __bsts_b_tail6 = get_enum_index(__bsts_a_3, 1);
-            BValue __bsts_a_2 = __bsts_b_tail6;
+            BValue __bsts_b_head0 = get_enum_index(__bsts_a_3, 0);
+            BValue __bsts_b_tail0 = get_enum_index(__bsts_a_3, 1);
+            BValue __bsts_a_2 = __bsts_b_tail0;
             BValue __bsts_a_4 = call_fn2(__bstsi_slot[0],
                 __bsts_a_5,
-                __bsts_b_head5);
+                __bsts_b_head0);
             __bsts_a_3 = __bsts_a_2;
             __bsts_a_5 = __bsts_a_4;
         }
@@ -145,23 +145,23 @@ BValue __bsts_t_closure0(BValue* __bstsi_slot,
 }
 
 BValue ___bsts_g_Bosatsu_l_Predef_l_foldl__List(BValue __bsts_b_lst0,
-    BValue __bsts_b_item1,
-    BValue __bsts_b_fn2) {
-    BValue __bsts_l_captures2[1] = { __bsts_b_fn2 };
-    BValue __bsts_b_loop7 = alloc_closure2(1,
+    BValue __bsts_b_item0,
+    BValue __bsts_b_fn0) {
+    BValue __bsts_l_captures2[1] = { __bsts_b_fn0 };
+    BValue __bsts_b_loop0 = alloc_closure2(1,
         __bsts_l_captures2,
         __bsts_t_closure0);
-    return call_fn2(__bsts_b_loop7, __bsts_b_lst0, __bsts_b_item1);
+    return call_fn2(__bsts_b_loop0, __bsts_b_lst0, __bsts_b_item0);
 }
 
-BValue __bsts_t_lambda3(BValue __bsts_b_tail2, BValue __bsts_b_h3) {
-    return alloc_enum2(1, __bsts_b_h3, __bsts_b_tail2);
+BValue __bsts_t_lambda3(BValue __bsts_b_tail0, BValue __bsts_b_h0) {
+    return alloc_enum2(1, __bsts_b_h0, __bsts_b_tail0);
 }
 
 BValue ___bsts_g_Bosatsu_l_Predef_l_reverse__concat(BValue __bsts_b_front0,
-    BValue __bsts_b_back1) {
+    BValue __bsts_b_back0) {
     return ___bsts_g_Bosatsu_l_Predef_l_foldl__List(__bsts_b_front0,
-        __bsts_b_back1,
+        __bsts_b_back0,
         alloc_boxed_pure_fn2(__bsts_t_lambda3));
 }
 


### PR DESCRIPTION
close #1126

This properly handles masking by renaming so that substitution can always proceed. This opened up three optimizations in the tests, but in real code the kind of shadowing this is dealing with may not often happen, so I don't know if it matters much.

(I should really do this with a real benchmark suite).