### PR TITLE
refactor Package and PackageMap some

### DIFF
--- a/core/src/main/scala/org/bykn/bosatsu/Package.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/Package.scala
@@ -550,7 +550,6 @@ object Package {
           val bs = exps.map(_.tag)
           Right(i.map(_ => bs))
         case None =>
-          val exMap = pack.exports.groupByNel(_.name)
           Left(
             PackageError.UnknownImportName(
               inside,
@@ -559,7 +558,7 @@ object Package {
                 (n: Identifier, ())
               }.toMap,
               i,
-              exMap.iterator.flatMap(_._2.toList).toList
+              pack.exports
             )
           )
         }
@@ -576,14 +575,13 @@ object Package {
           val bs = exps.map(_.tag)
           Right(i.map(_ => bs))
         case None =>
-          val exMap = iface.exports.groupByNel(_.name)
           Left(
             PackageError.UnknownImportFromInterface(
               inside,
               iface.name,
               iface.exports.map(_.name),
               i,
-              exMap.iterator.flatMap(_._2.toList).toList
+              iface.exports
             )
           )
       }

--- a/core/src/main/scala/org/bykn/bosatsu/Package.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/Package.scala
@@ -591,7 +591,7 @@ object Package {
     }
   }
 
-  implicit class ResolvedMedthods(private val resolved: Resolved) extends AnyVal {
+  implicit class ResolvedMethods(private val resolved: Resolved) extends AnyVal {
       def importName[F[_], A](
         fromPackage: PackageName,
         item: ImportedName[Unit]

--- a/core/src/main/scala/org/bykn/bosatsu/PackageMap.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/PackageMap.scala
@@ -145,8 +145,8 @@ object PackageMap {
 
   type Inferred = Typed[Declaration]
 
-  /** This builds a DAG of actual packages where names have been replaced by the
-    * fully resolved packages
+  /** This builds a DAG of actual packages where on Import the PackageName have been replaced by the
+    * Either a Package.Interface (which gives exports only) or this same recursive structure.
     */
   def resolvePackages[A, B, C](
       map: PackageMap[PackageName, A, B, C],
@@ -328,7 +328,7 @@ object PackageMap {
 
     // we know all the package names are unique here
     def foldMap(
-        m: Map[PackageName, (A, Package.Parsed)]
+        m: SortedMap[PackageName, (A, Package.Parsed)]
     ): (List[PackageError], PackageMap.ParsedImp) = {
       val initPm = PackageMap
         .empty[
@@ -338,7 +338,8 @@ object PackageMap {
           (List[Statement], ImportMap[PackageName, Unit])
         ]
 
-      m.iterator.foldLeft((List.empty[PackageError], initPm)) {
+      // since the map is sorted, this order is deteriministic
+      m.foldLeft((List.empty[PackageError], initPm)) {
         case ((errs, pm), (_, (_, pack))) =>
           val (lerrs, pp) = toProg(pack)
           (lerrs.toList ::: errs, pm + pp)
@@ -350,14 +351,14 @@ object PackageMap {
     // combine the import errors now:
     val check: Ior[NonEmptyList[PackageError], Unit] =
       errs match {
-        case Nil =>
-          Ior.right(())
+        case Nil => Ior.right(())
         case h :: tail =>
           Ior.left(NonEmptyList(h, tail))
       }
     // keep all the errors
     val nuEr: Ior[NonEmptyList[PackageError], Unit] =
       NonEmptyMap.fromMap(nonUnique) match {
+        case None => Ior.right(())
         case Some(nenu) =>
           val paths = nenu.map { case ((a, _), rest) =>
             (a.show, rest.map(_._1.show))
@@ -367,8 +368,6 @@ object PackageMap {
               PackageError.DuplicatedPackageError(paths)
             )
           )
-        case None =>
-          Ior.right(())
       }
 
     (nuEr, check, res.toIor).parMapN((_, _, r) => r)
@@ -418,54 +417,6 @@ object PackageMap {
               (nameToRes(p), i)
             }
 
-          def getImport[A, B](
-              packF: Package.Inferred,
-              exMap: Map[Identifier, NonEmptyList[ExportedName[A]]],
-              i: ImportedName[B]
-          ): Ior[NonEmptyList[PackageError], ImportedName[NonEmptyList[A]]] =
-            exMap.get(i.originalName) match {
-              case None =>
-                Ior.left(
-                  NonEmptyList.one(
-                    PackageError.UnknownImportName(
-                      nm,
-                      packF.name,
-                      packF.program._1.lets.iterator.map { case (n, _, _) =>
-                        (n: Identifier, ())
-                      }.toMap,
-                      i,
-                      exMap.iterator.flatMap(_._2.toList).toList
-                    )
-                  )
-                )
-              case Some(exps) =>
-                val bs = exps.map(_.tag)
-                Ior.right(i.map(_ => bs))
-            }
-
-          def getImportIface[A, B](
-              packF: Package.Interface,
-              exMap: Map[Identifier, NonEmptyList[ExportedName[A]]],
-              i: ImportedName[B]
-          ): Ior[NonEmptyList[PackageError], ImportedName[NonEmptyList[A]]] =
-            exMap.get(i.originalName) match {
-              case None =>
-                Ior.left(
-                  NonEmptyList.one(
-                    PackageError.UnknownImportFromInterface(
-                      nm,
-                      packF.name,
-                      packF.exports.map(_.name),
-                      i,
-                      exMap.iterator.flatMap(_._2.toList).toList
-                    )
-                  )
-                )
-              case Some(exps) =>
-                val bs = exps.map(_.tag)
-                Ior.right(i.map(_ => bs))
-            }
-
           /*
            * This resolves imports from PackageNames into fully typed Packages
            *
@@ -474,6 +425,9 @@ object PackageMap {
            * distinct object has its own entry in the list
            */
           type IName = NonEmptyList[Referant[Kind.Arg]]
+
+          def resFromEither[A, B](either: Either[A, B]): IorT[F, NonEmptyList[A], B] =
+            IorT.fromEither(either.left.map(NonEmptyList.one(_)))
 
           def stepImport(
               fixpack: Package.Resolved,
@@ -487,21 +441,21 @@ object PackageMap {
                 IorT(recurse(p))
                   .flatMap { case (_, packF) =>
                     val packInterface = Package.interfaceOf(packF)
-                    val exMap = packF.exports.groupByNel(_.name)
-                    val ior = getImport(packF, exMap, item)
+                    val either = packF.getImport(nm, item)
                       .map((packInterface, _))
-                    IorT.fromIor(ior)
+
+                    resFromEither(either)
                   }
               case Left(iface) =>
                 /*
                  * this import is already an interface, we can stop here
                  */
-                val exMap = iface.exports.groupByNel(_.name)
                 // this is very fast and does not need to be done in a thread
-                val ior =
-                  getImportIface(iface, exMap, item)
+                val e =
+                  iface.getImportIface(nm, item)
                     .map((iface, _))
-                IorT.fromIor(ior)
+
+                resFromEither(e)
             }
 
           val inferImports: FutVal[


### PR DESCRIPTION
trying to get towards improving the cli to compile C generated code, and I want to simplify some.

I'm rethinking the idea of always normalizing packages on compile since that normalization is expensive but also probably doesn't help python or the interpreter much.

It would help a compiled language with an optimizer since we can apply optimizations at the bosatsu layer that lower layers can't do (since they don't know the invariants).