### PR TITLE
Add lib check command

### DIFF
--- a/core/src/main/scala/org/bykn/bosatsu/hashing/Algo.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/hashing/Algo.scala
@@ -1,5 +1,6 @@
 package org.bykn.bosatsu.hashing
 
+import cats.arrow.FunctionK
 import cats.parse.Parser
 import pt.kcry.blake3.{Blake3 => B3, Hasher => B3Hasher}
 
@@ -50,6 +51,9 @@ object Algo {
     type A
     def algo: Algo[A]
     def value: F[A]
+
+    def mapK[G[_]](fn: FunctionK[F, G]): WithAlgo[G] =
+      WithAlgo[G, A](algo, fn(value))
 
     override def equals(obj: Any): Boolean =
       obj match {

--- a/core/src/main/scala/org/bykn/bosatsu/library/Command.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/library/Command.scala
@@ -1,9 +1,11 @@
 package org.bykn.bosatsu.library
 
 import cats.{Monad, MonoidK}
+import cats.data.NonEmptyList
 import com.monovore.decline.Opts
-import org.bykn.bosatsu.tool.{CliException, Output}
+import org.bykn.bosatsu.tool.{CliException, CompilerApi, Output, PathGen}
 import org.bykn.bosatsu.hashing.{Algo, HashValue}
+import org.bykn.bosatsu.LocationMap.Colorize
 import org.bykn.bosatsu.{Json, PlatformIO}
 import org.typelevel.paiges.Doc
 import scala.collection.immutable.SortedMap
@@ -11,6 +13,7 @@ import scala.collection.immutable.SortedMap
 import _root_.bosatsu.{TypedAst => proto}
 
 import cats.syntax.all._
+import org.bykn.bosatsu.tool.PackageResolver
 
 object Command {
   def opts[F[_], P](platformIO: PlatformIO[F, P]): Opts[F[Output[P]]] = {
@@ -74,196 +77,6 @@ object Command {
 
     def confPath(root: P, name: Name): P =
       platformIO.resolve(root, s"${name.name}_conf.json")
-
-    def fetchAllDeps(casDir: P, deps: List[proto.LibDependency]): F[Doc] = {
-      import platformIO.parallelF
-
-      // Right(true): succeeded to download
-      // Right(false): succeeded with cached
-      // Left: failed to download or add to cache
-      type DownloadRes = Either[Throwable, Boolean]
-      type FetchState = SortedMap[
-        (String, Version),
-        SortedMap[Algo.WithAlgo[HashValue], DownloadRes]
-      ]
-
-      def hashes(dep: proto.LibDependency): List[Algo.WithAlgo[HashValue]] =
-        for {
-          desc <- dep.desc.toList
-          hash <- desc.hashes
-          hashValue <- Algo.parseIdent.parseAll(hash).toOption.toList
-        } yield hashValue
-
-      def depUris(dep: proto.LibDependency): List[String] =
-        dep.desc.toList.flatMap(_.uris)
-
-      def casPaths(
-          dep: proto.LibDependency
-      ): SortedMap[Algo.WithAlgo[HashValue], P] =
-        hashes(dep)
-          .map { withAlgo =>
-            val algoName = withAlgo.algo.name
-            val hex1 = withAlgo.value.hex.take(2)
-            val hex2 = withAlgo.value.hex.drop(2)
-
-            val path =
-              platformIO.resolve(casDir, algoName :: hex1 :: hex2 :: Nil)
-
-            (withAlgo, path)
-          }
-          .to(SortedMap)
-
-      def libFromCas(dep: proto.LibDependency): F[Option[proto.Library]] =
-        casPaths(dep).values.toList.collectFirstSomeM { path =>
-          platformIO.fileExists(path).flatMap {
-            case true  => platformIO.readLibrary(path).map(h => Some(h.arg))
-            case false => Monad[F].pure(None)
-          }
-        }
-
-      def fetchIfNeeded(
-          dep: proto.LibDependency
-      ): F[SortedMap[Algo.WithAlgo[HashValue], DownloadRes]] = {
-        val paths = casPaths(dep)
-        val uris = depUris(dep)
-
-        paths.transform { (hashValue, path) =>
-          platformIO
-            .fileExists(path)
-            .flatMap {
-              case true => Monad[F].pure(Right(false)).widen[DownloadRes]
-              case false =>
-                {
-                  // We need to download
-                  uris
-                    .foldM((List.empty[(String, Throwable)], false)) {
-                      case ((fails, false), uri) =>
-                        platformIO
-                          .fetchHash(hashValue.algo, hashValue.value, path, uri)
-                          .attempt
-                          .map {
-                            case Right(_) => ((fails, true))
-                            case Left(e)  => (((uri, e) :: fails, false))
-                          }
-                      case (done, _) => Monad[F].pure(done)
-                    }
-                    .map {
-                      case (_, true) =>
-                        // we were able to download
-                        Right(true)
-                      case (fails, false) =>
-                        // couldn't download
-                        Left(
-                          CliException(
-                            s"download failure: ${dep.name} with ${fails.size} fails.",
-                            if (fails.isEmpty)
-                              Doc.text(
-                                s"failed to fetch ${dep.name} with no uris."
-                              )
-                            else {
-                              Doc.text(
-                                s"failed to fetch ${dep.name} with ${fails.size} fails:"
-                              ) +
-                                (Doc.line + Doc.intercalate(
-                                  Doc.line + Doc.line,
-                                  fails.map { case (uri, f) =>
-                                    Doc.text(
-                                      s"uri=$uri failed with ${f.getMessage}"
-                                    )
-                                  }
-                                )).nested(4)
-                            }
-                          )
-                        )
-                    }
-                }
-                  .widen[DownloadRes]
-            }
-        }.parSequence
-      }
-
-      def versionOf(dep: proto.LibDependency): Version =
-        dep.desc.flatMap(_.version) match {
-          case None    => Version.zero
-          case Some(v) => Version.fromProto(v)
-        }
-
-      def step(
-          fetched: FetchState,
-          batch: List[proto.LibDependency]
-      ): F[(FetchState, List[proto.LibDependency])] =
-        batch
-          .parTraverse { dep =>
-            fetchIfNeeded(dep).map(fetchMap => (dep, fetchMap))
-          }
-          .flatMap { thisFetched =>
-            val nextFetched = fetched ++ thisFetched.map { case (dep, fm) =>
-              (dep.name, versionOf(dep)) -> fm
-            }
-
-            val nextBatchF: F[List[proto.LibDependency]] =
-              thisFetched
-                .parTraverse { case (dep, _) =>
-                  libFromCas(dep)
-                }
-                .map { fetchedLibsOpt =>
-                  val fetchedDeps = fetchedLibsOpt.flatMap {
-                    case None      => Nil
-                    case Some(dep) =>
-                      // we will find the transitivies by walking them
-                      dep.publicDependencies.toList ::: dep.privateDependencies.toList
-                  }
-
-                  fetchedDeps.filterNot { dep =>
-                    nextFetched.contains((dep.name, versionOf(dep)))
-                  }
-                }
-
-            nextBatchF.map((nextFetched, _))
-          }
-
-      moduleIOMonad
-        .tailRecM((SortedMap.empty: FetchState, deps)) { case (fetched, deps) =>
-          step(fetched, deps).map {
-            case (state, Nil) => Right(state)
-            case next         => Left(next)
-          }
-        }
-        .flatMap { fs =>
-          val depStr = if (fs.size == 1) "dependency" else "dependencies"
-          val header = Doc.text(s"fetched ${fs.size} transitive ${depStr}.")
-
-          val resultDoc = header + Doc.line + Doc.intercalate(
-            Doc.hardLine,
-            fs.toList.map { case ((n, v), hashes) =>
-              val sortedHashes = hashes.toList.sortBy(_._1.toIdent)
-              val hashDoc = Doc.intercalate(
-                Doc.comma + Doc.line,
-                sortedHashes.map { case (wh, msg) =>
-                  val ident = wh.toIdent
-                  msg match {
-                    case Right(true)  => Doc.text(show"fetched $ident")
-                    case Right(false) => Doc.text(show"cached $ident")
-                    case Left(err) =>
-                      Doc.text(show"failed: $ident ${err.getMessage}")
-                  }
-                }
-              )
-
-              Doc.text(show"$n $v:") + (Doc.line + hashDoc).nested(4).grouped
-            }
-          )
-
-          val success = fs.forall { case (_, dl) =>
-            dl.forall { case (_, res) => res.isRight }
-          }
-          if (success) moduleIOMonad.pure(resultDoc)
-          else
-            moduleIOMonad.raiseError(
-              CliException("failed to fetch", err = resultDoc)
-            )
-        }
-    }
 
     val initCommand =
       Opts.subcommand("init", "initialize a config") {
@@ -329,7 +142,7 @@ object Command {
     /*
      Git the path to the repo root, the name of the library we are working with and the path to that library
      */
-    val rootAndName: Opts[F[(P, Name, P)]] =
+    val rootNameRoot: Opts[F[(P, Name, P)]] =
       // either there is only one path, or we need to have both
       (topLevelOpt, optName.orNone)
         .mapN { (gitRootF, optName) =>
@@ -367,12 +180,15 @@ object Command {
           } yield (
             gitRoot,
             name,
-            platformIO.resolve(
-              platformIO.resolve(gitRoot, path),
-              show"${name}_conf.json"
-            )
+            platformIO.resolve(gitRoot, path)
           )
         }
+
+    val rootAndName: Opts[F[(P, Name, P)]] =
+      cats.Functor[Opts].compose[F].map(rootNameRoot) {
+        case (gitRoot, name, path) =>
+          (gitRoot, name, confPath(path, name))
+      }
 
     val gitShaOpt: Opts[F[String]] =
       Opts
@@ -469,9 +285,62 @@ object Command {
             pnp <- fpnp
             (gitRoot, name, confPath) = pnp
             conf <- readLibConf(name, confPath)
-            casDir = casDirFn(gitRoot)
-            msg <- fetchAllDeps(casDir, conf.publicDeps ::: conf.privateDeps)
+            cas = new Cas(casDirFn(gitRoot), platformIO)
+            msg <- cas.fetchAllDeps(conf.publicDeps ::: conf.privateDeps)
           } yield (Output.Basic(msg, None): Output[P])
+        }
+      }
+
+    def check(
+        conf: LibConfig,
+        casDir: P,
+        confDir: P,
+        colorize: Colorize
+    ): F[Doc] = {
+      val cas = new Cas(casDir, platformIO)
+      val inputRes =
+        PackageResolver.search(NonEmptyList.one(confDir), platformIO)
+      for {
+        pubPriv <- cas.depsFromCas(conf.publicDeps, conf.privateDeps)
+        (pubLibs, privLibs) = pubPriv
+        pubDecodes <- pubLibs.traverse(DecodedLibrary.decode(_))
+        privDecodes <- privLibs.traverse(DecodedLibrary.decode(_))
+        inputSrcs <- PathGen
+          .recursiveChildren(confDir, ".bosatsu")(platformIO)
+          .read
+        _ <- NonEmptyList.fromList(inputSrcs) match {
+          case Some(inputNel) =>
+            platformIO.withEC { ec =>
+              CompilerApi.typeCheck(
+                platformIO,
+                inputNel,
+                pubDecodes.flatMap(_.interfaces) ::: privDecodes.flatMap(
+                  _.interfaces
+                ),
+                colorize,
+                inputRes
+              )(ec)
+            }.void
+          case None =>
+            moduleIOMonad.unit
+        }
+      } yield Doc.text("")
+    }
+
+    val checkCommand =
+      Opts.subcommand(
+        "check",
+        "check all the code, but do not build the final output library (faster than build)."
+      ) {
+        (rootNameRoot, casDirOpts, Colorize.optsConsoleDefault).mapN {
+          (fpnp, casDirFn, colorize) =>
+            for {
+              pnp <- fpnp
+              (gitRoot, name, confDir) = pnp
+              conf <- readLibConf(name, confPath(confDir, name))
+              casDir = casDirFn(gitRoot)
+              msg <- check(conf, casDir, confDir, colorize)
+            } yield (Output.Basic(msg, None): Output[P])
         }
       }
 
@@ -480,7 +349,251 @@ object Command {
         listCommand ::
         assembleCommand ::
         fetchCommand ::
+        checkCommand ::
         Nil
     )
+  }
+
+  class Cas[F[_], P](casDir: P, platformIO: PlatformIO[F, P]) {
+    import platformIO.moduleIOMonad
+    import platformIO.parallelF
+
+    // Right(true): succeeded to download
+    // Right(false): succeeded with cached
+    // Left: failed to download or add to cache
+    type DownloadRes = Either[Throwable, Boolean]
+    type FetchState = SortedMap[
+      (String, Version),
+      SortedMap[Algo.WithAlgo[HashValue], DownloadRes]
+    ]
+
+    def hashes(dep: proto.LibDependency): List[Algo.WithAlgo[HashValue]] =
+      for {
+        desc <- dep.desc.toList
+        hash <- desc.hashes
+        hashValue <- Algo.parseIdent.parseAll(hash).toOption.toList
+      } yield hashValue
+
+    def casPaths(
+        dep: proto.LibDependency
+    ): SortedMap[Algo.WithAlgo[HashValue], P] =
+      hashes(dep)
+        .map { withAlgo =>
+          val algoName = withAlgo.algo.name
+          val hex1 = withAlgo.value.hex.take(2)
+          val hex2 = withAlgo.value.hex.drop(2)
+
+          val path =
+            platformIO.resolve(casDir, algoName :: hex1 :: hex2 :: Nil)
+
+          (withAlgo, path)
+        }
+        .to(SortedMap)
+
+    def libFromCas(dep: proto.LibDependency): F[Option[proto.Library]] =
+      casPaths(dep).values.toList.collectFirstSomeM { path =>
+        platformIO.fileExists(path).flatMap {
+          case true  => platformIO.readLibrary(path).map(h => Some(h.arg))
+          case false => Monad[F].pure(None)
+        }
+      }
+
+    def depsFromCas(
+        pubDeps: List[proto.LibDependency],
+        privDeps: List[proto.LibDependency]
+    ): F[(List[proto.Library], List[proto.Library])] =
+      (
+        pubDeps.parTraverse(dep => libFromCas(dep).map(dep -> _)),
+        privDeps.parTraverse(dep => libFromCas(dep).map(dep -> _))
+      ).parTupled
+        .flatMap { case (pubLibs, privLibs) =>
+          val missingPubs = pubLibs.collect { case (dep, None) => dep }
+          val missingPrivs = privLibs.collect { case (dep, None) => dep }
+
+          if (missingPubs.isEmpty && missingPrivs.isEmpty) {
+            moduleIOMonad.pure(
+              (
+                pubLibs.collect { case (_, Some(lib)) => lib },
+                privLibs.collect { case (_, Some(lib)) => lib }
+              )
+            )
+          } else {
+            // report the missing libraries and suggest running fetch
+            val pubDoc = Doc.text("public dependencies:") + (
+              Doc.line + Doc.intercalate(
+                Doc.comma + Doc.line,
+                missingPubs.map(dep => Doc.text(dep.name))
+              )
+            ).nested(4).grouped
+
+            val privDoc = Doc.text("private dependencies:") + (
+              Doc.line + Doc.intercalate(
+                Doc.comma + Doc.line,
+                missingPrivs.map(dep => Doc.text(dep.name))
+              )
+            ).nested(4).grouped
+
+            moduleIOMonad
+              .raiseError(
+                CliException(
+                  "missing deps from cas",
+                  Doc.text(
+                    "missing "
+                  ) + pubDoc + Doc.line + privDoc + Doc.line + Doc.text(
+                    "run `lib fetch` to insert these libraries into the cas."
+                  )
+                )
+              )
+          }
+        }
+
+    def depUris(dep: proto.LibDependency): List[String] =
+      dep.desc.toList.flatMap(_.uris)
+
+    def versionOf(dep: proto.LibDependency): Version =
+      dep.desc.flatMap(_.version) match {
+        case None    => Version.zero
+        case Some(v) => Version.fromProto(v)
+      }
+
+    def fetchIfNeeded(
+        dep: proto.LibDependency
+    ): F[SortedMap[Algo.WithAlgo[HashValue], DownloadRes]] = {
+      val paths = casPaths(dep)
+      val uris = depUris(dep)
+
+      paths.transform { (hashValue, path) =>
+        platformIO
+          .fileExists(path)
+          .flatMap {
+            case true => Monad[F].pure(Right(false)).widen[DownloadRes]
+            case false =>
+              {
+                // We need to download
+                uris
+                  .foldM((List.empty[(String, Throwable)], false)) {
+                    case ((fails, false), uri) =>
+                      platformIO
+                        .fetchHash(hashValue.algo, hashValue.value, path, uri)
+                        .attempt
+                        .map {
+                          case Right(_) => ((fails, true))
+                          case Left(e)  => (((uri, e) :: fails, false))
+                        }
+                    case (done, _) => Monad[F].pure(done)
+                  }
+                  .map {
+                    case (_, true) =>
+                      // we were able to download
+                      Right(true)
+                    case (fails, false) =>
+                      // couldn't download
+                      Left(
+                        CliException(
+                          s"download failure: ${dep.name} with ${fails.size} fails.",
+                          if (fails.isEmpty)
+                            Doc.text(
+                              s"failed to fetch ${dep.name} with no uris."
+                            )
+                          else {
+                            Doc.text(
+                              s"failed to fetch ${dep.name} with ${fails.size} fails:"
+                            ) +
+                              (Doc.line + Doc.intercalate(
+                                Doc.line + Doc.line,
+                                fails.map { case (uri, f) =>
+                                  Doc.text(
+                                    s"uri=$uri failed with ${f.getMessage}"
+                                  )
+                                }
+                              )).nested(4)
+                          }
+                        )
+                      )
+                  }
+              }
+                .widen[DownloadRes]
+          }
+      }.parSequence
+    }
+
+    def fetchAllDeps(deps: List[proto.LibDependency]): F[Doc] = {
+
+      def step(
+          fetched: FetchState,
+          batch: List[proto.LibDependency]
+      ): F[(FetchState, List[proto.LibDependency])] =
+        batch
+          .parTraverse { dep =>
+            fetchIfNeeded(dep).map(fetchMap => (dep, fetchMap))
+          }
+          .flatMap { thisFetched =>
+            val nextFetched = fetched ++ thisFetched.map { case (dep, fm) =>
+              (dep.name, versionOf(dep)) -> fm
+            }
+
+            val nextBatchF: F[List[proto.LibDependency]] =
+              thisFetched
+                .parTraverse { case (dep, _) =>
+                  libFromCas(dep)
+                }
+                .map { fetchedLibsOpt =>
+                  val fetchedDeps = fetchedLibsOpt.flatMap {
+                    case None      => Nil
+                    case Some(dep) =>
+                      // we will find the transitivies by walking them
+                      dep.publicDependencies.toList ::: dep.privateDependencies.toList
+                  }
+
+                  fetchedDeps.filterNot { dep =>
+                    nextFetched.contains((dep.name, versionOf(dep)))
+                  }
+                }
+
+            nextBatchF.map((nextFetched, _))
+          }
+
+      moduleIOMonad
+        .tailRecM((SortedMap.empty: FetchState, deps)) { case (fetched, deps) =>
+          step(fetched, deps).map {
+            case (state, Nil) => Right(state)
+            case next         => Left(next)
+          }
+        }
+        .flatMap { fs =>
+          val depStr = if (fs.size == 1) "dependency" else "dependencies"
+          val header = Doc.text(s"fetched ${fs.size} transitive ${depStr}.")
+
+          val resultDoc = header + Doc.line + Doc.intercalate(
+            Doc.hardLine,
+            fs.toList.map { case ((n, v), hashes) =>
+              val sortedHashes = hashes.toList.sortBy(_._1.toIdent)
+              val hashDoc = Doc.intercalate(
+                Doc.comma + Doc.line,
+                sortedHashes.map { case (wh, msg) =>
+                  val ident = wh.toIdent
+                  msg match {
+                    case Right(true)  => Doc.text(show"fetched $ident")
+                    case Right(false) => Doc.text(show"cached $ident")
+                    case Left(err) =>
+                      Doc.text(show"failed: $ident ${err.getMessage}")
+                  }
+                }
+              )
+
+              Doc.text(show"$n $v:") + (Doc.line + hashDoc).nested(4).grouped
+            }
+          )
+
+          val success = fs.forall { case (_, dl) =>
+            dl.forall { case (_, res) => res.isRight }
+          }
+          if (success) moduleIOMonad.pure(resultDoc)
+          else
+            moduleIOMonad.raiseError(
+              CliException("failed to fetch", err = resultDoc)
+            )
+        }
+    }
   }
 }

--- a/core/src/main/scala/org/bykn/bosatsu/library/Command.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/library/Command.scala
@@ -3,7 +3,13 @@ package org.bykn.bosatsu.library
 import cats.{Monad, MonoidK}
 import cats.data.NonEmptyList
 import com.monovore.decline.Opts
-import org.bykn.bosatsu.tool.{CliException, CompilerApi, Output, PathGen}
+import org.bykn.bosatsu.tool.{
+  CliException,
+  CompilerApi,
+  Output,
+  PathGen,
+  PackageResolver
+}
 import org.bykn.bosatsu.hashing.{Algo, HashValue}
 import org.bykn.bosatsu.LocationMap.Colorize
 import org.bykn.bosatsu.{Json, PlatformIO}
@@ -13,7 +19,6 @@ import scala.collection.immutable.SortedMap
 import _root_.bosatsu.{TypedAst => proto}
 
 import cats.syntax.all._
-import org.bykn.bosatsu.tool.PackageResolver
 
 object Command {
   def opts[F[_], P](platformIO: PlatformIO[F, P]): Opts[F[Output[P]]] = {
@@ -299,7 +304,7 @@ object Command {
     ): F[Doc] = {
       val cas = new Cas(casDir, platformIO)
       val inputRes =
-        PackageResolver.search(NonEmptyList.one(confDir), platformIO)
+        PackageResolver.LocalRoots[F, P](NonEmptyList.one(confDir), None)
       for {
         pubPriv <- cas.depsFromCas(conf.publicDeps, conf.privateDeps)
         (pubLibs, privLibs) = pubPriv

--- a/core/src/main/scala/org/bykn/bosatsu/library/LibConfig.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/library/LibConfig.scala
@@ -1,17 +1,25 @@
 package org.bykn.bosatsu.library
 
 import _root_.bosatsu.{TypedAst => proto}
+import cats.MonadError
 import cats.data.{NonEmptyChain, NonEmptyList, Validated, ValidatedNec}
 import cats.syntax.all._
 import java.util.regex.Pattern
 import java.util.regex.PatternSyntaxException
-import org.bykn.bosatsu.{Json, Package, PackageName, ProtoConverter, Kind}
+import org.bykn.bosatsu.{
+  Json,
+  Package,
+  PackageName,
+  PackageMap,
+  ProtoConverter,
+  Kind
+}
 import org.bykn.bosatsu.tool.CliException
 import org.bykn.bosatsu.rankn.TypeEnv
 import org.bykn.bosatsu.hashing.{Hashed, HashValue, Algo}
 import org.typelevel.paiges.{Doc, Document}
 import scala.util.{Failure, Success, Try}
-import scala.collection.immutable.SortedMap
+import scala.collection.immutable.{SortedMap, SortedSet}
 
 import LibConfig.{Error, LibMethods, LibHistoryMethods, ValidationResult}
 
@@ -942,5 +950,32 @@ object LibConfig {
           publicDeps = publicDeps.toList.flatten,
           privateDeps = privateDeps.toList.flatten
         )
+    }
+}
+
+case class DecodedLibrary(
+    protoLib: proto.Library,
+    interfaces: List[Package.Interface],
+    implementations: PackageMap.Typed[Unit]
+) {
+  lazy val publicPackageNames: SortedSet[PackageName] =
+    interfaces.iterator.map(_.name).to(SortedSet)
+}
+
+object DecodedLibrary {
+  def decode[F[_]](
+      protoLib: proto.Library
+  )(implicit F: MonadError[F, Throwable]): F[DecodedLibrary] =
+    F.fromTry(
+      ProtoConverter
+        .packagesFromProto(protoLib.exportedIfaces, protoLib.internalPackages)
+    ).map { case (ifs, impls) =>
+      // TODO: should verify somewhere that all the package names are distinct, but since this is presumed to be
+      // a good library maybe that's a waste
+      DecodedLibrary(
+        protoLib,
+        ifs,
+        PackageMap(impls.iterator.map(pack => (pack.name, pack)).to(SortedMap))
+      )
     }
 }

--- a/core/src/main/scala/org/bykn/bosatsu/library/LibConfig.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/library/LibConfig.scala
@@ -37,9 +37,9 @@ case class LibConfig(
     */
   def assemble(
       vcsIdent: String,
-      previous: Option[Hashed[Algo.Blake3, proto.Library]],
+      previous: Option[DecodedLibrary[Algo.Blake3]],
       packs: List[Package.Typed[Unit]],
-      deps: List[Hashed[Algo.Blake3, proto.Library]]
+      deps: List[DecodedLibrary[Algo.Blake3]]
   ): ValidatedNec[Error, proto.Library] =
     validate(previous, packs, deps)
       .andThen { vr =>
@@ -68,9 +68,9 @@ case class LibConfig(
     *   9. there is a valid solution for transitive dependencies
     */
   def validate(
-      previous: Option[Hashed[Algo.Blake3, proto.Library]],
+      previous: Option[DecodedLibrary[Algo.Blake3]],
       packs: List[Package.Typed[Unit]],
-      deps: List[Hashed[Algo.Blake3, proto.Library]]
+      deps: List[DecodedLibrary[Algo.Blake3]]
   ): ValidatedNec[Error, ValidationResult] = {
 
     import Error.inv
@@ -81,25 +81,25 @@ case class LibConfig(
     val privatePacks: List[Package.Typed[Unit]] =
       packs.filter(p => allPackages.exists(_.accepts(p.name)))
 
-    val nameToDep = deps.groupByNel(_.arg.name)
+    val nameToDep = deps.groupByNel(_.protoLib.name)
 
-    val publicDepLibs: List[proto.Library] =
+    val publicDepLibs: List[DecodedLibrary[Algo.Blake3]] =
       publicDeps.flatMap { dep =>
         nameToDep.get(dep.name) match {
           case None =>
             // this will be a validation error later
             Nil
-          case Some(libs) => libs.head.arg :: Nil
+          case Some(libs) => libs.head :: Nil
         }
       }
 
-    val privateDepLibs: List[proto.Library] =
+    val privateDepLibs: List[DecodedLibrary[Algo.Blake3]] =
       privateDeps.flatMap { dep =>
         nameToDep.get(dep.name) match {
           case None =>
             // this will be a validation error later
             Nil
-          case Some(libs) => libs.head.arg :: Nil
+          case Some(libs) => libs.head :: Nil
         }
       }
 
@@ -107,9 +107,8 @@ case class LibConfig(
     val packToLibName: Map[PackageName, Name] =
       (exportedPacks.iterator.map(p => (p.name, name)) ++
         (publicDepLibs.iterator ++ privateDepLibs.iterator).flatMap { lib =>
-          lib.exportedIfaces
-            .flatMap(iface => PackageName.parse(ProtoConverter.iname(iface)))
-            .map((_, Name(lib.name)))
+          lib.interfaces
+            .map(iface => (iface.name, Name(lib.protoLib.name)))
         }).toMap
 
     val prop1 =
@@ -118,7 +117,8 @@ case class LibConfig(
         case h :: t => inv(Error.ExtraPackages(NonEmptyList(h, t)))
       }
 
-    val prop2 = previous.traverse_ { case Hashed(_, p) =>
+    val prop2 = previous.traverse_ { dec =>
+      val p = dec.protoLib
       val prevLt = p.version match {
         case Some(prevV) =>
           if (Ordering[Version].lt(prevV, nextVersion)) Validated.unit
@@ -147,14 +147,15 @@ case class LibConfig(
     }
 
     val prop3 = previous match {
-      case Some(Hashed(_, prevLib)) =>
+      case Some(dec) =>
+        val prevLib = dec.protoLib
         prevLib.version match {
           case Some(prevVersion) =>
             if (prevVersion.justBefore(nextVersion)) {
               val dk = prevVersion.diffKindTo(nextVersion)
               if (!dk.isMajor) {
                 val diff = LibConfig.validNextVersion(
-                  prevLib,
+                  dec,
                   dk,
                   exportedPacks,
                   publicDepLibs
@@ -168,7 +169,7 @@ case class LibConfig(
                       dk.isPatch &&
                       LibConfig
                         .validNextVersion(
-                          prevLib,
+                          dec,
                           Version.DiffKind.Minor,
                           exportedPacks,
                           publicDepLibs
@@ -207,11 +208,7 @@ case class LibConfig(
     val prop4 = {
       val validDepPacks: List[PackageName] =
         PackageName.PredefName :: exportedPacks.map(_.name) :::
-          publicDepLibs.flatMap { lib =>
-            lib.exportedIfaces.flatMap { iface =>
-              PackageName.parse(ProtoConverter.iname(iface))
-            }
-          }
+          publicDepLibs.flatMap(lib => lib.interfaces.map(_.name))
 
       val validSet = validDepPacks.toSet
 
@@ -221,8 +218,8 @@ case class LibConfig(
         invalidDeps.traverse_ { badPn =>
           val msg =
             if (
-              privateDepLibs.exists(_.exportedIfaces.exists { iface =>
-                ProtoConverter.iname(iface) === badPn.asString
+              privateDepLibs.exists(_.interfaces.exists { iface =>
+                iface.name === badPn
               })
             ) "package from private dependency"
             else if (privatePacks.exists(_.name === badPn))
@@ -321,8 +318,8 @@ case class LibConfig(
           inv(
             Error.DuplicateDep(
               "argument dep",
-              e.arg.name,
-              e.arg.descriptor.getOrElse(proto.LibDescriptor())
+              e.protoLib.name,
+              e.protoLib.descriptor.getOrElse(proto.LibDescriptor())
             )
           )
         )
@@ -333,7 +330,7 @@ case class LibConfig(
           case None =>
             inv(Error.MissingDep(note = note, dep = dep))
           case Some(deps) =>
-            val hash = deps.head.hash.toIdent
+            val hash = deps.head.hashValue.toIdent
             if (dep.desc.exists(_.hashes.exists(_ == hash))) Validated.unit
             else {
               // the hash doesn't match
@@ -341,8 +338,8 @@ case class LibConfig(
                 Error.DepHashMismatch(
                   note,
                   dep,
-                  deps.head.hash,
-                  deps.head.arg
+                  deps.head.hashValue,
+                  deps.head.protoLib
                 )
               )
             }
@@ -365,19 +362,21 @@ case class LibConfig(
 
   // just build the library without any validations
   def unvalidatedAssemble(
-      previous: Option[Hashed[Algo.Blake3, proto.Library]],
+      previous: Option[DecodedLibrary[Algo.Blake3]],
       vcsIdent: String,
       packs: List[Package.Typed[Unit]],
       unusedTrans: List[proto.LibDependency]
   ): Either[Throwable, proto.Library] = {
     val depth = previous match {
-      case None                     => 0
-      case Some(Hashed(_, prevLib)) => prevLib.depth + 1
+      case None      => 0
+      case Some(dec) => dec.protoLib.depth + 1
     }
 
     val thisHistory = previous match {
       case None => proto.LibHistory()
-      case Some(Hashed(hash, p)) =>
+      case Some(dec) =>
+        val hash = dec.hashValue
+        val p = dec.protoLib
         val prevHistory = p.history.getOrElse(proto.LibHistory())
         val v = p.descriptor match {
           case Some(desc) =>
@@ -660,14 +659,16 @@ object LibConfig {
     * them
     */
   def unusedTransitiveDeps(
-      publicDeps: List[proto.Library]
+      publicDeps: List[DecodedLibrary[Algo.Blake3]]
   ): ValidatedNec[Error, SortedMap[String, proto.LibDependency]] = {
     val usedDeps =
-      publicDeps.iterator.map(lib => (lib.name, lib.descriptor)).toMap
+      publicDeps.iterator
+        .map(lib => (lib.protoLib.name, lib.protoLib.descriptor))
+        .toMap
 
     val allTransitiveDeps = (
-      publicDeps.map(_.toDep) :::
-        publicDeps.flatMap(_.unusedTransitivePublicDependencies)
+      publicDeps.map(_.protoLib.toDep) :::
+        publicDeps.flatMap(_.protoLib.unusedTransitivePublicDependencies)
     )
       .groupByNel(_.name)
 
@@ -706,17 +707,18 @@ object LibConfig {
   }
 
   def validNextVersion(
-      prevLib: proto.Library,
+      prevDec: DecodedLibrary[Algo.Blake3],
       dk: Version.DiffKind,
       exportedPacks: List[Package.Typed[Unit]],
-      publicDepLibs: List[proto.Library]
+      publicDepLibs: List[DecodedLibrary[Algo.Blake3]]
   ): ValidatedNec[Error, Unit] = {
+    val prevLib = prevDec.protoLib
     val oldPublicVersions =
       (prevLib.publicDependencies.toList ::: prevLib.unusedTransitivePublicDependencies.toList)
         .groupByNel(_.name)
     val newPublicVersions =
-      (publicDepLibs.map(_.toDep) ::: publicDepLibs.flatMap(
-        _.unusedTransitivePublicDependencies
+      (publicDepLibs.map(_.protoLib.toDep) ::: publicDepLibs.flatMap(
+        _.protoLib.unusedTransitivePublicDependencies
       )).distinct.groupByNel(_.name)
 
     val allLibNames = oldPublicVersions.keySet | newPublicVersions.keySet
@@ -761,35 +763,33 @@ object LibConfig {
       }
     }
 
-    val publicTypes: ValidatedNec[Error, TypeEnv[Kind.Arg]] =
+    val depTypes: TypeEnv[Kind.Arg] =
       publicDepLibs
-        .traverse { lib =>
-          lib.ifaces.map(_.foldMap(_.exportedTypeEnv))
+        .foldMap { lib =>
+          lib.interfaces.foldMap(_.exportedTypeEnv)
         }
-        .map(_.combineAll)
 
-    compatPublicDepChange *> publicTypes.andThen { depTypes =>
-      prevLib.ifaces.andThen { prevIfaces =>
-        val prevExports = prevIfaces.iterator
-          .map(iface => (iface.name, iface.exports))
-          .to(SortedMap)
-        val prevTE = depTypes ++ prevIfaces.foldMap(_.exportedTypeEnv)
+    val prevIfaces = prevDec.interfaces
+    compatPublicDepChange *> {
+      val prevExports = prevIfaces.iterator
+        .map(iface => (iface.name, iface.exports))
+        .to(SortedMap)
+      val prevTE = depTypes ++ prevIfaces.foldMap(_.exportedTypeEnv)
 
-        val currExports = exportedPacks.iterator
-          .map(pack => (pack.name, pack.exports))
-          .to(SortedMap)
-        val currTE = depTypes ++ exportedPacks.foldMap(_.exportedTypeEnv)
+      val currExports = exportedPacks.iterator
+        .map(pack => (pack.name, pack.exports))
+        .to(SortedMap)
+      val currTE = depTypes ++ exportedPacks.foldMap(_.exportedTypeEnv)
 
-        val diff = ApiDiff(prevExports, prevTE, currExports, currTE)
+      val diff = ApiDiff(prevExports, prevTE, currExports, currTE)
 
-        val badDiffs = diff
-          .badDiffs(dk) { diff =>
-            Error.InvalidDiff(dk, diff)
-          }
-          .toVector
+      val badDiffs = diff
+        .badDiffs(dk) { diff =>
+          Error.InvalidDiff(dk, diff)
+        }
+        .toVector
 
-        badDiffs.traverse_(Error.inv(_))
-      }
+      badDiffs.traverse_(Error.inv(_))
     }
   }
 
@@ -895,14 +895,6 @@ object LibConfig {
       proto.LibDependency(name = lib.name, desc = lib.descriptor)
 
     def version: Option[Version] = lib.descriptor.flatMap(_.parsedVersion)
-
-    def ifaces: ValidatedNec[Error, List[Package.Interface]] =
-      ProtoConverter.packagesFromProto(lib.exportedIfaces, Nil) match {
-        case Success((ifaces, _)) => Validated.valid(ifaces)
-        case Failure(err) =>
-          Error.inv(Error.CannotDecodeLibraryIfaces(lib, err))
-      }
-
   }
 
   implicit val libConfigWriter: Json.Writer[LibConfig] =
@@ -953,7 +945,8 @@ object LibConfig {
     }
 }
 
-case class DecodedLibrary(
+case class DecodedLibrary[A](
+    hashValue: HashValue[A],
     protoLib: proto.Library,
     interfaces: List[Package.Interface],
     implementations: PackageMap.Typed[Unit]
@@ -963,17 +956,21 @@ case class DecodedLibrary(
 }
 
 object DecodedLibrary {
-  def decode[F[_]](
-      protoLib: proto.Library
-  )(implicit F: MonadError[F, Throwable]): F[DecodedLibrary] =
+  def decode[F[_], A](
+      protoLib: Hashed[A, proto.Library]
+  )(implicit F: MonadError[F, Throwable]): F[DecodedLibrary[A]] =
     F.fromTry(
       ProtoConverter
-        .packagesFromProto(protoLib.exportedIfaces, protoLib.internalPackages)
+        .packagesFromProto(
+          protoLib.arg.exportedIfaces,
+          protoLib.arg.internalPackages
+        )
     ).map { case (ifs, impls) =>
       // TODO: should verify somewhere that all the package names are distinct, but since this is presumed to be
       // a good library maybe that's a waste
-      DecodedLibrary(
-        protoLib,
+      DecodedLibrary[A](
+        protoLib.hash,
+        protoLib.arg,
         ifs,
         PackageMap(impls.iterator.map(pack => (pack.name, pack)).to(SortedMap))
       )


### PR DESCRIPTION
this doesn't do any linking, just checking compilation.

To deal with libraries correctly in test and build we need to re-implement the compilers to not use an identifier which is (PackageName, Identifier), but for packages that are imported more than once use (Library, Version, PackageName, Identifier)... this will be a somewhat major refactor that is next up.