### PR TITLE
Add field to Matchless to show package source

### DIFF
--- a/core/src/main/scala/org/bykn/bosatsu/Evaluation.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/Evaluation.scala
@@ -43,13 +43,13 @@ case class Evaluation[T](pm: PackageMap.Typed[T], externals: Externals) {
       thisPack: PackageName,
       lets: List[(Bindable, RecursionKind, TypedExpr[T])]
   ): List[(Bindable, Eval[Value])] = {
-    val exprs: List[(Bindable, Matchless.Expr)] =
+    val exprs: List[(Bindable, Matchless.Expr[Unit])] =
       rankn.RefSpace.allocCounter
         .flatMap { c =>
           lets
             .traverse { case (name, rec, te) =>
               Matchless
-                .fromLet(name, rec, te, gdr, c)
+                .fromLet((), name, rec, te, gdr, c)
                 .map((name, _))
             }
         }

--- a/core/src/main/scala/org/bykn/bosatsu/Matchless.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/Matchless.scala
@@ -280,8 +280,9 @@ object Matchless {
 
   private[this] val empty = (PackageName.PredefName, Constructor("EmptyList"))
   private[this] val cons = (PackageName.PredefName, Constructor("NonEmptyList"))
-  private[this] val reverseFn =
-    Global[Nothing](???, PackageName.PredefName, Identifier.Name("reverse"))
+  private[this] val revName = Identifier.Name("reverse")
+  private[this] def reverseFn[A](from: A) =
+    Global[A](from, PackageName.PredefName, revName)
 
   // drop all items in the tail after the first time fn returns true
   // as a result, we have 0 or 1 items where fn is true in the result
@@ -919,7 +920,10 @@ object Matchless {
                             optAnonLeft match {
                               case Some((anonLeft, ln)) =>
                                 val revList =
-                                  App(reverseFn, NonEmptyList.one(anonLeft))
+                                  App(
+                                    reverseFn(from),
+                                    NonEmptyList.one(anonLeft)
+                                  )
                                 (
                                   anonLeft :: letTail,
                                   Some(anonLeft),

--- a/core/src/main/scala/org/bykn/bosatsu/MatchlessFromTypedExpr.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/MatchlessFromTypedExpr.scala
@@ -5,7 +5,7 @@ import Identifier.Bindable
 import cats.implicits._
 
 object MatchlessFromTypedExpr {
-  type Compiled = Map[PackageName, List[(Bindable, Matchless.Expr)]]
+  type Compiled = Map[PackageName, List[(Bindable, Matchless.Expr[Unit])]]
   // compile a set of packages given a set of external remappings
   def compile[A](
       pm: PackageMap.Typed[A]
@@ -16,18 +16,19 @@ object MatchlessFromTypedExpr {
     // on JS Par.F[A] is actually Id[A], so we need to hold hands a bit
 
     val allItemsList = pm.toMap.toList
-      .traverse[Par.F, (PackageName, List[(Bindable, Matchless.Expr)])] {
+      .traverse[Par.F, (PackageName, List[(Bindable, Matchless.Expr[Unit])])] {
         case (pname, pack) =>
           val lets = pack.lets
 
           Par.start {
-            val exprs: List[(Bindable, Matchless.Expr)] =
+            val exprs: List[(Bindable, Matchless.Expr[Unit])] =
               rankn.RefSpace.allocCounter
                 .flatMap { c =>
                   lets
                     .traverse { case (name, rec, te) =>
+                      // TODO: add from so we can resolve packages correctly
                       Matchless
-                        .fromLet(name, rec, te, gdr, c)
+                        .fromLet((), name, rec, te, gdr, c)
                         .map((name, _))
                     }
                 }

--- a/core/src/main/scala/org/bykn/bosatsu/MatchlessFromTypedExpr.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/MatchlessFromTypedExpr.scala
@@ -5,11 +5,11 @@ import Identifier.Bindable
 import cats.implicits._
 
 object MatchlessFromTypedExpr {
-  type Compiled = Map[PackageName, List[(Bindable, Matchless.Expr[Unit])]]
+  type Compiled[+A] = Map[PackageName, List[(Bindable, Matchless.Expr[A])]]
   // compile a set of packages given a set of external remappings
   def compile[A](
       pm: PackageMap.Typed[A]
-  )(implicit ec: Par.EC): Compiled = {
+  )(implicit ec: Par.EC): Compiled[Unit] = {
 
     val gdr = pm.getDataRepr
 

--- a/core/src/main/scala/org/bykn/bosatsu/MatchlessToValue.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/MatchlessToValue.scala
@@ -15,7 +15,7 @@ object MatchlessToValue {
 
   // reuse some cache structures across a number of calls
   def traverse[F[_]: Functor](
-      me: F[Expr]
+      me: F[Expr[Unit]]
   )(resolve: (PackageName, Identifier) => Eval[Value]): F[Eval[Value]] = {
     val env = new Impl.Env(resolve)
     val fns = Functor[F].map(me) { expr =>
@@ -208,7 +208,7 @@ object MatchlessToValue {
 
     class Env(resolve: (PackageName, Identifier) => Eval[Value]) {
       // evaluating boolExpr can mutate an existing value in muts
-      private def boolExpr(ix: BoolExpr): Scoped[Boolean] =
+      private def boolExpr(ix: BoolExpr[Unit]): Scoped[Boolean] =
         ix match {
           case EqualsLit(expr, lit) =>
             val litAny = lit.unboxToAny
@@ -300,7 +300,7 @@ object MatchlessToValue {
         }
 
       // the locals can be recusive, so we box into Eval for laziness
-      def loop(me: Expr): Scoped[Value] =
+      def loop(me: Expr[Unit]): Scoped[Value] =
         me match {
           case Lambda(Nil, None, args, res) =>
             val resFn = loop(res)
@@ -360,7 +360,7 @@ object MatchlessToValue {
               }
               scope.muts(result.ident).get()
             }
-          case Global(p, n) =>
+          case Global(_, p, n) =>
             val res = resolve(p, n)
 
             // this has to be lazy because it could be

--- a/core/src/test/scala/org/bykn/bosatsu/MatchlessTests.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/MatchlessTests.scala
@@ -52,19 +52,19 @@ class MatchlessTest extends AnyFunSuite {
 
   test("matchless.fromLet is pure: f(x) == f(x)") {
     forAll(genInputs) { case (b, r, t, fn) =>
-      def run(): Option[Matchless.Expr] =
+      def run(): Option[Matchless.Expr[Unit]] =
         // ill-formed inputs can fail
-        Try(Matchless.fromLet(b, r, t)(fn)).toOption
+        Try(Matchless.fromLet((), b, r, t)(fn)).toOption
 
       assert(run() == run())
     }
   }
 
-  lazy val genMatchlessExpr: Gen[Matchless.Expr] =
+  lazy val genMatchlessExpr: Gen[Matchless.Expr[Unit]] =
     genInputs
       .map { case (b, r, t, fn) =>
         // ill-formed inputs can fail
-        Try(Matchless.fromLet(b, r, t)(fn)).toOption
+        Try(Matchless.fromLet((), b, r, t)(fn)).toOption
       }
       .flatMap {
         case Some(e) => Gen.const(e)
@@ -157,10 +157,10 @@ class MatchlessTest extends AnyFunSuite {
     forAll(genMatchlessExpr) {
       case ifexpr @ Matchless.If(_, _, _) =>
         val (chain, rest) = ifexpr.flatten
-        def unflatten(
-            ifs: NonEmptyList[(Matchless.BoolExpr, Matchless.Expr)],
-            elseX: Matchless.Expr
-        ): Matchless.If =
+        def unflatten[A](
+            ifs: NonEmptyList[(Matchless.BoolExpr[A], Matchless.Expr[A])],
+            elseX: Matchless.Expr[A]
+        ): Matchless.If[A] =
           ifs.tail match {
             case Nil => Matchless.If(ifs.head._1, ifs.head._2, elseX)
             case head :: next =>

--- a/core/src/test/scala/org/bykn/bosatsu/TestUtils.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/TestUtils.scala
@@ -105,7 +105,10 @@ object TestUtils {
   def checkMatchless[A](
       statement: String
   )(
-      fn: Map[PackageName, List[(Identifier.Bindable, Matchless.Expr)]] => A
+      fn: Map[
+        PackageName,
+        List[(Identifier.Bindable, Matchless.Expr[Unit])]
+      ] => A
   ): A = {
     val stmts = Parser.unsafeParse(Statement.parser, statement)
     Package.inferBody(testPackage, Nil, stmts).strictToValidated match {


### PR DESCRIPTION
This is so we can support multiple versions of packages simultaneously. The motivation here is to allow private dependencies in a library which don't have to be fixed to the same version as every transitive dependency.

The idea will be to make `(LibraryName, LibraryVersion)` as a `from` and then we can lookup in that context a PackageName which will tell you which `LibraryName, LibraryVersion` is in scope.