### PR TITLE
Use CompilationNamespace to abstract over Libraries vs stand-alone

### DIFF
--- a/cli/src/test/scala/org/bykn/bosatsu/codegen/clang/ClangGenTest.scala
+++ b/cli/src/test/scala/org/bykn/bosatsu/codegen/clang/ClangGenTest.scala
@@ -1,8 +1,6 @@
 package org.bykn.bosatsu.codegen.clang
 
-import cats.data.NonEmptyList
 import org.bykn.bosatsu.{PackageName, PackageMap, TestUtils, Identifier}
-import org.bykn.bosatsu.MatchlessFromTypedExpr
 
 import org.bykn.bosatsu.DirectEC.directEC
 
@@ -21,22 +19,12 @@ class ClangGenTest extends munit.FunSuite {
     println(exCode.render(80))
     sys.error("stop")
      */
-    val matchlessMap = MatchlessFromTypedExpr.compile((), pm)
-    val topoSort = pm.topoSort.toSuccess.get
-    val sortedEnv =
-      cats.Functor[Vector].compose[NonEmptyList].map(topoSort) { pn =>
-        (pn, matchlessMap(pn))
-      }
-
-    val res = ClangGen.renderMain(
-      sortedEnv = sortedEnv,
-      externals = ClangGen.ExternalResolver.FromJvmExternals,
-      value = (
+    val res =
+      ClangGen(pm).renderMain(
         PackageName.PredefName,
         Identifier.Name("range"),
         Code.Ident("run_main")
       )
-    )
 
     res match {
       case Right(d) =>

--- a/cli/src/test/scala/org/bykn/bosatsu/codegen/python/PythonGenTest.scala
+++ b/cli/src/test/scala/org/bykn/bosatsu/codegen/python/PythonGenTest.scala
@@ -3,7 +3,7 @@ package org.bykn.bosatsu.codegen.python
 import cats.Show
 import java.io.{ByteArrayInputStream, InputStream}
 import java.util.concurrent.Semaphore
-import org.bykn.bosatsu.{MatchlessFromTypedExpr, PackageName, TestUtils}
+import org.bykn.bosatsu.{PackageName, TestUtils}
 import org.scalacheck.Gen
 import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks.{
   forAll,
@@ -89,11 +89,10 @@ class PythonGenTest extends AnyFunSuite {
     val natPathBosatu: String = "test_workspace/Nat.bosatsu"
 
     val bosatsuPM = compileFile(natPathBosatu)
-    val matchless = MatchlessFromTypedExpr.compile((), bosatsuPM)
 
     val packMap =
-      PythonGen.renderAll(matchless, Map.empty, Map.empty, Map.empty)
-    val natDoc = packMap(PackageName.parts("Bosatsu", "Nat"))._2
+      PythonGen.renderSource(bosatsuPM, Map.empty, Map.empty)
+    val natDoc = packMap(())(PackageName.parts("Bosatsu", "Nat"))._2
     val natStr = natDoc.renderTrim(80)
 
     JythonBarrier.run {
@@ -148,11 +147,10 @@ class PythonGenTest extends AnyFunSuite {
       val intr = new PythonInterpreter()
 
       val bosatsuPM = compileFile(path)
-      val matchless = MatchlessFromTypedExpr.compile((), bosatsuPM)
 
       val packMap =
-        PythonGen.renderAll(matchless, Map.empty, Map.empty, Map.empty)
-      val doc = packMap(pn)._2
+        PythonGen.renderSource(bosatsuPM, Map.empty, Map.empty)
+      val doc = packMap(())(pn)._2
 
       intr.execfile(isfromString(doc.renderTrim(80)), "test.py")
       checkTest(intr.get(testName), pn.asString)

--- a/core/.js/src/main/scala/org/bykn/bosatsu/Par.scala
+++ b/core/.js/src/main/scala/org/bykn/bosatsu/Par.scala
@@ -22,6 +22,8 @@ object Par {
   def shutdownService(es: ExecutionService): Unit = es
   def ecFromService(es: ExecutionService): EC = DummyImplicit.dummyImplicit
 
+  def withEC[A](fn: EC => A): A = fn(DummyImplicit.dummyImplicit)
+
   @inline def start[A](a: => A): F[A] = a
 
   @inline def await[A](f: F[A]): A = f

--- a/core/.jvm/src/main/scala/org/bykn/bosatsu/Par.scala
+++ b/core/.jvm/src/main/scala/org/bykn/bosatsu/Par.scala
@@ -24,6 +24,15 @@ object Par {
   def ecFromService(es: ExecutionService): EC =
     ExecutionContext.fromExecutor(es)
 
+  // Used in testing generally, we don't want to make more than one of these per app
+  def withEC[A](fn: EC => A): A = {
+    val srv = newService()
+    try {
+      val ec = ecFromService(srv)
+      fn(ec)
+    } finally shutdownService(srv)
+  }
+
   @inline def start[A](a: => A)(implicit ec: EC): F[A] =
     Future(a)
 

--- a/core/src/main/scala/org/bykn/bosatsu/MainModule.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/MainModule.scala
@@ -7,6 +7,7 @@ import com.monovore.decline.{Argument, Command, Help, Opts}
 import cats.parse.{Parser => P}
 import org.typelevel.paiges.Doc
 import org.bykn.bosatsu.Parser.argFromParser
+import org.bykn.bosatsu.codegen.CompilationSource
 import org.bykn.bosatsu.tool.{
   CliException,
   CompilerApi,
@@ -378,7 +379,7 @@ class MainModule[IO[_], Path](val platformIO: PlatformIO[IO, Path]) {
             (packs, names) = pn
             data <- generator.transpiler.renderAll(
               outDir,
-              packs,
+              CompilationSource.namespace(packs),
               generator.args
             )
           } yield Output.TranspileOut(data)

--- a/core/src/main/scala/org/bykn/bosatsu/codegen/CompilationNamespace.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/codegen/CompilationNamespace.scala
@@ -1,0 +1,32 @@
+package org.bykn.bosatsu.codegen
+
+import cats.data.NonEmptyList
+import org.bykn.bosatsu.{PackageName, Identifier, MatchlessFromTypedExpr}
+import org.bykn.bosatsu.rankn.Type
+import org.bykn.bosatsu.graph.Toposort
+import scala.collection.immutable.{SortedMap, SortedSet}
+
+trait CompilationNamespace[K] {
+  implicit def keyOrder: Ordering[K]
+
+  def identOf(k: K, pn: PackageName): NonEmptyList[String]
+  def depFor(src: K, pn: PackageName): K
+  def rootKey: K
+
+  def isRoot(k: K): Boolean = keyOrder.equiv(k, rootKey)
+
+  def globalIdent(k: K, pn: PackageName): NonEmptyList[String] =
+    identOf(depFor(k, pn), pn)
+
+  def topoSort: Toposort.Result[(K, PackageName)]
+  def compiled: SortedMap[K, MatchlessFromTypedExpr.Compiled[K]]
+  def testValues: Map[PackageName, Identifier.Bindable]
+  def mainValues(
+      mainTypeFn: Type => Boolean
+  ): Map[PackageName, (Identifier.Bindable, Type)]
+  def externals
+      : SortedMap[K, Map[PackageName, List[(Identifier.Bindable, Type)]]]
+  def treeShake(roots: Set[(PackageName, Identifier)]): CompilationNamespace[K]
+
+  def rootPackages: SortedSet[PackageName]
+}

--- a/core/src/main/scala/org/bykn/bosatsu/codegen/CompilationSource.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/codegen/CompilationSource.scala
@@ -1,0 +1,83 @@
+package org.bykn.bosatsu.codegen
+
+import cats.data.NonEmptyList
+import org.bykn.bosatsu.{
+  Identifier,
+  MatchlessFromTypedExpr,
+  PackageName,
+  PackageMap,
+  Par
+}
+import org.bykn.bosatsu.rankn.Type
+import scala.collection.immutable.{SortedMap, SortedSet}
+
+import cats.syntax.all._
+
+trait CompilationSource[A] { self =>
+  type ScopeKey
+  def namespace(a: A): CompilationNamespace[ScopeKey]
+}
+
+object CompilationSource {
+
+  def apply[A](implicit cs: CompilationSource[A]): CompilationSource[A] {
+    type ScopeKey = cs.ScopeKey
+  } = cs
+
+  def namespace[A, S](a: A)(implicit
+      cs: CompilationSource[A] { type ScopeKey = S }
+  ): CompilationNamespace[S] =
+    cs.namespace(a)
+
+  implicit def packageMapSrc[A](implicit
+      ec: Par.EC
+  ): CompilationSource[PackageMap.Typed[A]] { type ScopeKey = Unit } =
+    new CompilationSource[PackageMap.Typed[A]] { self =>
+      type ScopeKey = Unit
+
+      def namespace(pm: PackageMap.Typed[A]): CompilationNamespace[Unit] =
+        new CompilationNamespace[Unit] {
+          implicit val keyOrder: Ordering[ScopeKey] = new Ordering[Unit] {
+            def compare(x: Unit, y: Unit): Int = 0
+          }
+
+          def identOf(k: Unit, pn: PackageName): NonEmptyList[String] = pn.parts
+          def depFor(src: Unit, pn: PackageName): Unit = ()
+          def rootKey: Unit = ()
+
+          lazy val compiled = SortedMap(
+            () -> MatchlessFromTypedExpr.compile((), pm)
+          )
+
+          lazy val topoSort = pm.topoSort.map(p => ((), p))
+
+          lazy val testValues = pm.testValues
+
+          def mainValues(
+              mainTypeFn: Type => Boolean
+          ): Map[PackageName, (Identifier.Bindable, Type)] =
+            pm.toMap.iterator.flatMap { case (n, p) =>
+              val optEval = p.lets.findLast { case (_, _, te) =>
+                // TODO this should really e checking that te.getType <:< a key
+                // in the map.
+                mainTypeFn(te.getType)
+              }
+              optEval.map { case (b, _, te) =>
+                (n, (b, te.getType))
+              }
+            }.toMap
+
+          lazy val externals: SortedMap[ScopeKey, Map[PackageName, List[
+            (Identifier.Bindable, Type)
+          ]]] =
+            SortedMap(() -> pm.allExternals)
+
+          def treeShake(
+              roots: Set[(PackageName, Identifier)]
+          ): CompilationNamespace[Unit] =
+            self.namespace(PackageMap.treeShake(pm, roots))
+
+          def rootPackages: SortedSet[PackageName] = pm.toMap.keySet
+        }
+    }
+}

--- a/core/src/main/scala/org/bykn/bosatsu/codegen/Transpiler.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/codegen/Transpiler.scala
@@ -80,13 +80,13 @@ object CompilationSource {
 
   def apply[A](implicit cs: CompilationSource[A]): CompilationSource[A] = cs
 
-  implicit def packageMapSrc(implicit
+  implicit def packageMapSrc[A](implicit
       ec: Par.EC
-  ): CompilationSource[PackageMap.Typed[Any]] { type ScopeKey = Unit } =
-    new CompilationSource[PackageMap.Typed[Any]] { self =>
+  ): CompilationSource[PackageMap.Typed[A]] { type ScopeKey = Unit } =
+    new CompilationSource[PackageMap.Typed[A]] { self =>
       type ScopeKey = Unit
 
-      def namespace(pm: PackageMap.Typed[Any]): CompilationNamespace[Unit] =
+      def namespace(pm: PackageMap.Typed[A]): CompilationNamespace[Unit] =
         new CompilationNamespace[Unit] {
           implicit val keyOrder: Ordering[ScopeKey] = new Ordering[Unit] {
             def compare(x: Unit, y: Unit): Int = 0

--- a/core/src/main/scala/org/bykn/bosatsu/codegen/Transpiler.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/codegen/Transpiler.scala
@@ -1,8 +1,21 @@
 package org.bykn.bosatsu.codegen
 
+import cats.data.NonEmptyList
 import com.monovore.decline.Opts
-import org.bykn.bosatsu.{PackageMap, Par, PlatformIO}
+import org.bykn.bosatsu.{
+  MatchlessFromTypedExpr,
+  PackageName,
+  PackageMap,
+  Par,
+  PlatformIO
+}
 import org.typelevel.paiges.Doc
+import scala.collection.immutable.{SortedMap, SortedSet}
+import org.bykn.bosatsu.Identifier
+import org.bykn.bosatsu.rankn.Type
+import org.bykn.bosatsu.graph.Toposort
+
+import cats.syntax.all._
 
 trait Transpiler {
   type Args[F[_], P]
@@ -12,11 +25,11 @@ trait Transpiler {
   def opts[F[_], P](plat: PlatformIO[F, P]): Opts[Transpiler.Optioned[F, P]]
 
   // return paths to be resolved against the base output path
-  def renderAll[F[_], P](
+  def renderAll[F[_], P, S](
       outDir: P,
-      pm: PackageMap.Typed[Any],
+      pm: S,
       args: Args[F, P]
-  )(implicit ec: Par.EC): F[List[(P, Doc)]]
+  )(implicit ec: Par.EC, CS: CompilationSource[S]): F[List[(P, Doc)]]
 }
 
 object Transpiler {
@@ -30,4 +43,92 @@ object Transpiler {
     val transpiler: Transpiler
     def args: transpiler.Args[F, P]
   }
+}
+
+trait CompilationNamespace[K] {
+  implicit def keyOrder: Ordering[K]
+
+  def identOf(k: K, pn: PackageName): NonEmptyList[String]
+  def depFor(src: K, pn: PackageName): K
+  def rootKey: K
+
+  def isRoot(k: K): Boolean = keyOrder.equiv(k, rootKey)
+
+  def globalIdent(k: K, pn: PackageName): NonEmptyList[String] =
+    identOf(depFor(k, pn), pn)
+
+  def topoSort: Toposort.Result[(K, PackageName)]
+  def compiled: SortedMap[K, MatchlessFromTypedExpr.Compiled[K]]
+  def testValues: Map[PackageName, Identifier.Bindable]
+  def mainValues(
+      mainTypeFn: Type => Boolean
+  ): Map[PackageName, (Identifier.Bindable, Type)]
+  def externals
+      : SortedMap[K, Map[PackageName, List[(Identifier.Bindable, Type)]]]
+  def treeShake(roots: Set[(PackageName, Identifier)]): CompilationNamespace[K]
+
+  def rootPackages: SortedSet[PackageName]
+}
+
+trait CompilationSource[A] { self =>
+  type ScopeKey
+  def namespace(a: A): CompilationNamespace[ScopeKey]
+
+}
+
+object CompilationSource {
+
+  def apply[A](implicit cs: CompilationSource[A]): CompilationSource[A] = cs
+
+  implicit def packageMapSrc(implicit
+      ec: Par.EC
+  ): CompilationSource[PackageMap.Typed[Any]] { type ScopeKey = Unit } =
+    new CompilationSource[PackageMap.Typed[Any]] { self =>
+      type ScopeKey = Unit
+
+      def namespace(pm: PackageMap.Typed[Any]): CompilationNamespace[Unit] =
+        new CompilationNamespace[Unit] {
+          implicit val keyOrder: Ordering[ScopeKey] = new Ordering[Unit] {
+            def compare(x: Unit, y: Unit): Int = 0
+          }
+
+          def identOf(k: Unit, pn: PackageName): NonEmptyList[String] = pn.parts
+          def depFor(src: Unit, pn: PackageName): Unit = ()
+          def rootKey: Unit = ()
+
+          lazy val compiled = SortedMap(
+            () -> MatchlessFromTypedExpr.compile((), pm)
+          )
+
+          lazy val topoSort = pm.topoSort.map(p => ((), p))
+
+          lazy val testValues = pm.testValues
+
+          def mainValues(
+              mainTypeFn: Type => Boolean
+          ): Map[PackageName, (Identifier.Bindable, Type)] =
+            pm.toMap.iterator.flatMap { case (n, p) =>
+              val optEval = p.lets.findLast { case (_, _, te) =>
+                // TODO this should really e checking that te.getType <:< a key
+                // in the map.
+                mainTypeFn(te.getType)
+              }
+              optEval.map { case (b, _, te) =>
+                (n, (b, te.getType))
+              }
+            }.toMap
+
+          lazy val externals: SortedMap[ScopeKey, Map[PackageName, List[
+            (Identifier.Bindable, Type)
+          ]]] =
+            SortedMap(() -> pm.allExternals)
+
+          def treeShake(
+              roots: Set[(PackageName, Identifier)]
+          ): CompilationNamespace[Unit] =
+            self.namespace(PackageMap.treeShake(pm, roots))
+
+          def rootPackages: SortedSet[PackageName] = pm.toMap.keySet
+        }
+    }
 }

--- a/core/src/main/scala/org/bykn/bosatsu/codegen/Transpiler.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/codegen/Transpiler.scala
@@ -1,21 +1,8 @@
 package org.bykn.bosatsu.codegen
 
-import cats.data.NonEmptyList
 import com.monovore.decline.Opts
-import org.bykn.bosatsu.{
-  MatchlessFromTypedExpr,
-  PackageName,
-  PackageMap,
-  Par,
-  PlatformIO
-}
+import org.bykn.bosatsu.{PlatformIO, Par}
 import org.typelevel.paiges.Doc
-import scala.collection.immutable.{SortedMap, SortedSet}
-import org.bykn.bosatsu.Identifier
-import org.bykn.bosatsu.rankn.Type
-import org.bykn.bosatsu.graph.Toposort
-
-import cats.syntax.all._
 
 trait Transpiler {
   type Args[F[_], P]
@@ -27,9 +14,9 @@ trait Transpiler {
   // return paths to be resolved against the base output path
   def renderAll[F[_], P, S](
       outDir: P,
-      pm: S,
+      ns: CompilationNamespace[S],
       args: Args[F, P]
-  )(implicit ec: Par.EC, CS: CompilationSource[S]): F[List[(P, Doc)]]
+  )(implicit ec: Par.EC): F[List[(P, Doc)]]
 }
 
 object Transpiler {
@@ -43,92 +30,4 @@ object Transpiler {
     val transpiler: Transpiler
     def args: transpiler.Args[F, P]
   }
-}
-
-trait CompilationNamespace[K] {
-  implicit def keyOrder: Ordering[K]
-
-  def identOf(k: K, pn: PackageName): NonEmptyList[String]
-  def depFor(src: K, pn: PackageName): K
-  def rootKey: K
-
-  def isRoot(k: K): Boolean = keyOrder.equiv(k, rootKey)
-
-  def globalIdent(k: K, pn: PackageName): NonEmptyList[String] =
-    identOf(depFor(k, pn), pn)
-
-  def topoSort: Toposort.Result[(K, PackageName)]
-  def compiled: SortedMap[K, MatchlessFromTypedExpr.Compiled[K]]
-  def testValues: Map[PackageName, Identifier.Bindable]
-  def mainValues(
-      mainTypeFn: Type => Boolean
-  ): Map[PackageName, (Identifier.Bindable, Type)]
-  def externals
-      : SortedMap[K, Map[PackageName, List[(Identifier.Bindable, Type)]]]
-  def treeShake(roots: Set[(PackageName, Identifier)]): CompilationNamespace[K]
-
-  def rootPackages: SortedSet[PackageName]
-}
-
-trait CompilationSource[A] { self =>
-  type ScopeKey
-  def namespace(a: A): CompilationNamespace[ScopeKey]
-
-}
-
-object CompilationSource {
-
-  def apply[A](implicit cs: CompilationSource[A]): CompilationSource[A] = cs
-
-  implicit def packageMapSrc[A](implicit
-      ec: Par.EC
-  ): CompilationSource[PackageMap.Typed[A]] { type ScopeKey = Unit } =
-    new CompilationSource[PackageMap.Typed[A]] { self =>
-      type ScopeKey = Unit
-
-      def namespace(pm: PackageMap.Typed[A]): CompilationNamespace[Unit] =
-        new CompilationNamespace[Unit] {
-          implicit val keyOrder: Ordering[ScopeKey] = new Ordering[Unit] {
-            def compare(x: Unit, y: Unit): Int = 0
-          }
-
-          def identOf(k: Unit, pn: PackageName): NonEmptyList[String] = pn.parts
-          def depFor(src: Unit, pn: PackageName): Unit = ()
-          def rootKey: Unit = ()
-
-          lazy val compiled = SortedMap(
-            () -> MatchlessFromTypedExpr.compile((), pm)
-          )
-
-          lazy val topoSort = pm.topoSort.map(p => ((), p))
-
-          lazy val testValues = pm.testValues
-
-          def mainValues(
-              mainTypeFn: Type => Boolean
-          ): Map[PackageName, (Identifier.Bindable, Type)] =
-            pm.toMap.iterator.flatMap { case (n, p) =>
-              val optEval = p.lets.findLast { case (_, _, te) =>
-                // TODO this should really e checking that te.getType <:< a key
-                // in the map.
-                mainTypeFn(te.getType)
-              }
-              optEval.map { case (b, _, te) =>
-                (n, (b, te.getType))
-              }
-            }.toMap
-
-          lazy val externals: SortedMap[ScopeKey, Map[PackageName, List[
-            (Identifier.Bindable, Type)
-          ]]] =
-            SortedMap(() -> pm.allExternals)
-
-          def treeShake(
-              roots: Set[(PackageName, Identifier)]
-          ): CompilationNamespace[Unit] =
-            self.namespace(PackageMap.treeShake(pm, roots))
-
-          def rootPackages: SortedSet[PackageName] = pm.toMap.keySet
-        }
-    }
 }

--- a/core/src/main/scala/org/bykn/bosatsu/codegen/clang/ClangGen.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/codegen/clang/ClangGen.scala
@@ -1,19 +1,12 @@
 package org.bykn.bosatsu.codegen.clang
 
-import cats.{Eval, Monad, Traverse}
+import cats.{Eval, Functor, Monad, Traverse}
 import cats.data.{StateT, EitherT, NonEmptyList, Chain}
 import java.math.BigInteger
 import java.nio.charset.StandardCharsets
 import org.bykn.bosatsu.codegen.Idents
 import org.bykn.bosatsu.rankn.{DataRepr, Type}
-import org.bykn.bosatsu.{
-  Identifier,
-  Lit,
-  Matchless,
-  Predef,
-  PackageName,
-  PackageMap
-}
+import org.bykn.bosatsu.{Identifier, Lit, Matchless, Predef, PackageName}
 import org.bykn.bosatsu.pattern.StrPart
 import org.bykn.bosatsu.Matchless.Expr
 import org.bykn.bosatsu.Identifier.Bindable
@@ -21,8 +14,9 @@ import org.typelevel.paiges.Doc
 import scala.collection.immutable.{SortedMap, SortedSet}
 
 import cats.syntax.all._
+import org.bykn.bosatsu.codegen.CompilationNamespace
 
-object ClangGen {
+class ClangGen[K](ns: CompilationNamespace[K]) {
   sealed abstract class Error {
     // TODO: implement this in a nice way
     def display: Doc = Doc.text(this.toString)
@@ -32,14 +26,18 @@ object ClangGen {
     case class UnknownValue(pack: PackageName, value: Bindable) extends Error
     case class InvariantViolation(message: String, expr: Expr[Any])
         extends Error
-    case class Unbound(bn: Bindable, inside: Option[(PackageName, Bindable)])
+    case class Unbound(bn: Bindable, inside: Option[(K, PackageName, Bindable)])
         extends Error
     case class ExpectedStaticString(str: String) extends Error
   }
 
+  def generateExternalsStub: SortedMap[String, Doc] =
+    ExternalResolver.stdExternals.generateExternalsStub
+
   trait ExternalResolver {
-    def names: SortedMap[PackageName, SortedSet[Bindable]]
+    def names: Iterable[(K, PackageName, SortedSet[Bindable])]
     def apply(
+        key: K,
         p: PackageName,
         b: Bindable
     ): Option[(Code.Include, Code.Ident, Int)]
@@ -59,11 +57,11 @@ object ClangGen {
         Doc.intercalate(Doc.hardLine, includes.map(Code.toDoc))
 
       SortedMap.empty[String, Doc] ++ names.iterator
-        .flatMap { case (p, binds) =>
+        .flatMap { case (k, p, binds) =>
 
           val fns = binds.iterator
             .flatMap { n =>
-              apply(p, n)
+              apply(k, p, n)
             }
             .map { case (i, n, arity) =>
               i.filename -> Code.toDoc(toStmt(n, arity))
@@ -82,10 +80,10 @@ object ClangGen {
   }
 
   object ExternalResolver {
-    def stdExtFileName(pn: PackageName): String =
-      s"${Idents.escape("bosatsu_ext_", pn.asString)}.h"
+    def stdExtFileName(key: K, pn: PackageName): String =
+      s"${Idents.escape("bosatsu_ext_", ns.globalIdent(key, pn).mkString_("/"))}.h"
 
-    def stdExternals(pm: PackageMap.Typed[Any]): ExternalResolver = {
+    def stdExternals: ExternalResolver = {
 
       def tpeArity(t: Type): Int =
         t match {
@@ -93,32 +91,37 @@ object ClangGen {
           case _                               => 0
         }
 
-      val allExt = pm.allExternals
-      val extMap = allExt.iterator.map { case (p, vs) =>
-        val fileName = ExternalResolver.stdExtFileName(p)
+      val keyedExt = ns.externals
+      val extMap = keyedExt.iterator.flatMap { case (k, allExt) =>
+        allExt.iterator.map { case (p, vs) =>
+          val fileName = ExternalResolver.stdExtFileName(k, p)
 
-        val fns = vs.iterator.map { case (n, tpe) =>
-          val cIdent = generatedName(p, n)
-          n -> (cIdent, tpeArity(tpe))
-        }.toMap
+          val fns = vs.iterator.map { case (n, tpe) =>
+            val cIdent = generatedName(k, p, n)
+            n -> (cIdent, tpeArity(tpe))
+          }.toMap
 
-        p -> (Code.Include.quote(fileName), fns)
+          (k, p) -> (Code.Include.quote(fileName), fns)
+        }
       }.toMap
 
       new ExternalResolver {
-        lazy val names: SortedMap[PackageName, SortedSet[Bindable]] =
-          allExt.iterator
-            .map { case (p, vs) =>
-              p -> vs.iterator.map { case (b, _) => b }.to(SortedSet)
-            }
-            .to(SortedMap)
+        lazy val names: Iterable[(K, PackageName, SortedSet[Bindable])] =
+          (for {
+            kPmap <- keyedExt.iterator
+            (k, pmap) = kPmap
+            packBinds <- pmap.iterator
+            (pack, binds) = packBinds
+            bindSet = binds.iterator.map(_._1).to(SortedSet)
+          } yield (k, pack, bindSet)).to(LazyList)
 
         def apply(
+            k: K,
             p: PackageName,
             b: Bindable
         ): Option[(Code.Include, Code.Ident, Int)] =
           for {
-            (include, inner) <- extMap.get(p)
+            (include, inner) <- extMap.get((k, p))
             (ident, arity) <- inner.get(b)
           } yield (include, ident, arity)
       }
@@ -127,12 +130,16 @@ object ClangGen {
     val FromJvmExternals: ExternalResolver =
       new ExternalResolver {
         val predef_c =
-          Code.Include.quote(stdExtFileName(PackageName.PredefName))
+          Code.Include.quote(stdExtFileName(ns.rootKey, PackageName.PredefName))
 
         def predef(s: String, arity: Int) =
           (PackageName.PredefName -> Identifier.Name(s)) -> (
             predef_c,
-            ClangGen.generatedName(PackageName.PredefName, Identifier.Name(s)),
+            generatedName(
+              ns.rootKey,
+              PackageName.PredefName,
+              Identifier.Name(s)
+            ),
             arity
           )
 
@@ -142,7 +149,7 @@ object ClangGen {
           }
           .toMap[(PackageName, Identifier), (Code.Include, Code.Ident, Int)]
 
-        lazy val names: SortedMap[PackageName, SortedSet[Bindable]] = {
+        lazy val names: Iterable[(K, PackageName, SortedSet[Bindable])] = {
           val sm = Predef.jvmExternals.toMap.iterator
             .map { case (pn, _) => pn }
             .toList
@@ -150,6 +157,7 @@ object ClangGen {
 
           sm.map { case (k, vs) =>
             (
+              ns.rootKey,
               k,
               vs.toList.iterator
                 .map { case (_, n) => Identifier.Name(n) }
@@ -157,23 +165,34 @@ object ClangGen {
             )
           }
         }
-        def apply(p: PackageName, b: Bindable) = ext.get((p, b))
+        def apply(k: K, p: PackageName, b: Bindable) = ext.get((p, b))
       }
   }
 
+  val sortedEnv
+      : Vector[NonEmptyList[(K, PackageName, List[(Bindable, Expr[K])])]] =
+    Functor[Vector]
+      .compose[NonEmptyList]
+      .map(ns.topoSort.layers) { case (k, p) =>
+        val exprs = for {
+          pms <- ns.compiled.get(k).toList
+          exprs <- pms.get(p).toList
+          expr <- exprs
+        } yield expr
+
+        (k, p, exprs)
+      }
+
   private def renderDeps(
-      env: Impl.Env,
-      sortedEnv: Vector[
-        NonEmptyList[(PackageName, List[(Bindable, Expr[Unit])])]
-      ]
+      env: Impl.Env
   ): env.T[Unit] = {
     import env._
 
     Traverse[Vector]
       .compose[NonEmptyList]
-      .traverse_(sortedEnv) { case (pn, values) =>
+      .traverse_(sortedEnv) { case (k, pn, values) =>
         values.traverse_ { case (bindable, expr) =>
-          renderTop(pn, bindable, expr)
+          renderTop(k, pn, bindable, expr)
         }
       }
   }
@@ -181,64 +200,58 @@ object ClangGen {
   // the Code.Ident should be a function with signature:
   // int run_main(BValue main_value, int argc, char** args)
   def renderMain(
-      sortedEnv: Vector[
-        NonEmptyList[(PackageName, List[(Bindable, Expr[Unit])])]
-      ],
-      externals: ExternalResolver,
-      value: (PackageName, Bindable, Code.Ident)
+      pn: PackageName,
+      value: Bindable,
+      runner: Code.Ident
   ): Either[Error, Doc] = {
     val env = Impl.Env.impl
     import env.monadImpl
 
     val res =
-      renderDeps(env, sortedEnv) *> env.renderMain(value._1, value._2, value._3)
+      renderDeps(env) *> env.renderMain(pn, value, runner)
 
     val allValues: Impl.AllValues =
       sortedEnv.iterator
         .flatMap(_.iterator)
-        .flatMap { case (p, vs) =>
+        .flatMap { case (k, p, vs) =>
           vs.iterator.map { case (b, e) =>
-            (p, b) -> (e, generatedName(p, b))
+            (k, p, b) -> (e, generatedName(k, p, b))
           }
         }
         .toMap
 
-    env.run(allValues, externals, res)
+    env.run(allValues, ExternalResolver.stdExternals, res)
   }
 
   def renderTests(
-      sortedEnv: Vector[
-        NonEmptyList[(PackageName, List[(Bindable, Expr[Unit])])]
-      ],
-      externals: ExternalResolver,
       values: List[(PackageName, Bindable)]
   ): Either[Error, Doc] = {
     val env = Impl.Env.impl
     import env.monadImpl
 
-    val res = renderDeps(env, sortedEnv) *> env.renderTests(values)
+    val res = renderDeps(env) *> env.renderTests(values)
 
     val allValues: Impl.AllValues =
       sortedEnv.iterator
         .flatMap(_.iterator)
-        .flatMap { case (p, vs) =>
+        .flatMap { case (k, p, vs) =>
           vs.iterator.map { case (b, e) =>
-            (p, b) -> (e, generatedName(p, b))
+            (k, p, b) -> (e, generatedName(k, p, b))
           }
         }
         .toMap
 
-    env.run(allValues, externals, res)
+    env.run(allValues, ExternalResolver.stdExternals, res)
   }
 
-  private def fullName(p: PackageName, b: Bindable): String =
-    p.asString + "/" + b.asString
+  private def fullName(k: K, p: PackageName, b: Bindable): String =
+    ns.identOf(k, p).mkString_("/") + "/" + b.asString
 
-  def generatedName(p: PackageName, b: Bindable): Code.Ident =
-    Code.Ident(Idents.escape("___bsts_g_", fullName(p, b)))
+  def generatedName(k: K, p: PackageName, b: Bindable): Code.Ident =
+    Code.Ident(Idents.escape("___bsts_g_", fullName(k, p, b)))
 
   private object Impl {
-    type AllValues = Map[(PackageName, Bindable), (Expr[Unit], Code.Ident)]
+    type AllValues = Map[(K, PackageName, Bindable), (Expr[K], Code.Ident)]
 
     trait Env {
       import Matchless._
@@ -252,7 +265,7 @@ object ClangGen {
       ): Either[Error, Doc]
       def appendStatement(stmt: Code.Statement): T[Unit]
       def error[A](e: => Error): T[A]
-      def globalIdent(pn: PackageName, bn: Bindable): T[Code.Ident]
+      def globalIdent(k: K, pn: PackageName, bn: Bindable): T[Code.Ident]
       def bind[A](bn: Bindable)(in: T[A]): T[A]
       def getBinding(bn: Bindable): T[Code.Ident]
       def bindAnon[A](idx: Long)(in: T[A]): T[A]
@@ -267,15 +280,19 @@ object ClangGen {
       // used for temporary variables of type BValue
       def newLocalName(tag: String): T[Code.Ident]
       def newTopName(tag: String): T[Code.Ident]
-      def directFn(p: PackageName, b: Bindable): T[Option[(Code.Ident, Int)]]
+      def directFn(
+          k: K,
+          p: PackageName,
+          b: Bindable
+      ): T[Option[(Code.Ident, Int)]]
       def directFn(b: Bindable): T[Option[(Code.Ident, Boolean, Int)]]
-      def inTop[A](p: PackageName, bn: Bindable)(ta: T[A]): T[A]
+      def inTop[A](k: K, p: PackageName, bn: Bindable)(ta: T[A]): T[A]
       def inFnStatement[A](in: T[A]): T[A]
-      def currentTop: T[Option[(PackageName, Bindable)]]
-      def staticValueName(p: PackageName, b: Bindable): T[Code.Ident]
-      def constructorFn(p: PackageName, b: Bindable): T[Code.Ident]
+      def currentTop: T[Option[(K, PackageName, Bindable)]]
+      def staticValueName(k: K, p: PackageName, b: Bindable): T[Code.Ident]
+      def constructorFn(k: K, p: PackageName, b: Bindable): T[Code.Ident]
 
-      def cachedIdent(key: Expr[Unit])(value: => T[Code.Ident]): T[Code.Ident]
+      def cachedIdent(key: Expr[K])(value: => T[Code.Ident]): T[Code.Ident]
 
       /////////////////////////////////////////
       // the below are independent of the environment implementation
@@ -346,7 +363,7 @@ object ClangGen {
 
       def handleLet(
           name: Either[LocalAnon, Bindable],
-          argV: Expr[Unit],
+          argV: Expr[K],
           in: T[Code.ValueLike]
       ): T[Code.ValueLike] =
         name match {
@@ -383,7 +400,7 @@ object ClangGen {
               }
         }
       // The type of this value must be a C _Bool
-      def boolToValue(boolExpr: BoolExpr[Unit]): T[Code.ValueLike] =
+      def boolToValue(boolExpr: BoolExpr[K]): T[Code.ValueLike] =
         boolExpr match {
           case EqualsLit(expr, lit) =>
             innerToValue(expr).flatMap { vl =>
@@ -869,7 +886,7 @@ object ClangGen {
 
       // We have to lift functions to the top level and not
       // create any nesting
-      def innerFn(fn: FnExpr[Unit]): T[Code.ValueLike] = {
+      def innerFn(fn: FnExpr[K]): T[Code.ValueLike] = {
         val nameSuffix = fn.recursiveName match {
           case None    => ""
           case Some(n) => Idents.escape("_", n.asString)
@@ -960,10 +977,10 @@ object ClangGen {
           case Lit.Str(toStr) => StringApi.fromString(toStr)
         }
 
-      def innerApp(app: App[Unit]): T[Code.ValueLike] =
+      def innerApp(app: App[K]): T[Code.ValueLike] =
         app match {
-          case App(Global(_, pack, fnName), args) =>
-            directFn(pack, fnName).flatMap {
+          case App(Global(k, pack, fnName), args) =>
+            directFn(k, pack, fnName).flatMap {
               case Some((ident, _)) =>
                 // directly invoke instead of by treating them like lambdas
                 args.traverse(innerToValue(_)).flatMap { argsVL =>
@@ -971,7 +988,7 @@ object ClangGen {
                 }
               case None =>
                 // the ref be holding the result of another function call
-                (globalIdent(pack, fnName), args.traverse(innerToValue(_)))
+                (globalIdent(k, pack, fnName), args.traverse(innerToValue(_)))
                   .flatMapN { (fnVL, argsVL) =>
                     // we need to invoke call_fn<idx>(fn, arg0, arg1, ....)
                     // but since these are ValueLike, we need to handle more carefully
@@ -1050,19 +1067,19 @@ object ClangGen {
             }
         }
 
-      def innerToValue(expr: Expr[Unit]): T[Code.ValueLike] =
+      def innerToValue(expr: Expr[K]): T[Code.ValueLike] =
         expr match {
-          case fn: FnExpr[Unit] => innerFn(fn)
+          case fn: FnExpr[K] => innerFn(fn)
           case Let(name, argV, in) =>
             handleLet(name, argV, innerToValue(in))
           case app @ App(_, _) => innerApp(app)
-          case Global(_, pack, name) =>
-            directFn(pack, name)
+          case Global(k, pack, name) =>
+            directFn(k, pack, name)
               .flatMap {
                 case Some((ident, arity)) =>
                   pv(boxFn(ident, arity))
                 case None =>
-                  globalIdent(pack, name).map(nm => nm())
+                  globalIdent(k, pack, name).map(nm => nm())
               }
           case Local(arg) =>
             directFn(arg)
@@ -1212,7 +1229,7 @@ object ClangGen {
               }
         }
 
-      def fnStatement(fnName: Code.Ident, fn: FnExpr[Unit]): T[Code.Statement] =
+      def fnStatement(fnName: Code.Ident, fn: FnExpr[K]): T[Code.Statement] =
         inFnStatement(fn match {
           case Lambda(captures, name, args, expr) =>
             val body = innerToValue(expr).map(Code.returnValue(_))
@@ -1251,12 +1268,12 @@ object ClangGen {
             }
         })
 
-      def renderTop(p: PackageName, b: Bindable, expr: Expr[Unit]): T[Unit] =
-        inTop(p, b) {
+      def renderTop(k: K, p: PackageName, b: Bindable, expr: Expr[K]): T[Unit] =
+        inTop(k, p, b) {
           expr match {
-            case fn: FnExpr[Unit] =>
+            case fn: FnExpr[K] =>
               for {
-                fnName <- globalIdent(p, b)
+                fnName <- globalIdent(k, p, b)
                 stmt <- fnStatement(fnName, fn)
                 _ <- appendStatement(stmt)
               } yield ()
@@ -1268,9 +1285,9 @@ object ClangGen {
               // then we generate a function to populate the value
               for {
                 vl <- innerToValue(someValue)
-                value <- staticValueName(p, b)
-                consFn <- constructorFn(p, b)
-                readFn <- globalIdent(p, b)
+                value <- staticValueName(k, p, b)
+                consFn <- constructorFn(k, p, b)
+                readFn <- globalIdent(k, p, b)
                 _ <- makeConstructorsStatement(value, consFn, vl, readFn)
               } yield ()
           }
@@ -1372,10 +1389,10 @@ object ClangGen {
               includeSet: Set[Code.Include],
               includes: Chain[Code.Include],
               stmts: Chain[Code.Statement],
-              currentTop: Option[(PackageName, Bindable)],
+              currentTop: Option[(K, PackageName, Bindable)],
               binds: Map[Bindable, BindState],
               counter: Long,
-              identCache: Map[Expr[Unit], Code.Ident]
+              identCache: Map[Expr[K], Code.Ident]
           ) {
             def finalFile: Doc =
               Doc.intercalate(
@@ -1465,15 +1482,15 @@ object ClangGen {
               EitherT[Eval, Error, (State, A)](Eval.now(fn(s).map((s, _))))
             )
 
-          def globalIdent(pn: PackageName, bn: Bindable): T[Code.Ident] =
+          def globalIdent(k: K, pn: PackageName, bn: Bindable): T[Code.Ident] =
             tryUpdate { s =>
-              s.externals(pn, bn) match {
+              s.externals(k, pn, bn) match {
                 case Some((incl, ident, _)) =>
                   // TODO: suspect that we are ignoring arity here
                   val withIncl = s.include(incl)
                   Right((withIncl, ident))
                 case None =>
-                  val key = (pn, bn)
+                  val key = (k, pn, bn)
                   s.allValues.get(key) match {
                     case Some((_, ident)) => Right((s, ident))
                     case None             => Left(Error.UnknownValue(pn, bn))
@@ -1569,17 +1586,18 @@ object ClangGen {
             }
           // record that this name is a top level function, so applying it can be direct
           def directFn(
+              k: K,
               pack: PackageName,
               b: Bindable
           ): T[Option[(Code.Ident, Int)]] =
             StateT { s =>
-              val key = (pack, b)
+              val key = (k, pack, b)
               s.allValues.get(key) match {
-                case Some((fn: Matchless.FnExpr[Unit], ident)) =>
+                case Some((fn: Matchless.FnExpr[K], ident)) =>
                   result(s, Some((ident, fn.arity)))
                 case None =>
                   // this is external
-                  s.externals(pack, b) match {
+                  s.externals(k, pack, b) match {
                     case Some((incl, ident, arity)) if arity > 0 =>
                       val withIncl = s.include(incl)
                       result(withIncl, Some((ident, arity)))
@@ -1610,10 +1628,13 @@ object ClangGen {
               _ <- update((s: State) => (s.copy(binds = bindState), ()))
             } yield a
 
-          def inTop[A](p: PackageName, bn: Bindable)(ta: T[A]): T[A] =
+          def inTop[A](k: K, p: PackageName, bn: Bindable)(ta: T[A]): T[A] =
             for {
               bindState <- update { (s: State) =>
-                (s.copy(binds = Map.empty, currentTop = Some((p, bn))), s.binds)
+                (
+                  s.copy(binds = Map.empty, currentTop = Some((k, p, bn))),
+                  s.binds
+                )
               }
               a <- ta
               _ <- update { (s: State) =>
@@ -1621,16 +1642,20 @@ object ClangGen {
               }
             } yield a
 
-          val currentTop: T[Option[(PackageName, Bindable)]] =
+          val currentTop: T[Option[(K, PackageName, Bindable)]] =
             StateT((s: State) => result(s, s.currentTop))
 
-          def staticValueName(p: PackageName, b: Bindable): T[Code.Ident] =
+          def staticValueName(
+              k: K,
+              p: PackageName,
+              b: Bindable
+          ): T[Code.Ident] =
             monadImpl.pure(
-              Code.Ident(Idents.escape("___bsts_s_", fullName(p, b)))
+              Code.Ident(Idents.escape("___bsts_s_", fullName(k, p, b)))
             )
-          def constructorFn(p: PackageName, b: Bindable): T[Code.Ident] =
+          def constructorFn(k: K, p: PackageName, b: Bindable): T[Code.Ident] =
             monadImpl.pure(
-              Code.Ident(Idents.escape("___bsts_c_", fullName(p, b)))
+              Code.Ident(Idents.escape("___bsts_c_", fullName(k, p, b)))
             )
 
           // the Code.Ident should be a function with signature:
@@ -1650,7 +1675,7 @@ object ClangGen {
               return code;
             }
              */
-            globalIdent(p, b).flatMap { mainCons =>
+            globalIdent(ns.rootKey, p, b).flatMap { mainCons =>
               val mainValue = Code.Ident("main_value")
               val mainBody = Code.Statements(
                 Code.Ident("GC_init")().stmt,
@@ -1682,7 +1707,10 @@ object ClangGen {
           def renderTests(values: List[(PackageName, Bindable)]): T[Unit] =
             values
               .traverse { case (p, b) =>
-                (StringApi.staticString(p.asString), globalIdent(p, b)).tupled
+                (
+                  StringApi.staticString(p.asString),
+                  globalIdent(ns.rootKey, p, b)
+                ).tupled
               }
               .flatMap { packVals =>
                 /*
@@ -1734,7 +1762,7 @@ object ClangGen {
             }
 
           def cachedIdent(
-              key: Expr[Unit]
+              key: Expr[K]
           )(value: => T[Code.Ident]): T[Code.Ident] =
             StateT { s =>
               s.identCache.get(key) match {

--- a/core/src/main/scala/org/bykn/bosatsu/codegen/clang/ClangGen.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/codegen/clang/ClangGen.scala
@@ -4,7 +4,11 @@ import cats.{Eval, Functor, Monad, Traverse}
 import cats.data.{StateT, EitherT, NonEmptyList, Chain}
 import java.math.BigInteger
 import java.nio.charset.StandardCharsets
-import org.bykn.bosatsu.codegen.Idents
+import org.bykn.bosatsu.codegen.{
+  CompilationNamespace,
+  CompilationSource,
+  Idents
+}
 import org.bykn.bosatsu.rankn.{DataRepr, Type}
 import org.bykn.bosatsu.{Identifier, Lit, Matchless, Predef, PackageName}
 import org.bykn.bosatsu.pattern.StrPart
@@ -14,7 +18,6 @@ import org.typelevel.paiges.Doc
 import scala.collection.immutable.{SortedMap, SortedSet}
 
 import cats.syntax.all._
-import org.bykn.bosatsu.codegen.CompilationNamespace
 
 class ClangGen[K](ns: CompilationNamespace[K]) {
   sealed abstract class Error {
@@ -1780,4 +1783,11 @@ class ClangGen[K](ns: CompilationNamespace[K]) {
       }
     }
   }
+}
+
+object ClangGen {
+  def apply[S](src: S)(implicit
+      CS: CompilationSource[S]
+  ): ClangGen[CS.ScopeKey] =
+    new ClangGen(CS.namespace(src))
 }

--- a/core/src/main/scala/org/bykn/bosatsu/codegen/clang/ClangTranspiler.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/codegen/clang/ClangTranspiler.scala
@@ -3,18 +3,14 @@ package org.bykn.bosatsu.codegen.clang
 import cats.data.{NonEmptyList, Validated}
 import com.monovore.decline.{Argument, Opts}
 import java.util.regex.{Pattern => RegexPat}
-import org.bykn.bosatsu.codegen.Transpiler
+import org.bykn.bosatsu.codegen.{Transpiler, CompilationSource}
 import org.bykn.bosatsu.{
   BuildInfo,
   Identifier,
   Json,
-  MatchlessFromTypedExpr,
-  Package,
   PackageName,
-  PackageMap,
   Par,
   PlatformIO,
-  TypedExpr,
   TypeName
 }
 import org.bykn.bosatsu.tool.{CliException, ExitCode}
@@ -25,28 +21,30 @@ import scala.util.{Failure, Success, Try}
 import Identifier.Bindable
 
 import cats.syntax.all._
+import org.bykn.bosatsu.codegen.CompilationNamespace
 
 case object ClangTranspiler extends Transpiler {
 
   sealed abstract class EmitMode {
-    def apply[A](
-        pm: PackageMap.Typed[A],
+    def apply[K](
+        cs: CompilationNamespace[K],
         roots: Set[(PackageName, Identifier)]
-    ): PackageMap.Typed[A]
+    ): CompilationNamespace[K]
   }
   object EmitMode {
     case object Shake extends EmitMode {
-      def apply[A](
-          pm: PackageMap.Typed[A],
+      def apply[K](
+          cs: CompilationNamespace[K],
           roots: Set[(PackageName, Identifier)]
-      ): PackageMap.Typed[A] =
-        PackageMap.treeShake(pm, roots)
+      ): CompilationNamespace[K] =
+        cs.treeShake(roots)
     }
     case object All extends EmitMode {
-      def apply[A](
-          pm: PackageMap.Typed[A],
+      def apply[K](
+          cs: CompilationNamespace[K],
           roots: Set[(PackageName, Identifier)]
-      ): PackageMap.Typed[A] = pm
+      ): CompilationNamespace[K] =
+        cs
     }
 
     implicit val argumentEmitMode: Argument[EmitMode] =
@@ -73,12 +71,14 @@ case object ClangTranspiler extends Transpiler {
         filter: Option[PackageName => Boolean],
         filterRegexes: NonEmptyList[String]
     ) extends Mode("test") {
-      def values(p: PackageMap.Typed[Any]): List[(PackageName, Bindable)] =
+      def values[K](
+          ns: CompilationNamespace[K]
+      ): List[(PackageName, Bindable)] =
         (filter match {
           case None =>
-            p.testValues.toList
+            ns.testValues.toList
           case Some(k) =>
-            p.testValues.iterator.filter { case (p, _) => k(p) }.toList
+            ns.testValues.iterator.filter { case (p, _) => k(p) }.toList
         }).sortBy(_._1)
     }
 
@@ -224,14 +224,6 @@ case object ClangTranspiler extends Transpiler {
       }
     }
 
-  case class GenError(error: ClangGen.Error)
-      extends Exception(s"clang gen error: ${error.display.render(80)}")
-      with CliException {
-    def errDoc: Doc = error.display
-    def stdOutDoc: Doc = Doc.empty
-    def exitCode: ExitCode = ExitCode.Error
-  }
-
   private def spacePackList(ps: Iterable[PackageName]): Doc =
     (Doc.line + Doc.intercalate(
       Doc.comma + Doc.line,
@@ -240,12 +232,12 @@ case object ClangTranspiler extends Transpiler {
       .nested(4)
       .grouped
 
-  case class CircularPackagesFound(loop: NonEmptyList[PackageName])
+  case class CircularPackagesFound(loop: NonEmptyList[(Any, PackageName)])
       extends Exception("circular deps in packages")
       with CliException {
     def errDoc: Doc =
       (Doc.text("circular dependencies found in packages:") + spacePackList(
-        loop.toList
+        loop.toList.map(_._2) // ??? TODO report the key in a sane way
       ))
     def stdOutDoc: Doc = Doc.empty
     def exitCode: ExitCode = ExitCode.Error
@@ -273,8 +265,10 @@ case object ClangTranspiler extends Transpiler {
     def exitCode: ExitCode = ExitCode.Error
   }
 
-  def externalsFor(pm: PackageMap.Typed[Any]): ClangGen.ExternalResolver =
-    ClangGen.ExternalResolver.stdExternals(pm)
+  /*
+  def externalsFor[K](ns: CompilationNamespace[K]): ClangGen.ExternalResolver =
+    ClangGen.ExternalResolver.stdExternals(ns)
+   */
 
   /** given the type (and possible the value) we return a C function name that
     * takes this value and the C args and returns an exit code which the main
@@ -282,10 +276,10 @@ case object ClangTranspiler extends Transpiler {
     *
     * int run_main(BValue main_value, int argc, char** args)
     */
-  def validMain[A](te: TypedExpr[A]): Either[String, Code.Ident] = {
+  def validMain(tpe: Type): Either[String, Code.Ident] = {
     val ProgMain =
       Type.Const.Defined(PackageName.parts("Bosatsu", "Prog"), TypeName("Main"))
-    te.getType match {
+    tpe match {
       case Type.TyConst(ProgMain) =>
         Right(Code.Ident("bsts_Bosatsu_Prog_run_main"))
       case notMain =>
@@ -295,37 +289,28 @@ case object ClangTranspiler extends Transpiler {
     }
   }
 
-  def renderAll[F[_], P](
+  def renderAll[F[_], P, S](
       outDir: P,
-      pm: PackageMap.Typed[Any],
+      pm: S,
       args: Args[F, P]
-  )(implicit ec: Par.EC): F[List[(P, Doc)]] = {
+  )(implicit ec: Par.EC, CS: CompilationSource[S]): F[List[(P, Doc)]] = {
     import args.platformIO._
 
     // we have to render the code in sorted order
-    val sorted = pm.topoSort
-    NonEmptyList.fromList(sorted.loopNodes) match {
+    val ns = CS.namespace(pm)
+    NonEmptyList.fromList(ns.topoSort.loopNodes) match {
       case Some(loop) => moduleIOMonad.raiseError(CircularPackagesFound(loop))
-      case None =>
-        val ext = externalsFor(pm)
+      case None       =>
+        // val ext = externalsFor(pm)
         val doc = args.mode match {
           case Mode.Main(p) =>
-            pm.toMap.get(p).flatMap(Package.mainValue(_)) match {
-              case Some((b, _, t)) =>
+            ns.mainValues(_ => true).get(p) match {
+              case Some((b, t)) =>
                 validMain(t) match {
                   case Right(mainRun) =>
-                    val pm1 = args.emit(pm, Set((p, b)))
-                    val matchlessMap = MatchlessFromTypedExpr.compile((), pm1)
-                    val sortedEnv = cats
-                      .Functor[Vector]
-                      .compose[NonEmptyList]
-                      .map(sorted.layers)(pn => pn -> matchlessMap(pn))
-
-                    ClangGen.renderMain(
-                      sortedEnv = sortedEnv,
-                      externals = ext,
-                      value = (p, b, mainRun)
-                    )
+                    val ns1 = args.emit(ns, Set((p, b)))
+                    val clangGen = new ClangGen(ns1)
+                    clangGen.renderMain(p, b, mainRun)
                   case Left(invalid) =>
                     return moduleIOMonad.raiseError(
                       InvalidMainValue(p, invalid)
@@ -337,35 +322,36 @@ case object ClangTranspiler extends Transpiler {
                 )
             }
           case test @ Mode.Test(_, re) =>
-            test.values(pm) match {
-              case Nil =>
-                return moduleIOMonad.raiseError(
-                  NoTestsFound(pm.toMap.keySet.toList.sorted, re)
-                )
-              case nonEmpty =>
-                val pm1 = args.emit(pm, nonEmpty.toSet)
-                val matchlessMap = MatchlessFromTypedExpr.compile((), pm1)
-                val sortedEnv = cats
-                  .Functor[Vector]
-                  .compose[NonEmptyList]
-                  .map(sorted.layers)(pn => pn -> matchlessMap(pn))
-
-                ClangGen.renderTests(
-                  sortedEnv = sortedEnv,
-                  externals = ext,
-                  values = nonEmpty
-                )
+            val tvs = test.values(ns)
+            if (tvs.isEmpty) {
+              return moduleIOMonad.raiseError(
+                NoTestsFound(ns.rootPackages.toList, re)
+              )
+            } else {
+              val ns1 = args.emit(ns, tvs.toSet)
+              val clangGen = new ClangGen(ns1)
+              clangGen.renderTests(
+                values = tvs.toList.sorted
+              )
             }
         }
 
         doc match {
-          case Left(err) => moduleIOMonad.raiseError(GenError(err))
+          case Left(err) =>
+            moduleIOMonad.raiseError(
+              CliException(
+                s"clang gen error: ${err.display.render(80)}",
+                err = err.display
+              )
+            )
+
           case Right(doc) =>
             val outputName = resolve(outDir, args.output.cOut)
             val externalHeaders =
               if (args.generateExternals.generate) {
-                ext.generateExternalsStub.iterator.map { case (n, d) =>
-                  resolve(outDir, n) -> d
+                (new ClangGen(ns)).generateExternalsStub.iterator.map {
+                  case (n, d) =>
+                    resolve(outDir, n) -> d
                 }.toList
               } else Nil
 

--- a/core/src/main/scala/org/bykn/bosatsu/codegen/python/PythonGen.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/codegen/python/PythonGen.scala
@@ -604,17 +604,17 @@ object PythonGen {
       ec: Par.EC
   ): SortedMap[CS.ScopeKey, Map[PackageName, (Module, Doc)]] = {
     val ns = CS.namespace(src)
-    renderAll(ns.compiled, externals, evaluators, ns)
+    renderAll(ns, externals, evaluators)
   }
 
   // compile a set of packages given a set of external remappings
   def renderAll[K](
-      pm: SortedMap[K, Map[PackageName, List[(Bindable, Expr[K])]]],
+      ns: CompilationNamespace[K],
       externals: Map[(PackageName, Bindable), (Module, Code.Ident)],
-      evaluators: Map[PackageName, (Bindable, Module, Code.Ident)],
-      ns: CompilationNamespace[K]
+      evaluators: Map[PackageName, (Bindable, Module, Code.Ident)]
   )(implicit ec: Par.EC): SortedMap[K, Map[PackageName, (Module, Doc)]] = {
 
+    val pm = ns.compiled
     val externalRemap: (PackageName, Bindable) => Env[Option[ValueLike]] = {
       (p, b) =>
         externals.get((p, b)) match {

--- a/core/src/main/scala/org/bykn/bosatsu/codegen/python/PythonTranspiler.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/codegen/python/PythonTranspiler.scala
@@ -115,9 +115,8 @@ case object PythonTranspiler extends Transpiler {
           def toPath(ns: NonEmptyList[String]): P =
             resolve(outDir, ns.toList)
 
-          val cmp = ns.compiled
           val docs = PythonGen
-            .renderAll(cmp, extMap, evalMap, ns)
+            .renderAll(ns, extMap, evalMap)
             .iterator
             .flatMap { case (_, packs) =>
               packs.iterator.map { case (_, (path, doc)) =>

--- a/core/src/main/scala/org/bykn/bosatsu/codegen/python/PythonTranspiler.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/codegen/python/PythonTranspiler.scala
@@ -4,7 +4,7 @@ import cats.data.NonEmptyList
 import cats.implicits.catsKernelOrderingForOrder
 import com.monovore.decline.{Argument, Opts}
 import org.bykn.bosatsu.CollectionUtils.listToUnique
-import org.bykn.bosatsu.codegen.{CompilationSource, Transpiler}
+import org.bykn.bosatsu.codegen.{CompilationNamespace, Transpiler}
 import org.bykn.bosatsu.{Par, Parser, PlatformIO}
 import org.typelevel.paiges.Doc
 import scala.util.Try
@@ -58,9 +58,9 @@ case object PythonTranspiler extends Transpiler {
 
   def renderAll[F[_], P, S](
       outDir: P,
-      pm: S,
+      ns: CompilationNamespace[S],
       args: Args[F, P]
-  )(implicit ec: Par.EC, CS: CompilationSource[S]): F[List[(P, Doc)]] = {
+  )(implicit ec: Par.EC): F[List[(P, Doc)]] = {
 
     import args.platformIO._
 
@@ -77,8 +77,6 @@ case object PythonTranspiler extends Transpiler {
 
         val exts = extMap.keySet
         val intrinsic = PythonGen.intrinsicValues
-
-        val ns = CS.namespace(pm)
 
         val allExternals = ns.externals
         val missingExternals =

--- a/core/src/main/scala/org/bykn/bosatsu/graph/Dag.scala
+++ b/core/src/main/scala/org/bykn/bosatsu/graph/Dag.scala
@@ -35,7 +35,8 @@ sealed trait Dag[A] {
         NonEmptyList.fromListUnsafe(layerMap(idx).toList)
       }
       .to(Vector)
-    Toposort.Success(ls, deps(_).toList)
+
+    Toposort.Success(ls)
   }
 
   override def equals(that: Any) =
@@ -132,14 +133,6 @@ object Dag {
 
     (clusterMap.get(_), dag)
   }
-
-  def fromToposorted[A: Ordering](s: Toposort.Success[A]): Dag[A] =
-    new Dag[A] {
-      val nodes = s.layers.iterator.flatMap(nel => nel.toList).to(SortedSet)
-      val depCache = MMap.empty[A, SortedSet[A]]
-      def deps(a: A): SortedSet[A] =
-        depCache.getOrElseUpdate(a, s.nfn(a).to(SortedSet))
-    }
 
   def transitiveSet[A: Ordering](
       nodes: List[A]

--- a/core/src/test/scala/org/bykn/bosatsu/graph/DagTest.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/graph/DagTest.scala
@@ -89,7 +89,7 @@ class DagTest extends AnyFunSuite {
       val clusterVec = dag.nodes.toVector.zipWithIndex
       for {
         (c1, idx) <- clusterVec
-        (c2, idx2) <- (0 until idx).map(clusterVec(_))
+        (c2, _) <- (0 until idx).map(clusterVec(_))
       } assert((c1 & c2).isEmpty)
 
       // every node is in one cluster

--- a/core/src/test/scala/org/bykn/bosatsu/graph/DagTest.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/graph/DagTest.scala
@@ -98,7 +98,7 @@ class DagTest extends AnyFunSuite {
 
       // if we toposort a dag, we always succeed
       implicit val setOrd = ListOrdering.byIterator[SortedSet[Int], Int]
-      val sortRes @ Toposort.Success(_, _) = Toposort.sort(dag.nodes) { n =>
+      val sortRes @ Toposort.Success(_) = Toposort.sort(dag.nodes) { n =>
         dag.deps(n).toList
       }
       assert(sortRes.isSuccess)
@@ -108,7 +108,6 @@ class DagTest extends AnyFunSuite {
         }
       }
       assert(dag.layers == sortRes.layers.length)
-      assert(Dag.fromToposorted(sortRes) === dag)
       assert(sortRes.layers == dag.toToposorted.layers)
 
       // if we dagify again we get singletons:

--- a/core/src/test/scala/org/bykn/bosatsu/graph/ToposortTest.scala
+++ b/core/src/test/scala/org/bykn/bosatsu/graph/ToposortTest.scala
@@ -76,7 +76,7 @@ class ToposortTest extends AnyFunSuite {
     val genDag = Gen.mapOf(pair).map(Dag(_))
     forAll(genDag) { case Dag(graph) =>
       val allNodes = graph.flatMap { case (h, t) => h :: t }.toSet
-      val Toposort.Success(sorted, _) =
+      val Toposort.Success(sorted) =
         Toposort.sort(allNodes)(graph.getOrElse(_, Nil))
       assert(sorted.flatMap(_.toList).sorted == allNodes.toList.sorted)
       noEdgesToLater(sorted)(n => graph.getOrElse(n, Nil))


### PR DESCRIPTION
The idea here is to have an interface abstract over all the questions we ask of compiling a collection of code. This should support the previous way of "one world" for all packages, vs the "multiverse" approach of libraries having public and private dependencies and not forcing a resolution to a single version of all transitive libraries.

