### PR TITLE
Use actions/setup-java to get aarch on macos

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,9 +5,12 @@ jobs:
       - uses: "actions/checkout@v2.1.0"
       - uses: "coursier/cache-action@v6"
       - name: "java ${{matrix.java}} setup"
-        uses: "olafurpg/setup-scala@v14"
+        uses: "actions/setup-java@v5"
         with:
+          distribution: "temurin"
           java-version: "${{matrix.java}}"
+      - name: "install sbt"
+        uses: "sbt/setup-sbt@v1"
       - name: "run JVM tests"
         run: |
           sbt "coreJVM/test; cli/test; doc; paradox"
@@ -24,9 +27,12 @@ jobs:
       - uses: "actions/checkout@v2.1.0"
       - uses: "coursier/cache-action@v6"
       - name: "java ${{matrix.java}} setup"
-        uses: "olafurpg/setup-scala@v14"
+        uses: "actions/setup-java@v5"
         with:
+          distribution: "temurin"
           java-version: "${{matrix.java}}"
+      - name: "install sbt"
+        uses: "sbt/setup-sbt@v1"
       - name: "python setup"
         uses: "actions/setup-python@v2"
         with:
@@ -51,9 +57,12 @@ jobs:
       - uses: "actions/checkout@v2.1.0"
       - uses: "coursier/cache-action@v6"
       - name: "java ${{matrix.java}} setup"
-        uses: "olafurpg/setup-scala@v14"
+        uses: "actions/setup-java@v5"
         with:
+          distribution: "temurin"
           java-version: "${{matrix.java}}"
+      - name: "install sbt"
+        uses: "sbt/setup-sbt@v1"
       - name: "run coreJS tests"
         run: |
           sbt "coreJS/test; jsapiJS/compile"
@@ -72,9 +81,12 @@ jobs:
           fetch-depth: 0
       - uses: "coursier/cache-action@v6"
       - name: "java ${{matrix.java}} setup"
-        uses: "olafurpg/setup-scala@v14"
+        uses: "actions/setup-java@v5"
         with:
+          distribution: "temurin"
           java-version: "${{matrix.java}}"
+      - name: "install sbt"
+        uses: "sbt/setup-sbt@v1"
       - name: "run tests with coverage"
         run: |
           sbt "coverage; clean; coreJVM/test; cli/test; coverageReport"
@@ -93,10 +105,13 @@ jobs:
     steps:
       - uses: "actions/checkout@v2.1.0"
       - uses: "coursier/cache-action@v6"
-      - name: "graalvm setup"
-        uses: "olafurpg/setup-scala@v14"
+      - name: "java ${{matrix.java}} setup"
+        uses: "actions/setup-java@v5"
         with:
+          distribution: "temurin"
           java-version: "${{matrix.java}}"
+      - name: "install sbt"
+        uses: "sbt/setup-sbt@v1"
       - name: "build native image"
         run: |
           sbt "cli/nativeImage"
@@ -114,10 +129,13 @@ jobs:
     steps:
       - uses: "actions/checkout@v2.1.0"
       - uses: "coursier/cache-action@v6"
-      - name: "graalvm setup"
-        uses: "olafurpg/setup-scala@v14"
+      - name: "java ${{matrix.java}} setup"
+        uses: "actions/setup-java@v5"
         with:
+          distribution: "temurin"
           java-version: "${{matrix.java}}"
+      - name: "install sbt"
+        uses: "sbt/setup-sbt@v1"
       - name: "build node"
         run: |
           sbt "cliJSJS/fullOptJS"
@@ -148,10 +166,13 @@ jobs:
           - '17'
     steps:
       - uses: "actions/checkout@v2.1.0"
-      - name: "java setup"
-        uses: "olafurpg/setup-scala@v14"
+      - name: "java ${{matrix.java}} setup"
+        uses: "actions/setup-java@v5"
         with:
+          distribution: "temurin"
           java-version: "${{matrix.java}}"
+      - name: "install sbt"
+        uses: "sbt/setup-sbt@v1"
       - name: "build assembly"
         run: 'sbt "cli/assembly"'
       - name: "install boehm"
@@ -182,9 +203,12 @@ jobs:
       - uses: "actions/checkout@v2.1.0"
       - uses: "coursier/cache-action@v6"
       - name: "java ${{matrix.java}} setup"
-        uses: "olafurpg/setup-scala@v14"
+        uses: "actions/setup-java@v5"
         with:
+          distribution: "temurin"
           java-version: "${{matrix.java}}"
+      - name: "install sbt"
+        uses: "sbt/setup-sbt@v1"
       - name: "build assembly"
         run: 'sbt "++3.8.1; cli/assembly"'
       - name: "dry run bosatsu lib publish"

--- a/.github/workflows/codecov_main.yml
+++ b/.github/workflows/codecov_main.yml
@@ -14,9 +14,12 @@ jobs:
           fetch-depth: 0
       - uses: "coursier/cache-action@v6"
       - name: "java ${{matrix.java}} setup"
-        uses: "olafurpg/setup-scala@v14"
+        uses: "actions/setup-java@v5"
         with:
+          distribution: "temurin"
           java-version: "${{matrix.java}}"
+      - name: "install sbt"
+        uses: "sbt/setup-sbt@v1"
       - name: "run tests with coverage"
         run: |
           sbt "coverage; clean; coreJVM/test; cli/test; coverageReport"

--- a/.github/workflows/deploy_web.yml
+++ b/.github/workflows/deploy_web.yml
@@ -19,9 +19,12 @@ jobs:
       - uses: "actions/checkout@v2.1.0"
       - uses: "coursier/cache-action@v6"
       - name: "java 17 setup"
-        uses: "olafurpg/setup-scala@v14"
+        uses: "actions/setup-java@v5"
         with:
+          distribution: "temurin"
           java-version: "17"
+      - name: "install sbt"
+        uses: "sbt/setup-sbt@v1"
       - name: "build app"
         run: |
           export NODE_OPTIONS=--openssl-legacy-provider

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,9 +19,12 @@ jobs:
           fetch-depth: 0
       - uses: coursier/cache-action@v6
       - name: Java 17 setup
-        uses: olafurpg/setup-scala@v14
+        uses: actions/setup-java@v5
         with:
+          distribution: "temurin"
           java-version: "17"
+      - name: Install sbt
+        uses: sbt/setup-sbt@v1
       - name: Verify tag matches sbt version
         env:
           TAG_NAME: ${{ github.ref_name }}
@@ -70,9 +73,12 @@ jobs:
           fetch-depth: 0
       - uses: coursier/cache-action@v6
       - name: Java 17 setup
-        uses: olafurpg/setup-scala@v14
+        uses: actions/setup-java@v5
         with:
+          distribution: "temurin"
           java-version: "17"
+      - name: Install sbt
+        uses: sbt/setup-sbt@v1
       - name: Build jar and node JS
         env:
           BOSATSU_C_RUNTIME_HASH: ${{ needs.prepare.outputs.c_runtime_hash }}
@@ -101,9 +107,12 @@ jobs:
           fetch-depth: 0
       - uses: coursier/cache-action@v6
       - name: Java 17 setup
-        uses: olafurpg/setup-scala@v14
+        uses: actions/setup-java@v5
         with:
+          distribution: "temurin"
           java-version: "17"
+      - name: Install sbt
+        uses: sbt/setup-sbt@v1
       - name: Install musl toolchain
         run: sudo apt-get update && sudo apt-get install -y musl-tools build-essential
       - name: Build musl zlib
@@ -147,9 +156,13 @@ jobs:
           fetch-depth: 0
       - uses: coursier/cache-action@v6
       - name: Java 17 setup
-        uses: olafurpg/setup-scala@v14
+        uses: actions/setup-java@v5
         with:
+          distribution: "temurin"
           java-version: "17"
+          architecture: "aarch64"
+      - name: Install sbt
+        uses: sbt/setup-sbt@v1
       - name: Build native image (macos)
         env:
           BOSATSU_C_RUNTIME_HASH: ${{ needs.prepare.outputs.c_runtime_hash }}
@@ -184,9 +197,12 @@ jobs:
           path: release_assets
           merge-multiple: true
       - name: Java 17 setup
-        uses: olafurpg/setup-scala@v14
+        uses: actions/setup-java@v5
         with:
+          distribution: "temurin"
           java-version: "17"
+      - name: Install sbt
+        uses: sbt/setup-sbt@v1
       - name: Build assembly for lib publish
         env:
           BOSATSU_C_RUNTIME_HASH: ${{ needs.prepare.outputs.c_runtime_hash }}


### PR DESCRIPTION
Here is an example of failed release:

https://github.com/johnynek/bosatsu/actions/runs/21417516998/job/61669593232

It seems that what is happening is that on macos we are getting intel JVMs. Those intel jvms cause us to get intel native-image and build intel binaries. We want arm binaries.