### PR TITLE
Leverage pattern totality in Matchless matrix compliation

### DIFF
--- a/cli/src/test/scala/dev/bosatsu/codegen/clang/ClangGenTest.scala
+++ b/cli/src/test/scala/dev/bosatsu/codegen/clang/ClangGenTest.scala
@@ -42,7 +42,7 @@ class ClangGenTest extends munit.FunSuite {
       To inspect the code, change the hash, and it will print the code out
      */
     testFilesCompilesToHash("test_workspace/Ackermann.bosatsu")(
-      "be878824116684f66b889b506aa09952"
+      "5fe02e75ce4990b55a6672ee0bf982c6"
     )
   }
 }


### PR DESCRIPTION
The original (linear) pattern compilation kept track that the last pattern must match due to totality. But the matrix based algorithm of #1519 didn't. This PR introduces that. It can be even more efficient here because as we build the matching tree, all the leafs are known to be total.