### PR TITLE
Clarify rank-n inference docs and enforce lambda param annotations

### DIFF
--- a/core/src/main/scala/dev/bosatsu/rankn/Infer.scala
+++ b/core/src/main/scala/dev/bosatsu/rankn/Infer.scala
@@ -28,6 +28,14 @@ import HasRegion.region
 import Identifier.{Bindable, Constructor}
 import scala.collection.immutable.SortedMap
 
+/** The type inference/checking effect for Bosatsu's rank-n system.
+  *
+  * The core algorithm is a bidirectional, constraint-based system inspired by:
+  * https://www.microsoft.com/en-us/research/publication/practical-type-inference-for-arbitrary-rank-types/
+  *
+  * We infer or check expressions against expected types, generate and solve
+  * metavariables, and use subsumption checks to decide when coercions are safe.
+  */
 sealed abstract class Infer[+A] {
   import Infer.Error
 
@@ -58,6 +66,16 @@ sealed abstract class Infer[+A] {
     runVar(v, tpes, kinds).run.value
 }
 
+/** Companion for the inference engine.
+  *
+  * Differences from the paper:
+  * - Generalized type application (TyApply) as a first-class type former.
+  * - Kinds include variance; kind subsumption is checked during inference.
+  * - Pattern matching with typed patterns and binding environments.
+  * - Existential types (skolemization + escape checks) integrated into inference.
+  * - Limited impredicativity via instantiation in some application/annotation
+  *   paths to handle common practical cases.
+  */
 object Infer {
 
   type Pattern = GenPattern[(PackageName, Constructor), Type]


### PR DESCRIPTION
## Summary
- Bind annotated lambda parameters to their annotation types in check mode so the body cannot see through annotations.
- Replace several inference TODOs with explicit rationale/comments (kinds/meta handling, match typing, instantiation) and add high-level Infer scaladoc with paper link and differences.
- Clarify subsumption/coercion behavior around lambda checking and instantiation paths.

## Testing
- sbt coreJVM/test
- sbt "coreJVM/testOnly dev.bosatsu.rankn.RankNInferTest dev.bosatsu.EvaluationTest; cli/testOnly dev.bosatsu.cli.PathModuleTest"
- sbt "cli/testOnly dev.bosatsu.PathModuleTest"