### PR TITLE
Add compile-time Identifier.literal and replace unsafe literals

### DIFF
--- a/core/src/main/scala/dev/bosatsu/Identifier.scala
+++ b/core/src/main/scala/dev/bosatsu/Identifier.scala
@@ -3,6 +3,7 @@ package dev.bosatsu
 import cats.Order
 import cats.parse.{Parser0 => P0, Parser => P}
 import org.typelevel.paiges.{Doc, Document}
+import scala.quoted.{Expr, Quotes}
 
 import Parser.{lowerIdent, upperIdent}
 
@@ -122,6 +123,48 @@ object Identifier {
 
   def unsafeBindable(str: String): Bindable =
     unsafeParse(bindableParser, str)
+
+  /** Build an Identifier from a compile-time string literal.
+    *
+    * The literal must parse as either a [[Name]] or [[Constructor]], and the
+    * parsed `asString` must exactly match the provided literal content.
+    */
+  transparent inline def literal(inline str: String): Identifier =
+    ${ literalImpl('str) }
+
+  private def literalImpl(strExpr: Expr[String])(using q: Quotes): Expr[Identifier] = {
+    import q.reflect.report
+
+    strExpr.value match {
+      case Some(str) =>
+        parser.parseAll(str) match {
+          case Right(Name(name)) if name == str =>
+            '{ Name(${ Expr(str) }) }
+          case Right(Constructor(cons)) if cons == str =>
+            '{ Constructor(${ Expr(str) }) }
+          case Right(Name(name)) =>
+            report.errorAndAbort(
+              s"""Identifier.literal("$str") parsed as Name("$name"), which does not round-trip exactly."""
+            )
+          case Right(Constructor(cons)) =>
+            report.errorAndAbort(
+              s"""Identifier.literal("$str") parsed as Constructor("$cons"), which does not round-trip exactly."""
+            )
+          case Right(other) =>
+            report.errorAndAbort(
+              s"""Identifier.literal("$str") must parse as Name or Constructor, but parsed as ${other.sourceCodeRepr}."""
+            )
+          case Left(err) =>
+            report.errorAndAbort(
+              s"""Identifier.literal("$str") is invalid: $err"""
+            )
+        }
+      case None =>
+        report.errorAndAbort(
+          s"Identifier.literal requires a string literal, but found: ${strExpr.show}"
+        )
+    }
+  }
 
   def optionParse[A](pa: P0[A], str: String): Option[A] =
     Parser.optionParse(pa, str)

--- a/core/src/main/scala/dev/bosatsu/codegen/python/PythonGen.scala
+++ b/core/src/main/scala/dev/bosatsu/codegen/python/PythonGen.scala
@@ -749,14 +749,14 @@ object PythonGen {
       val results: Map[Bindable, (List[ValueLike] => Env[ValueLike], Int)] =
         Map(
           (
-            Identifier.unsafeBindable("add"),
+            Identifier.literal("add"),
             (
               input => Env.onLast2(input.head, input.tail.head)(_.evalPlus(_)),
               2
             )
           ),
           (
-            Identifier.unsafeBindable("sub"),
+            Identifier.literal("sub"),
             (
               { input =>
                 Env.onLast2(input.head, input.tail.head)(_.evalMinus(_))
@@ -765,7 +765,7 @@ object PythonGen {
             )
           ),
           (
-            Identifier.unsafeBindable("times"),
+            Identifier.literal("times"),
             (
               { input =>
                 Env.onLast2(input.head, input.tail.head)(_.evalTimes(_))
@@ -774,7 +774,7 @@ object PythonGen {
             )
           ),
           (
-            Identifier.unsafeBindable("div"),
+            Identifier.literal("div"),
             (
               { input =>
                 Env.onLast2(input.head, input.tail.head) { (a, b) =>
@@ -791,7 +791,7 @@ object PythonGen {
             )
           ),
           (
-            Identifier.unsafeBindable("mod_Int"),
+            Identifier.literal("mod_Int"),
             (
               { input =>
                 Env.onLast2(input.head, input.tail.head) { (a, b) =>
@@ -807,9 +807,9 @@ object PythonGen {
               2
             )
           ),
-          (Identifier.unsafeBindable("cmp_Int"), (cmpFn, 2)),
+          (Identifier.literal("cmp_Int"), (cmpFn, 2)),
           (
-            Identifier.unsafeBindable("eq_Int"),
+            Identifier.literal("eq_Int"),
             (
               { input =>
                 Env.onLast2(input.head, input.tail.head)(
@@ -820,7 +820,7 @@ object PythonGen {
             )
           ),
           (
-            Identifier.unsafeBindable("shift_left_Int"),
+            Identifier.literal("shift_left_Int"),
             (
               { input =>
                 Env.onLast2(input.head, input.tail.head)(
@@ -831,7 +831,7 @@ object PythonGen {
             )
           ),
           (
-            Identifier.unsafeBindable("shift_right_Int"),
+            Identifier.literal("shift_right_Int"),
             (
               { input =>
                 Env.onLast2(input.head, input.tail.head)(
@@ -842,7 +842,7 @@ object PythonGen {
             )
           ),
           (
-            Identifier.unsafeBindable("and_Int"),
+            Identifier.literal("and_Int"),
             (
               { input =>
                 Env.onLast2(input.head, input.tail.head)(
@@ -853,7 +853,7 @@ object PythonGen {
             )
           ),
           (
-            Identifier.unsafeBindable("or_Int"),
+            Identifier.literal("or_Int"),
             (
               { input =>
                 Env.onLast2(input.head, input.tail.head)(
@@ -864,7 +864,7 @@ object PythonGen {
             )
           ),
           (
-            Identifier.unsafeBindable("xor_Int"),
+            Identifier.literal("xor_Int"),
             (
               { input =>
                 Env.onLast2(input.head, input.tail.head)(
@@ -875,7 +875,7 @@ object PythonGen {
             )
           ),
           (
-            Identifier.unsafeBindable("not_Int"),
+            Identifier.literal("not_Int"),
             (
               {
                 // leverage not(x) == -1 - x
@@ -885,7 +885,7 @@ object PythonGen {
             )
           ),
           (
-            Identifier.unsafeBindable("gcd_Int"),
+            Identifier.literal("gcd_Int"),
             (
               { input =>
                 (
@@ -937,7 +937,7 @@ object PythonGen {
           //     _i = tmp_i
           //   return _a
           (
-            Identifier.unsafeBindable("int_loop"),
+            Identifier.literal("int_loop"),
             (
               { input =>
                 (
@@ -994,7 +994,7 @@ object PythonGen {
             )
           ),
           (
-            Identifier.unsafeBindable("concat_String"),
+            Identifier.literal("concat_String"),
             (
               { input =>
                 Env.onLastM(input.head) { listOfStrings =>
@@ -1019,7 +1019,7 @@ object PythonGen {
             )
           ),
           (
-            Identifier.unsafeBindable("int_to_String"),
+            Identifier.literal("int_to_String"),
             (
               { input =>
                 Env.onLast(input.head) {
@@ -1032,7 +1032,7 @@ object PythonGen {
             )
           ),
           (
-            Identifier.unsafeBindable("string_to_Int"),
+            Identifier.literal("string_to_Int"),
             (
               { input =>
                 Env.onLast(input.head) { s =>
@@ -1061,12 +1061,12 @@ object PythonGen {
             )
           ),
           (
-            Identifier.unsafeBindable("char_to_String"),
+            Identifier.literal("char_to_String"),
             // we encode chars as strings so this is just identity
             ({ input => Env.envMonad.pure(input.head) }, 1)
           ),
           (
-            Identifier.unsafeBindable("trace"),
+            Identifier.literal("trace"),
             (
               { input =>
                 Env.onLast2(input.head, input.tail.head) { (msg, i) =>
@@ -1079,7 +1079,7 @@ object PythonGen {
             )
           ),
           (
-            Identifier.unsafeBindable("partition_String"),
+            Identifier.literal("partition_String"),
             (
               { input =>
                 Env.newAssignableVar
@@ -1111,7 +1111,7 @@ object PythonGen {
             )
           ),
           (
-            Identifier.unsafeBindable("rpartition_String"),
+            Identifier.literal("rpartition_String"),
             (
               { input =>
                 Env.newAssignableVar
@@ -1140,18 +1140,18 @@ object PythonGen {
               2
             )
           ),
-          (Identifier.unsafeBindable("cmp_String"), (cmpFn, 2))
+          (Identifier.literal("cmp_String"), (cmpFn, 2))
         )
 
       val arrayResults
           : Map[Bindable, (List[ValueLike] => Env[ValueLike], Int)] =
         Map(
           (
-            Identifier.unsafeBindable("empty_Array"),
+            Identifier.literal("empty_Array"),
             ((_: List[ValueLike]) => Env.pure(emptyArray), 0)
           ),
           (
-            Identifier.unsafeBindable("tabulate_Array"),
+            Identifier.literal("tabulate_Array"),
             (
               { input =>
                 (Env.newAssignableVar, Env.newAssignableVar).tupled.flatMap {
@@ -1190,7 +1190,7 @@ object PythonGen {
             )
           ),
           (
-            Identifier.unsafeBindable("from_List_Array"),
+            Identifier.literal("from_List_Array"),
             (
               { input =>
                 Env.newAssignableVar.flatMap { pyList =>
@@ -1212,7 +1212,7 @@ object PythonGen {
             )
           ),
           (
-            Identifier.unsafeBindable("to_List_Array"),
+            Identifier.literal("to_List_Array"),
             (
               { input =>
                 (
@@ -1246,7 +1246,7 @@ object PythonGen {
             )
           ),
           (
-            Identifier.unsafeBindable("size_Array"),
+            Identifier.literal("size_Array"),
             (
               { input =>
                 Env.onLast(input.head)(arrayLen)
@@ -1255,7 +1255,7 @@ object PythonGen {
             )
           ),
           (
-            Identifier.unsafeBindable("get_map_Array"),
+            Identifier.literal("get_map_Array"),
             (
               { input =>
                 Env.onLasts(input) {
@@ -1280,7 +1280,7 @@ object PythonGen {
             )
           ),
           (
-            Identifier.unsafeBindable("get_or_Array"),
+            Identifier.literal("get_or_Array"),
             (
               { input =>
                 Env.onLasts(input) {
@@ -1305,7 +1305,7 @@ object PythonGen {
             )
           ),
           (
-            Identifier.unsafeBindable("foldl_Array"),
+            Identifier.literal("foldl_Array"),
             (
               { input =>
                 (
@@ -1349,7 +1349,7 @@ object PythonGen {
             )
           ),
           (
-            Identifier.unsafeBindable("map_Array"),
+            Identifier.literal("map_Array"),
             (
               { input =>
                 (
@@ -1392,7 +1392,7 @@ object PythonGen {
             )
           ),
           (
-            Identifier.unsafeBindable("set_or_self_Array"),
+            Identifier.literal("set_or_self_Array"),
             (
               { input =>
                 (
@@ -1434,7 +1434,7 @@ object PythonGen {
             )
           ),
           (
-            Identifier.unsafeBindable("sort_Array"),
+            Identifier.literal("sort_Array"),
             (
               { input =>
                 (
@@ -1493,7 +1493,7 @@ object PythonGen {
             )
           ),
           (
-            Identifier.unsafeBindable("concat_all_Array"),
+            Identifier.literal("concat_all_Array"),
             (
               { input =>
                 (
@@ -1571,7 +1571,7 @@ object PythonGen {
             )
           ),
           (
-            Identifier.unsafeBindable("slice_Array"),
+            Identifier.literal("slice_Array"),
             (
               { input =>
                 (

--- a/core/src/test/scala/dev/bosatsu/rankn/RankNInferTest.scala
+++ b/core/src/test/scala/dev/bosatsu/rankn/RankNInferTest.scala
@@ -95,11 +95,11 @@ class RankNInferTest extends munit.FunSuite {
     Map(
       (
         Some(PackageName.PredefName),
-        Identifier.unsafe("True")
+        Identifier.literal("True")
       ) -> Type.BoolType,
       (
         Some(PackageName.PredefName),
-        Identifier.unsafe("False")
+        Identifier.literal("False")
       ) -> Type.BoolType
     )
   val boolTypes: Map[(PackageName, Constructor), Infer.Cons] =
@@ -429,7 +429,7 @@ class RankNInferTest extends munit.FunSuite {
 
     val constructors = Map(
       (
-        Identifier.unsafe("Some"),
+        Identifier.literal("Some"),
         Type.Fun(Type.IntType, optType)
       )
     )
@@ -505,7 +505,7 @@ class RankNInferTest extends munit.FunSuite {
 
     val constructors = Map(
       (
-        Identifier.unsafe("Some"),
+        Identifier.literal("Some"),
         Type.forAll(
           NonEmptyList.of(b("a")),
           Type.Fun(
@@ -515,7 +515,7 @@ class RankNInferTest extends munit.FunSuite {
         )
       ),
       (
-        Identifier.unsafe("None"),
+        Identifier.literal("None"),
         Type.forAll(
           NonEmptyList.of(b("a")),
           Type.TyApply(optType, tv("a"))
@@ -639,7 +639,7 @@ class RankNInferTest extends munit.FunSuite {
 
     val constructors = Map(
       (
-        Identifier.unsafe("Pure"),
+        Identifier.literal("Pure"),
         Type.forAll(
           NonEmptyList.of(b1("f")),
           Type.Fun(
@@ -652,7 +652,7 @@ class RankNInferTest extends munit.FunSuite {
         )
       ),
       (
-        Identifier.unsafe("Some"),
+        Identifier.literal("Some"),
         Type.forAll(
           NonEmptyList.of(b("a")),
           Type.Fun(
@@ -662,7 +662,7 @@ class RankNInferTest extends munit.FunSuite {
         )
       ),
       (
-        Identifier.unsafe("None"),
+        Identifier.literal("None"),
         Type.forAll(
           NonEmptyList.of(b("a")),
           Type.TyApply(optType, tv("a"))


### PR DESCRIPTION
## Summary

This PR introduces a compile-time-safe identifier literal API and migrates existing static literal callsites to it.

### What changed

- Added `Identifier.literal` in `/Users/oscar/code/bosatsu2/core/src/main/scala/dev/bosatsu/Identifier.scala` as a Scala 3 `transparent inline` macro.
- The macro requires a compile-time string literal and validates it by parsing with `Identifier.parser`.
- It only accepts literals that parse to:
  - `Identifier.Name`
  - `Identifier.Constructor`
- It also enforces exact round-trip (`asString == original literal`) and aborts compilation on invalid inputs.
- Replaced static literal usages of:
  - `Identifier.unsafeBindable(...)` in `/Users/oscar/code/bosatsu2/core/src/main/scala/dev/bosatsu/codegen/python/PythonGen.scala`
  - `Identifier.unsafe("...")` (literal cases) in `/Users/oscar/code/bosatsu2/core/src/test/scala/dev/bosatsu/rankn/RankNInferTest.scala`

## Motivation

We previously parsed some static identifier strings at runtime via `Identifier.unsafe` / `Identifier.unsafeBindable`.  
For literals, this is unnecessary and can hide malformed identifiers until runtime.

This change moves that validation to compile time, tightening safety and feedback loops.

Notably, there are now no remaining calls to `Identifier.unsafe` in the main code base, removing one potential (though remote) runtime error source.

## Validation

- Ran: `sbt clean test:compile`
- Result: successful compile across the build.