### PR TITLE
Add TypedAst.proto to release assets

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -256,6 +256,7 @@ jobs:
           set -euo pipefail
           mkdir -p release_assets
           cp bosatsu release_assets/
+          cp proto/src/main/protobuf/bosatsu/TypedAst.proto release_assets/
           cp .bosatsu_lib_publish/*.bosatsu_lib release_assets/
           chmod +x release_assets/bosatsu || true
           required_files=(
@@ -264,6 +265,7 @@ jobs:
             "bosatsu-linux"
             "bosatsu-macos"
             "bosatsu"
+            "TypedAst.proto"
             "${C_RUNTIME_ARCHIVE}"
           )
           for file in "${required_files[@]}"; do

--- a/release.md
+++ b/release.md
@@ -1,6 +1,6 @@
 # Release process
 
-This repo publishes releases when a `v*` tag is pushed. The GitHub Actions workflow builds and uploads all assets (jar, node JS, native images, c_runtime archive, bosatsu libs, SHA256SUMS), then commits updated `*_conf.json` files back to `main`.
+This repo publishes releases when a `v*` tag is pushed. The GitHub Actions workflow builds and uploads all assets (jar, node JS, native images, c_runtime archive, bosatsu libs, `TypedAst.proto`, `SHA256SUMS`, `B3SUMS`), then commits updated `*_conf.json` files back to `main`.
 
 ## Create a release
 


### PR DESCRIPTION
## Summary
- copy `proto/src/main/protobuf/bosatsu/TypedAst.proto` into `release_assets` during release staging
- add `TypedAst.proto` to required release files validation
- update release docs to list `TypedAst.proto` and `B3SUMS` among published assets

Closes #1588