### PR TITLE
Fix lib build regression on dependency package imports

### DIFF
--- a/core/src/main/scala/dev/bosatsu/library/Command.scala
+++ b/core/src/main/scala/dev/bosatsu/library/Command.scala
@@ -502,7 +502,14 @@ object Command {
           hashedLib = Hashed.viaBytes[Algo.Blake3, proto.Library](protoLib)(
             _.toByteArray
           )
-          decLib <- DecodedLibrary.decode(hashedLib)
+          decLib = DecodedLibrary(
+            conf.name,
+            conf.nextVersion,
+            hashedLib.hash,
+            protoLib,
+            Nil,
+            allPacks
+          )
           allDeps =
             (cs.pubDecodes.iterator ++ cs.privDecodes.iterator).map { dec =>
               (dec.name.name, dec.version) -> dec.toHashed


### PR DESCRIPTION
## Summary
- add a `MemoryMain` regression test covering `lib check` pass + `lib build` on a package that imports from a private dependency in CAS
- avoid re-decoding the just-assembled local proto library in `decodedWithDeps`
- build `DecodedLibrary` directly from the already typechecked local packages, preserving external dependency imports without triggering `ProtoConverter.packagesFromProto` missing-node crashes

## Repro covered
- before this change, the new test fails with `could not find node named: Dep/Foo ...`
- after this change, `lib build` succeeds for the same setup

## Verification
- `sbt "coreJVM/testOnly dev.bosatsu.ToolAndLibCommandTest"`
- `sbt "coreJVM/testOnly dev.bosatsu.LibBuildImplicitPackageTest"`
