### PR TITLE
Fix missing-name diagnostics and identifier/type rendering

### DIFF
--- a/core/src/main/scala/dev/bosatsu/rankn/Infer.scala
+++ b/core/src/main/scala/dev/bosatsu/rankn/Infer.scala
@@ -301,14 +301,20 @@ object Infer {
     case class ExpectedRho(tpe: Type, context: String, region: Region)
         extends InternalError {
       // $COVERAGE-OFF$ we don't test these messages, maybe they should be removed
-      def message = s"expected $tpe to be a Type.Rho, at $context"
+      def message = {
+        val tpeStr = Type.fullyResolvedDocument.document(tpe).render(80)
+        s"expected $tpeStr to be a Type.Rho, at $context"
+      }
       // $COVERAGE-ON$ we don't test these messages, maybe they should be removed
     }
 
     case class UnknownKindOfVar(tpe: Type, region: Region, mess: String)
         extends InternalError {
       // $COVERAGE-OFF$ we don't test these messages, maybe they should be removed
-      def message = s"unknown var in $tpe: $mess at $region"
+      def message = {
+        val tpeStr = Type.fullyResolvedDocument.document(tpe).render(80)
+        s"unknown var in $tpeStr: $mess at $region"
+      }
       // $COVERAGE-ON$ we don't test these messages, maybe they should be removed
     }
 

--- a/core/src/test/scala/dev/bosatsu/EvaluationTest.scala
+++ b/core/src/test/scala/dev/bosatsu/EvaluationTest.scala
@@ -2162,6 +2162,18 @@ baz = bar
       )
       ()
     }
+
+    val missingIfaceImport = PackageError.UnknownImportFromInterface(
+      PackageName.parts("Bosatsu", "Prog"),
+      PackageName.parts("Bosatsu", "Prog"),
+      Nil,
+      ImportedName.OriginalName(Identifier.Name("ignore_env"), ()),
+      Nil
+    )
+    assertEquals(
+      missingIfaceImport.message(Map.empty, Colorize.None),
+      "in file: <unknown source>, package Bosatsu/Prog\ndoes not have name ignore_env."
+    )
   }
 
   test("pattern example from pair to triple") {


### PR DESCRIPTION
## Summary
- fix `UnknownImportFromInterface` to render imported identifiers with `sourceCodeRepr` instead of case-class `toString`
- suppress `Nearest:` in that diagnostic when there are no candidates
- audit and update related compiler diagnostics to consistently render `Identifier` values with `sourceCodeRepr`
- update internal infer diagnostics to render `Type` values with `Type.fullyResolvedDocument`
- add regression coverage for the `Name(...)` / empty `Nearest:` import-interface message

## Testing
- `sbt "coreJVM/testOnly dev.bosatsu.SourceConverterTest" "coreJVM/testOnly dev.bosatsu.EvaluationTest"`

Fixes #1597
