### PR TITLE
Decode libraries using dependency interfaces

### DIFF
--- a/core/src/main/scala/dev/bosatsu/library/DecodedLibraryWithDeps.scala
+++ b/core/src/main/scala/dev/bosatsu/library/DecodedLibraryWithDeps.scala
@@ -65,7 +65,7 @@ object DecodedLibraryWithDeps {
   )(load: proto.LibDependency => F[Hashed[Algo.Blake3, proto.Library]])(implicit
       F: MonadError[F, Throwable]
   ): F[DecodedLibraryWithDeps[Algo.Blake3]] =
-    DecodedLibrary.decode(protoLib).flatMap(decodeAll(_)(load))
+    DecodedLibrary.decodeWithDeps(protoLib)(load).flatMap(decodeAll(_)(load))
 
   def decodeAll[F[_]](
       dec: DecodedLibrary[Algo.Blake3]
@@ -119,7 +119,7 @@ object DecodedLibraryWithDeps {
           case Some(d) => StateT.pure[F, S, Value](d)
           case None    =>
             StateT
-              .liftF(load(dep).flatMap(DecodedLibrary.decode(_)))
+              .liftF(load(dep).flatMap(DecodedLibrary.decodeWithDeps(_)(load)))
               .flatMap(decodeAndStore(_))
         }
       } yield res


### PR DESCRIPTION
## Summary
- allow ProtoConverter.packagesFromProto to accept external dependency interfaces and use them when resolving package deps/import lookups
- add DecodedLibrary.decodeWithDeps with a (Name, Version) cache to recursively load and decode public + private + unused_transitive_public dependencies
- switch CAS-backed decode paths to decodeWithDeps in library command flows and in DecodedLibraryWithDeps
- add a regression test proving package decode succeeds when external dependency interfaces are supplied

## Testing
- sbt "coreJVM/test:compile" "coreJVM/test"
