### PR TITLE
Improve comment-out parsing behavior (issue #1635)

### DIFF
--- a/core/src/main/scala/dev/bosatsu/Statement.scala
+++ b/core/src/main/scala/dev/bosatsu/Statement.scala
@@ -303,7 +303,7 @@ object Statement {
 
       val sep = (Indy
         .lift(P.char(',') <* maybeSpace))
-        .combineK(Indy.toEOLIndent)
+        .combineK(Indy.toEOLIndentWithComments)
         .void
 
       val variants = Indy.lift(constructorP <* maybeSpace).nonEmptyList(sep)

--- a/core/src/test/scala/dev/bosatsu/ParserTest.scala
+++ b/core/src/test/scala/dev/bosatsu/ParserTest.scala
@@ -2119,6 +2119,148 @@ x = z ->
     )
   }
 
+  test("commenting out line patterns (issue 1635)") {
+    def parses(src: String): Boolean =
+      Package.parser(None).parseAll(src).isRight
+
+    val cases = List(
+      (
+        "commented first list item",
+        """package Probe
+          |
+          |x = [
+          |  #1,
+          |  2
+          |]
+          |""".stripMargin
+      ),
+      (
+        "commented middle list item",
+        """package Probe
+          |
+          |x = [
+          |  1,
+          |  #2,
+          |  3
+          |]
+          |""".stripMargin
+      ),
+      (
+        "commented binding in paren block",
+        """package Probe
+          |
+          |x = (
+          |  a = 1
+          |  #b = 2
+          |  a
+          |)
+          |""".stripMargin
+      ),
+      (
+        "commented line in if branch",
+        """package Probe
+          |
+          |x = if True:
+          |  #1
+          |  2
+          |else:
+          |  3
+          |""".stripMargin
+      ),
+      (
+        "issue 1635 shape: last list item commented out",
+        """package Probe
+          |
+          |tests = TestSuite("Repro tests", [
+          |  Assertion(True, "always"),
+          |  #Assertion(False, "commented out"),
+          |])
+          |""".stripMargin
+      ),
+      (
+        "only list item commented out",
+        """package Probe
+          |
+          |x = [
+          |  #1
+          |]
+          |""".stripMargin
+      ),
+      (
+        "last tuple item commented out",
+        """package Probe
+          |
+          |x = (
+          |  1,
+          |  #2,
+          |)
+          |""".stripMargin
+      ),
+      (
+        "last call arg commented out",
+        """package Probe
+          |
+          |def f(a): a
+          |
+          |x = f(
+          |  1,
+          |  #2,
+          |)
+          |""".stripMargin
+      ),
+      (
+        "last dict pair commented out",
+        """package Probe
+          |
+          |x = {
+          |  "a": 1,
+          |  #"b": 2,
+          |}
+          |""".stripMargin
+      ),
+      (
+        "match case line commented out",
+        """package Probe
+          |
+          |def f(x):
+          |  match x:
+          |    #case 1:
+          |    #  1
+          |    case _:
+          |      2
+          |
+          |x = f(1)
+          |""".stripMargin
+      ),
+      (
+        "commented enum variant line",
+        """package Probe
+          |
+          |enum X:
+          |  A
+          |  #B
+          |  C
+          |""".stripMargin
+      ),
+      (
+        "commented elif line",
+        """package Probe
+          |
+          |x = if False:
+          |  1
+          |#elif True:
+          |#  2
+          |else:
+          |  3
+          |""".stripMargin
+      )
+    )
+
+    cases.foreach { case (name, src) =>
+      assert(parses(src), s"expected to parse: $name")
+    }
+  }
+
   test("Parser.integerWithBase works") {
     case class Args(bi: BigInteger, asString: String, base: Int)
     def intersperse(str: String): Gen[String] =


### PR DESCRIPTION
## Summary
- add focused parser tests for commenting-out lines across list/tuple/call/dict/match/enum/elif contexts
- allow separator-level `#...` lines in list-like contexts by introducing comment-aware separator trivia parsers
- support comment-only lines between block entries using `Indy.toEOLIndentWithComments`
- support leading comment-only lines before the first `match case` branch

## Notes on behavior
- comments in separator positions are treated as parse-time trivia (discarded), which keeps parser complexity low and avoids adding backtracking
- existing structured comment parsing for declaration-level comments is preserved

## Testing
- `sbt "coreJVM/testOnly dev.bosatsu.ParserTest"`
- `sbt "coreJVM/testOnly dev.bosatsu.SyntaxParseTest"`

close #1635
