### PR TITLE
Fix top-level Assertion output in C test runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -206,6 +206,18 @@ jobs:
         run: "./bosatsuj tool transpile --input_dir test_workspace/ --input test_workspace/Bosatsu/IO/Error.bosatsu --input test_workspace/Bosatsu/IO/Std.bosatsu --package_root test_workspace/ c --outdir c_out --test --exe_out test_exe --cc_flag=-O0 --cc_lib=-lm"
       - name: "run generated c code"
         run: ./c_out/test_exe
+      - name: "check single assertion test output"
+        run: |
+          rm -rf issue1642_repro
+          mkdir issue1642_repro
+          cat > issue1642_repro/Foo.bosatsu <<'EOF'
+          package Foo
+          test = Assertion(True, "foo")
+          EOF
+          ./bosatsuj tool transpile --input issue1642_repro/Foo.bosatsu --package_root issue1642_repro c --outdir issue1642_repro/out --test --exe_out test_exe --cc_flag=-O0 --cc_lib=-lm
+          issue1642_repro/out/test_exe | tee issue1642_repro/output.txt
+          grep -Eq '^Foo:$' issue1642_repro/output.txt
+          grep -Eq '^    passed: .*1' issue1642_repro/output.txt
       - name: "run lib test"
         run: |
           ./bosatsuj lib fetch

--- a/c_runtime/bosatsu_runtime.c
+++ b/c_runtime/bosatsu_runtime.c
@@ -2323,6 +2323,16 @@ void print_indent(int indent) {
   }
 }
 
+static void bsts_print_test_summary(int indent, int passes, int fails) {
+  print_indent(indent);
+  if (fails == 0) {
+    printf("passed: \033[32m%i\033[0m\n", passes);
+  }
+  else {
+    printf("passed: \033[32m%i\033[0m, failed: \033[31m%i\033[0m\n", passes, fails);
+  }
+}
+
 BSTS_PassFail bsts_check_test(BValue v, int indent) {
   int passes = 0;
   int fails = 0;
@@ -2359,13 +2369,7 @@ BSTS_PassFail bsts_check_test(BValue v, int indent) {
       this_passes += tests.passes;
       this_fails += tests.fails;
     }
-    print_indent(next_indent);
-    if (this_fails == 0) {
-      printf("passed: \033[32m%i\033[0m\n", this_passes);
-    }
-    else {
-      printf("passed: \033[32m%i\033[0m, failed: \033[31m%i\033[0m\n", this_passes, this_fails);
-    }
+    bsts_print_test_summary(next_indent, this_passes, this_fails);
     passes += this_passes;
     fails += this_fails;
   }
@@ -2378,6 +2382,9 @@ BSTS_Test_Result bsts_test_run(char* package_name, BConstruct test_value) {
   BValue res = test_value();
   printf("%s:\n", package_name);
   BSTS_PassFail this_test = bsts_check_test(res, 4);
+  if (get_variant(res) == 0) {
+    bsts_print_test_summary(4, this_test.passes, this_test.fails);
+  }
   BSTS_Test_Result test_res = { package_name, this_test.passes, this_test.fails };
   return test_res;
 }


### PR DESCRIPTION
## Summary
- print per-package pass/fail summaries for top-level `Assertion` tests in the C runtime (matching suite-style output)
- factor summary printing into a shared helper used by both suite and top-level assertion paths
- add a `testC` workflow regression check in `.github/workflows/ci.yml` that compiles a minimal single-assertion package and verifies the expected output line

Closes #1642.

## Verification
- `make -C c_runtime PROFILE=debug && ./c_runtime/test_exe`
- local repro command from the new CI step confirms output includes:
  - `Foo:`
  - `    passed: ...1`
