### PR TITLE
Unify typo diagnostics and improve typo suggestions

### DIFF
--- a/core/src/main/scala/dev/bosatsu/NameSuggestion.scala
+++ b/core/src/main/scala/dev/bosatsu/NameSuggestion.scala
@@ -1,0 +1,115 @@
+package dev.bosatsu
+
+object NameSuggestion {
+  sealed abstract class ScopePriority(val rank: Int) derives CanEqual
+  object ScopePriority {
+    case object Local extends ScopePriority(0)
+    case object SamePackage extends ScopePriority(1)
+    case object Imported extends ScopePriority(2)
+  }
+
+  final case class Candidate[+A](
+      ident: Identifier,
+      value: A,
+      scope: ScopePriority = ScopePriority.Imported
+  )
+
+  private final case class Scored[+A](
+      candidate: Candidate[A],
+      distance: Int,
+      longestPrefix: Int,
+      relationRank: Int,
+      lengthDelta: Int
+  ) {
+    def sortKey: (Int, Int, Int, Int, Int, String) =
+      (
+        candidate.scope.rank,
+        relationRank,
+        distance,
+        -longestPrefix,
+        lengthDelta,
+        candidate.ident.asString
+      )
+  }
+
+  def nearest[A](
+      ident: Identifier,
+      existing: Iterable[Candidate[A]],
+      count: Int
+  ): List[Candidate[A]] =
+    if (count <= 0) Nil
+    else {
+      val query = ident.asString
+      if (query.isEmpty) Nil
+      else {
+        val scored = existing.iterator
+          .filterNot(_.ident == ident)
+          .map(score(query, _))
+          .toList
+
+        val bestByName = scored
+          .groupBy(_.candidate.ident)
+          .valuesIterator
+          .map(_.minBy(_.sortKey))
+          .toList
+
+        bestByName
+          .filter(likelyTypo(query, _))
+          .sortBy(_.sortKey)
+          .take(count)
+          .map(_.candidate)
+      }
+    }
+
+  def best[A](
+      ident: Identifier,
+      existing: Iterable[Candidate[A]]
+  ): Option[Candidate[A]] =
+    nearest(ident, existing, 1).headOption
+
+  private def score[A](query: String, candidate: Candidate[A]): Scored[A] = {
+    val cand = candidate.ident.asString
+    val relationRank =
+      if (cand.startsWith(query) || query.startsWith(cand)) 0
+      else if (cand.contains(query) || query.contains(cand)) 1
+      else 2
+
+    Scored(
+      candidate,
+      EditDistance.string(query, cand),
+      commonPrefix(query, cand),
+      relationRank,
+      (query.length - cand.length).abs
+    )
+  }
+
+  private def likelyTypo(query: String, scored: Scored[?]): Boolean = {
+    val cand = scored.candidate.ident.asString
+    if (cand.isEmpty) false
+    else {
+      val maxLen = query.length.max(cand.length)
+      val minLen = query.length.min(cand.length)
+      val normalizedDist = scored.distance.toDouble / maxLen.toDouble
+
+      val prefixMatch = scored.relationRank == 0
+      val substringMatch =
+        scored.relationRank == 1 && (minLen >= 3 || scored.lengthDelta <= 2)
+
+      prefixMatch ||
+      substringMatch ||
+      (scored.longestPrefix >= 3 && scored.lengthDelta <= 4) ||
+      (minLen <= 3 && scored.distance <= 1) ||
+      (minLen <= 6 && scored.distance <= 2 && normalizedDist <= 0.6) ||
+      (scored.distance <= 3 && normalizedDist <= 0.34 && scored.lengthDelta <= 4)
+    }
+  }
+
+  private def commonPrefix(a: String, b: String): Int = {
+    val max = a.length.min(b.length)
+    var idx = 0
+    while ((idx < max) && (a.charAt(idx) == b.charAt(idx))) {
+      idx += 1
+    }
+    idx
+  }
+}

--- a/core/src/test/scala/dev/bosatsu/ErrorMessageTest.scala
+++ b/core/src/test/scala/dev/bosatsu/ErrorMessageTest.scala
@@ -339,7 +339,21 @@ package B
 main = a""")) { case te: PackageError.TypeErrorIn =>
       val msg = te.message(Map.empty, Colorize.None)
       assert(!msg.contains("Name("))
-      assert(msg.contains("package B\nname \"a\" unknown"))
+      assert(msg.contains("package B\nUnknown name `a`."))
+      ()
+    }
+
+    evalFail(List("""
+package A
+
+x = missing_name
+y = missing_name
+
+main = 1
+""")) { case te: PackageError.TypeErrorIn =>
+      val msg = te.message(Map.empty, Colorize.None)
+      assert(msg.contains("Unknown name `missing_name`."))
+      assert(msg.contains("This unknown name appears 2 times."))
       ()
     }
 
@@ -376,7 +390,7 @@ main = match x:
 """)) { case te @ PackageError.SourceConverterErrorsIn(_, _, _) =>
       val msg = te.message(Map.empty, Colorize.None)
       assert(!msg.contains("Name("))
-      assert(msg.contains("package B\nunknown constructor Foo"))
+      assert(msg.contains("package B\nUnknown constructor `Foo`."))
       ()
     }
 
@@ -393,7 +407,7 @@ main = match 1:
           Map.empty,
           Colorize.None
         ),
-        "in file: <unknown source>, package B\nunknown constructor X1\nRegion(49,50)"
+        "in file: <unknown source>, package B\nUnknown constructor `X1`.\nDid you mean constructor `X`?\nRegion(49,50)"
       )
       ()
     }
@@ -448,6 +462,30 @@ main = fn
           Colorize.None
         ),
         "in file: <unknown source>, package A\nrecur but no recursive call to fn\nRegion(25,47)\n"
+      )
+      ()
+    }
+
+    evalFail(List("""
+package A
+
+def parse_loopTypo(x):
+  recur x:
+    case 0: parse_loop(x)
+    case _: parse_loop(x)
+
+main = parse_loopTypo
+""")) { case te @ PackageError.RecursionError(_, _) =>
+      val msg = te.message(Map.empty, Colorize.None)
+      assert(
+        msg.contains(
+          "Function name looks renamed: declared `parse_loopTypo`, but recursive calls use `parse_loop`."
+        )
+      )
+      assert(
+        msg.contains(
+          "Did you mean `parse_loopTypo` in recursive calls? (2 occurrences)"
+        )
       )
       ()
     }
@@ -906,6 +944,79 @@ get = Pair(first, _, _, ...) -> first
 res = get(Pair(1, "two"))
 """)) { case s @ PackageError.SourceConverterErrorsIn(_, _, _) =>
       s.message(Map.empty, Colorize.None); ()
+    }
+
+    runBosatsuTest(
+      List("""
+package A
+
+struct Pair(first, second)
+
+get = Pair(first, _, ...) -> first
+
+res = get(Pair(1, "two"))
+
+tests = TestSuite("test record",
+  [
+    Assertion(res.eq_Int(1), "res == 1"),
+  ])
+"""),
+      "A",
+      1
+    )
+
+    evalFail(List("""
+package A
+
+struct Pair(first, second)
+
+main = Nope { first: 1, second: "two" }
+""")) { case s @ PackageError.SourceConverterErrorsIn(_, _, _) =>
+      val msg = s.message(Map.empty, Colorize.None)
+      assert(msg.contains("Unknown constructor `Nope`."))
+      ()
+    }
+
+    evalFail(List("""
+package A
+
+struct Pair(first, second)
+
+get = Nope(first, ...) -> first
+
+main = get(Pair(1, "two"))
+""")) { case s @ PackageError.SourceConverterErrorsIn(_, _, _) =>
+      val msg = s.message(Map.empty, Colorize.None)
+      assert(msg.contains("Unknown constructor `Nope`."))
+      ()
+    }
+
+    evalFail(List("""
+package A
+
+struct Pair(first, second)
+
+get = Nope { first } -> first
+
+main = get(Pair(1, "two"))
+""")) { case s @ PackageError.SourceConverterErrorsIn(_, _, _) =>
+      val msg = s.message(Map.empty, Colorize.None)
+      assert(msg.contains("Unknown constructor `Nope`."))
+      ()
+    }
+
+    evalFail(List("""
+package A
+
+struct Pair(first, second)
+
+get = Nope { first, ... } -> first
+
+main = get(Pair(1, "two"))
+""")) { case s @ PackageError.SourceConverterErrorsIn(_, _, _) =>
+      val msg = s.message(Map.empty, Colorize.None)
+      assert(msg.contains("Unknown constructor `Nope`."))
+      ()
     }
   }
 
@@ -1822,7 +1933,7 @@ main = Assertion(res, "")
   }
 
 
-  test("we always suggest names which share a prefix with an unknown name") {
+  test("unknown name suggestions prefer local names and include substring matches") {
     val testCode = List("""
 package P1
 
@@ -1835,16 +1946,219 @@ main = fof
 
     evalFail(testCode) { case kie: PackageError.TypeErrorIn =>
       val message = kie.message(Map.empty, Colorize.None)
-      assertEquals(
-        message,
-        """in file: <unknown source>, package P1
-name "fof" unknown.
-Closest: fofoooooooo, ofof.
-
-Region(47,50)"""
+      assert(message.contains("in file: <unknown source>, package P1"))
+      assert(message.contains("Unknown name `fof`."))
+      assert(
+        message.contains(
+          "Did you mean one of: local value `fofoooooooo`, local value `ofof`?"
+        )
       )
+      assert(message.contains("Region(47,50)"))
       ()
     }
+  }
+
+  test("unknown name suggestions include candidates when one is a substring") {
+    val testCode = List("""
+package P1
+
+foo = 1
+
+main = xxfoo
+""")
+
+    evalFail(testCode) { case kie: PackageError.TypeErrorIn =>
+      val message = kie.message(Map.empty, Colorize.None)
+      assert(message.contains("Unknown name `xxfoo`."))
+      assert(message.contains("Did you mean local value `foo`?"))
+      ()
+    }
+  }
+
+  test("unknown constructor in type errors suggests nearest constructors") {
+    val pack = PackageName.parts("P")
+    val miss = Identifier.Constructor("JNul")
+    val known = Identifier.Constructor("JNull")
+    val inferEnv = new rankn.Infer.Env(
+      rankn.RefSpace.constRef(0L),
+      Map.empty,
+      Map(
+        (pack, known) -> (
+          Nil,
+          Nil,
+          Nil,
+          rankn.Type.Const.Defined(pack, TypeName(Identifier.Constructor("Json")))
+        )
+      ),
+      Map.empty
+    )
+    val err = PackageError.TypeErrorIn(
+      rankn.Infer.Error.UnknownConstructor((pack, miss), Region(0, 1), inferEnv),
+      pack,
+      Nil,
+      Map.empty,
+      Map.empty
+    )
+    val message = err.message(Map.empty, Colorize.None)
+    assert(message.contains("Unknown constructor `JNul`."))
+    assert(message.contains("Did you mean constructor `JNull`?"))
+  }
+
+  test("repeated unknown constructors are aggregated with occurrence counts") {
+    val pack = PackageName.parts("P")
+    val miss = Identifier.Constructor("JNul")
+    val known = Identifier.Constructor("JNull")
+    val inferEnv = new rankn.Infer.Env(
+      rankn.RefSpace.constRef(0L),
+      Map.empty,
+      Map(
+        (pack, known) -> (
+          Nil,
+          Nil,
+          Nil,
+          rankn.Type.Const.Defined(pack, TypeName(Identifier.Constructor("Json")))
+        )
+      ),
+      Map.empty
+    )
+    val err = PackageError.TypeErrorIn(
+      rankn.Infer.Error.Combine(
+        rankn.Infer.Error.UnknownConstructor((pack, miss), Region(0, 1), inferEnv),
+        rankn.Infer.Error.UnknownConstructor((pack, miss), Region(2, 3), inferEnv)
+      ),
+      pack,
+      Nil,
+      Map.empty,
+      Map.empty
+    )
+    val message = err.message(Map.empty, Colorize.None)
+    assert(message.contains("Unknown constructor `JNul`."))
+    assert(message.contains("This unknown constructor appears 2 times."))
+  }
+
+  test("unknown constructor in totality diagnostics suggests nearest constructors") {
+    val pack = PackageName.parts("P")
+    val known = Identifier.Constructor("JNull")
+    val miss = Identifier.Constructor("JNul")
+    val jsonDt = rankn.DefinedType[Nothing](
+      packageName = pack,
+      name = TypeName(Identifier.Constructor("Json")),
+      annotatedTypeParams = Nil,
+      constructors = List(rankn.ConstructorFn(known, Nil))
+    )
+    val typeEnv = rankn.TypeEnv.fromDefinitions(List(jsonDt))
+    given Region = Region(0, 1)
+    val tag = Declaration.Var(Identifier.Name("x"))
+    val pat: Pattern[(PackageName, Identifier.Constructor), rankn.Type] =
+      Pattern.PositionalStruct((pack, miss), Nil)
+    val lit = Expr.Literal[Declaration](Lit.Integer(0L), tag)
+    val matchExpr = Expr.Match(
+      lit,
+      cats.data.NonEmptyList.one(Expr.Branch(pat, None, lit)),
+      tag
+    )
+    val totalityErr = PackageError.TotalityCheckError(
+      pack,
+      TotalityCheck.InvalidPattern(
+        matchExpr,
+        TotalityCheck.UnknownConstructor((pack, miss), pat, typeEnv)
+      )
+    )
+    val message = totalityErr.message(Map.empty, Colorize.None)
+    assert(message.contains("Unknown constructor `JNul`."))
+    assert(message.contains("Did you mean constructor `JNull`?"))
+  }
+
+  test("source converter unknown constructor supports multiple suggestions and context") {
+    val miss = Identifier.Constructor("JBoool")
+    val pat = Pattern.PositionalStruct(
+      Pattern.StructKind.Named(miss, Pattern.StructKind.Style.TupleLike),
+      Pattern.WildCard :: Nil
+    )
+    val err = SourceConverter.UnknownConstructor(
+      miss,
+      pat,
+      List(
+        Identifier.Constructor("JBool"),
+        Identifier.Constructor("JBoole"),
+        Identifier.Constructor("JBooolX")
+      ),
+      Region(0, 1)
+    )
+    val message = err.message
+    assert(message.contains("Unknown constructor `JBoool`."))
+    assert(message.contains("Nearest constructors in scope:"))
+    assert(message.contains(" in"))
+  }
+
+  test("source converter unknown constructor can omit suggestions") {
+    val miss = Identifier.Constructor("Nope")
+    val pat = Pattern.PositionalStruct(
+      Pattern.StructKind.Named(miss, Pattern.StructKind.Style.TupleLike),
+      Nil
+    )
+    val err = SourceConverter.UnknownConstructor(miss, pat, Nil, Region(0, 1))
+    val message = err.message
+    assertEquals(message, "Unknown constructor `Nope`.")
+  }
+
+  test("name suggestion helper handles edge inputs and low-confidence candidates") {
+    val zeroCount = NameSuggestion.nearest(
+      Identifier.Name("abc"),
+      List(NameSuggestion.Candidate(Identifier.Name("abcd"), "x")),
+      0
+    )
+    assertEquals(zeroCount, Nil)
+
+    val emptyQuery = NameSuggestion.nearest(
+      Identifier.Name(""),
+      List(NameSuggestion.Candidate(Identifier.Name("abcd"), "x")),
+      3
+    )
+    assertEquals(emptyQuery, Nil)
+
+    val emptyCandidate = NameSuggestion.nearest(
+      Identifier.Name("abcd"),
+      List(NameSuggestion.Candidate(Identifier.Name(""), "x")),
+      3
+    )
+    assertEquals(emptyCandidate, Nil)
+
+    val lowConfidence = NameSuggestion.nearest(
+      Identifier.Name("abcdef"),
+      List(NameSuggestion.Candidate(Identifier.Name("uvwxyz"), "x")),
+      3
+    )
+    assertEquals(lowConfidence, Nil)
+  }
+
+  test("name suggestion fallback heuristic catches close edits without shared prefixes") {
+    val suggestions = NameSuggestion.nearest(
+      Identifier.Name("abbbbbbb"),
+      List(NameSuggestion.Candidate(Identifier.Name("axbbbbbb"), "fallback-hit")),
+      3
+    )
+    assertEquals(suggestions.map(_.value), List("fallback-hit"))
+  }
+
+  test("name suggestion deduplicates names and keeps strongest scope match") {
+    val suggestions = NameSuggestion.nearest(
+      Identifier.Name("computd"),
+      List(
+        NameSuggestion.Candidate(
+          Identifier.Name("computed"),
+          "imported",
+          NameSuggestion.ScopePriority.Imported
+        ),
+        NameSuggestion.Candidate(
+          Identifier.Name("computed"),
+          "local",
+          NameSuggestion.ScopePriority.Local
+        )
+      ),
+      3
+    )
+    assertEquals(suggestions.map(_.value), List("local"))
   }
 
 }


### PR DESCRIPTION
## Summary
- unify unknown-name and unknown-constructor diagnostics to a consistent style (`Unknown ...` + `Did you mean ...`)
- add a shared `NameSuggestion` helper with stronger typo heuristics:
  - scope-aware ranking (local, same package, imported)
  - prefix/substring relation boost
  - edit-distance + prefix/length tie-breakers
  - substring matching in both directions
- improve `recur` rename-typo diagnostics to prioritize likely root cause with occurrence counts
- aggregate duplicate unknown-name and unknown-constructor follow-on errors in combined type errors
- add nearest-constructor suggestions in SourceConverter constructor errors and totality diagnostics
- extend `ErrorMessageTest` with focused coverage for touched message paths and heuristic edge cases

## Examples of improved output
- `Unknown name \`computd\`.\nDid you mean local value \`computed\`?`
- `Unknown constructor \`JNul\`.\nDid you mean constructor \`JNull\`?`
- `Function name looks renamed: declared \`parse_loopTypo\`, but recursive calls use \`parse_loop\`.\nDid you mean \`parse_loopTypo\` in recursive calls? (N occurrences)`

## Validation
- `sbt "project coreJVM" "testOnly dev.bosatsu.ErrorMessageTest"`
- `sbt "project coreJVM" "coverageOn" "testOnly dev.bosatsu.ErrorMessageTest" "coverageReport" "coverageOff"`

Touched-path statement coverage from scoverage line-level data:
- `core/src/main/scala/dev/bosatsu/PackageError.scala`: 97.98% (97/99)
- `core/src/main/scala/dev/bosatsu/DefRecursionCheck.scala`: 100.00% (26/26)
- `core/src/main/scala/dev/bosatsu/SourceConverter.scala`: 100.00% (141/141)
- `core/src/main/scala/dev/bosatsu/NameSuggestion.scala`: 100.00% (80/80)

Closes #1658
