### PR TITLE
Allow commas in multiline enum variant lists

### DIFF
--- a/core/src/main/scala/dev/bosatsu/Statement.scala
+++ b/core/src/main/scala/dev/bosatsu/Statement.scala
@@ -307,7 +307,8 @@ object Statement {
         val commaSep =
           (P.char(',') *> maybeSpace *> Indy.toEOLIndentWithComments(indent).?)
             .void
-        val sep = commaSep.orElse(Indy.toEOLIndentWithComments(indent))
+        val lineSep = Indy.toEOLIndentWithComments(indent).backtrack
+        val sep = commaSep.orElse(lineSep)
         val rest = (sep.soft *> constructor).rep0
         val trailingComment = (maybeSpace *> Parser.lineComment).?.void
 

--- a/core/src/test/scala/dev/bosatsu/ParserTest.scala
+++ b/core/src/test/scala/dev/bosatsu/ParserTest.scala
@@ -1831,6 +1831,14 @@ def foo(
   B(y: Int) # trailing"""
     )
 
+    roundTrip(
+      Statement.parser.map(_.map(_.replaceRegions(emptyRegion))),
+      """enum Bool:
+  False, True
+
+"""
+    )
+
     roundTripExact(
       Statement.parser,
       """def run(z):


### PR DESCRIPTION
## Summary
- allow enum branch commas to work both inline and across indented lines
- allow an optional trailing comma after the final enum branch
- add parser regression coverage for multiline enum variants with trailing commas

Fixes #1678.

## Testing
- sbt "coreJVM/testOnly dev.bosatsu.ParserTest"