### PR TITLE
Improve Nullable implementation and add law-style tests

### DIFF
--- a/core/src/main/scala/dev/bosatsu/Nullable.scala
+++ b/core/src/main/scala/dev/bosatsu/Nullable.scala
@@ -1,8 +1,9 @@
 package dev.bosatsu
 
+import cats.Eq
 import scala.quoted.*
 
-opaque type Nullable[T] = T | Null
+opaque type Nullable[+T] = T | Null
 
 object Nullable:
 
@@ -11,10 +12,16 @@ object Nullable:
       ${ foldImpl('nullable, 'ifNull, 'fn) }
 
     inline def isNull: Boolean =
-      fold(true)(_ => false)
+      {
+        given CanEqual[T | Null, Null] = CanEqual.derived
+        nullable == null
+      }
 
     inline def nonNull: Boolean =
-      fold(false)(_ => true)
+      {
+        given CanEqual[T | Null, Null] = CanEqual.derived
+        nullable != null
+      }
 
     inline def map[B](inline fn: T => B): Nullable[B] =
       fold(null: Null)(fn)
@@ -31,13 +38,32 @@ object Nullable:
   inline def apply[A](inline a: A | Null): Nullable[A] =
     a
 
+  def fromOption[A](opt: Option[A]): Nullable[A] =
+    opt match
+      case Some(a) => a
+      case None    => null
+
+  given [A: Eq]: Eq[Nullable[A]] with
+    def eqv(na: Nullable[A], nb: Nullable[A]): Boolean =
+      val a: A | Null = na
+      val b: A | Null = nb
+      given CanEqual[A | Null, Null] = CanEqual.derived
+      if (a == null) b == null
+      else if (b == null) false
+      else Eq[A].eqv(a, b)
+
+  def empty[A]: Nullable[A] =
+    null
+
   private def foldImpl[T: Type, A: Type](
       nullable: Expr[Nullable[T]],
       ifNull: Expr[A],
       fn: Expr[T => A]
   )(using Quotes): Expr[A] =
+    val nullableUnion: Expr[T | Null] = '{ $nullable.asInstanceOf[T | Null] }
+
     '{
-      val n = $nullable
+      val n = $nullableUnion
       given CanEqual[T | Null, Null] = CanEqual.derived
       if (n == null) $ifNull
       else {

--- a/core/src/test/scala/dev/bosatsu/NullableTest.scala
+++ b/core/src/test/scala/dev/bosatsu/NullableTest.scala
@@ -1,0 +1,79 @@
+package dev.bosatsu
+
+import cats.instances.all.*
+import cats.syntax.all.*
+import org.scalacheck.Arbitrary
+import org.scalacheck.Prop.forAll
+
+class NullableTest extends munit.ScalaCheckSuite:
+
+  given [A: Arbitrary]: Arbitrary[Nullable[A]] =
+    Arbitrary(Arbitrary.arbitrary[Option[A]].map(Nullable.fromOption(_)))
+
+  property("map isomorphic to Option.map") {
+    forAll { (n: Nullable[Int], fn: Int => String) =>
+      assertEquals(n.map(fn).toOption, n.toOption.map(fn))
+    }
+  }
+
+  property("flatMap isomorphic to Option.flatMap") {
+    forAll { (n: Nullable[Int], fn: Int => Option[String]) =>
+      assertEquals(
+        n.flatMap(i => Nullable.fromOption(fn(i))).toOption,
+        n.toOption.flatMap(fn)
+      )
+    }
+  }
+
+  property("fold isomorphic to Option.fold") {
+    forAll { (n: Nullable[Int], ifNull: Long, fn: Int => Long) =>
+      val left: Long = n.fold(ifNull)(fn)
+      val right: Long = n.toOption.fold(ifNull)(fn)
+      assertEquals(left, right)
+    }
+  }
+
+  property("isNull/nonNull match Option emptiness") {
+    forAll { (n: Nullable[Int]) =>
+      assertEquals(n.isNull, n.toOption.isEmpty)
+      assertEquals(n.nonNull, n.toOption.nonEmpty)
+    }
+  }
+
+  property("iterator isomorphic to Option.iterator") {
+    forAll { (n: Nullable[Int]) =>
+      assertEquals(n.iterator.toList, n.toOption.iterator.toList)
+    }
+  }
+
+  property("fromOption(toOption) round trips") {
+    forAll { (n: Nullable[Int]) =>
+      assert(Nullable.fromOption(n.toOption) === n)
+    }
+  }
+
+  test("fromOption(Option(null)) equals Nullable(null)") {
+    val left: Nullable[String] = Nullable.fromOption(Option(null.asInstanceOf[String]))
+    val right: Nullable[String] = Nullable(null)
+    assert(left === right)
+  }
+
+  test("works for literal lambdas in fold using == null") {
+    given CanEqual[String | Null, Null] = CanEqual.derived
+
+    val nonNull: Nullable[String | Null] = Nullable("abc")
+    val isNull: Nullable[String | Null] = Nullable.empty
+
+    assert(!nonNull.fold(false)(_ == null))
+    assert(!isNull.fold(false)(_ == null))
+  }
+
+  test("works for literal lambdas in fold using != null") {
+    given CanEqual[String | Null, Null] = CanEqual.derived
+
+    val nonNull: Nullable[String | Null] = Nullable("abc")
+    val isNull: Nullable[String | Null] = Nullable.empty
+
+    assert(nonNull.fold(true)(_ != null))
+    assert(isNull.fold(true)(_ != null))
+  }


### PR DESCRIPTION
## Summary
- make `Nullable` covariant and add `empty`/`fromOption` helpers
- simplify `isNull`/`nonNull` to direct null checks with local `CanEqual`
- keep `fold` macro straightforward (no special-case optimization path)
- add `Eq[Nullable[A]]` in `Nullable` companion
- add `NullableTest` with Option-isomorphism and iterator/round-trip/null coverage

## Validation
- `sbt "coreJVM/testOnly dev.bosatsu.NullableTest" coreJS/compile`
