### PR TITLE
Fix unConstMult cost-law regression and add op-count cost law

### DIFF
--- a/core/src/main/scala/dev/bosatsu/RingOpt.scala
+++ b/core/src/main/scala/dev/bosatsu/RingOpt.scala
@@ -1527,8 +1527,10 @@ object RingOpt {
     Require(mult > 0, s"mult = $mult must be > 0")
     Require(neg > 0, s"neg = $neg must be > 0")
 
-    def costOf(opCounts: Expr.OpCounts): Int =
-      (opCounts.mul * mult) + (opCounts.add * add) + (opCounts.neg * neg)
+    def costOf(opCounts: Expr.OpCounts): Long =
+      (opCounts.mul.toLong * mult) +
+        (opCounts.add.toLong * add) +
+        (opCounts.neg.toLong * neg)
 
     def cost[A](e: Expr[A]): Long = {
       val counts = Expr.opCounts(e)

--- a/core/src/test/scala/dev/bosatsu/RingOptLaws.scala
+++ b/core/src/test/scala/dev/bosatsu/RingOptLaws.scala
@@ -278,7 +278,7 @@ class RingOptLaws extends munit.ScalaCheckSuite {
   property("costOf(opCounts(e)) == cost(e)") {
     forAll { (e: Expr[BigInt], w: Weights) =>
       val counts = Expr.opCounts(e)
-      assertEquals(w.costOf(counts).toLong, w.cost(e), s"e=$e, counts=$counts")
+      assertEquals(w.costOf(counts), w.cost(e), s"e=$e, counts=$counts")
     }
   }
 


### PR DESCRIPTION
## Summary
- Fix `unConstMult` so extracted `(coeff, inner)` is accepted only when reconstructing `Mult(Integer(coeff), inner)` does not increase operator counts (`mul`/`add`/`neg`) versus the original expression (except `inner.isOne || inner.isZero`).
- Move expression op counting into shared `Expr.opCounts` with `Expr.OpCounts`.
- Add `OpCounts.asCheapOrCheaperThan` helper and use it in `unConstMult`.
- Add `Weights.costOf(opCounts: Expr.OpCounts)`.
- Add law: `costOf(opCounts(e)) == cost(e)`.

## Why
Close #1709 which exposed a failure of the `unConstMult` law asserting that reconstructing with `Mult(Integer(i), x)` does not increase weighted cost. This guard prevents returning decompositions that violate that invariant.

## Testing
- `sbt "coreJVM/testOnly dev.bosatsu.RingOptLaws"`
