### PR TITLE
Fix greedySearch selection and add TotalityTest regression

### DIFF
--- a/core/src/main/scala/dev/bosatsu/set/SetOps.scala
+++ b/core/src/main/scala/dev/bosatsu/set/SetOps.scala
@@ -160,7 +160,7 @@ object SetOps {
         val peek = diffs.take(lookahead)
         val trials = SetOps.allPerms(peek).map { peeks =>
           val u1 = fn(union, peeks)
-          (u1, peek.head)
+          (u1, peeks.head)
         }
         val smallest = trials.iterator.minBy(_._1)
         // choose a diff that starts the most

--- a/core/src/test/scala/dev/bosatsu/TotalityTest.scala
+++ b/core/src/test/scala/dev/bosatsu/TotalityTest.scala
@@ -668,6 +668,86 @@ enum Either: Left(l), Right(r)
 
   override def missingBranchesIfAddedRegressions: List[List[Pat]] =
     patterns("""[[*foo, "$.{_}", "$.{_}"], [[b, *_]]]""") ::
+      {
+        import Pattern._
+        import Pattern.ListPart.{Item, NamedList, WildList}
+        import Pattern.StrPart.{LitStr, NamedChar, WildChar}
+        import Identifier.{Constructor, Name, Operator}
+
+        val largeInt = Literal(Lit.Integer(2147483648L))
+        val p0 =
+          ListPat(
+            List(
+              WildList,
+              Item(
+                Union(
+                  largeInt,
+                  NonEmptyList.of(
+                    StrPat(
+                      NonEmptyList.of(
+                        LitStr("fmvzwe"),
+                        NamedChar(Name("ziiz")),
+                        WildChar
+                      )
+                    ),
+                    StrPat(
+                      NonEmptyList.of(
+                        WildChar,
+                        NamedChar(Name("woyi"))
+                      )
+                    )
+                  )
+                )
+              ),
+              Item(
+                StrPat(
+                  NonEmptyList.of(
+                    LitStr("vf"),
+                    NamedChar(Operator("|")),
+                    NamedChar(Name("k7"))
+                  )
+                )
+              )
+            )
+          )
+
+        val p1 =
+          ListPat(
+            List(
+              Item(StrPat(NonEmptyList.of(WildChar))),
+              Item(
+                PositionalStruct(
+                  (PackageName(NonEmptyList.one("Tdaeo")), Constructor("Mkbvflxqji")),
+                  List(StrPat(NonEmptyList.of(NamedChar(Name("ym")))), WildCard)
+                )
+              ),
+              Item(Var(Operator("%+"))),
+              Item(ListPat(Nil)),
+              Item(
+                ListPat(
+                  List(
+                    NamedList(Name("hqhkcqz1feX")),
+                    Item(WildCard),
+                    Item(
+                      PositionalStruct(
+                        (
+                          PackageName(
+                            NonEmptyList.of("V", "LfMnybi", "Hwxgqe2s")
+                          ),
+                          Constructor("ZLl")
+                        ),
+                        Nil
+                      )
+                    ),
+                    Item(WildCard)
+                  )
+                )
+              )
+            )
+          )
+
+        List(p0, p1, Literal(Lit.fromInt(-1)))
+      } ::
       Nil
 
   test("var pattern is super or same") {


### PR DESCRIPTION
## Summary
- fix `SetOps.greedySearch` to pick the head of each trial permutation (`peeks.head`) instead of always using `peek.head`
- add a focused unit test that fails with the old behavior and passes with the fix
- add the issue #1733 counterexample to `TotalityTest` so the regression is deterministic without a ScalaCheck seed override

## Testing
- sbt "coreJVM/testOnly dev.bosatsu.set.SetOpsTests" "coreJVM/testOnly dev.bosatsu.TotalityTest"

Closes #1733
