### PR TITLE
Fix docs nav overflow and markdown list rendering

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -77,6 +77,7 @@ lazy val docs = (project in file("docs"))
   .settings(
     name := "paradox docs",
     paradoxTheme := Some(builtinParadoxTheme("generic")),
+    Compile / paradoxNavigationDepth := 1,
     Compile / paradoxProperties ++= Map(
       "empty" -> "",
       "version" -> version.value
@@ -133,13 +134,23 @@ lazy val docs = (project in file("docs"))
             IO.relativize(paradoxGeneratedRoot, f).getOrElse(f.getPath)
           )
 
-      val linkLines = markdownFiles.map { file =>
+      val tocLinkLines = markdownFiles.map { file =>
         val relPath = IO
           .relativize(paradoxGeneratedRoot, file)
           .getOrElse(file.getName)
           .replace(java.io.File.separatorChar, '/')
         val title = relPath.stripSuffix(".md")
         s"* [$title]($relPath)"
+      }
+
+      val pageLinkLines = markdownFiles.map { file =>
+        val relPath = IO
+          .relativize(paradoxGeneratedRoot, file)
+          .getOrElse(file.getName)
+          .replace(java.io.File.separatorChar, '/')
+        val title = relPath.stripSuffix(".md")
+        val htmlPath = s"${title}.html"
+        s"* [$title]($htmlPath)"
       }
 
       val generatedIndex =
@@ -149,8 +160,12 @@ lazy val docs = (project in file("docs"))
            |`./bosatsuj lib doc --outdir core_alpha_docs --include_predef`
            |
            |@@@ index
-           |${linkLines.mkString("\n")}
+           |${tocLinkLines.mkString("\n")}
            |@@@
+           |
+           |## Browse all generated docs
+           |
+           |${pageLinkLines.mkString("\n")}
            |""".stripMargin
 
       IO.write(paradoxGeneratedRoot / "index.md", generatedIndex)

--- a/docs/src/main/paradox/design-docs/index.md
+++ b/docs/src/main/paradox/design-docs/index.md
@@ -16,6 +16,18 @@ This section collects implementation design documents for Bosatsu.
 * [Lexicographic `recur` Tuple Design](lexicographic_recur_design.md)
 @@@
 
+## Browse design docs
+
+* [Compiler Leveraging Type Inhabitedness](compiler_leveraging_type_inhabitedness.html)
+* [Pattern Guards Design](pattern_guards_design.html)
+* [Issue 1628: Pattern Value Reuse in `TypedExprNormalization`](issue_1628_pattern_value_reuse_design.html)
+* [Issue 1676: Default Values in Struct and Enum Constructors](issue_1676_default_values_struct_enum_design.html)
+* [Issue 356: Struct Update Syntax (`..old`)](issue_356_struct_update_syntax_design.html)
+* [Well-Typed Statement Generator Design](well_typed_statement_generator_design.html)
+* [Quantifier Evidence on `TypedExpr.Annotation`](quantifier-evidence-design.html)
+* [Issue 1718: Instantiate/Pushdown Unification Plan](issue_1718_instantiate_pushdown_unification_plan.html)
+* [Lexicographic `recur` Tuple Design](lexicographic_recur_design.html)
+
 ## Notes
 
 1. This page is the canonical index for design docs.

--- a/docs/src/main/paradox/design-docs/lexicographic_recur_design.md
+++ b/docs/src/main/paradox/design-docs/lexicographic_recur_design.md
@@ -24,6 +24,7 @@ The acceptance rule is lexicographic decrease in the order written in `recur (..
 
 ## Current Behavior (Relevant)
 `DefRecursionCheck` currently:
+
 1. Allows only one `recur` argument position (`getRecurIndex`).
 2. Requires recursive calls to be structurally smaller only in that one position.
 3. Does not enforce lexicographic decrease across multiple arguments.
@@ -32,11 +33,13 @@ This is why Ackermann currently needs higher-order encoding (`ack1` returning `N
 
 ## Proposed Language Rule
 `recur` target may be:
+
 1. A single name (existing behavior).
 2. A tuple of names, each name bound directly to a function parameter.
 
 For `recur (r0, r1, ..., rk)` a recursive call with corresponding call arguments
 `(a0, a1, ..., ak)` is legal iff:
+
 1. There exists an index `i` such that `ai` is structurally smaller than `ri` in the current branch.
 2. For every `j < i`, `aj` is exactly `rj` (syntactic equality to the original parameter name).
 3. Arguments `j > i` are unrestricted for this specific call.
@@ -44,6 +47,7 @@ For `recur (r0, r1, ..., rk)` a recursive call with corresponding call arguments
 This is standard lexicographic descent on a well-founded structural order.
 
 Why `case (Succ(n_prev), Zero): ack(n_prev, Succ(Zero))` is safe:
+
 1. The first component decreases (`n_prev < n` structurally).
 2. Lexicographic order permits any second component once an earlier component decreased.
 
@@ -53,12 +57,15 @@ Why `case (Succ(n_prev), Zero): ack(n_prev, Succ(Zero))` is safe:
 Replace the single recursion position with a recursion target vector.
 
 Current:
+
 1. `InDefRecurred(..., group: Int, index: Int, ...)`
 2. `InRecurBranch(..., allowedNames: Set[Bindable])`
 
 Proposed:
+
 1. `RecurTarget` = ordered non-empty vector of parameter positions:
    `NonEmptyList[(groupIndex, argIndex, paramName)]`
+
 2. `InDefRecurred(..., target: RecurTarget, ...)`
 3. `InRecurBranch(..., allowedPerComponent: NonEmptyList[Set[Bindable]])`
 
@@ -66,26 +73,31 @@ Proposed:
 
 ## Target parsing (`getRecurTarget`)
 Replace `getRecurIndex` with `getRecurTarget`:
+
 1. If `recur` arg is `Var(v)`, resolve exactly as today, target length = 1.
 2. If `recur` arg is `TupleCons(items)`, each item must be `Var(v)` and map to a distinct def parameter position.
 3. Otherwise reject.
 
 Conservative constraints:
+
 1. No duplicates in tuple target.
 2. Every tuple element must resolve to a top-level parameter binding (not a local, not an expression).
 
 ## Branch analysis
 For each branch pattern:
+
 1. Single target: keep existing behavior (`pat.substructures`).
 2. Tuple target of arity `k`:
    1. If branch pattern is a tuple pattern with arity `k`, compute component-wise:
       `allowedPerComponent(i) = componentPattern(i).substructures.toSet`.
+
    2. Otherwise, set all components to empty sets (no provable decrease in this branch).
 
 This is conservative and sound.
 
 ## Recursive call check
 For a recursive call to function `f` in `InRecurBranch`:
+
 1. Extract call argument at each target position (existing `argsOnDefName` + indexing by group/index).
 2. For each component `i`, classify call arg as:
    1. `Equal` if arg is exactly `Var(paramName_i)`.
@@ -129,6 +141,7 @@ Use when call arguments fail the lexicographic predicate.
 ## Examples
 
 Accepted:
+
 1. `ack(n_prev, Succ(Zero))` in branch `(Succ(n_prev), Zero)` (decrease in component 0).
 2. `ack(n, m_prev)` in branch `(Succ(n_prev), Succ(m_prev))` (component 0 equal, component 1 decreases).
 3. `ack(n_prev, ack(n, m_prev))` because:
@@ -136,11 +149,13 @@ Accepted:
    2. inner call decreases component 1 with component 0 equal.
 
 Rejected:
+
 1. `ack(n, Succ(m))` in branch `(Succ(n_prev), Succ(m_prev))` (no component proven to decrease).
 2. Calls that decrease component 1 while component 0 is changed to a non-equal non-decreasing value.
 
 ## Test plan
 Update `core/src/test/scala/dev/bosatsu/DefRecursionCheckTest.scala` with:
+
 1. Positive: direct two-arg Ackermann form with `recur (n, m)`.
 2. Positive: branch where earlier component decreases and later increases.
 3. Positive: nested recursive call in later argument (`ack(n_prev, ack(n, m_prev))`).
@@ -152,10 +167,12 @@ Update `core/src/test/scala/dev/bosatsu/DefRecursionCheckTest.scala` with:
 
 ## Impact outside recursion checker
 Required:
+
 1. Tests in `DefRecursionCheckTest`.
 2. User docs (`docs/src/main/paradox/recursion.md`, and possibly `language_guide.md`) to document tuple `recur` + lexicographic rule.
 
 Not required:
+
 1. Parser/AST shape changes: `recur` arg already accepts general expressions including tuples.
 2. Type inference, totality checker, Matchless lowering, or codegen changes.
 3. `PackageError` plumbing changes (new `RecursionError` cases flow through existing wrapper).

--- a/docs/src/main/paradox/design-docs/pattern_guards_design.md
+++ b/docs/src/main/paradox/design-docs/pattern_guards_design.md
@@ -24,18 +24,23 @@ while preserving Bosatsu's totality guarantees and keeping codegen predictable.
 ### Semantics and syntax
 1. OCaml supports branch guards (`when`) evaluated after the pattern matches, with top-down branch order.
 Source: [OCaml Reference Manual 5.3 (patterns/matching)](https://caml.inria.fr/pub/distrib/ocaml-5.3/ocaml-5.3-refman.html)
+
 2. Haskell supports guards and pattern guards; guards are checked after pattern matching in source order.
 Source: [Haskell 2010 Report, Expressions](https://www.haskell.org/onlinereport/haskell2010/haskellch3.html)
+
 3. Scala 3 case clauses allow optional guards (`case Pattern [Guard] =>`), with a first-match style operational reading.
 Source: [Scala 3 Language Specification, Pattern Matching](https://scala-lang.org/files/archive/spec/3.4/08-pattern-matching.html)
+
 4. Rust supports `pattern if guard` and explicitly states guards run after the pattern matches.
 Source: [Rust Reference, match expressions](https://doc.rust-lang.org/reference/expressions/match-expr.html)
 
 ### Exhaustiveness and guard complexity
 1. Rust documents that match guards are not used for exhaustiveness checking.
 Source: [The Rust Book, Match Guards](https://doc.rust-lang.org/book/ch19-03-pattern-syntax.html)
+
 2. GHC's pattern-match checker models guards and can be expensive; docs describe an exponential blow-up driver and a model cap (`-fmax-pmcheck-models`).
 Source: [GHC Users Guide, -fmax-pmcheck-models](https://ghc.gitlab.haskell.org/ghc/doc/users_guide/using-warnings.html#ghc-flag--fmax-pmcheck-models)
+
 3. OCaml tooling still carries explicit guard-related warning categories (for example `All_clauses_guarded` in compiler warnings API), which signals practical caution around guarded coverage.
 Source: [OCaml compiler-libs Warnings](https://ocaml.github.io/odoc/ocaml-base-compiler/compiler-libs.common/Warnings/index.html)
 
@@ -55,6 +60,7 @@ case <pattern> [if <nonbinding-expr>] : <declaration>
 
 ## Dynamic semantics
 For each branch, in order:
+
 1. Try to match the pattern against the scrutinee.
 2. If it fails, continue.
 3. If it succeeds, evaluate the guard in the pattern-extended scope.
@@ -75,6 +81,7 @@ No change to evaluation order of the scrutinee or branch ordering.
 Current code uses `(Pattern, Expr)` pairs throughout parser, source IR, typed IR, normalization, proto, and codegen lowering. With guards, tuples become brittle.
 
 Introduce explicit branch records in all relevant AST layers:
+
 1. Parsed declaration branch: `pattern`, optional `guard`, `body`.
 2. Untyped Expr branch: `pattern`, optional `guard`, `body`.
 3. TypedExpr branch: `pattern`, optional typed `guard`, typed `body`.
@@ -83,6 +90,7 @@ This reduces accidental field-order bugs and makes normalization/lowering logic 
 
 ### 2. Conservative totality policy
 To preserve Bosatsu totality without theorem proving:
+
 1. Only unguarded branches contribute to exhaustiveness coverage.
 2. Guarded branches are checked for pattern validity and body totality, but do not reduce `missingBranches`.
 3. Reachability uses only prior unguarded coverage for shadowing.
@@ -96,6 +104,7 @@ No changes to `TotalityCheck.patternSetOps` are required.
 Set algebra remains over `Pattern` only.
 
 Changes are localized to branch selection in totality analysis:
+
 1. Project branches to coverage patterns via `branch.guard.isEmpty` (or future `guardIsTriviallyTrue`).
 2. Run existing `missingBranches`, `unreachableBranches`, `difference`, `intersection` unchanged.
 
@@ -103,10 +112,12 @@ Changes are localized to branch selection in totality analysis:
 
 ### Parser and source AST
 Files:
+
 1. `core/src/main/scala/dev/bosatsu/Declaration.scala`
 2. `core/src/main/scala/dev/bosatsu/SourceConverter.scala`
 
 Changes:
+
 1. Parse optional guard between pattern and `:`.
 2. Pretty-printer emits `case <pat> if <guard>:` when present.
 3. Source conversion converts guard under the same pattern-bound scope as branch body.
@@ -116,21 +127,25 @@ Changes:
 
 ### Type inference and typed AST
 Files:
+
 1. `core/src/main/scala/dev/bosatsu/Expr.scala`
 2. `core/src/main/scala/dev/bosatsu/TypedExpr.scala`
 3. `core/src/main/scala/dev/bosatsu/rankn/Infer.scala`
 
 Changes:
+
 1. `checkBranch`/`inferBranch` accept optional guard.
 2. After `typeCheckPattern`, extend env with bindings, then typecheck guard as `Bool`.
 3. Continue to branch body typing exactly as today.
 
 ### Totality and errors
 Files:
+
 1. `core/src/main/scala/dev/bosatsu/TotalityCheck.scala`
 2. `core/src/main/scala/dev/bosatsu/PackageError.scala`
 
 Changes:
+
 1. Exhaustiveness input patterns become "unguarded branch patterns".
 2. Unreachable logic ignores prior guarded branches as covering evidence.
 3. Error text adds explicit hint that guarded branches do not establish totality.
@@ -138,10 +153,12 @@ Changes:
 
 ### Recursion and lint-style analyses
 Files:
+
 1. `core/src/main/scala/dev/bosatsu/DefRecursionCheck.scala`
 2. `core/src/main/scala/dev/bosatsu/UnusedLetCheck.scala`
 
 Changes:
+
 1. Guards must be traversed anywhere branch bodies are traversed today.
 2. Pattern-bound names are in scope for guards.
 3. In recursive contexts, a recursive call inside a guard is allowed iff that call would be allowed in that branch body.
@@ -149,21 +166,25 @@ Changes:
 
 ### TypedExprNormalization (guard-aware)
 Files:
+
 1. `core/src/main/scala/dev/bosatsu/TypedExprNormalization.scala`
 2. `core/src/main/scala/dev/bosatsu/Package.scala` (ordering note)
 
 Guard-specific requirements:
+
 1. Any substitution/inlining rule that can affect branch expressions must also apply to guard expressions.
 2. When moving lets/lambdas across match branches, free-variable and shadowing checks must consider both guard and body.
 3. Pattern-bound names still shadow outer names in guards exactly as they do in branch bodies.
 
 Guard simplification rules:
+
 1. Normalize/infer substitutions into the guard first.
 2. If the normalized guard becomes `True`, remove the guard from that branch.
 3. If the normalized guard becomes `False`, remove that branch as unreachable.
 4. Run existing match simplifications after guard elimination (for example, simpler trailing wildcard rewrites).
 
 Pattern-independent guard hoisting (optimization):
+
 1. If a guard does not reference any names bound by its pattern, it can be hoisted into the scrutinee shape:
    1. `match x: case p if g: a; case p2: b`
    2. `=> let g0 = g in match (x, g0): case (p, True): a; case (p2, _): b`
@@ -175,6 +196,7 @@ Pattern-independent guard hoisting (optimization):
 5. Do not apply this rewrite when guard depends on pattern-bound names.
 
 Why this matters:
+
 1. It avoids regressions where a rewrite updates the branch body but leaves the guard stale.
 2. It enables practical optimization from existing inlining/constant-folding work.
 3. It gives us a path to compile some guards with pure matrix specialization rather than late guard checks.
@@ -185,10 +207,12 @@ So guard elimination in normalization improves generated code quality and downst
 
 ### Serialization
 Files:
+
 1. `proto/src/main/protobuf/bosatsu/TypedAst.proto`
 2. `core/src/main/scala/dev/bosatsu/ProtoConverter.scala`
 
 Changes:
+
 1. Extend `Branch` with optional `guardExpr`.
 2. Decode absent guard as `None`.
 3. Encode guard when present.
@@ -199,10 +223,12 @@ Old decoders could ignore unknown guard fields, so rollout should include a form
 ## Matchless Design
 
 Files:
+
 1. `core/src/main/scala/dev/bosatsu/Matchless.scala`
 
 ### Data model
 Extend matrix row:
+
 1. `pats`
 2. optional `guard`
 3. `rhs`
@@ -213,6 +239,7 @@ Keep constructor/literal specialization unchanged.
 Guard logic is added only when a row becomes selected (all remaining pats are wildcards).
 
 At row selection:
+
 1. Build `rhsExpr = lets(binds, rhs)`.
 2. If no guard: return `rhsExpr` (existing behavior).
 3. If guarded:
@@ -227,12 +254,14 @@ This preserves left-to-right semantics and matrix sharing.
 `matchExprOrderedCheap` must also incorporate guards, because it is used for non-orthogonal list/string patterns and small matches.
 
 Effective branch test becomes:
+
 1. pattern condition
 2. then guard condition (short-circuited)
 
 ### `mustMatch` optimization impact
 Current optimization can skip some final pattern checks.  
 With guards:
+
 1. Pattern-shape checks may still be skipped where valid.
 2. Guard checks are never skipped unless proven trivially true.
 
@@ -240,11 +269,13 @@ With guards:
 
 ## Performance
 Pros:
+
 1. Matrix shape-specialization logic stays mostly unchanged.
 2. Set algebra complexity does not increase.
 3. Guard simplification in `TypedExprNormalization` can remove runtime guard checks.
 
 Costs:
+
 1. Additional guard evaluation and branching in compiled Matchless.
 2. Potential duplication of bound projection work between guard and rhs.
 3. More normalization work because guard expressions participate in substitution and simplification.
@@ -252,10 +283,12 @@ Costs:
 
 ## Error reporting
 Pros:
+
 1. Sound totality is preserved without predicate proving.
 2. Diagnostics remain deterministic and simple.
 
 Costs:
+
 1. More conservative non-total errors ("add unguarded fallback") even for logically exhaustive guarded partitions.
 2. Reachability may be less precise for guards that are always true/false but not syntactically obvious.
 3. Special-casing Predef `True` in SourceConverter is slightly non-uniform, but it avoids surprising non-total errors for explicit `if True`.

--- a/docs/src/main/paradox/language_guide.md
+++ b/docs/src/main/paradox/language_guide.md
@@ -6,6 +6,7 @@ This guide is a quick tour of Bosatsu syntax. For installation and running code,
 Bosatsu aims to be simple, but not always easy.
 
 Simple here means the language has a small core model:
+
 1. structs and enums
 1. creating values
 1. creating functions
@@ -162,6 +163,7 @@ conventions:
 
 1. Bindable names (defs, values, parameters, locals) use lowercase with
    underscore separation.
+
 1. Type and constructor names use UpperCamelCase.
 1. If a bindable name includes a type name, put the full type name at the end
    after an underscore.
@@ -371,6 +373,7 @@ loops, but only when the compiler can prove they terminate. That restriction is
 what preserves type-system soundness.
 
 Most loops are either:
+
 1. structural recursion on subvalues (like a list tail or tree branch), or
 1. explicit fuel recursion on a decreasing `Nat`.
 
@@ -516,6 +519,7 @@ Defaults are only applied when using record syntax (`Rec { ... }`), and only for
 omitted fields. Positional constructor calls (`Rec(...)`) do not fill defaults.
 
 Two rules apply to constructor defaults:
+
 1. A field with a default must have an explicit type annotation.
 1. A default expression may only reference imports, or top-level values defined
 earlier in the same file (including earlier defaults). It may not reference
@@ -551,6 +555,7 @@ In `File { size: 4096, ..base }`, explicitly listed fields override values from
 `base`, and omitted fields are copied from `base`.
 
 Rules for record updates:
+
 1. They are written with `..expr` in record construction syntax.
 1. `...` is only for patterns (not construction).
 1. You must explicitly set at least one field.
@@ -639,6 +644,7 @@ enum List:
 ```
 
 Data-structures have two simple rules:
+
 1. they must form a DAG
 2. if they refer to themselves, they do so in covariant positions (roughly, not
    as inputs to functions).
@@ -777,12 +783,15 @@ def run[a](fa: FreeF[a]) -> a:
 ```
 
 When to use existentials:
+
 - To hide intermediate types in data constructors while still allowing later
   consumption (e.g. `Mapped`/`Map2` store an internal `b` or `c` plus functions
   that know how to use them).
+
 - To model heterogeneous or stateful structures where the internal type varies
   but is not part of the public API (e.g. existential tails in custom list-like
   structures, or continuations with hidden state).
+
 - To return or store values that must remain opaque to callers while keeping
   internal consistency inside a match branch.
 
@@ -854,6 +863,7 @@ Sometimes such opacity is useful to enforce modularity.
 ## Value usage requirements
 Bosatsu requires top-level values to be used. A top-level value must be
 transitively reachable from at least one of these roots:
+
 1. an exported value
 1. the package main value (the last top-level value in the package)
 1. the package test value (the last top-level value with type `Bosatsu/Predef::Test`)
@@ -876,14 +886,17 @@ That makes the intent explicit to readers and to the compiler.
 ## Testing
 Bosatsu tests are regular values of type `Bosatsu/Predef::Test`.
 `Bosatsu/Predef` defines:
+
 1. `Assertion(value: Bool, message: String)`
 1. `TestSuite(name: String, tests: List[Test])`
 
 Common patterns in `test_workspace/*.bosatsu`:
+
 1. A single assertion:
 ```
 test = Assertion(eq_Int(add(1, 1), 2), "1 + 1 == 2")
 ```
+
 1. A suite of assertions:
 ```
 tests = TestSuite("math tests", [
@@ -891,6 +904,7 @@ tests = TestSuite("math tests", [
   Assertion(eq_Int(mul(3, 4), 12), "3 * 4"),
 ])
 ```
+
 1. Nested/composed suites, including generated tests:
 ```
 tests = TestSuite("all tests", [

--- a/docs/src/main/paradox/recursion.md
+++ b/docs/src/main/paradox/recursion.md
@@ -19,11 +19,14 @@ plain language:
 1. Structural recursion (well-founded recursion):
    each recursive call is on a strictly smaller argument under a well-founded
    order (for example, list tail, tree child, predecessor `Nat`).
+
 1. Fuel pattern (step-indexed style):
    add an explicit counter/fuel argument, decrement it on each recursive call,
    and stop when fuel reaches zero.
+
 1. Accessibility predicate / domain predicate:
    a predicate describing inputs on which a recursive function terminates.
+
 1. Bove-Capretta method:
    define a recursive function by structural recursion on evidence that the
    input is in the domain predicate; then separately prove totality by proving
@@ -44,17 +47,22 @@ def len(lst: List[a]) -> Int:
 ```
 
 At a high level:
+
 1. `recur` matches a parameter name, or a tuple of parameter names, of the
    nearest enclosing `def`.
+
 1. With a single target (`recur x`), recursive calls are allowed only when the
    call argument for `x` is structurally smaller.
+
 1. With a tuple target (`recur (x0, x1, ..., xk)`), recursive calls must be
    lexicographically smaller in that target order.
+
    1. Compare call arguments at target positions left-to-right.
    1. The first position that differs must be structurally smaller.
    1. All earlier target positions must be equal.
    1. If a position becomes unrelated/non-decreasing before any smaller
       position appears, the call is rejected.
+
 1. These value-level restrictions are only part of totality. Bosatsu also
    restricts recursive types to covariant positions (issue #104:
    https://github.com/johnynek/bosatsu/issues/104), so type-level recursion is
@@ -82,6 +90,7 @@ def for_all(xs: List[a], fn: a -> Bool) -> Bool:
 ```
 
 Other examples:
+
 1. `exists`, `eq_List`, `zip`, `size1` in `List.bosatsu`.
 1. `equal_List` in `recordset.bosatsu`.
 
@@ -171,6 +180,7 @@ def fib(b: BinNat) -> BinNat:
 ```
 
 Other examples:
+
 1. `run` in `Eval.bosatsu` (evaluation budget).
 1. `recur_max` in `Parser.bosatsu` (bounded parse steps).
 1. `rand_Queue_depth` and `geometric` in `Queue.bosatsu` and `Rand.bosatsu`.
@@ -252,6 +262,7 @@ If direct string recursion is awkward, you can compute a string length, convert
 to `Nat`, and recurse on that `Nat` as the parse budget.
 
 Sketch:
+
 1. `len = to_Nat(length_String(input))`
 1. `loop(len, input)` with `recur len`
 1. consume string as you go, and always recurse with the predecessor fuel
@@ -270,8 +281,10 @@ def ack(n: Nat, m: Nat) -> Nat:
 ```
 
 Why this is accepted:
+
 1. `ack(n_prev, Succ(Zero))` is valid because the first target (`n`) decreases.
    The second target may increase/reset once an earlier target has decreased.
+
 1. `ack(n, m_prev)` is valid because `n` is equal and `m` decreases.
 1. `ack(n_prev, ack(n, m_prev))` is valid because:
    1. the outer call decreases `n`;
@@ -299,11 +312,14 @@ The design request for this page is tracked at
 https://github.com/johnynek/bosatsu/issues/410.
 
 How that maps to Bosatsu practice:
+
 1. Fuel pattern: add a decreasing counter, return `None` or fallback on
    exhaustion (`Eval.run`, `Parser.recur_max`, `BinNat.fib`).
+
 1. Domain/companion pattern (Bove-Capretta spirit): build a companion structure
    that justifies recursive calls (`List.sort` with `size`, `Rand.one_of` with
    list length).
+
 1. Bosatsu keeps these ideas at the program level (data and recursion shape)
    instead of requiring explicit accessibility/domain proof terms in source
    code.
@@ -313,24 +329,32 @@ How that maps to Bosatsu practice:
 1. If not, compute a bound and recurse on that fuel (`Nat` is usually easiest).
 1. If recursion uses multiple arguments, prefer `recur (a, b, ...)` and check
    lexicographic decrease in that order.
+
 1. For parsing-like string scans, either recurse on string tail directly or use
    length-derived fuel.
 
 ## References
 1. Ana Bove and Venanzio Capretta, "Modelling general recursion in type
    theory" (MSCS, 2005): https://people.cs.nott.ac.uk/pszvc/publications/General_Recursion_MSCS_2005.pdf
+
 1. Ana Bove, "General Recursion in Type Theory" (TYPES 2002):
    https://doi.org/10.1007/3-540-39185-1_3
+
 1. Venanzio Capretta, "General Recursion via Coinductive Types" (LMCS, 2005):
    https://lmcs.episciences.org/2265
+
 1. Conor McBride, "Turing-Completeness Totally Free" (2015):
    https://personal.cis.strath.ac.uk/conor.mcbride/TotallyFree.pdf
+
 1. Casper Bach Poulsen, Arjen Rouvoet, Andrew Tolmach, Robbert Krebbers, and
    Eelco Visser, "Intrinsically-Typed Definitional Interpreters for Imperative
    Languages" (POPL, 2018): https://casperbp.net/store/intrinsicallytyped.pdf
+
 1. Background on well-founded/domain-style termination arguments:
    https://en.wikipedia.org/wiki/Well-founded_relation
+
 1. Project issue for this docs task:
    https://github.com/johnynek/bosatsu/issues/410
+
 1. Related Bosatsu implementation discussion:
    https://github.com/johnynek/bosatsu/pull/406


### PR DESCRIPTION
## Summary
- fix issue #1719 by reducing Paradox sidebar depth so only top-level docs entries appear in left navigation
- keep design-doc and core-alpha pages in Paradox TOC while adding explicit visible landing-page indexes for both sections
- normalize markdown list spacing across user docs and active design docs so ordered lists render as actual `<ol>/<li>` blocks instead of inline `1. ...` text

## Details
- set `Compile / paradoxNavigationDepth := 1` in `/Users/oscar/code/bosatsu3/build.sbt`
- update generated core-alpha index content generation to include both TOC wiring and a visible HTML link list
- add a visible HTML index section to `/Users/oscar/code/bosatsu3/docs/src/main/paradox/design-docs/index.md`
- add list-boundary spacing fixes in:
  - `/Users/oscar/code/bosatsu3/docs/src/main/paradox/language_guide.md`
  - `/Users/oscar/code/bosatsu3/docs/src/main/paradox/recursion.md`
  - `/Users/oscar/code/bosatsu3/docs/src/main/paradox/design-docs/compiler_leveraging_type_inhabitedness.md`
  - `/Users/oscar/code/bosatsu3/docs/src/main/paradox/design-docs/issue_1628_pattern_value_reuse_design.md`
  - `/Users/oscar/code/bosatsu3/docs/src/main/paradox/design-docs/issue_1676_default_values_struct_enum_design.md`
  - `/Users/oscar/code/bosatsu3/docs/src/main/paradox/design-docs/issue_356_struct_update_syntax_design.md`
  - `/Users/oscar/code/bosatsu3/docs/src/main/paradox/design-docs/lexicographic_recur_design.md`
  - `/Users/oscar/code/bosatsu3/docs/src/main/paradox/design-docs/pattern_guards_design.md`
  - `/Users/oscar/code/bosatsu3/docs/src/main/paradox/design-docs/well_typed_statement_generator_design.md`

## Validation
- `sbt "docs/paradox"`
- verified sidebar in generated HTML only shows top-level entries (Design Docs/Core Alpha are links, not expanded trees)
- verified no paragraphized ordered-list artifacts remain via:
  - `rg -n "<p>.*\\b1\\.\\s" docs/target/paradox/site/main -g '*.html'` (no matches)

Fixes #1719
