### PR TITLE
Use tuple-backed storage for Python Array backend

### DIFF
--- a/core/.jvm/src/test/scala/dev/bosatsu/codegen/python/PythonGenJvmTest.scala
+++ b/core/.jvm/src/test/scala/dev/bosatsu/codegen/python/PythonGenJvmTest.scala
@@ -1,0 +1,35 @@
+package dev.bosatsu.codegen.python
+
+import dev.bosatsu.{PackageName, Par, TestUtils}
+
+class PythonGenJvmTest extends munit.FunSuite {
+  test("array intrinsic representation uses tuple-backed storage") {
+    Par.withEC {
+      val pm = TestUtils.compileFile(
+        "test_workspace/Bosatsu/Collection/Array.bosatsu",
+        "test_workspace/List.bosatsu",
+        "test_workspace/Option.bosatsu",
+        "test_workspace/Char.bosatsu",
+        "test_workspace/Bool.bosatsu",
+        "test_workspace/Nat.bosatsu"
+      )
+      val rendered = PythonGen.renderSource(pm, Map.empty, Map.empty)
+      val doc =
+        rendered(())(PackageName.parts("Bosatsu", "Collection", "Array"))._2
+      val code = doc.render(120)
+
+      assert(
+        code.contains("return (tuple("),
+        s"expected tuple-backed array payloads in generated code:\n$code"
+      )
+      assert(
+        code.contains(" = list("),
+        s"expected mutable list copy for in-place updates/sort:\n$code"
+      )
+      assert(
+        !code.contains("return ([], 0, 0)"),
+        s"unexpected list-backed empty array representation:\n$code"
+      )
+    }
+  }
+}

--- a/core/src/test/scala/dev/bosatsu/codegen/python/PythonGenTest.scala
+++ b/core/src/test/scala/dev/bosatsu/codegen/python/PythonGenTest.scala
@@ -1,7 +1,7 @@
 package dev.bosatsu.codegen.python
 
 import dev.bosatsu.Generators.bindIdentGen
-import dev.bosatsu.{PackageName, Par, TestUtils}
+import dev.bosatsu.{Par, TestUtils}
 import dev.bosatsu.codegen.CompilationSource
 import org.scalacheck.Prop.forAll
 
@@ -106,36 +106,6 @@ class PythonGenTest extends munit.ScalaCheckSuite {
           normalizeGeneratedTemps(expected)
         )
       }
-    }
-  }
-
-  test("array intrinsic representation uses tuple-backed storage") {
-    Par.withEC {
-      val pm = TestUtils.compileFile(
-        "test_workspace/Bosatsu/Collection/Array.bosatsu",
-        "test_workspace/List.bosatsu",
-        "test_workspace/Option.bosatsu",
-        "test_workspace/Char.bosatsu",
-        "test_workspace/Bool.bosatsu",
-        "test_workspace/Nat.bosatsu"
-      )
-      val rendered = PythonGen.renderSource(pm, Map.empty, Map.empty)
-      val doc =
-        rendered(())(PackageName.parts("Bosatsu", "Collection", "Array"))._2
-      val code = doc.render(120)
-
-      assert(
-        code.contains("return (tuple("),
-        s"expected tuple-backed array payloads in generated code:\n$code"
-      )
-      assert(
-        code.contains(" = list("),
-        s"expected mutable list copy for in-place updates/sort:\n$code"
-      )
-      assert(
-        !code.contains("return ([], 0, 0)"),
-        s"unexpected list-backed empty array representation:\n$code"
-      )
     }
   }
 }


### PR DESCRIPTION
## Summary
- make Python backend Arrays store data as tuple-backed payloads
- convert array slices to mutable lists only for set/sort in-place updates
- add a regression test for tuple-backed Array code generation

closes #1666