### PR TITLE
Fix RingOpt remult cost regression for maybeDivInt

### DIFF
--- a/core/src/main/scala/dev/bosatsu/RingOpt.scala
+++ b/core/src/main/scala/dev/bosatsu/RingOpt.scala
@@ -476,16 +476,22 @@ object RingOpt {
           // negation should always be cheaper than multiplication
           if (c == -1) normalizeNeg
           else {
-            // we know c != 1, 0, -1
-            // we know that this is not 1, 0, -1 because absorbMultConst handles those
-            if (c < 0) {
-              // see if we can remove a Neg
-              cheapNeg match {
-                case Some(n) => Mult(n, Integer(-c))
-                case None    => Mult(this, Integer(c))
-              }
-            } else {
-              Mult(this, Integer(c))
+            expr match {
+              // Keep the sign on the literal when we can so we don't add a
+              // standalone Neg node and increase cost.
+              case Neg(n) => n.bestEffortConstMult(-c)
+              case _      =>
+                // we know c != 1, 0, -1
+                // we know that this is not 1, 0, -1 because absorbMultConst handles those
+                if (c < 0) {
+                  // see if we can remove a Neg
+                  cheapNeg match {
+                    case Some(n) => Mult(n, Integer(-c))
+                    case None    => Mult(this, Integer(c))
+                  }
+                } else {
+                  Mult(this, Integer(c))
+                }
             }
           }
       }

--- a/core/src/test/scala/dev/bosatsu/RingOptLaws.scala
+++ b/core/src/test/scala/dev/bosatsu/RingOptLaws.scala
@@ -333,6 +333,20 @@ class RingOptLaws extends munit.ScalaCheckSuite {
       }
     }
   }
+
+  test("maybeDivInt remult regression #1742") {
+    val div = BigInt(4)
+    val e: Expr[BigInt] =
+      Mult(Integer(-div), Mult(Symbol(BigInt(1)), Symbol(BigInt(2))))
+    val w = Weights(mult = 3, add = 2, neg = 2)
+
+    val res = e.maybeDivInt(div).getOrElse(fail("expected a quotient"))
+    val remult = res.bestEffortConstMult(div)
+
+    assertEquals(Expr.toValue(remult), Expr.toValue(e))
+    assert(w.cost(remult) <= w.cost(e), show"e=$e, res=$res, remult=$remult")
+  }
+
   property("unConstMult <=> maybeDivInt relationship") {
     // if unConstMult works, we could divide by the same const using maybeDivInt
     val law1Prop = forAll { (e: Expr[BigInt]) =>


### PR DESCRIPTION
## Summary
- add a minimized deterministic regression test for issue #1742 in `RingOptLaws`
- fix `bestEffortConstMult` so `Neg(expr) * c` pushes sign into the constant (`expr * -c`) before fallback multiplication
- avoid introducing an extra standalone `Neg` node during remultiplication, which could increase weighted cost

## Root Cause
For expressions shaped like `(-k * e) / k`, `maybeDivInt(k)` returns `-e`. Re-multiplying with `bestEffortConstMult(k)` previously produced `(-e) * k`, which adds a `Neg` node instead of keeping sign on the integer literal. With positive neg weight this makes remultiplication more expensive than the original expression.

## Validation
- `sbt "coreJVM/testOnly *RingOptLaws"`

Closes #1742
