### PR TITLE
Add evaluation regression for non-tail polymorphic recursion

### DIFF
--- a/core/src/test/scala/dev/bosatsu/EvaluationTest.scala
+++ b/core/src/test/scala/dev/bosatsu/EvaluationTest.scala
@@ -2667,6 +2667,34 @@ def call(a):
       "PolyRec",
       1
     )
+
+  }
+
+  test("polymorphic recursion runs in non-tail position") {
+    evalTest(
+      List("""
+package PolyRec
+
+enum Nat: Z, S(prev: Nat)
+
+struct Box[a](value: a)
+
+def box_more[a](count: Nat, box: Box[a]) -> Nat:
+  recur count:
+    case Z: Z
+    case S(prev): S(box_more(prev, Box(box)))
+
+def to_int(n: Nat) -> Int:
+  recur n:
+    case Z: 0
+    case S(prev): to_int(prev).add(1)
+
+start = S(S(S(Z)))
+main = to_int(box_more(start, Box("x")))
+"""),
+      "PolyRec",
+      VInt(3)
+    )
   }
 
   test("recursion on continuations") {


### PR DESCRIPTION
## Summary
- add an `EvaluationTest` case for polymorphic recursion in a non-tail position
- use `case S(prev): S(box_more(prev, Box(box)))` to force work after the recursive call
- assert runtime behavior is identity on `Nat` (via `to_int`, input `S(S(S(Z)))` -> `3`)

## Context
- follow-up to #1759 (Matchless lowering for polymorphic recursion)
- related issue: #1749 (already closed by #1759)

This keeps coverage at the evaluation/runtime level for the non-tail polymorphic-recursion path.
