### PR TITLE
Bump scalawasiz3 to 0.0.6 and simplify Z3 integration tests

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -338,7 +338,7 @@ lazy val core =
 
 lazy val coreJVM =
   core.jvm.settings(
-    libraryDependencies += "dev.bosatsu" %% "scalawasiz3" % "0.0.4" % Test
+    libraryDependencies += "dev.bosatsu" %% "scalawasiz3" % "0.0.6" % Test
   )
 lazy val coreJS =
   core.js.enablePlugins(ScalaJSPlugin).enablePlugins(ScalaJSBundlerPlugin)

--- a/core/.jvm/src/test/scala/dev/bosatsu/Z3SolverIntegrationTest.scala
+++ b/core/.jvm/src/test/scala/dev/bosatsu/Z3SolverIntegrationTest.scala
@@ -57,10 +57,6 @@ class Z3SolverIntegrationTest extends munit.FunSuite {
         |(declare-fun intValue () Int)
         |(declare-fun next_i () Int)
         |
-        |; concrete witness assignments keep this query stable in the embedded WASM runtime
-        |(assert (= intValue 2))
-        |(assert (= next_i 1))
-        |
         |; path condition at recursive call
         |(assert (> intValue 0))
         |(assert (> next_i 0))
@@ -101,10 +97,6 @@ class Z3SolverIntegrationTest extends munit.FunSuite {
         |(declare-fun intValue () Int)
         |(declare-fun next_i () Int)
         |
-        |; expected satisfying assignment from the design doc example
-        |(assert (= intValue 1))
-        |(assert (= next_i 1))
-        |
         |(assert (> intValue 0))
         |(assert (> next_i 0))
         |
@@ -123,13 +115,12 @@ class Z3SolverIntegrationTest extends munit.FunSuite {
   test("design doc divide-and-conquer split check is unsat") {
     assertStatus(
       """
-        |(set-logic QF_LIA)
+        |(set-logic ALL)
         |(declare-const n1 Int)
         |(declare-const n2 Int)
         |(declare-const n3 Int)
         |
-        |; concrete split case: n1 = 2 gives n2 = 1 and n3 = 1
-        |(assert (= n1 2))
+        |(assert (>= n1 2))
         |(assert (= n2 (div n1 2)))
         |(assert (= n3 (- n1 n2)))
         |
@@ -148,7 +139,6 @@ class Z3SolverIntegrationTest extends munit.FunSuite {
         |(set-logic QF_LIA)
         |(declare-fun i () Int)
         |(declare-fun next_i () Int)
-        |(assert (= i 1))
         |(assert (> i 0))
         |(assert (= next_i i))
         |(assert (not (< next_i i)))


### PR DESCRIPTION
Implemented issue #1775 by updating `coreJVM` test dependency `dev.bosatsu::scalawasiz3` from `0.0.4` to `0.0.6` in `build.sbt`. Simplified `core/.jvm/src/test/scala/dev/bosatsu/Z3SolverIntegrationTest.scala` back to the original query shapes from commit `8bf8062160ab36e0180f302b2984c92693e6cef1` (removed concrete witness pinning, restored general split constraints, and removed the extra concrete `i = 1` assertion), while keeping model-detection logic aligned with actual runtime output format (`define-fun`). Reproduced the issue behavior pre-fix by running the simplified tests against `0.0.4` (4 failing tests with `Failed executing embedded z3.wasm: Trapped on unreachable instruction`), then verified the fix with `0.0.6` (`sbt "coreJVM/testOnly dev.bosatsu.Z3SolverIntegrationTest"`: 5 passed, 0 failed).

Fixes #1775

Source issue: https://github.com/johnynek/bosatsu/issues/1775