### PR TITLE
Add `scripts/test_basic.sh` for batch basic tests

### DIFF
--- a/scripts/test_basic.sh
+++ b/scripts/test_basic.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+sbt -batch "cli/test; coreJVM/test"


### PR DESCRIPTION
Implemented issue #1793 with a single focused change: added executable `scripts/test_basic.sh` that runs `sbt` in batch mode for `cli/test` and `coreJVM/test`.

Changes:
- Added new file: `scripts/test_basic.sh` (mode `100755`)
- Script contents:
  - `#!/usr/bin/env bash`
  - `set -euo pipefail`
  - `sbt -batch "cli/test; coreJVM/test"`

Validation performed:
- `bash -n scripts/test_basic.sh` (syntax check)
- Executed `./scripts/test_basic.sh` successfully; sbt completed with all tests passing (`Passed: Total 1366, Failed 0, Errors 0`).

Fixes #1793