### PR TITLE
Fix #1801 false-positive TypedRecursion parity failures from ill-kinded generator instantiations

### DIFF
--- a/core/src/test/scala/dev/bosatsu/TypedExprRecursionParitySeedRegressionTest.scala
+++ b/core/src/test/scala/dev/bosatsu/TypedExprRecursionParitySeedRegressionTest.scala
@@ -1,0 +1,72 @@
+package dev.bosatsu
+
+import cats.data.{NonEmptyList, Validated}
+import cats.syntax.all._
+import IorMethods.IorExtension
+import org.scalacheck.Prop.forAll
+import org.typelevel.paiges.Document
+
+class TypedExprRecursionParitySeedRegressionTest
+    extends munit.ScalaCheckSuite
+    with ParTest {
+  override def scalaCheckInitialSeed =
+    "Fo4swOwXPC3xNI0E1pz2E4fwpHywwBXoLbvPIYU53bF="
+
+  override def scalaCheckTestParameters =
+    super.scalaCheckTestParameters.withMinSuccessfulTests(
+      if (Platform.isScalaJvm) 12 else 12
+    )
+
+  private def renderStatements(statements: List[Statement]): String =
+    statements.map(Document[Statement].document(_).render(80)).mkString
+
+  private def legacyPass(statements: List[Statement]): Boolean =
+    statements.traverse_(LegacyDefRecursionCheck.checkStatement(_)).isValid
+
+  private def typedPass(
+      packageName: PackageName,
+      statements: List[Statement],
+      source: String
+  ): Boolean = {
+    val parsed = Package.fromStatements(packageName, statements)
+    given cats.Show[String] = cats.Show.fromToString
+    PackageMap
+      .typeCheckParsed(
+        NonEmptyList.one((("<generated>", LocationMap(source)), parsed)),
+        Nil,
+        "<predef>",
+        CompileOptions.Default
+      )
+      .strictToValidated match {
+      case Validated.Valid(_) =>
+        true
+      case Validated.Invalid(errs) =>
+        val recursionErrors = errs.toList.collect {
+          case re: PackageError.RecursionError => re
+        }
+        if (recursionErrors.nonEmpty && recursionErrors.size == errs.length) {
+          false
+        } else {
+          val sourceMap = Map(packageName -> (LocationMap(source), "<generated>"))
+          val msg = errs.toList
+            .map(_.message(sourceMap, LocationMap.Colorize.None))
+            .mkString("\n-----\n")
+          fail(s"typed pipeline failed for non-recursion reason:\n$msg")
+        }
+    }
+  }
+
+  property("phase 3 seed repro: legacy vs typed recursion parity") {
+    // Regression for issue #1801.
+    forAll(WellTypedGen.wellTypedProgramGen(WellTypedGen.Config.phase3)) { program =>
+      val source = renderStatements(program.statements)
+      val legacy = legacyPass(program.statements)
+      val typed = typedPass(program.packageName, program.statements, source)
+      assertEquals(
+        typed,
+        legacy,
+        s"legacy/typed recursion mismatch for source:\n$source"
+      )
+    }
+  }
+}


### PR DESCRIPTION
Reproduced issue #1801 by forcing `TypedExprRecursionParityTest` to use seed `Fo4swOwXPC3xNI0E1pz2E4fwpHywwBXoLbvPIYU53bF=`; phase 3 failed with a non-recursion kind-unification error.

Diagnosis: this is a false positive in the parity property. `WellTypedGen.instantiatedFnArgsForGoal` was matching polymorphic result shapes but did not validate kind/variance subsumption for inferred substitutions, so it could instantiate a bound like `+* -> *` with an invariant `* -> *` constructor and generate ill-kinded programs unrelated to recursion.

Fix implemented:
- Updated `core/src/test/scala/dev/bosatsu/WellTypedGen.scala` to validate substitution kinds during polymorphic function-application generation:
  - Added kind lookup across known built-ins, function/tuple constructors, and local generated type constructors.
  - Added `kindSubsumes` check using `Type.kindOfOption` + `Kind.leftSubsumesRight`.
  - Rejected candidate substitutions whose kinds do not satisfy the quantified bound.
- Added regression suite `core/src/test/scala/dev/bosatsu/TypedExprRecursionParitySeedRegressionTest.scala` with the exact failing seed and phase-3 parity property.

Validation run:
- `sbt "coreJVM/testOnly dev.bosatsu.TypedExprRecursionParityTest dev.bosatsu.TypedExprRecursionParitySeedRegressionTest"` ✅
- `sbt "coreJVM/testOnly dev.bosatsu.WellTypedTests"` ✅
- `sbt "coreJVM/test:compile"` ✅

Fixes #1801