### PR TITLE
Increase Z3SolverIntegrationTest munit timeout to 2 minutes

### DIFF
--- a/core/.jvm/src/test/scala/dev/bosatsu/Z3SolverIntegrationTest.scala
+++ b/core/.jvm/src/test/scala/dev/bosatsu/Z3SolverIntegrationTest.scala
@@ -1,8 +1,10 @@
 package dev.bosatsu
 
 import dev.bosatsu.scalawasiz3.{Z3Result, Z3Solver}
+import scala.concurrent.duration.DurationInt
 
 class Z3SolverIntegrationTest extends munit.FunSuite {
+  override val munitTimeout = 2.minutes
 
   private def parseFirstStatus(stdout: String): Option[String] =
     stdout.linesIterator


### PR DESCRIPTION
Updated /core/.jvm/src/test/scala/dev/bosatsu/Z3SolverIntegrationTest.scala to set `override val munitTimeout = 2.minutes` and added the required `DurationInt` import. Verified with `sbt "coreJVM/testOnly dev.bosatsu.Z3SolverIntegrationTest"` (5 passed, 0 failed).

Fixes #1805