### PR TITLE
Implement #1778: persist source hash/region provenance in proto and Matchless

### DIFF
--- a/cli/src/main/scala/dev/bosatsu/IOPlatformIO.scala
+++ b/cli/src/main/scala/dev/bosatsu/IOPlatformIO.scala
@@ -226,7 +226,7 @@ object IOPlatformIO extends PlatformIO[IO, JPath] {
   def readInterfacesAndPackages(
       ifacePaths: List[Path],
       packagePaths: List[Path]
-  ): IO[(List[Package.Interface], List[Package.Typed[Unit]])] =
+  ): IO[(List[Package.Interface], List[Package.Typed[Any]])] =
     (
       ifacePaths.traverse(read[proto.Interfaces](_)),
       packagePaths.traverse(read[proto.Packages](_))
@@ -242,7 +242,7 @@ object IOPlatformIO extends PlatformIO[IO, JPath] {
   def readInterfaces(paths: List[Path]): IO[List[Package.Interface]] =
     readInterfacesAndPackages(paths, Nil).map(_._1)
 
-  def readPackages(paths: List[Path]): IO[List[Package.Typed[Unit]]] =
+  def readPackages(paths: List[Path]): IO[List[Package.Typed[Any]]] =
     readInterfacesAndPackages(Nil, paths).map(_._2)
 
   def readLibrary(path: Path): IO[Hashed[Algo.Blake3, proto.Library]] =

--- a/cli/src/test/scala/dev/bosatsu/IOPlatformIOTest.scala
+++ b/cli/src/test/scala/dev/bosatsu/IOPlatformIOTest.scala
@@ -5,10 +5,31 @@ import cats.implicits._
 import cats.effect.{IO, Resource}
 import java.io.File
 import java.nio.file.{Files, Path, Paths}
+import dev.bosatsu.hashing.Algo
+import dev.bosatsu.IorMethods.IorExtension
 import org.scalacheck.Gen
 import org.scalacheck.Prop.forAll
 
 class IOPlatformIOTest extends munit.ScalaCheckSuite {
+  private def stripTypedProvenance[A](pack: Package.Typed[A]): Package.Typed[Unit] = {
+    val noExprTags = Package.typedFunctor.map(pack)(_ => ())
+    Package.setProgramFrom(noExprTags, ())
+  }
+
+  private def typeCheckOne(src: String, packName: PackageName): Package.Typed[Declaration] =
+    Par.noParallelism {
+      val parsed = Parser.unsafeParse(Package.parser(None), src)
+      val nel = cats.data.NonEmptyList.one((("test", LocationMap(src)), parsed))
+      val pm = PackageMap
+        .typeCheckParsed(nel, Nil, "<predef>", CompileOptions.Default)
+        .strictToValidated
+        .fold(
+          errs => fail(errs.toList.mkString("typecheck failed: ", "\n", "")),
+          identity
+        )
+      pm.toMap(packName)
+    }
+
   val sortedEq: Eq[List[Package.Interface]] =
     new Eq[List[Package.Interface]] {
       given Eq[Package.Interface] =
@@ -56,10 +77,42 @@ class IOPlatformIOTest extends munit.ScalaCheckSuite {
         for {
           _ <- IOPlatformIO.writePackages(packList, path)
           packList1 <- IOPlatformIO.readPackages(path :: Nil)
-          psort = packList1.sortBy(_.name)
-          _ = assertEquals(psort, packList)
+          psort = packList1.sortBy(_.name).map(stripTypedProvenance(_))
+          expected = packList.map(stripTypedProvenance(_))
+          _ = assertEquals(psort, expected)
         } yield ()
       }
+    }
+  }
+
+  test("package file roundtrip preserves source hash and expression regions") {
+    val packName = PackageName.parts("IO", "Regions")
+    val src =
+      """package IO/Regions
+        |
+        |export one
+        |
+        |one = 1
+        |""".stripMargin
+    val typed = typeCheckOne(src, packName)
+    val hashIdent =
+      Algo.hashBytes[Algo.Blake3]("io-platform-source".getBytes("UTF-8"))
+        .toIdent(using Algo.blake3Algo)
+    val withHash = Package.withSourceHashIdent(typed, Some(hashIdent))
+
+    testWithTempFile { path =>
+      for {
+        _ <- IOPlatformIO.writePackages(withHash :: Nil, path)
+        decoded <- IOPlatformIO.readPackages(path :: Nil)
+        pack = decoded.find(_.name == packName).getOrElse(
+          fail(s"missing decoded package: ${packName.asString}")
+        )
+        _ = assertEquals(Package.sourceHashIdent(pack), Some(hashIdent))
+        _ = assert(
+          pack.lets.exists { case (_, _, te) => te.tag.isInstanceOf[Region] },
+          "expected at least one decoded let expression to carry Region metadata"
+        )
+      } yield ()
     }
   }
 

--- a/cli/src/test/scala/dev/bosatsu/codegen/clang/ClangGenTest.scala
+++ b/cli/src/test/scala/dev/bosatsu/codegen/clang/ClangGenTest.scala
@@ -42,7 +42,7 @@ class ClangGenTest extends munit.FunSuite {
       To inspect the code, change the hash, and it will print the code out
      */
     testFilesCompilesToHash("test_workspace/Ackermann.bosatsu")(
-      "32eeba83ae74c2c8fa75703823fe7298"
+      "a8e0db44e1ba172e86af65fc7bf8df3c"
     )
   }
 }

--- a/cliJS/src/main/scala/dev/bosatsu/Fs2PlatformIO.scala
+++ b/cliJS/src/main/scala/dev/bosatsu/Fs2PlatformIO.scala
@@ -207,7 +207,7 @@ object Fs2PlatformIO extends PlatformIO[IO, Path] {
         }
       }
 
-  def readPackages(paths: List[Path]): IO[List[Package.Typed[Unit]]] =
+  def readPackages(paths: List[Path]): IO[List[Package.Typed[Any]]] =
     paths
       .parTraverse { path =>
         for {

--- a/core/src/main/scala/dev/bosatsu/MatchlessFromTypedExpr.scala
+++ b/core/src/main/scala/dev/bosatsu/MatchlessFromTypedExpr.scala
@@ -47,6 +47,10 @@ object MatchlessFromTypedExpr {
         val lets = pack.lets
 
         Par.start {
+          val packageHashIdent =
+            Package
+              .sourceHashIdent(pack)
+              .getOrElse(Package.emptySourceHashIdent)
           val exprs: List[(Bindable, Matchless.Expr[K])] =
             rankn.RefSpace.allocCounter
               .flatMap { c =>
@@ -54,7 +58,15 @@ object MatchlessFromTypedExpr {
                   .traverse { case (name, rec, te) =>
                     // TODO: add from so we can resolve packages correctly
                     Matchless
-                      .fromLet(from, name, rec, te, variantOf, c)
+                      .fromLet(
+                        from,
+                        packageHashIdent,
+                        name,
+                        rec,
+                        te,
+                        variantOf,
+                        c
+                      )
                       .map((name, _))
                   }
               }

--- a/core/src/main/scala/dev/bosatsu/MemoryMain.scala
+++ b/core/src/main/scala/dev/bosatsu/MemoryMain.scala
@@ -18,7 +18,7 @@ class MemoryMain[G[_]](
 
   def runWith(
       files: Iterable[(Chain[String], String)],
-      packages: Iterable[(Chain[String], List[Package.Typed[Unit]])] = Nil,
+      packages: Iterable[(Chain[String], List[Package.Typed[Any]])] = Nil,
       interfaces: Iterable[(Chain[String], List[Package.Interface])] = Nil
   )(
       cmd: List[String]
@@ -42,7 +42,7 @@ object MemoryMain {
   sealed abstract class FileContent
   object FileContent {
     case class Str(str: String) extends FileContent
-    case class Packages(ps: List[Package.Typed[Unit]]) extends FileContent
+    case class Packages(ps: List[Package.Typed[Any]]) extends FileContent
     case class Interfaces(ifs: List[Package.Interface]) extends FileContent
     case class Lib(lib: Hashed[Algo.Blake3, proto.Library]) extends FileContent
   }
@@ -137,7 +137,7 @@ object MemoryMain {
 
     def from[G[_]](
         files: Iterable[(Chain[String], String)],
-        packages: Iterable[(Chain[String], List[Package.Typed[Unit]])] = Nil,
+        packages: Iterable[(Chain[String], List[Package.Typed[Any]])] = Nil,
         interfaces: Iterable[(Chain[String], List[Package.Interface])] = Nil
     )(implicit G: MonadError[G, Throwable]): G[State] =
       for {
@@ -319,7 +319,7 @@ object MemoryMain {
         else None
       }
 
-      def readPackages(paths: List[Path]): F[List[Package.Typed[Unit]]] =
+      def readPackages(paths: List[Path]): F[List[Package.Typed[Any]]] =
         StateT
           .get[G, MemoryMain.State]
           .flatMap { files =>
@@ -329,7 +329,7 @@ object MemoryMain {
                   case Some(Right(MemoryMain.FileContent.Packages(res))) =>
                     moduleIOMonad.pure(res)
                   case other =>
-                    moduleIOMonad.raiseError[List[Package.Typed[Unit]]](
+                    moduleIOMonad.raiseError[List[Package.Typed[Any]]](
                       new Exception(s"expect Packages content, found: $other")
                     )
                 }

--- a/core/src/main/scala/dev/bosatsu/PlatformIO.scala
+++ b/core/src/main/scala/dev/bosatsu/PlatformIO.scala
@@ -58,7 +58,7 @@ trait PlatformIO[F[_], Path] {
       case None    => moduleIOMonad.raiseError(new Exception(msg))
     }
 
-  def readPackages(paths: List[Path]): F[List[Package.Typed[Unit]]]
+  def readPackages(paths: List[Path]): F[List[Package.Typed[Any]]]
   def readInterfaces(paths: List[Path]): F[List[Package.Interface]]
   def readLibrary(path: Path): F[Hashed[Algo.Blake3, proto.Library]]
 

--- a/core/src/test/scala/dev/bosatsu/Issue1633Test.scala
+++ b/core/src/test/scala/dev/bosatsu/Issue1633Test.scala
@@ -202,7 +202,11 @@ main = parse_value(" null")
               _,
               Matchless.Lambda(captures, _, _, _)
             ) =>
-          assertEquals(captures, Matchless.Local(capturedBName) :: Nil)
+          captures match {
+            case Matchless.Local(`capturedBName`) :: Nil => ()
+            case other =>
+              fail(s"unexpected lambda captures: $other")
+          }
         case other =>
           fail(s"unexpected parse_value lowering shape: $other")
       }

--- a/core/src/test/scala/dev/bosatsu/MatchlessInterfaceTest.scala
+++ b/core/src/test/scala/dev/bosatsu/MatchlessInterfaceTest.scala
@@ -23,6 +23,62 @@ class MatchlessInterfaceTest extends munit.FunSuite {
     }
   }
 
+  private def exprSourceInfos(
+      expr: Matchless.Expr[Unit]
+  ): List[Matchless.SourceInfo] = {
+    val nested =
+      expr match {
+        case Matchless.Lambda(captures, _, _, body) =>
+          captures.flatMap(exprSourceInfos) ::: exprSourceInfos(body)
+        case Matchless.WhileExpr(cond, effectExpr, _) =>
+          boolSourceInfos(cond) ::: exprSourceInfos(effectExpr)
+        case Matchless.App(fn, args) =>
+          exprSourceInfos(fn) ::: args.toList.flatMap(exprSourceInfos)
+        case Matchless.Let(_, value, in) =>
+          exprSourceInfos(value) ::: exprSourceInfos(in)
+        case Matchless.LetMut(_, in) =>
+          exprSourceInfos(in)
+        case Matchless.If(cond, thenExpr, elseExpr) =>
+          boolSourceInfos(cond) ::: exprSourceInfos(
+            thenExpr
+          ) ::: exprSourceInfos(elseExpr)
+        case Matchless.Always(cond, thenExpr) =>
+          boolSourceInfos(cond) ::: exprSourceInfos(thenExpr)
+        case Matchless.PrevNat(of) =>
+          exprSourceInfos(of)
+        case _ =>
+          Nil
+      }
+
+    expr.sourceInfo :: nested
+  }
+
+  private def boolSourceInfos(
+      boolExpr: Matchless.BoolExpr[Unit]
+  ): List[Matchless.SourceInfo] = {
+    val nested =
+      boolExpr match {
+        case Matchless.EqualsLit(expr, _) =>
+          exprSourceInfos(expr)
+        case Matchless.EqualsNat(expr, _) =>
+          exprSourceInfos(expr)
+        case Matchless.And(left, right) =>
+          boolSourceInfos(left) ::: boolSourceInfos(right)
+        case Matchless.CheckVariant(expr, _, _, _) =>
+          exprSourceInfos(expr)
+        case Matchless.SetMut(_, expr) =>
+          exprSourceInfos(expr)
+        case Matchless.LetBool(_, value, in) =>
+          exprSourceInfos(value) ::: boolSourceInfos(in)
+        case Matchless.LetMutBool(_, in) =>
+          boolSourceInfos(in)
+        case Matchless.TrueConst =>
+          Nil
+      }
+
+    boolExpr.sourceInfo :: nested
+  }
+
   test("Matchless can compile constructors from imported interfaces") {
     val natSrc =
       """package Bosatsu/Num/Nat
@@ -54,6 +110,14 @@ class MatchlessInterfaceTest extends munit.FunSuite {
       given Order[Unit] = Order.fromOrdering
       val compiled = MatchlessFromTypedExpr.compile((), fibPm)
       assert(compiled.contains(PackageName.parts("My", "Fib")))
+      val infos = compiled(PackageName.parts("My", "Fib")).flatMap {
+        case (_, expr) => exprSourceInfos(expr)
+      }
+      assert(infos.nonEmpty)
+      assert(
+        infos.forall(_.packageHashIdent == Package.emptySourceHashIdent),
+        infos.toString
+      )
     }
   }
 }

--- a/proto/src/main/protobuf/bosatsu/TypedAst.proto
+++ b/proto/src/main/protobuf/bosatsu/TypedAst.proto
@@ -320,6 +320,11 @@ message MatchExpr {
   repeated Branch branches = 2;
 }
 
+message Region {
+  int64 start = 1;
+  int64 end = 2;
+}
+
 message TypedExpr {
   oneof value {
     GenericExpr genericExpr = 1;
@@ -333,6 +338,7 @@ message TypedExpr {
     LoopExpr loopExpr = 9;
     RecurExpr recurExpr = 10;
   }
+  Region region = 11;
 }
 
 message Let {
@@ -344,6 +350,10 @@ message Let {
 message ExternalDef {
   int32 name = 1;
   int32 typeOf = 2;
+}
+
+message PackageSourceHash {
+  string ident = 1;
 }
 
 message Package {
@@ -358,6 +368,7 @@ message Package {
   repeated ExportedName exports = 8;
   repeated Let lets = 9;
   repeated ExternalDef externalDefs = 10;
+  PackageSourceHash sourceHash = 11;
 }
 
 message Packages {


### PR DESCRIPTION
Implemented the accepted #1778 design to preserve source provenance for implementations while keeping interfaces metadata-free and deterministic.

What changed:
- `TypedAst.proto`:
  - Added `Region` message.
  - Added `PackageSourceHash` wrapper message.
  - Added optional `region` on `TypedExpr`.
  - Added optional `sourceHash` on `Package`.
- Package provenance plumbing:
  - Added package source metadata support in `Package` (`sourceHashIdent`, helpers, empty-hash sentinel).
  - `CompilerApi` now computes and attaches source hash idents from UTF-8 source bytes for compiled implementations.
- Proto conversion and compatibility:
  - `ProtoConverter` now encodes/decodes typed-expression regions and package source hash.
  - Legacy artifacts without new fields still decode.
  - Invalid present hash idents fail decode clearly.
  - Decoded typed package handling now preserves provenance (`Package.Typed[Any]`) through proto and IO flows.
- Matchless provenance model:
  - Added required `Matchless.SourceInfo(packageHashIdent, region)` on Matchless expressions/booleans.
  - Added sentinel fallback (`SourceInfo.empty`) for missing legacy provenance.
  - Lowering (`Matchless.fromLet` / `MatchlessFromTypedExpr`) now threads package hash + region provenance.
  - Rewrite/optimization paths preserve/inherit source info.
- Platform IO propagation:
  - Updated `PlatformIO`, JVM/JS impls, and `MemoryMain` signatures/flows to preserve decoded provenance metadata.
- Tests:
  - Expanded `ProtoConverterTest` for region/hash roundtrips, legacy decode behavior, invalid hash rejection, and interface-byte determinism/permutation invariance.
  - Added Matchless provenance tests (`MatchlessTests`, `MatchlessInterfaceTest`).
  - Added interface-only library metadata exclusion test (`LibConfigTest`).
  - Added package file provenance roundtrip assertions (`IOPlatformIOTest`).
  - Updated dependent tests for new Matchless/source metadata behavior (`Issue1633Test`, normalization helpers, etc.).
  - Updated `ClangGenTest` Ackermann golden hash to the new deterministic generated output.

Validation run:
- `sbt "coreJVM/test; cli/test"`
  - `coreJVM/test` passed.
  - Initial `cli/test` failed only at `dev.bosatsu.codegen.clang.ClangGenTest` golden hash mismatch; fixed expected hash.
- Re-ran `sbt "cli/test"` -> passed.
- Re-ran `sbt "coreJVM/test:compile; coreJVM/testOnly dev.bosatsu.MatchlessTest"` after final test-file cleanup -> passed.

Fixes #1778

Implements design doc: [docs/design/1778-design-changes-to-the-code-to-enable-coverage-checking.md](https://github.com/johnynek/bosatsu/blob/main/docs/design/1778-design-changes-to-the-code-to-enable-coverage-checking.md)

Design source PR: https://github.com/johnynek/bosatsu/pull/1779