### PR TITLE
Add `--run` support to `tool eval` and `lib eval`

### DIFF
--- a/cli/src/main/scala/dev/bosatsu/Main.scala
+++ b/cli/src/main/scala/dev/bosatsu/Main.scala
@@ -4,10 +4,7 @@ import cats.effect.{ExitCode, IO, IOApp}
 
 object Main extends IOApp {
   def fromToolExit(ec: tool.ExitCode): ExitCode =
-    ec match {
-      case tool.ExitCode.Success => ExitCode.Success
-      case tool.ExitCode.Error   => ExitCode.Error
-    }
+    ExitCode(ec.toInt)
   def run(args: List[String]): IO[ExitCode] =
     PathModule.runAndReport(args) match {
       case Right(io)  => io.map(fromToolExit)

--- a/cliJS/src/main/scala/dev/bosatsu/tool/Fs2Main.scala
+++ b/cliJS/src/main/scala/dev/bosatsu/tool/Fs2Main.scala
@@ -4,10 +4,7 @@ import cats.effect.{ExitCode => ceExitCode, IO, IOApp}
 
 object Fs2Main extends IOApp {
   def fromToolExit(ec: ExitCode): ceExitCode =
-    ec match {
-      case ExitCode.Success => ceExitCode.Success
-      case ExitCode.Error   => ceExitCode.Error
-    }
+    ceExitCode(ec.toInt)
   def run(args: List[String]): IO[ceExitCode] =
     Fs2Module.runAndReport(args) match {
       case Right(io)  => io.map(fromToolExit)

--- a/core/src/main/scala/dev/bosatsu/tool/ExitCode.scala
+++ b/core/src/main/scala/dev/bosatsu/tool/ExitCode.scala
@@ -4,4 +4,12 @@ sealed abstract class ExitCode(val toInt: Int) derives CanEqual
 object ExitCode {
   case object Success extends ExitCode(0)
   case object Error extends ExitCode(1)
+  final case class Other(override val toInt: Int) extends ExitCode(toInt)
+
+  def fromInt(code: Int): ExitCode =
+    code match {
+      case 0 => Success
+      case 1 => Error
+      case n => Other(n)
+    }
 }


### PR DESCRIPTION
Implemented issue #1831 with focused CLI/runtime changes:
- Added `--run` to both `tool eval` and `lib eval`.
- Added trailing argument capture for eval commands and forwarding into `PredefImpl.runProgMain`.
- Enforced that `--run` only works when the selected value has type `Bosatsu/Prog::Main`; otherwise returns a clear `CliException`.
- Added a new `Output.RunMainResult` reporting path to execute the main program, emit captured stdout/stderr, and return the program exit code.
- Extended tool exit code modeling to preserve non-0/1 codes (`ExitCode.Other` + `ExitCode.fromInt`) and updated JVM/JS entrypoint mapping.
- Added tests:
  - `ToolAndLibCommandTest`: `tool eval --run` and `lib eval --run` execute `Bosatsu/Prog::Main` with forwarded args and return expected exit codes; non-main rejection test.
  - `PathModuleTest`: runs `tool eval --run` on `Bosatsu/FibBench::main` (with `fibbench 20`) in CI-covered CLI tests.
- Required pre-push test command passed: `scripts/test_basic.sh`.

Fixes #1831