### PR TITLE
Add --json output mode for lib/tool show

### DIFF
--- a/docs/src/main/paradox/debugging_with_show.md
+++ b/docs/src/main/paradox/debugging_with_show.md
@@ -2,6 +2,7 @@
 
 `lib show` prints fully typechecked package data as EDN. It is useful when you
 want to inspect what Bosatsu inferred and what the compiler is lowering.
+Use `--json` when you want machine-readable output for tooling.
 
 ## Quick examples
 
@@ -15,6 +16,16 @@ All commands below assume running from this repository root.
 
 This prints one `(package ...)` form with sections like `:imports`, `:types`,
 `:externals`, and `:defs`.
+
+### Emit JSON instead of EDN
+
+```bash
+./bosatsuj lib show --name core_alpha --package Bosatsu/Char --json
+```
+
+`--json` emits a deterministic JSON projection of the same `show` data. The
+top-level value is an object with `"$form": "show"` and fields such as
+`interfaces` and `packages`.
 
 ### Show a single type
 


### PR DESCRIPTION
## Summary
- add a deterministic EDN -> JSON projection for `ShowEdn` output via `ShowEdn.showJson`
- add `--json` support to both `tool show` and `lib show` while keeping EDN default behavior
- document `lib show --json` in debugging docs
- add coverage for `tool show --json`, `lib show --json`, and JSON parseability of `showJson`

## Encoding shape
- keyword-arg list forms are emitted as JSON objects with a `"$form"` tag plus keyword fields
- non-form lists/vectors are emitted as arrays
- EDN symbols/keywords are emitted as strings (keywords prefixed with `:`)
- EDN maps with keyword keys become JSON objects; other map keys fall back to `{"$map": [[k,v], ...]}`

## Validation
- `sbt "coreJVM/testOnly dev.bosatsu.ToolAndLibCommandTest -- -z \"--json\"" "coreJVM/testOnly dev.bosatsu.tool.ShowEdnRoundTripTest"`
