### PR TITLE
Add --externals mode to show commands

### DIFF
--- a/core/src/main/scala/dev/bosatsu/library/Command.scala
+++ b/core/src/main/scala/dev/bosatsu/library/Command.scala
@@ -1491,6 +1491,12 @@ object Command {
             .orEmpty,
           Opts
             .flag(
+              "externals",
+              help = "show only package names and external value declarations"
+            )
+            .orFalse,
+          Opts
+            .flag(
               "no-opt",
               help = "disable normalization/optimization to inspect typed expressions before optimization"
             )
@@ -1503,10 +1509,22 @@ object Command {
             .orFalse,
           Opts.option[P]("output", help = "output path").orNone,
           Colorize.optsConsoleDefault
-        ).mapN { (fcc, packages, types, values, noOpt, jsonOut, output, colorize) =>
+        ).mapN {
+          (
+              fcc,
+              packages,
+              types,
+              values,
+              externalsOnly,
+              noOpt,
+              jsonOut,
+              output,
+              colorize
+          ) =>
           val compileOptions =
             if (noOpt) CompileOptions.NoOptimize else CompileOptions.Default
-          val request = ShowSelection.Request(packages, types, values)
+          val request =
+            ShowSelection.Request(packages, types, values, externalsOnly)
           for {
             cc <- fcc
             out <- platformIO.withEC {

--- a/core/src/main/scala/dev/bosatsu/tool_command/ShowCommand.scala
+++ b/core/src/main/scala/dev/bosatsu/tool_command/ShowCommand.scala
@@ -133,6 +133,12 @@ object ShowCommand {
         .orEmpty,
       Opts
         .flag(
+          "externals",
+          help = "show only package names and external value declarations"
+        )
+        .orFalse,
+      Opts
+        .flag(
           "json",
           help = "emit JSON instead of EDN for easier machine parsing"
         )
@@ -150,11 +156,13 @@ object ShowCommand {
           packages,
           types,
           values,
+          externalsOnly,
           jsonOut,
           output,
           errColor
       ) =>
-        val request = ShowSelection.Request(packages, types, values)
+        val request =
+          ShowSelection.Request(packages, types, values, externalsOnly)
         platformIO.withEC {
           for {
             (interfaces, packs0) <- loadAndCompile(


### PR DESCRIPTION
## Summary
- add a new `--externals` flag to both `lib show` and `tool show`
- when enabled, show output is restricted to external declarations only
- preserve selector validation (`--package`, `--type`, `--value`) and then apply externals-only projection

## Behavior
- `--externals` strips non-external content from selected packages
- each selected package only shows package name plus `externals` entries
- each external entry includes value name and external type
- packages without external values are omitted in externals-only mode
- interfaces are suppressed for externals-only output

## Tests
- added `lib show --externals only includes external values with types`
- added `tool show --externals only includes packages with external values`
- ran:
  - `sbt "coreJVM/testOnly dev.bosatsu.ToolAndLibCommandTest -- --tests *externals*"`
  - `sbt "coreJVM/testOnly dev.bosatsu.ToolAndLibCommandTest -- --tests *show*"`

## Manual verification on predef
- ran:
  - `sbt "cli/run lib show --name core_alpha --package Bosatsu/Predef --externals --color none"`
- confirmed output contains only `Bosatsu/Predef` plus `:externals` name/type entries
