### PR TITLE
Refactor BosatsuInt handling in Value for JVM and Scala.js

### DIFF
--- a/core/.js/src/main/scala/dev/bosatsu/BosatsuInt.scala
+++ b/core/.js/src/main/scala/dev/bosatsu/BosatsuInt.scala
@@ -1,0 +1,169 @@
+package dev.bosatsu
+
+import java.math.BigInteger
+
+object BosatsuInt {
+  opaque type Tpe = java.lang.Integer | BigInteger
+
+  private val MaxIntLong = Int.MaxValue.toLong
+  private val MinIntLong = Int.MinValue.toLong
+  private val MaxIntBI = BigInteger.valueOf(MaxIntLong)
+  private val MinIntBI = BigInteger.valueOf(MinIntLong)
+
+  private inline def intToBigInteger(i: java.lang.Integer): BigInteger =
+    BigInteger.valueOf(i.longValue())
+
+  inline def fromInt(i: Int): Tpe =
+    java.lang.Integer.valueOf(i)
+
+  inline def fromLong(l: Long): Tpe =
+    if (l >= MinIntLong && l <= MaxIntLong)
+      java.lang.Integer.valueOf(l.toInt)
+    else BigInteger.valueOf(l)
+
+  inline def fromBigInteger(bi: BigInteger): Tpe =
+    if (bi.compareTo(MinIntBI) >= 0 && bi.compareTo(MaxIntBI) <= 0)
+      java.lang.Integer.valueOf(bi.intValue())
+    else bi
+
+  def isInstance(a: Any): Boolean =
+    a match {
+      case _: java.lang.Integer => true
+      case _: BigInteger        => true
+      case _                    => false
+    }
+
+  def cast(a: Any): Tpe =
+    a match {
+      case i: java.lang.Integer => i
+      case bi: BigInteger       => bi
+      case other                =>
+        throw new ClassCastException(s"not a BosatsuInt: $other")
+    }
+
+  final class MatchResult(private val arg: Any) extends AnyVal {
+    def isEmpty: Boolean = !isInstance(arg)
+    def get: Tpe = cast(arg)
+  }
+
+  def unapply(a: Any): MatchResult =
+    new MatchResult(a)
+
+  extension (t: Tpe) {
+    inline def show: String =
+      t.toString
+
+    inline def toBigInteger: BigInteger =
+      t match {
+        case i: java.lang.Integer => intToBigInteger(i)
+        case bi: BigInteger       => bi
+      }
+
+    inline def compare(that: Tpe): Int =
+      (t, that) match {
+        case (a: java.lang.Integer, b: java.lang.Integer) =>
+          java.lang.Integer.compare(a.intValue(), b.intValue())
+        case (a: java.lang.Integer, b: BigInteger) =>
+          intToBigInteger(a).compareTo(b)
+        case (a: BigInteger, b: java.lang.Integer) =>
+          a.compareTo(intToBigInteger(b))
+        case (a: BigInteger, b: BigInteger) =>
+          a.compareTo(b)
+      }
+
+    inline def isZero: Boolean =
+      t match {
+        case i: java.lang.Integer => i.intValue() == 0
+        case bi: BigInteger       => bi.signum == 0
+      }
+
+    inline def toDouble: Double =
+      t match {
+        case i: java.lang.Integer => i.doubleValue()
+        case bi: BigInteger       => bi.doubleValue()
+      }
+
+    inline def +(that: Tpe): Tpe =
+      (t, that) match {
+        case (a: java.lang.Integer, b: java.lang.Integer) =>
+          val sum = a.longValue() + b.longValue()
+          if (sum >= MinIntLong && sum <= MaxIntLong)
+            java.lang.Integer.valueOf(sum.toInt)
+          else intToBigInteger(a).add(intToBigInteger(b))
+        case _ =>
+          fromBigInteger(t.toBigInteger.add(that.toBigInteger))
+      }
+
+    inline def -(that: Tpe): Tpe =
+      (t, that) match {
+        case (a: java.lang.Integer, b: java.lang.Integer) =>
+          val diff = a.longValue() - b.longValue()
+          if (diff >= MinIntLong && diff <= MaxIntLong)
+            java.lang.Integer.valueOf(diff.toInt)
+          else intToBigInteger(a).subtract(intToBigInteger(b))
+        case _ =>
+          fromBigInteger(t.toBigInteger.subtract(that.toBigInteger))
+      }
+
+    inline def *(that: Tpe): Tpe =
+      (t, that) match {
+        case (a: java.lang.Integer, b: java.lang.Integer) =>
+          val prod = a.longValue() * b.longValue()
+          if (prod >= MinIntLong && prod <= MaxIntLong)
+            java.lang.Integer.valueOf(prod.toInt)
+          else intToBigInteger(a).multiply(intToBigInteger(b))
+        case _ =>
+          fromBigInteger(t.toBigInteger.multiply(that.toBigInteger))
+      }
+
+    inline def &(that: Tpe): Tpe =
+      (t, that) match {
+        case (a: java.lang.Integer, b: java.lang.Integer) =>
+          java.lang.Integer.valueOf(a.intValue() & b.intValue())
+        case _ =>
+          fromBigInteger(t.toBigInteger.and(that.toBigInteger))
+      }
+
+    inline def |(that: Tpe): Tpe =
+      (t, that) match {
+        case (a: java.lang.Integer, b: java.lang.Integer) =>
+          java.lang.Integer.valueOf(a.intValue() | b.intValue())
+        case _ =>
+          fromBigInteger(t.toBigInteger.or(that.toBigInteger))
+      }
+
+    inline def ^(that: Tpe): Tpe =
+      (t, that) match {
+        case (a: java.lang.Integer, b: java.lang.Integer) =>
+          java.lang.Integer.valueOf(a.intValue() ^ b.intValue())
+        case _ =>
+          fromBigInteger(t.toBigInteger.xor(that.toBigInteger))
+      }
+
+    inline def unary_~ : Tpe =
+      t match {
+        case i: java.lang.Integer => java.lang.Integer.valueOf(~i.intValue())
+        case bi: BigInteger       => fromBigInteger(bi.not())
+      }
+
+    inline def increment: Tpe =
+      t match {
+        case i: java.lang.Integer =>
+          val iv = i.intValue()
+          if (iv < Int.MaxValue) java.lang.Integer.valueOf(iv + 1)
+          else MaxIntBI.add(BigInteger.ONE)
+        case bi: BigInteger =>
+          fromBigInteger(bi.add(BigInteger.ONE))
+      }
+
+    inline def decrement: Tpe =
+      t match {
+        case i: java.lang.Integer =>
+          val iv = i.intValue()
+          if (iv > Int.MinValue) java.lang.Integer.valueOf(iv - 1)
+          else MinIntBI.subtract(BigInteger.ONE)
+        case bi: BigInteger =>
+          fromBigInteger(bi.subtract(BigInteger.ONE))
+      }
+  }
+}

--- a/core/.jvm/src/main/scala/dev/bosatsu/BosatsuInt.scala
+++ b/core/.jvm/src/main/scala/dev/bosatsu/BosatsuInt.scala
@@ -1,0 +1,172 @@
+package dev.bosatsu
+
+import java.math.BigInteger
+
+object BosatsuInt {
+  opaque type Tpe = java.lang.Long | BigInteger
+
+  private val MaxLongBI = BigInteger.valueOf(Long.MaxValue)
+  private val MinLongBI = BigInteger.valueOf(Long.MinValue)
+
+  private inline def longToBigInteger(l: java.lang.Long): BigInteger =
+    BigInteger.valueOf(l.longValue())
+
+  inline def fromInt(i: Int): Tpe =
+    java.lang.Long.valueOf(i.toLong)
+
+  inline def fromLong(l: Long): Tpe =
+    java.lang.Long.valueOf(l)
+
+  inline def fromBigInteger(bi: BigInteger): Tpe =
+    if (bi.compareTo(MinLongBI) >= 0 && bi.compareTo(MaxLongBI) <= 0)
+      java.lang.Long.valueOf(bi.longValue())
+    else bi
+
+  def isInstance(a: Any): Boolean =
+    a match {
+      case _: java.lang.Long => true
+      case _: BigInteger     => true
+      case _                 => false
+    }
+
+  def cast(a: Any): Tpe =
+    a match {
+      case l: java.lang.Long => l
+      case bi: BigInteger    => bi
+      case other             =>
+        throw new ClassCastException(s"not a BosatsuInt: $other")
+    }
+
+  final class MatchResult(private val arg: Any) extends AnyVal {
+    def isEmpty: Boolean = !isInstance(arg)
+    def get: Tpe = cast(arg)
+  }
+
+  def unapply(a: Any): MatchResult =
+    new MatchResult(a)
+
+  extension (t: Tpe) {
+    inline def show: String =
+      t.toString
+
+    inline def toBigInteger: BigInteger =
+      t match {
+        case l: java.lang.Long => longToBigInteger(l)
+        case bi: BigInteger    => bi
+      }
+
+    inline def compare(that: Tpe): Int =
+      (t, that) match {
+        case (a: java.lang.Long, b: java.lang.Long) =>
+          java.lang.Long.compare(a.longValue(), b.longValue())
+        case (a: java.lang.Long, b: BigInteger) =>
+          longToBigInteger(a).compareTo(b)
+        case (a: BigInteger, b: java.lang.Long) =>
+          a.compareTo(longToBigInteger(b))
+        case (a: BigInteger, b: BigInteger) =>
+          a.compareTo(b)
+      }
+
+    inline def isZero: Boolean =
+      t match {
+        case l: java.lang.Long => l.longValue() == 0L
+        case bi: BigInteger    => bi.signum == 0
+      }
+
+    inline def toDouble: Double =
+      t match {
+        case l: java.lang.Long => l.doubleValue()
+        case bi: BigInteger    => bi.doubleValue()
+      }
+
+    inline def +(that: Tpe): Tpe =
+      (t, that) match {
+        case (a: java.lang.Long, b: java.lang.Long) =>
+          val av = a.longValue()
+          val bv = b.longValue()
+          val sum = av + bv
+          if (((av ^ sum) & (bv ^ sum)) < 0L)
+            longToBigInteger(a).add(longToBigInteger(b))
+          else java.lang.Long.valueOf(sum)
+        case _ =>
+          fromBigInteger(t.toBigInteger.add(that.toBigInteger))
+      }
+
+    inline def -(that: Tpe): Tpe =
+      (t, that) match {
+        case (a: java.lang.Long, b: java.lang.Long) =>
+          val av = a.longValue()
+          val bv = b.longValue()
+          val diff = av - bv
+          if (((av ^ bv) & (av ^ diff)) < 0L)
+            longToBigInteger(a).subtract(longToBigInteger(b))
+          else java.lang.Long.valueOf(diff)
+        case _ =>
+          fromBigInteger(t.toBigInteger.subtract(that.toBigInteger))
+      }
+
+    inline def *(that: Tpe): Tpe =
+      (t, that) match {
+        case (a: java.lang.Long, b: java.lang.Long) =>
+          val av = a.longValue()
+          val bv = b.longValue()
+          try java.lang.Long.valueOf(java.lang.Math.multiplyExact(av, bv))
+          catch {
+            case _: ArithmeticException =>
+              longToBigInteger(a).multiply(longToBigInteger(b))
+          }
+        case _ =>
+          fromBigInteger(t.toBigInteger.multiply(that.toBigInteger))
+      }
+
+    inline def &(that: Tpe): Tpe =
+      (t, that) match {
+        case (a: java.lang.Long, b: java.lang.Long) =>
+          java.lang.Long.valueOf(a.longValue() & b.longValue())
+        case _ =>
+          fromBigInteger(t.toBigInteger.and(that.toBigInteger))
+      }
+
+    inline def |(that: Tpe): Tpe =
+      (t, that) match {
+        case (a: java.lang.Long, b: java.lang.Long) =>
+          java.lang.Long.valueOf(a.longValue() | b.longValue())
+        case _ =>
+          fromBigInteger(t.toBigInteger.or(that.toBigInteger))
+      }
+
+    inline def ^(that: Tpe): Tpe =
+      (t, that) match {
+        case (a: java.lang.Long, b: java.lang.Long) =>
+          java.lang.Long.valueOf(a.longValue() ^ b.longValue())
+        case _ =>
+          fromBigInteger(t.toBigInteger.xor(that.toBigInteger))
+      }
+
+    inline def unary_~ : Tpe =
+      t match {
+        case l: java.lang.Long => java.lang.Long.valueOf(~l.longValue())
+        case bi: BigInteger    => fromBigInteger(bi.not())
+      }
+
+    inline def increment: Tpe =
+      t match {
+        case l: java.lang.Long =>
+          val lv = l.longValue()
+          if (lv < Long.MaxValue) java.lang.Long.valueOf(lv + 1L)
+          else MaxLongBI.add(BigInteger.ONE)
+        case bi: BigInteger =>
+          fromBigInteger(bi.add(BigInteger.ONE))
+      }
+
+    inline def decrement: Tpe =
+      t match {
+        case l: java.lang.Long =>
+          val lv = l.longValue()
+          if (lv > Long.MinValue) java.lang.Long.valueOf(lv - 1L)
+          else MinLongBI.subtract(BigInteger.ONE)
+        case bi: BigInteger =>
+          fromBigInteger(bi.subtract(BigInteger.ONE))
+      }
+  }
+}

--- a/core/src/main/scala/dev/bosatsu/MatchlessToValue.scala
+++ b/core/src/main/scala/dev/bosatsu/MatchlessToValue.scala
@@ -5,9 +5,11 @@ import cats.data.NonEmptyList
 import cats.evidence.Is
 import java.math.BigInteger
 import scala.collection.immutable.LongMap
+import dev.bosatsu.BosatsuInt as BInt
 
 import Identifier.Bindable
 import Value._
+import BInt.*
 
 object MatchlessToValue {
   import Matchless._
@@ -246,10 +248,10 @@ object MatchlessToValue {
     class Env[F](resolve: (F, PackageName, Identifier) => Eval[Value]) {
       private def valueEquals(left: Any, right: Any): Boolean =
         (left, right) match {
-          case (li: java.lang.Integer, ri: BigInteger) =>
-            BigInteger.valueOf(li.longValue()) == ri
-          case (li: BigInteger, ri: java.lang.Integer) =>
-            li == BigInteger.valueOf(ri.longValue())
+          case (BInt(li), ri: BigInteger) =>
+            li.toBigInteger == ri
+          case (li: BigInteger, BInt(ri)) =>
+            li == ri.toBigInteger
           case _ =>
             java.util.Objects.equals(
               left.asInstanceOf[AnyRef],

--- a/core/src/main/scala/dev/bosatsu/ValueToDoc.scala
+++ b/core/src/main/scala/dev/bosatsu/ValueToDoc.scala
@@ -2,13 +2,14 @@ package dev.bosatsu
 
 import cats.Eval
 import cats.implicits._
-import java.math.BigInteger
 import dev.bosatsu.rankn.{DefinedType, Type, DataFamily}
 import org.typelevel.paiges.{Doc, Document}
 import scala.collection.mutable.{Map => MMap}
+import dev.bosatsu.BosatsuInt as BInt
 
 import Value._
 import Identifier.Constructor
+import BInt.*
 
 import JsonEncodingError.IllTyped
 
@@ -54,10 +55,8 @@ case class ValueToDoc(getDefinedType: Type.Const => Option[DefinedType[Any]]) {
         case None     =>
           val res: Eval[Fn] = Eval.later(tpe match {
             case Type.IntType => {
-              case ExternalValue(v: java.lang.Integer) =>
-                Right(Doc.str(v))
-              case ExternalValue(v: BigInteger) =>
-                Right(Doc.str(v))
+              case ExternalValue(BInt(v)) =>
+                Right(Doc.str(v.show))
               case other =>
                 // $COVERAGE-OFF$this should be unreachable
                 Left(IllTyped(revPath.reverse, tpe, other))
@@ -328,8 +327,8 @@ case class ValueToDoc(getDefinedType: Type.Const => Option[DefinedType[Any]]) {
                       // this is nat-like
                       // TODO, maybe give a warning
                       {
-                        case ExternalValue(b: (BigInteger | java.lang.Integer)) =>
-                          Right(Doc.str(b))
+                        case ExternalValue(BInt(b)) =>
+                          Right(Doc.str(b.show))
                         case other =>
                           Left(IllTyped(revPath.reverse, tpe, other))
                       }

--- a/core/src/main/scala/dev/bosatsu/ValueToJson.scala
+++ b/core/src/main/scala/dev/bosatsu/ValueToJson.scala
@@ -7,8 +7,10 @@ import cats.implicits._
 import java.math.BigInteger
 import dev.bosatsu.rankn.{DefinedType, Type, DataFamily}
 import scala.collection.mutable.{Map => MMap, LinkedHashSet}
+import dev.bosatsu.BosatsuInt as BInt
 
 import Value._
+import BInt.*
 
 import JsonEncodingError._
 
@@ -285,10 +287,8 @@ case class ValueToJson(getDefinedType: Type.Const => Option[DefinedType[Any]]) {
         case None     =>
           val res: Eval[Fn] = Eval.later(tpe match {
             case Type.IntType => {
-              case ExternalValue(v: java.lang.Integer) =>
-                Right(Json.JNumberStr(v.toString))
-              case ExternalValue(v: BigInteger) =>
-                Right(Json.JNumberStr(v.toString))
+              case ExternalValue(BInt(v)) =>
+                Right(Json.JNumberStr(v.show))
               // $COVERAGE-OFF$this should be unreachable
               case other =>
                 Left(IllTyped(revPath.reverse, tpe, other))
@@ -416,10 +416,8 @@ case class ValueToJson(getDefinedType: Type.Const => Option[DefinedType[Any]]) {
                   }
                 case s: SumValue if s.variant == 3 =>
                   s.value.values match {
-                    case Array(ExternalValue(v: java.lang.Integer)) =>
-                      Right(Json.JNumberStr(v.toString))
-                    case Array(ExternalValue(v: BigInteger)) =>
-                      Right(Json.JNumberStr(v.toString))
+                    case Array(ExternalValue(BInt(v))) =>
+                      Right(Json.JNumberStr(v.show))
                     case _ =>
                       Left(IllTyped(revPath.reverse, tpe, s))
                   }
@@ -561,8 +559,8 @@ case class ValueToJson(getDefinedType: Type.Const => Option[DefinedType[Any]]) {
 
               dt.dataFamily match {
                 case DataFamily.Nat => {
-                  case ExternalValue(b: (BigInteger | java.lang.Integer)) =>
-                    Right(Json.JNumberStr(b.toString))
+                  case ExternalValue(BInt(b)) =>
+                    Right(Json.JNumberStr(b.show))
                   case other =>
                     Left(IllTyped(revPath.reverse, tpe, other))
                 }

--- a/core/src/main/scala/dev/bosatsu/tool/Output.scala
+++ b/core/src/main/scala/dev/bosatsu/tool/Output.scala
@@ -6,6 +6,7 @@ import cats.data.{Chain, NonEmptyList}
 import cats.implicits.catsKernelOrderingForOrder
 import cats.syntax.all._
 import dev.bosatsu.{
+  BosatsuInt as BInt,
   Json,
   Package,
   PackageName,
@@ -18,6 +19,7 @@ import dev.bosatsu.{
 import java.math.BigInteger
 import org.typelevel.paiges.Doc
 import dev.bosatsu.LocationMap.Colorize
+import BInt.*
 
 sealed abstract class Output[+Path] {
   final def report[F[_], P >: Path](
@@ -293,11 +295,11 @@ object Output {
 
     def asExitCode(value: Value): Either[String, ExitCode] =
       value match {
-        case Value.ExternalValue(i: java.lang.Integer) =>
-          Right(ExitCode.fromInt(i.intValue))
-        case Value.ExternalValue(i: BigInteger)
-            if i.compareTo(minInt) >= 0 && i.compareTo(maxInt) <= 0 =>
-          Right(ExitCode.fromInt(i.intValue))
+        case Value.ExternalValue(BInt(i)) =>
+          val bi = i.toBigInteger
+          if (bi.compareTo(minInt) >= 0 && bi.compareTo(maxInt) <= 0)
+            Right(ExitCode.fromInt(bi.intValue))
+          else Left(s"expected Main to return an Int exit code, found: $value")
         case other =>
           Left(s"expected Main to return an Int exit code, found: $other")
       }


### PR DESCRIPTION
Implemented issue #1839 with focused changes by introducing platform-specific `BosatsuInt` implementations: JVM now uses `java.lang.Long | java.math.BigInteger`, and Scala.js uses `java.lang.Integer | java.math.BigInteger`. Added new platform files at `core/.jvm/src/main/scala/dev/bosatsu/BosatsuInt.scala` and `core/.js/src/main/scala/dev/bosatsu/BosatsuInt.scala` with a common API (construction, conversion, arithmetic/bitwise ops, compare, extractor). Refactored `Value` to alias `BosatsuInt` to this API and updated integer handling in `Predef`, `ValueToDoc`, `ValueToJson`, `MatchlessToValue`, and `tool/Output` to use the shared interface/extractor instead of hard-coded `java.lang.Integer` matches. Required test command `scripts/test_basic.sh` passes, and `sbt "coreJS/compile"` also passes to validate Scala.js compilation.

Fixes #1839