### PR TITLE
Validate cached dependency descriptors on CAS hits for lib fetch/check

### DIFF
--- a/core/src/main/scala/dev/bosatsu/library/Command.scala
+++ b/core/src/main/scala/dev/bosatsu/library/Command.scala
@@ -2,7 +2,15 @@ package dev.bosatsu.library
 
 import cats.{Monad, MonoidK}
 import cats.arrow.FunctionK
-import cats.data.{Chain, Ior, NonEmptyChain, NonEmptyList, Validated, ValidatedNel}
+import cats.data.{
+  Chain,
+  Ior,
+  NonEmptyChain,
+  NonEmptyList,
+  Validated,
+  ValidatedNec,
+  ValidatedNel
+}
 import com.monovore.decline.{Argument, Opts}
 import dev.bosatsu.tool.{
   CliException,
@@ -2268,47 +2276,47 @@ object Command {
     private def validateCachedDependency(
         dep: proto.LibDependency,
         cached: Hashed[Algo.Blake3, proto.Library]
-    ): Either[Throwable, Unit] = {
+    ): ValidatedNec[Doc, Unit] = {
       val cachedLib = cached.arg
       val requestedVersion = Library.getVersion(dep)
       val cachedVersion = Library.getVersion(cachedLib)
-      val nameMatches = dep.name == cachedLib.name
-      val versionMatches = requestedVersion.forall(cachedVersion.contains)
 
-      if (nameMatches && versionMatches) Right(())
-      else {
-        val requestedVersionStr = requestedVersion.fold("unspecified")(_.render)
-        val cachedVersionStr = cachedVersion.fold("unspecified")(_.render)
-
-        Left(
-          CliException(
-            "cached library descriptor mismatch",
+      val nameCheck =
+        if (dep.name == cachedLib.name) Validated.validNec(())
+        else
+          Validated.invalidNec(
             Doc.text(
-              show"cached object ${cached.hash.toIdent} does not match dependency ${dep.name}."
-            ) +
-              Doc.line +
-              Doc.text(show"dependency name: ${dep.name}") +
-              Doc.line +
-              Doc.text(show"cached library name: ${cachedLib.name}") +
-              Doc.line +
-              Doc.text(show"dependency version: $requestedVersionStr") +
-              Doc.line +
-              Doc.text(show"cached library version: $cachedVersionStr")
+              show"name mismatch: dependency=${dep.name}, cached=${cachedLib.name}"
+            )
           )
-        )
-      }
+
+      val versionCheck =
+        requestedVersion match {
+          case None => Validated.validNec(())
+          case Some(v) if cachedVersion.contains(v) =>
+            Validated.validNec(())
+          case Some(v) =>
+            val cachedVersionStr = cachedVersion.fold("unspecified")(_.render)
+            Validated.invalidNec(
+              Doc.text(
+                show"version mismatch: dependency=${v.render}, cached=$cachedVersionStr"
+              )
+            )
+        }
+
+      (nameCheck, versionCheck).mapN((_, _) => ())
     }
 
-    private def validatedLibFromCas(
-        dep: proto.LibDependency
-    ): F[Option[Hashed[Algo.Blake3, proto.Library]]] =
-      libFromCas(dep).flatMap {
-        case None      => moduleIOMonad.pure(None)
-        case Some(lib) =>
-          moduleIOMonad.fromEither(
-            validateCachedDependency(dep, lib).map(_ => Some(lib))
-          )
-      }
+    private def cachedMismatchDoc(
+        dep: proto.LibDependency,
+        cached: Hashed[Algo.Blake3, proto.Library],
+        mismatches: NonEmptyChain[Doc]
+    ): Doc =
+      Doc.text(
+        show"cached object ${cached.hash.toIdent} for dependency ${dep.name}:"
+      ) +
+        (Doc.line + Doc.intercalate(Doc.line, mismatches.toNonEmptyList.toList))
+          .nested(2)
 
     def depsFromCas(
         pubDeps: List[proto.LibDependency],
@@ -2320,47 +2328,67 @@ object Command {
       )
     ] =
       (
-        pubDeps.parTraverse(dep => validatedLibFromCas(dep).map(dep -> _)),
-        privDeps.parTraverse(dep => validatedLibFromCas(dep).map(dep -> _))
+        pubDeps.parTraverse(dep => libFromCas(dep).map(dep -> _)),
+        privDeps.parTraverse(dep => libFromCas(dep).map(dep -> _))
       ).parTupled
         .flatMap { case (pubLibs, privLibs) =>
+          val cacheValidation = (pubLibs ::: privLibs).traverse_ {
+            case (_, None) => Validated.validNec(())
+            case (dep, Some(lib)) =>
+              validateCachedDependency(dep, lib).leftMap { mismatches =>
+                NonEmptyChain.one(cachedMismatchDoc(dep, lib, mismatches))
+              }
+          }
           val missingPubs = pubLibs.collect { case (dep, None) => dep }
           val missingPrivs = privLibs.collect { case (dep, None) => dep }
 
-          if (missingPubs.isEmpty && missingPrivs.isEmpty) {
-            moduleIOMonad.pure(
-              (
-                pubLibs.collect { case (_, Some(lib)) => lib },
-                privLibs.collect { case (_, Some(lib)) => lib }
-              )
-            )
-          } else {
-            // report the missing libraries and suggest running fetch
-            val pubDoc = Doc.text("public dependencies:") + (
-              Doc.line + Doc.intercalate(
-                Doc.comma + Doc.line,
-                missingPubs.map(dep => Doc.text(dep.name))
-              )
-            ).nested(4).grouped
-
-            val privDoc = Doc.text("private dependencies:") + (
-              Doc.line + Doc.intercalate(
-                Doc.comma + Doc.line,
-                missingPrivs.map(dep => Doc.text(dep.name))
-              )
-            ).nested(4).grouped
-
-            moduleIOMonad
-              .raiseError(
+          cacheValidation match {
+            case Validated.Invalid(errs) =>
+              moduleIOMonad.raiseError(
                 CliException(
-                  "missing deps from cas",
-                  Doc.text(
-                    "missing "
-                  ) + pubDoc + Doc.line + privDoc + Doc.line + Doc.text(
-                    "run `lib fetch` to insert these libraries into the cas."
+                  "cached library descriptor mismatch",
+                  Doc.intercalate(
+                    Doc.hardLine + Doc.hardLine,
+                    errs.toNonEmptyList.toList
                   )
                 )
               )
+            case Validated.Valid(_)     =>
+              if (missingPubs.isEmpty && missingPrivs.isEmpty) {
+                moduleIOMonad.pure(
+                  (
+                    pubLibs.collect { case (_, Some(lib)) => lib },
+                    privLibs.collect { case (_, Some(lib)) => lib }
+                  )
+                )
+              } else {
+                // report the missing libraries and suggest running fetch
+                val pubDoc = Doc.text("public dependencies:") + (
+                  Doc.line + Doc.intercalate(
+                    Doc.comma + Doc.line,
+                    missingPubs.map(dep => Doc.text(dep.name))
+                  )
+                ).nested(4).grouped
+
+                val privDoc = Doc.text("private dependencies:") + (
+                  Doc.line + Doc.intercalate(
+                    Doc.comma + Doc.line,
+                    missingPrivs.map(dep => Doc.text(dep.name))
+                  )
+                ).nested(4).grouped
+
+                moduleIOMonad
+                  .raiseError(
+                    CliException(
+                      "missing deps from cas",
+                      Doc.text(
+                        "missing "
+                      ) + pubDoc + Doc.line + privDoc + Doc.line + Doc.text(
+                        "run `lib fetch` to insert these libraries into the cas."
+                      )
+                    )
+                  )
+              }
           }
         }
 
@@ -2396,7 +2424,15 @@ object Command {
               platformIO.readLibrary(path).attempt.map[DownloadRes] {
                 case Left(err) => Left(err)
                 case Right(lib) =>
-                  validateCachedDependency(dep, lib).map(_ => false)
+                  validateCachedDependency(dep, lib)
+                    .leftMap { mismatches =>
+                      CliException(
+                        "cached library descriptor mismatch",
+                        cachedMismatchDoc(dep, lib, mismatches)
+                      )
+                    }
+                    .toEither
+                    .map(_ => false)
               }
             case false =>
               {

--- a/core/src/test/scala/dev/bosatsu/ToolAndLibCommandTest.scala
+++ b/core/src/test/scala/dev/bosatsu/ToolAndLibCommandTest.scala
@@ -173,6 +173,163 @@ class ToolAndLibCommandTest extends FunSuite {
     } yield (state4, depLib)
   }
 
+  private def stateWithTwoVersionMismatchedCachedDeps(
+      appSrc: String
+  ): ErrorOr[MemoryMain.State] = {
+    val depASrc =
+      """export depA,
+|
+|depA = 1
+|""".stripMargin
+    val depBSrc =
+      """export depB,
+|
+|depB = 2
+|""".stripMargin
+    val libs = Libraries(SortedMap(Name("mylib") -> "src"))
+    val conf =
+      LibConfig.init(Name("mylib"), "https://example.com", Version(0, 0, 1))
+    val files = List(
+      Chain("dep_a", "DepA", "Foo.bosatsu") -> depASrc,
+      Chain("dep_b", "DepB", "Foo.bosatsu") -> depBSrc,
+      Chain("repo", "bosatsu_libs.json") -> renderJson(libs),
+      Chain("repo", "src", "mylib_conf.json") -> renderJson(conf),
+      Chain("repo", "src", "MyLib", "Foo.bosatsu") -> appSrc
+    )
+
+    for {
+      s0 <- MemoryMain.State.from[ErrorOr](files)
+      s1 <- runWithState(
+        List(
+          "tool",
+          "check",
+          "--package_root",
+          "dep_a",
+          "--input",
+          "dep_a/DepA/Foo.bosatsu",
+          "--output",
+          "out/DepA.Foo.bosatsu_package"
+        ),
+        s0
+      )
+      (state1, _) = s1
+      s2 <- runWithState(
+        List(
+          "tool",
+          "assemble",
+          "--name",
+          "dep_a",
+          "--version",
+          "0.0.1",
+          "--package",
+          "out/DepA.Foo.bosatsu_package",
+          "--output",
+          "out/dep_a.bosatsu_lib"
+        ),
+        state1
+      )
+      (state2, _) = s2
+      s3 <- runWithState(
+        List(
+          "tool",
+          "check",
+          "--package_root",
+          "dep_b",
+          "--input",
+          "dep_b/DepB/Foo.bosatsu",
+          "--output",
+          "out/DepB.Foo.bosatsu_package"
+        ),
+        state2
+      )
+      (state3, _) = s3
+      s4 <- runWithState(
+        List(
+          "tool",
+          "assemble",
+          "--name",
+          "dep_b",
+          "--version",
+          "0.0.2",
+          "--package",
+          "out/DepB.Foo.bosatsu_package",
+          "--output",
+          "out/dep_b.bosatsu_lib"
+        ),
+        state3
+      )
+      (state4, _) = s4
+      depALib = readLibraryFile(state4, Chain("out", "dep_a.bosatsu_lib"))
+      depBLib = readLibraryFile(state4, Chain("out", "dep_b.bosatsu_lib"))
+      s5 <- runWithState(
+        List(
+          "lib",
+          "deps",
+          "add",
+          "--repo_root",
+          "repo",
+          "--dep",
+          "dep_a",
+          "--version",
+          "5.0.0",
+          "--hash",
+          depALib.hash.toIdent,
+          "--uri",
+          "https://example.com/dep_a.bosatsu_lib",
+          "--private",
+          "--no-fetch"
+        ),
+        state4
+      )
+      (state5, _) = s5
+      s6 <- runWithState(
+        List(
+          "lib",
+          "deps",
+          "add",
+          "--repo_root",
+          "repo",
+          "--dep",
+          "dep_b",
+          "--version",
+          "6.0.0",
+          "--hash",
+          depBLib.hash.toIdent,
+          "--uri",
+          "https://example.com/dep_b.bosatsu_lib",
+          "--private",
+          "--no-fetch"
+        ),
+        state5
+      )
+      (state6, _) = s6
+      state7 <- state6.withFile(
+        casPathFor(Chain("repo"), depALib),
+        MemoryMain.FileContent.Lib(depALib)
+      ) match {
+        case Some(next) => Right(next)
+        case None       =>
+          Left(
+            new Exception(
+              "failed to inject dep_a library into repo CAS"
+            )
+          )
+      }
+      state8 <- state7.withFile(
+        casPathFor(Chain("repo"), depBLib),
+        MemoryMain.FileContent.Lib(depBLib)
+      ) match {
+        case Some(next) => Right(next)
+        case None       =>
+          Left(
+            new Exception(
+              "failed to inject dep_b library into repo CAS"
+            )
+          )
+      }
+    } yield state8
+  }
+
   private def baseLibFiles(mainSrc: String): List[(Chain[String], String)] = {
     val libs = Libraries(SortedMap(Name("mylib") -> "src"))
     val conf =
@@ -3677,8 +3834,8 @@ main = 0
         fail(s"expected lib fetch failure, got: $out")
       case Left(err: CliException) =>
         val rendered = err.errDoc.render(120)
-        assert(rendered.contains("cached library descriptor mismatch"), rendered)
         assert(rendered.contains("dep 5.0.0:"), rendered)
+        assert(rendered.contains("cached library descriptor mismatch"), rendered)
       case Left(err) =>
         fail(err.getMessage)
     }
@@ -3696,8 +3853,8 @@ main = 0
         fail(s"expected lib fetch failure, got: $out")
       case Left(err: CliException) =>
         val rendered = err.errDoc.render(120)
-        assert(rendered.contains("cached library descriptor mismatch"), rendered)
         assert(rendered.contains("not_dep 0.0.1:"), rendered)
+        assert(rendered.contains("cached library descriptor mismatch"), rendered)
       case Left(err) =>
         fail(err.getMessage)
     }
@@ -3722,10 +3879,42 @@ main = 0
       case Left(err: CliException) =>
         val rendered = err.errDoc.render(120)
         assert(
-          rendered.contains("does not match dependency dep."),
+          rendered.contains("version mismatch: dependency=5.0.0, cached=0.0.1"),
           rendered
         )
-        assert(rendered.contains("dependency version: 5.0.0"), rendered)
+        assert(!rendered.contains("name mismatch:"), rendered)
+      case Left(err) =>
+        fail(err.getMessage)
+    }
+  }
+
+  test("lib check reports both cached dependency version mismatches") {
+    val appSrc =
+      """from DepA/Foo import depA
+|
+|from DepB/Foo import depB
+|
+|main = depA.add(depB)
+|""".stripMargin
+
+    val result = for {
+      state <- stateWithTwoVersionMismatchedCachedDeps(appSrc)
+      checked <- runWithState(List("lib", "check", "--repo_root", "repo"), state)
+    } yield checked
+
+    result match {
+      case Right((_, out)) =>
+        fail(s"expected lib check failure, got: $out")
+      case Left(err: CliException) =>
+        val rendered = err.errDoc.render(120)
+        assert(
+          rendered.contains("version mismatch: dependency=5.0.0, cached=0.0.1"),
+          rendered
+        )
+        assert(
+          rendered.contains("version mismatch: dependency=6.0.0, cached=0.0.2"),
+          rendered
+        )
       case Left(err) =>
         fail(err.getMessage)
     }


### PR DESCRIPTION
Implemented issue #1847 with focused CAS-path validation. In `Command.Cas`, added `validateCachedDependency` to enforce `dep.name == cachedLibrary.name` and (when specified) dependency descriptor version equality with the cached library descriptor version. Applied this in two places: (1) `fetchIfNeeded` now reads and validates cached `.bosatsu_lib` entries on cache hits before returning `Right(false)`, and returns a fetch failure when mismatched; (2) `depsFromCas` now loads via `validatedLibFromCas`, so `lib check` also fails on mismatched cached descriptors instead of silently passing. Added targeted regressions in `ToolAndLibCommandTest` covering: cache-hit fetch success with matching descriptor, cache-hit fetch failure on version mismatch, cache-hit fetch failure on name mismatch, and `lib check` failure on cached version mismatch. Required test command `scripts/test_basic.sh` was run and passed.

Fixes #1847