### PR TITLE
Fix generated C float bit literals to avoid signed-literal warning

### DIFF
--- a/core/src/main/scala/dev/bosatsu/codegen/clang/ClangGen.scala
+++ b/core/src/main/scala/dev/bosatsu/codegen/clang/ClangGen.scala
@@ -550,9 +550,10 @@ class ClangGen[K](ns: CompilationNamespace[K]) {
 
           case Lit.Str(toStr) => StringApi.fromString(toStr)
           case f: Lit.Float64 =>
+            val rawBits = BigInt(java.lang.Long.toUnsignedString(f.toRawLongBits))
             pv(
               Code.Ident("bsts_float64_from_bits")(
-                Code.IntLiteral(BigInt(f.toRawLongBits))
+                Code.Ident("UINT64_C")(Code.IntLiteral(rawBits))
               )
             )
         }

--- a/core/src/test/scala/dev/bosatsu/codegen/clang/ClangGenTest.scala
+++ b/core/src/test/scala/dev/bosatsu/codegen/clang/ClangGenTest.scala
@@ -450,6 +450,27 @@ main = 1.5
     }
   }
 
+  test("float literals with sign bit use unsigned bit literals") {
+    TestUtils.checkPackageMap("""
+main = -0.0
+""") { pm =>
+      val renderedE = Par.withEC {
+        ClangGen(pm).renderMain(
+          TestUtils.testPackage,
+          Identifier.Name("main"),
+          Code.Ident("run_main")
+        )
+      }
+      renderedE match {
+        case Left(err) =>
+          fail(err.toString)
+        case Right(doc) =>
+          val rendered = doc.render(80)
+          assert(rendered.contains("UINT64_C(9223372036854775808)"))
+      }
+    }
+  }
+
   test("float literal pattern matching uses float equality helper") {
     TestUtils.checkPackageMap("""
 def is_one(x):


### PR DESCRIPTION
Updated Clang C codegen for `Lit.Float64` to emit `bsts_float64_from_bits(UINT64_C(...))` using an unsigned 64-bit literal derived from raw bits, instead of emitting signed decimal literals. This removes the non-actionable clang warning for values with the sign bit set (for example `-9223372036854775808` in generated temp `test.c`). Added a regression test in `ClangGenTest` (`float literals with sign bit use unsigned bit literals`) that checks for `UINT64_C(9223372036854775808)` in rendered output. Verified with `sbt "coreJVM/testOnly dev.bosatsu.codegen.clang.ClangGenTest"` and required `scripts/test_basic.sh` (both passing).

Fixes #1858