### PR TITLE
Fix jsUI command routing after tool namespace refactor and add regression tests

### DIFF
--- a/jsui/src/main/scala/dev/bosatsu/jsui/Store.scala
+++ b/jsui/src/main/scala/dev/bosatsu/jsui/Store.scala
@@ -12,12 +12,19 @@ import Action.Cmd
 object Store {
   private type ErrorOr[A] = Either[Throwable, A]
   val memoryMain = MemoryMain[ErrorOr]
+  private val toolPrefix = List("tool")
+
+  private def toolCommandArgs(
+      subcommand: String,
+      args: String*
+  ): List[String] =
+    toolPrefix ::: (subcommand :: args.toList)
 
   type HandlerFn = Output[Chain[String]] => String
   def cmdHandler(cmd: Cmd): (List[String], HandlerFn) =
     cmd match {
       case Cmd.Eval =>
-        val args = List(
+        val args = toolCommandArgs(
           "eval",
           "--input",
           "root/WebDemo",
@@ -40,7 +47,7 @@ object Store {
         }
         (args, handler)
       case Cmd.Test =>
-        val args = List(
+        val args = toolCommandArgs(
           "test",
           "--input",
           "root/WebDemo",
@@ -63,7 +70,7 @@ object Store {
         }
         (args, handler)
       case Cmd.Show =>
-        val args = List(
+        val args = toolCommandArgs(
           "show",
           "--input",
           "root/WebDemo",

--- a/jsui/src/test/scala/dev/bosatsu/jsui/StoreTest.scala
+++ b/jsui/src/test/scala/dev/bosatsu/jsui/StoreTest.scala
@@ -1,0 +1,80 @@
+package dev.bosatsu.jsui
+
+import cats.data.Chain
+import dev.bosatsu.tool.Output
+
+class StoreTest extends munit.FunSuite {
+  private val webDemoPath = Chain("root", "WebDemo")
+  private val webDemoSource =
+    """main = add(40, 2)
+      |
+      |test = Assertion(main.eq_Int(42), "main computes 42")
+      |""".stripMargin
+
+  private val webDemoFiles = Map(webDemoPath -> webDemoSource)
+
+  private def runWith(args: List[String]): Either[Throwable, Output[Chain[String]]] =
+    Store.memoryMain.runWith(files = webDemoFiles)(args)
+
+  test("legacy root test argv fails with parse/help output") {
+    val legacyArgs = List(
+      "test",
+      "--input",
+      "root/WebDemo",
+      "--package_root",
+      "root",
+      "--test_file",
+      "root/WebDemo",
+      "--color",
+      "html"
+    )
+
+    runWith(legacyArgs) match {
+      case Left(err) =>
+        val msg = Option(err.getMessage).getOrElse(err.toString)
+        assert(msg.contains("Unexpected argument: test"), msg)
+        assert(msg.contains("Subcommands:"), msg)
+        assert(msg.contains("tool"), msg)
+      case Right(output) =>
+        fail(s"expected parse/help failure, got output: $output")
+    }
+  }
+
+  private def assertCommandOutput(cmd: Action.Cmd)(
+      check: Output[Chain[String]] => Unit
+  ): Unit = {
+    val (args, _) = Store.cmdHandler(cmd)
+    assertEquals(args.headOption, Some("tool"))
+
+    runWith(args) match {
+      case Right(output) =>
+        check(output)
+      case Left(err) =>
+        fail(Option(err.getMessage).getOrElse(err.toString))
+    }
+  }
+
+  test("cmdHandler eval args return EvaluationResult") {
+    assertCommandOutput(Action.Cmd.Eval) {
+      case Output.EvaluationResult(_, _, _) => ()
+      case other =>
+        fail(s"expected Output.EvaluationResult, got: $other")
+    }
+  }
+
+  test("cmdHandler test args return TestOutput") {
+    assertCommandOutput(Action.Cmd.Test) {
+      case Output.TestOutput(_, _) => ()
+      case other =>
+        fail(s"expected Output.TestOutput, got: $other")
+    }
+  }
+
+  test("cmdHandler show args return ShowOutput") {
+    assertCommandOutput(Action.Cmd.Show) {
+      case Output.ShowOutput(_, _, _) => ()
+      case other =>
+        fail(s"expected Output.ShowOutput, got: $other")
+    }
+  }
+}


### PR DESCRIPTION
Implemented issue #1859 per the merged design doc. Updated `jsui/src/main/scala/dev/bosatsu/jsui/Store.scala` so `Action.Cmd.Eval/Test/Show` now build argv as `tool eval|test|show ...` via a shared `toolCommandArgs` helper, keeping command-specific flags/handlers unchanged. Added `jsui/src/test/scala/dev/bosatsu/jsui/StoreTest.scala` with regression coverage for (1) reproducing the legacy root-command failure (`test --input ...` -> parse/help error including `Unexpected argument: test`) and (2) green-path execution using `Store.cmdHandler` args for Eval/Test/Show, asserting `Output.EvaluationResult`, `Output.TestOutput`, and `Output.ShowOutput`. Verification completed: `sbt "jsuiJS/test"` passed and required pre-push `scripts/test_basic.sh` passed.

Fixes #1859

Implements design doc: [docs/design/1859-web-ui-doesn-t-work-due-to-lib-tool-cli-refactor.md](https://github.com/johnynek/bosatsu/blob/main/docs/design/1859-web-ui-doesn-t-work-due-to-lib-tool-cli-refactor.md)

Design source PR: https://github.com/johnynek/bosatsu/pull/1860