### PR TITLE
Add log=failure to sbt test runs in script and CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
         uses: "sbt/setup-sbt@v1"
       - name: "run JVM tests"
         run: |
-          sbt "coreJVM/test; cli/test; doc; paradox"
+          sbt "coreJVM/testOnly * -- --log=failure; cli/testOnly * -- --log=failure; doc; paradox"
           ./test_cli.sh
     strategy:
       matrix:
@@ -95,8 +95,8 @@ jobs:
         uses: "sbt/setup-sbt@v1"
       - name: "run coreJS tests"
         run: |
-          sbt "coreJS/test; jsapiJS/compile"
-          sbt "jsuiJS/test"
+          sbt "coreJS/testOnly * -- --log=failure; jsapiJS/compile"
+          sbt "jsuiJS/testOnly * -- --log=failure"
     strategy:
       matrix:
         java:
@@ -129,7 +129,7 @@ jobs:
         uses: "sbt/setup-sbt@v1"
       - name: "run tests with coverage"
         run: |
-          sbt "coverage; clean; coreJVM/test; cli/test; coverageReport"
+          sbt "coverage; clean; coreJVM/testOnly * -- --log=failure; cli/testOnly * -- --log=failure; coverageReport"
       - name: Upload to Codecov
         uses: codecov/codecov-action@v5
         with:

--- a/.github/workflows/codecov_main.yml
+++ b/.github/workflows/codecov_main.yml
@@ -22,7 +22,7 @@ jobs:
         uses: "sbt/setup-sbt@v1"
       - name: "run tests with coverage"
         run: |
-          sbt "coverage; clean; coreJVM/test; cli/test; coverageReport"
+          sbt "coverage; clean; coreJVM/testOnly * -- --log=failure; cli/testOnly * -- --log=failure; coverageReport"
       - name: Upload to Codecov
         uses: codecov/codecov-action@v5
         with:

--- a/scripts/test_basic.sh
+++ b/scripts/test_basic.sh
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-sbt -batch "cli/test; coreJVM/test"
+sbt -batch "cli/testOnly * -- --log=failure; coreJVM/testOnly * -- --log=failure"

--- a/test_workspace/Bosatsu/Example/Json/Github/Workflows/Ci.bosatsu
+++ b/test_workspace/Bosatsu/Example/Json/Github/Workflows/Ci.bosatsu
@@ -168,7 +168,7 @@ workflow =
           Step {
             name: Set("run JVM tests"),
             run: Set(cat_lines([
-              "sbt \"coreJVM/test; cli/test; doc; paradox\"",
+              "sbt \"coreJVM/testOnly * -- --log=failure; cli/testOnly * -- --log=failure; doc; paradox\"",
               "./test_cli.sh",
               "",
             ])),
@@ -209,8 +209,8 @@ workflow =
           Step {
             name: Set("run coreJS tests"),
             run: Set(cat_lines([
-              "sbt \"coreJS/test; jsapiJS/compile\"",
-              "sbt \"jsuiJS/test\"",
+              "sbt \"coreJS/testOnly * -- --log=failure; jsapiJS/compile\"",
+              "sbt \"jsuiJS/testOnly * -- --log=failure\"",
               "",
             ])),
           },
@@ -226,7 +226,7 @@ workflow =
           Step {
             name: Set("run tests with coverage"),
             run: Set(cat_lines([
-              "sbt \"coverage; clean; coreJVM/test; cli/test; coverageReport\"",
+              "sbt \"coverage; clean; coreJVM/testOnly * -- --log=failure; cli/testOnly * -- --log=failure; coverageReport\"",
               "",
             ])),
           },

--- a/test_workspace/Bosatsu/Example/Json/Github/Workflows/CodecovMain.bosatsu
+++ b/test_workspace/Bosatsu/Example/Json/Github/Workflows/CodecovMain.bosatsu
@@ -51,7 +51,7 @@ workflow =
           Step {
             name: Set("run tests with coverage"),
             run: Set(cat_lines([
-              "sbt \"coverage; clean; coreJVM/test; cli/test; coverageReport\"",
+              "sbt \"coverage; clean; coreJVM/testOnly * -- --log=failure; cli/testOnly * -- --log=failure; coverageReport\"",
               "",
             ])),
           },


### PR DESCRIPTION
## Summary
- update `scripts/test_basic.sh` to run tests with `testOnly * -- --log=failure`
- update sbt test invocations in `.github/workflows/ci.yml` and `.github/workflows/codecov_main.yml` to pass `-- --log=failure`
- update workflow source-of-truth files used by parity tests:
  - `test_workspace/Bosatsu/Example/Json/Github/Workflows/Ci.bosatsu`
  - `test_workspace/Bosatsu/Example/Json/Github/Workflows/CodecovMain.bosatsu`

## Verification
- `./scripts/test_basic.sh` (pass)
- intentional failure check: added a temporary failing test and ran
  - `sbt -batch "cli/testOnly dev.bosatsu.LogFailureSmokeTest -- --log=failure"`
  - confirmed full failure output (assertion diff + stack trace + failed-test summary)
  - removed the temporary test afterward
- `./scripts/test_basic.sh` again (pass)
