### PR TITLE
Default lib compile cache to .bosatsuc/infer-cache with --no_cache override

### DIFF
--- a/cache_bench_summary.md
+++ b/cache_bench_summary.md
@@ -1,0 +1,55 @@
+# Cache Benchmark Summary
+
+Date: 2026-03-01
+
+## Scope
+
+Benchmarked Bosatsu CLI cache behavior for:
+
+- `lib check`
+- `lib build`
+
+Cache modes:
+
+- `no_cache` (explicit `--no_cache`)
+- `cold_cache` (empty cache dir each run)
+- `warm_cache` (cache pre-warmed before timed runs)
+
+## Method
+
+- Runner: `./bosatsuj`
+- Runs per mode: 3
+- Warm mode includes 1 unmeasured warmup run
+- Reported numbers below are median wall-clock seconds
+
+Commands:
+
+- `lib check`
+  - `./bosatsuj lib check --repo_root . --quiet --color none --no_cache`
+  - add `--cache_dir /tmp/bosatsu_bench_cache_check` for cache modes
+- `lib build`
+  - `./bosatsuj lib build --repo_root . --main_pack Bosatsu/IO/CreateModeMain --outdir /tmp/bosatsu_bench_build_out --color none --no_cache`
+  - add `--cache_dir /tmp/bosatsu_bench_cache_build` for cache modes
+
+## Results (Median of 3)
+
+### lib check
+
+- no_cache: `8.245s`
+- cold_cache: `8.716s`
+- warm_cache: `5.584s`
+- warm vs no_cache: `1.48x` faster (`32.3%` lower)
+- warm vs cold_cache: `1.56x` faster (`35.9%` lower)
+
+### lib build
+
+- no_cache: `11.360s`
+- cold_cache: `11.515s`
+- warm_cache: `7.477s`
+- warm vs no_cache: `1.52x` faster (`34.2%` lower)
+- warm vs cold_cache: `1.54x` faster (`35.1%` lower)
+
+## Raw Artifacts
+
+- `/tmp/bosatsu_bench_results.tsv`
+- `/tmp/bosatsu_bench_results_norm.tsv`

--- a/cli/src/main/scala/dev/bosatsu/IOPlatformIO.scala
+++ b/cli/src/main/scala/dev/bosatsu/IOPlatformIO.scala
@@ -187,6 +187,9 @@ object IOPlatformIO extends PlatformIO[IO, JPath] {
   def readUtf8(path: Path): IO[String] =
     IO.blocking(new String(Files.readAllBytes(path), "utf-8"))
 
+  def readBytes(path: Path): IO[Array[Byte]] =
+    IO.blocking(Files.readAllBytes(path))
+
   def fsDataType(p: Path): IO[Option[PlatformIO.FSDataType]] =
     IO.blocking {
       val f = p.toFile()

--- a/cliJS/src/main/scala/dev/bosatsu/Fs2PlatformIO.scala
+++ b/cliJS/src/main/scala/dev/bosatsu/Fs2PlatformIO.scala
@@ -183,6 +183,9 @@ object Fs2PlatformIO extends PlatformIO[IO, Path] {
   def readUtf8(p: Path): IO[String] =
     FilesIO.readUtf8(p).compile.string
 
+  def readBytes(p: Path): IO[Array[Byte]] =
+    FilesIO.readAll(p).compile.to(Array)
+
   def fsDataType(p: Path): IO[Option[PlatformIO.FSDataType]] =
     FilesIO
       .exists(p, followLinks = true)

--- a/core/src/main/scala/dev/bosatsu/MemoryMain.scala
+++ b/core/src/main/scala/dev/bosatsu/MemoryMain.scala
@@ -344,6 +344,32 @@ object MemoryMain {
             }
           }
 
+      def readBytes(p: Path): F[Array[Byte]] =
+        StateT
+          .get[G, State]
+          .flatMap { files =>
+            files.get(p) match {
+              case Some(Right(MemoryMain.FileContent.Bytes(bytes))) =>
+                moduleIOMonad.pure(bytes)
+              case Some(Right(MemoryMain.FileContent.Str(res))) =>
+                moduleIOMonad.pure(res.getBytes(StandardCharsets.UTF_8))
+              case Some(Right(MemoryMain.FileContent.Packages(packs))) =>
+                moduleIOMonad.fromTry(
+                  ProtoConverter.packagesToProto(packs).map(_.toByteArray)
+                )
+              case Some(Right(MemoryMain.FileContent.Interfaces(ifs))) =>
+                moduleIOMonad.fromTry(
+                  ProtoConverter.interfacesToProto(ifs).map(_.toByteArray)
+                )
+              case Some(Right(MemoryMain.FileContent.Lib(lib))) =>
+                moduleIOMonad.pure(lib.arg.toByteArray)
+              case other =>
+                moduleIOMonad.raiseError(
+                  new Exception(s"expect binary content, found: $other")
+                )
+            }
+          }
+
       def fsDataType(p: Path): StateT[G, State, Option[PlatformIO.FSDataType]] =
         StateT
           .get[G, State]

--- a/core/src/main/scala/dev/bosatsu/PackageMap.scala
+++ b/core/src/main/scala/dev/bosatsu/PackageMap.scala
@@ -435,6 +435,13 @@ object PackageMap {
       (List[Statement], ImportMap[PackageName, Unit])
     ]
     type ErrorOr[A] = Ior[NonEmptyList[PackageError], A]
+    type CacheDepHash = cache.DepHash
+
+    final case class InferredPack[H](
+        inferred: Package.Inferred,
+        depInterface: Package.Interface,
+        depInterfaceHash: H
+    )
 
     val resolvedByName: SortedMap[PackageName, ResolvedU] = ps.toMap
 
@@ -456,25 +463,33 @@ object PackageMap {
       sys.error("invariant violation: resolved package graph has a cycle")
     }
 
-    val inferPack: ResolvedU => F[ErrorOr[Package.Inferred]] =
-      Memoize.memoizeDag[F, ResolvedU, ErrorOr[Package.Inferred]] {
+    def toInferredPack(inferred: Package.Inferred): F[InferredPack[CacheDepHash]] = {
+      val depInterface = phases.dependencyInterface(inferred)
+      cache.dependencyHash(depInterface).map { depInterfaceHash =>
+        InferredPack(inferred, depInterface, depInterfaceHash)
+      }
+    }
+
+    val inferPack: ResolvedU => F[ErrorOr[InferredPack[CacheDepHash]]] =
+      Memoize.memoizeDag[F, ResolvedU, ErrorOr[InferredPack[CacheDepHash]]] {
         case (pack, recurse) =>
           pack match {
             case Package(nm, imports, exports, (stmt, imps)) =>
-              val depResultsF: F[ErrorOr[SortedMap[PackageName, Package.Inferred]]] =
+              val depResultsF
+                  : F[ErrorOr[SortedMap[PackageName, InferredPack[CacheDepHash]]]] =
                 imports.foldLeft(
                   Monad[F].pure(
                     Ior.right[NonEmptyList[PackageError], SortedMap[
                       PackageName,
-                      Package.Inferred
+                      InferredPack[CacheDepHash]
                     ]](SortedMap.empty)
                   )
                 ) { (accF, imp) =>
                   Package.unfix(imp.pack) match {
                     case Left(_)        => accF
                     case Right(depPack) =>
-                      val nextF: F[ErrorOr[(PackageName, Package.Inferred)]] =
-                        recurse(depPack).map(_.map(dep => dep.name -> dep))
+                      val nextF: F[ErrorOr[(PackageName, InferredPack[CacheDepHash])]] =
+                        recurse(depPack).map(_.map(dep => dep.inferred.name -> dep))
                       (accF, nextF).parMapN { (acc, next) =>
                         (acc, next).parMapN { (deps, dep) =>
                           deps.updated(dep._1, dep._2)
@@ -488,6 +503,13 @@ object PackageMap {
                   def depPackResult(depPack: ResolvedU): ErrorOr[Package.Inferred] =
                     Ior.right(depResults.get(depPack.name).expect {
                       s"invariant violation: missing dependency result for ${depPack.name}"
+                    }.inferred)
+
+                  def depPackMeta(
+                      depPack: ResolvedU
+                  ): ErrorOr[InferredPack[CacheDepHash]] =
+                    Ior.right(depResults.get(depPack.name).expect {
+                      s"invariant violation: missing dependency result for ${depPack.name}"
                     })
 
                   val parsedForKey: Package.Parsed =
@@ -498,7 +520,7 @@ object PackageMap {
                       stmt
                     )
 
-                  val depInterfaces
+                  def depInterfaces
                       : ErrorOr[SortedMap[PackageName, Package.Interface]] =
                     imports.foldLeft(
                       Ior.right[NonEmptyList[PackageError], SortedMap[
@@ -509,8 +531,8 @@ object PackageMap {
                       val next: ErrorOr[(PackageName, Package.Interface)] =
                         Package.unfix(imp.pack) match {
                           case Right(depPack) =>
-                            depPackResult(depPack).map { typedDep =>
-                              typedDep.name -> phases.dependencyInterface(typedDep)
+                            depPackMeta(depPack).map { inferredDep =>
+                              inferredDep.inferred.name -> inferredDep.depInterface
                             }
                           case Left(iface)    =>
                             Ior.right(iface.name -> iface)
@@ -518,6 +540,37 @@ object PackageMap {
 
                       (acc, next).parMapN { (ifaces, iface) =>
                         ifaces.updated(iface._1, iface._2)
+                      }
+                    }
+
+                  val depInterfaceHashesF
+                      : F[ErrorOr[SortedMap[PackageName, CacheDepHash]]] =
+                    imports.foldLeft(
+                      Monad[F].pure(
+                        Ior.right[NonEmptyList[PackageError], SortedMap[
+                          PackageName,
+                          CacheDepHash
+                        ]](SortedMap.empty)
+                      )
+                    ) { (accF, imp) =>
+                      val nextF: F[ErrorOr[(PackageName, CacheDepHash)]] =
+                        Package.unfix(imp.pack) match {
+                          case Right(depPack) =>
+                            Monad[F].pure(
+                              depPackMeta(depPack).map { inferredDep =>
+                                inferredDep.inferred.name -> inferredDep.depInterfaceHash
+                              }
+                            )
+                          case Left(iface)    =>
+                            cache
+                              .dependencyHash(iface)
+                              .map(hash => Ior.right(iface.name -> hash))
+                        }
+
+                      (accF, nextF).parMapN { (acc, next) =>
+                        (acc, next).parMapN { (hashes, hash) =>
+                          hashes.updated(hash._1, hash._2)
+                        }
                       }
                     }
 
@@ -571,40 +624,38 @@ object PackageMap {
                     }
                   }
 
-                  IorT
-                    .fromIor[F](depInterfaces)
-                    .flatMap { depIfaces =>
-                      IorT
-                        .liftF(
-                          cache.generateKey(
-                            parsedForKey,
-                            depIfaces,
-                            compileOptions,
-                            CompileCache.compilerIdentity,
-                            phases.id
-                          )
-                        )
-                        .flatMap { key =>
-                          IorT.liftF(cache.get(key)).flatMap {
-                            case Some(hit) =>
-                              IorT.rightT[F, NonEmptyList[PackageError]](hit)
-                            case None      =>
-                              IorT
-                                .fromIor[F](inferOnMiss(depIfaces))
-                                .flatMap { compiled =>
-                                  IorT
-                                    .liftF(cache.put(key, compiled))
-                                    .as(compiled)
-                                }
-                          }
-                        }
+                  import IorT.{fromIor, liftF}
+
+                  (for {
+                    depIfaceHashes <- IorT(depInterfaceHashesF)
+                    key <- liftF(
+                      cache.generateKey(
+                        parsedForKey,
+                        depIfaceHashes,
+                        compileOptions,
+                        CompileCache.compilerIdentity,
+                        phases.id
+                      )
+                    )
+                    getRes <- liftF(cache.get(key))
+                    res <- getRes match {
+                      case Some(hit) =>
+                        IorT.rightT[F, NonEmptyList[PackageError]](hit)
+                      case None      =>
+                        for {
+                          depIfaces <- fromIor[F](depInterfaces)
+                          compiled <- fromIor[F](inferOnMiss(depIfaces))
+                          _ <- liftF(cache.put(key, compiled))
+                        } yield compiled
                     }
+                    inferredPack <- liftF(toInferredPack(res))
+                  } yield inferredPack)
                 }
                 .value
           }
       }
 
-    val allResults: F[SortedMap[PackageName, ErrorOr[Package.Inferred]]] =
+    val allResults: F[SortedMap[PackageName, ErrorOr[InferredPack[CacheDepHash]]]] =
       resolvedByName.values.toList
         .parTraverse { pack =>
           inferPack(pack).map(pack.name -> _)
@@ -623,7 +674,15 @@ object PackageMap {
           s"invariant violation: missing inference results for: ${missingKeys.mkString(", ")}"
         )
       } else {
-        dedupeErrors(resultMap.sequence.map(PackageMap(_)))
+        dedupeErrors(resultMap.sequence.map { inferredByName =>
+          PackageMap(
+            SortedMap.from(
+              inferredByName.iterator.map { case (name, inferredPack) =>
+                name -> inferredPack.inferred
+              }
+            )
+          )
+        })
       }
     }
   }

--- a/core/src/main/scala/dev/bosatsu/PlatformIO.scala
+++ b/core/src/main/scala/dev/bosatsu/PlatformIO.scala
@@ -42,6 +42,7 @@ trait PlatformIO[F[_], Path] {
     }
 
   def readUtf8(p: Path): F[String]
+  def readBytes(p: Path): F[Array[Byte]]
   def parseUtf8[A](path: Path, p0: P0[A]): F[A] =
     readUtf8(path)
       .flatMap { str =>

--- a/core/src/main/scala/dev/bosatsu/cache/CompileCache.scala
+++ b/core/src/main/scala/dev/bosatsu/cache/CompileCache.scala
@@ -1,5 +1,6 @@
 package dev.bosatsu.cache
 
+import _root_.bosatsu.{TypedAst => proto}
 import cats.syntax.all._
 import dev.bosatsu.hashing.{Algo, Hashed, HashValue}
 import dev.bosatsu.{
@@ -13,9 +14,10 @@ import dev.bosatsu.{
   Statement
 }
 import java.nio.charset.StandardCharsets
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.atomic.{AtomicLong, AtomicReference}
 import org.typelevel.paiges.{Doc, Document}
 import scala.collection.immutable.SortedMap
-import scala.collection.mutable
 import scala.util.{Failure, Success, Try}
 
 object CompileCache {
@@ -32,7 +34,7 @@ object CompileCache {
   def filesystem[F[_], P](
       cacheDir: P,
       platformIO: PlatformIO[F, P]
-  ): InferCache[F] { type Key = FsKey } =
+  ): InferCache[F] { type Key = FsKey; type DepHash = HashValue[Algo.Blake3] } =
     new FilesystemCache(cacheDir, platformIO)
 
   def sourceExprHash(pack: Package.Parsed): HashValue[Algo.Blake3] = {
@@ -95,19 +97,93 @@ object CompileCache {
       platformIO: PlatformIO[F, P]
   ) extends InferCache[F] {
     type Key = FsKey
+    type DepHash = HashValue[Algo.Blake3]
 
     import platformIO.moduleIOMonad
 
-    private val interfaceHashMemo =
-      mutable.HashMap.empty[Package.Interface, Try[HashValue[Algo.Blake3]]]
+    private val statsEnabled = InferCache.statsEnabled
+    private val cacheDirLabel = platformIO.pathToString(cacheDir)
+    private val keyGenCalls = new AtomicLong(0L)
+    private val keyGenFailures = new AtomicLong(0L)
+    private val interfaceMemoHits = new AtomicLong(0L)
+    private val interfaceMemoMisses = new AtomicLong(0L)
+    private val dependencyHashCalls = new AtomicLong(0L)
+    private val getCalls = new AtomicLong(0L)
+    private val getHits = new AtomicLong(0L)
+    private val getMisses = new AtomicLong(0L)
+    private val getLinkReadErrors = new AtomicLong(0L)
+    private val getLinkParseMisses = new AtomicLong(0L)
+    private val getCasReadErrors = new AtomicLong(0L)
+    private val getCasDecodeMisses = new AtomicLong(0L)
+    private val firstGetLinkReadError = new AtomicReference[String](null)
+    private val firstGetCasReadError = new AtomicReference[String](null)
+    private val putCalls = new AtomicLong(0L)
+    private val putEncodeFailures = new AtomicLong(0L)
+    private val putCasAlreadyExists = new AtomicLong(0L)
+    private val putCasWrites = new AtomicLong(0L)
+    private val putCasWriteErrors = new AtomicLong(0L)
+    private val putLinkWrites = new AtomicLong(0L)
+    private val putLinkWriteErrors = new AtomicLong(0L)
 
-    // Scala.js does not support TrieMap; synchronize around a local mutable map.
+    private inline def statsUpdate(inline fn: => Unit): Unit =
+      if (statsEnabled) fn
+
+    private def ratioPct(numerator: Long, denominator: Long): String =
+      if (denominator == 0L) "n/a"
+      else f"${(numerator.toDouble * 100.0) / denominator.toDouble}%.2f%%"
+
+    private final class RefKey[A <: AnyRef](val ref: A) {
+      override def equals(that: Any): Boolean =
+        that match {
+          case other: RefKey[_] =>
+            (ref.asInstanceOf[AnyRef] eq other.ref.asInstanceOf[AnyRef])
+          case _                => false
+        }
+
+      override def hashCode(): Int =
+        System.identityHashCode(ref)
+    }
+
+    private val interfaceHashMemo =
+      new ConcurrentHashMap[
+        RefKey[Package.Interface],
+        Try[HashValue[Algo.Blake3]]
+      ]()
+    // inferAll memoizes each inferred package and computes that package's
+    // dependency interface hash once per run. We still hash "Left(iface)"
+    // dependencies on each importer edge, so this per-cache memo avoids
+    // repeated interface proto serialization for those shared externals.
+    private val interfaceByHashHex =
+      new ConcurrentHashMap[String, Package.Interface]()
+
     private def memoizedInterfaceHash(
         iface: Package.Interface
-    ): Try[HashValue[Algo.Blake3]] =
-      this.synchronized {
-        interfaceHashMemo.getOrElseUpdate(iface, interfaceHash(iface))
+    ): Try[HashValue[Algo.Blake3]] = {
+      val key = new RefKey(iface)
+      val cached = interfaceHashMemo.get(key)
+      if (cached != null) {
+        statsUpdate { interfaceMemoHits.incrementAndGet(); () }
+        cached
+      } else {
+        val computed = interfaceHash(iface)
+        val raced = interfaceHashMemo.putIfAbsent(key, computed)
+        if (raced == null) {
+          statsUpdate { interfaceMemoMisses.incrementAndGet(); () }
+          computed
+        } else {
+          statsUpdate { interfaceMemoHits.incrementAndGet(); () }
+          raced
+        }
       }
+    }
+
+    override def dependencyHash(interface: Package.Interface): F[DepHash] = {
+      statsUpdate { dependencyHashCalls.incrementAndGet(); () }
+      moduleIOMonad.fromTry(memoizedInterfaceHash(interface)).map { hash =>
+        interfaceByHashHex.putIfAbsent(hash.hex, interface)
+        hash
+      }
+    }
 
     private def keyPath(hash: HashValue[Algo.Blake3]): P =
       platformIO.resolve(
@@ -125,70 +201,150 @@ object CompileCache {
     private def parseHashIdent(str: String): Option[HashValue[Algo.Blake3]] =
       Algo.parseHashValue(blake3).parseAll(str.trim).toOption
 
-    private inline def onError[A](fa: F[A], inline fallback: => A): F[A] =
-      moduleIOMonad.handleError(fa)(_ => fallback)
+    private inline def onError[A](
+        fa: F[A],
+        inline fallback: => A,
+        inline onErr: Throwable => Unit
+    ): F[A] =
+      moduleIOMonad.handleError(fa) { err =>
+        onErr(err)
+        fallback
+      }
 
-    def generateKey(
+    override def generateKey(
         pack: Package.Parsed,
-        depInterfaces: SortedMap[PackageName, Package.Interface],
+        depInterfaceHashes: SortedMap[PackageName, DepHash],
         compileOptions: CompileOptions,
         compilerIdentity: String,
         phaseIdentity: String
-    ): F[Key] =
+    ): F[Key] = {
+      statsUpdate { keyGenCalls.incrementAndGet(); () }
       moduleIOMonad.fromTry {
-        val depHashesTry =
-          depInterfaces.iterator.foldLeft(
-            Success(
-              SortedMap.empty[PackageName, HashValue[Algo.Blake3]]
-            ): Try[SortedMap[PackageName, HashValue[Algo.Blake3]]]
-          ) { case (acc, (name, iface)) =>
-            acc.flatMap { depHashes =>
-              memoizedInterfaceHash(iface).map(depHashes.updated(name, _))
-            }
-          }
+        val depInterfacesBuilder =
+          SortedMap.newBuilder[PackageName, Package.Interface]
+        val depHashIter = depInterfaceHashes.iterator
 
-        depHashesTry.map { depHashes =>
-          FsKey(
-            packageName = pack.name,
-            compileOptions = compileOptions,
-            compilerIdentity = compilerIdentity,
-            phaseIdentity = phaseIdentity,
-            sourceExprHash = sourceExprHash(pack),
-            depInterfaceHashes = depHashes,
-            schemaVersion = schemaVersion
-          )
+        var failure: Option[Throwable] = None
+        while (depHashIter.hasNext && failure.isEmpty) {
+          val (name, hash) = depHashIter.next()
+          val iface = interfaceByHashHex.get(hash.hex)
+          if (iface eq null) {
+            failure = Some(
+              new IllegalStateException(
+                s"missing dependency interface for ${name.asString} (${hash.hex}); dependencyHash must be called before generateKey"
+              )
+            )
+          } else {
+            depInterfacesBuilder += ((name, iface))
+          }
+        }
+
+        failure match {
+          case None      =>
+            Success(
+              FsKey(
+                packageName = pack.name,
+                compileOptions = compileOptions,
+                compilerIdentity = compilerIdentity,
+                phaseIdentity = phaseIdentity,
+                sourceExprHash = sourceExprHash(pack),
+                depInterfaceHashes = depInterfaceHashes,
+                depInterfaces = depInterfacesBuilder.result(),
+                schemaVersion = schemaVersion
+              )
+            )
+          case Some(err) =>
+            statsUpdate { keyGenFailures.incrementAndGet(); () }
+            Failure(err)
         }
       }
+    }
 
     def get(key: Key): F[Option[Package.Inferred]] = {
+      statsUpdate { getCalls.incrementAndGet(); () }
       val keyHash = keyHashValue(key)
       val linkPath = keyPath(keyHash)
 
+      val readLink =
+        platformIO.readUtf8(linkPath).map { raw =>
+          parseHashIdent(raw) match {
+            case some @ Some(_) => some
+            case None           =>
+              statsUpdate { getLinkParseMisses.incrementAndGet(); () }
+              None
+          }
+        }
+
       onError(
-        platformIO.readUtf8(linkPath).map(parseHashIdent),
-        None
+        readLink,
+        None,
+        err =>
+          statsUpdate {
+            getLinkReadErrors.incrementAndGet()
+            val _ = firstGetLinkReadError.compareAndSet(
+              null,
+                s"${err.getClass.getName}:${Option(err.getMessage).getOrElse("")}"
+            )
+            ()
+          }
       ).flatMap {
         case None             =>
+          statsUpdate { getMisses.incrementAndGet(); () }
           moduleIOMonad.pure(None)
         case Some(outputHash) =>
           val packagePath = casPath(outputHash)
-          val read =
-            platformIO.readPackages(packagePath :: Nil).map {
+          val depIfaces = key.depInterfaces.valuesIterator.toList
+          val read = platformIO.readBytes(packagePath).flatMap { bytes =>
+            moduleIOMonad.fromTry {
+              for {
+                protoPackages <- Try(proto.Packages.parseFrom(bytes))
+                decoded <- ProtoConverter
+                  .packagesFromProto(Nil, protoPackages.packages, depIfaces)
+              } yield decoded._2
+            }.map {
               case pack :: Nil if pack.name == key.packageName =>
                 // Serialized package artifacts are tag-erased to Unit.
                 Some(pack.asInstanceOf[Package.Inferred])
               case _ =>
+                statsUpdate { getCasDecodeMisses.incrementAndGet(); () }
                 None
             }
-          onError(read, None)
+          }
+          onError(
+            read,
+            None,
+            err =>
+              statsUpdate {
+                getCasReadErrors.incrementAndGet()
+                val _ = firstGetCasReadError.compareAndSet(
+                  null,
+                    s"${err.getClass.getName}:${Option(err.getMessage).getOrElse("")}"
+                )
+                ()
+              }
+          )
+            .map {
+              case some @ Some(_) =>
+                statsUpdate { getHits.incrementAndGet(); () }
+                some
+              case None           =>
+                statsUpdate { getMisses.incrementAndGet(); () }
+                None
+            }
       }
     }
 
     def put(key: Key, value: Package.Inferred): F[Unit] =
       outputHashValue(value) match {
         case Failure(_)            =>
+          statsUpdate {
+            putCalls.incrementAndGet()
+            putEncodeFailures.incrementAndGet()
+            ()
+          }
           moduleIOMonad.unit
         case Success(hashedOutput) =>
+          statsUpdate { putCalls.incrementAndGet(); () }
           val outputHash = hashedOutput.hash
           val packagePath = casPath(outputHash)
 
@@ -196,11 +352,16 @@ object CompileCache {
             onError(
               platformIO.fileExists(packagePath).flatMap {
                 case true  =>
+                  statsUpdate { putCasAlreadyExists.incrementAndGet(); () }
                   moduleIOMonad.pure(true)
                 case false =>
-                  platformIO.writeBytes(packagePath, hashedOutput.arg).as(true)
+                  platformIO.writeBytes(packagePath, hashedOutput.arg).as {
+                    statsUpdate { putCasWrites.incrementAndGet(); () }
+                    true
+                  }
               },
-              false
+              false,
+              _ => statsUpdate { putCasWriteErrors.incrementAndGet(); () }
             )
 
           // Write CAS first, then key-link, so readers never see dangling links.
@@ -211,10 +372,53 @@ object CompileCache {
               val keyHash = keyHashValue(key)
               val linkPath = keyPath(keyHash)
               onError(
-                platformIO.writeDoc(linkPath, Doc.text(outputHash.toIdent)),
-                ()
+                platformIO.writeDoc(linkPath, Doc.text(outputHash.toIdent)).map {
+                  _ =>
+                    statsUpdate { putLinkWrites.incrementAndGet(); () }
+                },
+                (),
+                _ => statsUpdate { putLinkWriteErrors.incrementAndGet(); () }
               )
           }
+      }
+
+    override def statsSnapshot: Option[String] =
+      if (!statsEnabled) None
+      else {
+        val keyGenCallsV = keyGenCalls.get()
+        val keyGenFailuresV = keyGenFailures.get()
+        val interfaceMemoHitsV = interfaceMemoHits.get()
+        val interfaceMemoMissesV = interfaceMemoMisses.get()
+        val dependencyHashCallsV = dependencyHashCalls.get()
+        val getCallsV = getCalls.get()
+        val getHitsV = getHits.get()
+        val getMissesV = getMisses.get()
+        val getLinkReadErrorsV = getLinkReadErrors.get()
+        val getLinkParseMissesV = getLinkParseMisses.get()
+        val getCasReadErrorsV = getCasReadErrors.get()
+        val getCasDecodeMissesV = getCasDecodeMisses.get()
+        val putCallsV = putCalls.get()
+        val putEncodeFailuresV = putEncodeFailures.get()
+        val putCasAlreadyExistsV = putCasAlreadyExists.get()
+        val putCasWritesV = putCasWrites.get()
+        val putCasWriteErrorsV = putCasWriteErrors.get()
+        val putLinkWritesV = putLinkWrites.get()
+        val putLinkWriteErrorsV = putLinkWriteErrors.get()
+
+        val getHitRate = ratioPct(getHitsV, getCallsV)
+        val memoHitRate = ratioPct(interfaceMemoHitsV, interfaceMemoHitsV + interfaceMemoMissesV)
+        Some(
+          s"[compile-cache fs] cacheDir=$cacheDirLabel keyGenCalls=$keyGenCallsV keyGenFailures=$keyGenFailuresV " +
+            s"memoHits=$interfaceMemoHitsV memoMisses=$interfaceMemoMissesV memoHitRate=$memoHitRate " +
+            s"dependencyHashCalls=$dependencyHashCallsV " +
+            s"getCalls=$getCallsV getHits=$getHitsV getMisses=$getMissesV getHitRate=$getHitRate " +
+            s"getLinkReadErrors=$getLinkReadErrorsV getLinkParseMisses=$getLinkParseMissesV " +
+            s"getCasReadErrors=$getCasReadErrorsV getCasDecodeMisses=$getCasDecodeMissesV " +
+            s"""firstGetLinkReadError="${Option(firstGetLinkReadError.get()).getOrElse("")}" """ +
+            s"""firstGetCasReadError="${Option(firstGetCasReadError.get()).getOrElse("")}" """ +
+            s"putCalls=$putCallsV putEncodeFailures=$putEncodeFailuresV putCasAlreadyExists=$putCasAlreadyExistsV " +
+            s"putCasWrites=$putCasWritesV putCasWriteErrors=$putCasWriteErrorsV putLinkWrites=$putLinkWritesV putLinkWriteErrors=$putLinkWriteErrorsV"
+        )
       }
   }
 }

--- a/core/src/main/scala/dev/bosatsu/cache/FsKey.scala
+++ b/core/src/main/scala/dev/bosatsu/cache/FsKey.scala
@@ -1,9 +1,22 @@
 package dev.bosatsu.cache
 
 import dev.bosatsu.hashing.{Algo, HashValue}
-import dev.bosatsu.{CompileOptions, PackageName}
+import dev.bosatsu.{CompileOptions, Package, PackageName}
 import scala.collection.immutable.SortedMap
 
+/** Filesystem cache key plus decode context.
+  *
+  * We keep both dependency hashes and dependency interfaces on purpose:
+  * - `depInterfaceHashes` are part of cache identity and are what `keyHashValue`
+  *   hashes for stable key lookup.
+  * - `depInterfaces` are required when reading cached package bytes back, because
+  *   package decoding needs dependency interfaces in scope.
+  *
+  * Other fields are also part of identity:
+  * - package/mode/options/compiler/phase/schema ensure we do not mix artifacts
+  *   across incompatible compiler runs.
+  * - `sourceExprHash` invalidates cache entries when source meaning changes.
+  */
 final case class FsKey(
     packageName: PackageName,
     compileOptions: CompileOptions,
@@ -11,5 +24,6 @@ final case class FsKey(
     phaseIdentity: String,
     sourceExprHash: HashValue[Algo.Blake3],
     depInterfaceHashes: SortedMap[PackageName, HashValue[Algo.Blake3]],
+    depInterfaces: SortedMap[PackageName, Package.Interface],
     schemaVersion: Int
 )

--- a/core/src/main/scala/dev/bosatsu/cache/InferCache.scala
+++ b/core/src/main/scala/dev/bosatsu/cache/InferCache.scala
@@ -2,14 +2,16 @@ package dev.bosatsu.cache
 
 import cats.Applicative
 import dev.bosatsu.{CompileOptions, Package, PackageName}
+import java.util.concurrent.atomic.AtomicLong
 import scala.collection.immutable.SortedMap
 
 trait InferCache[F[_]] {
   type Key
+  type DepHash
 
   def generateKey(
       pack: Package.Parsed,
-      depInterfaces: SortedMap[PackageName, Package.Interface],
+      depInterfaceHashes: SortedMap[PackageName, DepHash],
       compileOptions: CompileOptions,
       compilerIdentity: String,
       phaseIdentity: String
@@ -17,28 +19,79 @@ trait InferCache[F[_]] {
 
   def get(key: Key): F[Option[Package.Inferred]]
   def put(key: Key, value: Package.Inferred): F[Unit]
+  def dependencyHash(interface: Package.Interface): F[DepHash]
+
+  def statsSnapshot: Option[String] = None
 }
 
 object InferCache {
-  def noop[F[_]: Applicative]: InferCache[F] { type Key = Unit } =
+  def statsEnabled: Boolean =
+    Option(System.getenv("BOSATSU_CACHE_STATS")).exists { raw =>
+      val v = raw.trim
+      v == "1" || v.equalsIgnoreCase("true") || v.equalsIgnoreCase("yes")
+    }
+
+  def noop[F[_]: Applicative]: InferCache[F] { type Key = Unit; type DepHash = Unit } =
     new InferCache[F] {
       type Key = Unit
+      type DepHash = Unit
+      private val statsEnabled = InferCache.statsEnabled
       private val noneF: F[Option[Package.Inferred]] =
         Applicative[F].pure(None)
+      private val generateKeyCalls = new AtomicLong(0L)
+      private val getCalls = new AtomicLong(0L)
+      private val putCalls = new AtomicLong(0L)
+      private val dependencyHashCalls = new AtomicLong(0L)
 
       def generateKey(
           pack: Package.Parsed,
-          depInterfaces: SortedMap[PackageName, Package.Interface],
+          depInterfaceHashes: SortedMap[PackageName, DepHash],
           compileOptions: CompileOptions,
           compilerIdentity: String,
           phaseIdentity: String
-      ): F[Key] =
+      ): F[Key] = {
+        val _ = depInterfaceHashes
+        if (statsEnabled) {
+          generateKeyCalls.incrementAndGet()
+          ()
+        }
         Applicative[F].unit
+      }
 
-      def get(key: Key): F[Option[Package.Inferred]] =
+      def get(key: Key): F[Option[Package.Inferred]] = {
+        if (statsEnabled) {
+          getCalls.incrementAndGet()
+          ()
+        }
         noneF
+      }
 
-      def put(key: Key, value: Package.Inferred): F[Unit] =
+      def put(key: Key, value: Package.Inferred): F[Unit] = {
+        if (statsEnabled) {
+          putCalls.incrementAndGet()
+          ()
+        }
         Applicative[F].unit
+      }
+
+      def dependencyHash(interface: Package.Interface): F[DepHash] = {
+        if (statsEnabled) {
+          dependencyHashCalls.incrementAndGet()
+          ()
+        }
+        Applicative[F].unit
+      }
+
+      override def statsSnapshot: Option[String] =
+        if (!statsEnabled) None
+        else {
+          val generateKeyCallsV = generateKeyCalls.get()
+          val getCallsV = getCalls.get()
+          val putCallsV = putCalls.get()
+          val dependencyHashCallsV = dependencyHashCalls.get()
+          Some(
+            s"[compile-cache noop] generateKeyCalls=$generateKeyCallsV getCalls=$getCallsV putCalls=$putCallsV dependencyHashCalls=$dependencyHashCallsV"
+          )
+        }
     }
 }

--- a/core/src/main/scala/dev/bosatsu/library/Command.scala
+++ b/core/src/main/scala/dev/bosatsu/library/Command.scala
@@ -365,13 +365,45 @@ object Command {
         )
         .orNone
         .map {
-          case None => { root =>
-            platformIO.resolve(root, ".bosatsuc" :: "cas" :: Nil)
-          }
-          case Some(d) => { _ => d }
+          case Some(d) =>
+            (_: P) => d
+          case None    =>
+            (root: P) => platformIO.resolve(root, ".bosatsuc" :: "cas" :: Nil)
         }
 
-    case class ConfigConf(conf: LibConfig, cas: Cas[F, P], confDir: P) {
+    val compileCacheDirOpt: Opts[P => Option[P]] = {
+      val defaultDirFn: P => Option[P] = (root: P) =>
+        Some(platformIO.resolve(root, ".bosatsuc" :: "infer-cache" :: Nil))
+      val noCacheFn: P => Option[P] = (_: P) => None
+
+      // Shared across all lib commands that invoke compiler inference/typechecking.
+      // --cache_dir and --no_cache are mutually exclusive via orElse branches.
+      Opts
+        .option[P](
+          "cache_dir",
+          help =
+            "cache directory for compiled package artifacts (default: .bosatsuc/infer-cache in repo root)"
+        )
+        .map { cacheDir =>
+          (_: P) => Some(cacheDir)
+        }
+        .orElse(
+          Opts
+            .flag(
+              "no_cache",
+              help = "disable compiled package artifact cache for this run"
+            )
+            .as(noCacheFn)
+        )
+        .orElse(Opts(defaultDirFn))
+    }
+
+    case class ConfigConf(
+        conf: LibConfig,
+        cas: Cas[F, P],
+        confDir: P,
+        gitRoot: P
+    ) {
       private def loadFromCas(
           dep: proto.LibDependency
       ): F[Hashed[Algo.Blake3, proto.Library]] =
@@ -459,7 +491,8 @@ object Command {
         def packageMap(
             colorize: Colorize,
             sourcePackageFilter: Option[PackageName => Boolean] = None,
-            compileOptions: CompileOptions
+            compileOptions: CompileOptions,
+            compileCacheDirOpt: Option[P] = None
         ): F[PackageMap.Inferred] =
           PathGen
             .recursiveChildren(confDir, ".bosatsu")(platformIO)
@@ -552,7 +585,8 @@ object Command {
                             ),
                           colorize,
                           inputRes,
-                          compileOptions
+                          compileOptions,
+                          compileCacheDirOpt
                         )
                       }
                       .map(_._1)
@@ -583,7 +617,8 @@ object Command {
       def docPackages(
           colorize: Colorize,
           outdir: P,
-          includePredef: Boolean
+          includePredef: Boolean,
+          compileCacheDirOpt: Option[P] = None
       ): F[List[(P, Doc)]] =
         for {
           cs <- checkState
@@ -606,7 +641,8 @@ object Command {
               ),
               colorize,
               inputRes,
-              CompileOptions.Default
+              CompileOptions.Default,
+              compileCacheDirOpt
             )
           }
           (compiled, sourcePaths) = checked
@@ -627,11 +663,17 @@ object Command {
       def check(
           colorize: Colorize,
           sourcePackageFilter: Option[PackageName => Boolean] = None,
-          compileOptions: CompileOptions
+          compileOptions: CompileOptions,
+          compileCacheDirOpt: Option[P] = None
       ): F[LibConfig.ValidationResult] =
         for {
           cs <- checkState
-          allPacks <- cs.packageMap(colorize, sourcePackageFilter, compileOptions)
+          allPacks <- cs.packageMap(
+            colorize,
+            sourcePackageFilter,
+            compileOptions,
+            compileCacheDirOpt
+          )
           res <- sourcePackageFilter match {
             case None =>
               val validated = conf.validate(
@@ -650,11 +692,17 @@ object Command {
 
       def decodedWithDeps(
           colorize: Colorize,
-          compileOptions: CompileOptions
+          compileOptions: CompileOptions,
+          compileCacheDirOpt: Option[P] = None
       ): F[DecodedLibraryWithDeps[Algo.Blake3]] =
         for {
           cs <- checkState
-          allPacks <- cs.packageMap(colorize, None, compileOptions)
+          allPacks <- cs.packageMap(
+            colorize,
+            None,
+            compileOptions,
+            compileCacheDirOpt
+          )
           validated = conf.validate(
             cs.prevThis,
             allPacks.toMap.values.toList,
@@ -673,14 +721,16 @@ object Command {
       def decodedWithDepsFiltered(
           colorize: Colorize,
           sourcePackageFilter: PackageName => Boolean,
-          compileOptions: CompileOptions
+          compileOptions: CompileOptions,
+          compileCacheDirOpt: Option[P] = None
       ): F[DecodedLibraryWithDeps[Algo.Blake3]] =
         for {
           cs <- checkState
           allPacks <- cs.packageMap(
             colorize,
             Some(sourcePackageFilter),
-            compileOptions
+            compileOptions,
+            compileCacheDirOpt
           )
           decWithLibs <- decodedWithDepsFromPackages(cs, allPacks, Nil)
         } yield decWithLibs
@@ -743,24 +793,36 @@ object Command {
 
       def decodedWithDepsFilteredForTest(
           colorize: Colorize,
-          sourcePackageFilter: PackageName => Boolean
+          sourcePackageFilter: PackageName => Boolean,
+          compileCacheDirOpt: Option[P] = None
       ): F[DecodedLibraryWithDeps[Algo.Blake3]] =
         decodedWithDepsFiltered(
           colorize,
           sourcePackageFilter,
-          CompileOptions.Default
+          CompileOptions.Default,
+          compileCacheDirOpt
         )
 
       def build(
           colorize: Colorize,
           trans: Transpiler.Optioned[F, P],
-          sourcePackageFilter: Option[PackageName => Boolean] = None
+          sourcePackageFilter: Option[PackageName => Boolean] = None,
+          compileCacheDirOpt: Option[P] = None
       ): F[Doc] =
         for {
           decWithLibs <- sourcePackageFilter match {
-            case None         => decodedWithDeps(colorize, CompileOptions.Default)
+            case None         =>
+              decodedWithDeps(
+                colorize,
+                CompileOptions.Default,
+                compileCacheDirOpt
+              )
             case Some(filter) =>
-              decodedWithDepsFilteredForTest(colorize, filter)
+              decodedWithDepsFilteredForTest(
+                colorize,
+                filter,
+                compileCacheDirOpt
+              )
           }
           outputs <- platformIO.withEC {
             trans.renderAll(decWithLibs)
@@ -770,13 +832,18 @@ object Command {
           }
         } yield Doc.empty
 
-      def buildLibrary(vcsIdent: String, colorize: Colorize): F[proto.Library] =
+      def buildLibrary(
+          vcsIdent: String,
+          colorize: Colorize,
+          compileCacheDirOpt: Option[P] = None
+      ): F[proto.Library] =
         for {
           cs <- checkState
           allPacks <- cs.packageMap(
             colorize,
             None,
-            CompileOptions.Default
+            CompileOptions.Default,
+            compileCacheDirOpt
           )
           validated = conf.assemble(
             vcsIdent = vcsIdent,
@@ -885,7 +952,7 @@ object Command {
             conf <- readLibConf(name, confPath(confDir, name))
             casDir = casDirFn(gitRoot)
             cas = new Cas(casDir, platformIO)
-          } yield ConfigConf(conf, cas, confDir)
+          } yield ConfigConf(conf, cas, confDir, gitRoot)
         }
     }
 
@@ -1375,14 +1442,20 @@ object Command {
         val sourceFilterOpt: Opts[Option[PackageName => Boolean]] =
           ClangTranspiler.Mode.testOpts[F](Opts(false)).map(_.filter)
 
-        (ConfigConf.opts, sourceFilterOpt, Colorize.optsConsoleDefault).mapN {
-          (fcc, sourceFilter, colorize) =>
+        (
+          ConfigConf.opts,
+          sourceFilterOpt,
+          compileCacheDirOpt,
+          Colorize.optsConsoleDefault
+        ).mapN { (fcc, sourceFilter, cacheDirFn, colorize) =>
             for {
               cc <- fcc
+              cacheDir = cacheDirFn(cc.gitRoot)
               _ <- cc.check(
                 colorize,
                 sourceFilter,
-                CompileOptions.TypeCheckOnly
+                CompileOptions.TypeCheckOnly,
+                cacheDir
               )
               msg = Doc.text("")
             } yield (Output.Basic(msg, None): Output[P])
@@ -1487,8 +1560,9 @@ object Command {
             )
             .orFalse,
           Opts.arguments[String]("arg").orEmpty,
+          compileCacheDirOpt,
           Colorize.optsConsoleDefault
-        ).mapN { (fcc, target, runMain, runArgs, colorize) =>
+        ).mapN { (fcc, target, runMain, runArgs, cacheDirFn, colorize) =>
           def toCliException(ex: Throwable): Throwable =
             CliException.Basic(Option(ex.getMessage).getOrElse(ex.toString))
 
@@ -1497,12 +1571,14 @@ object Command {
 
           for {
             cc <- fcc
+            cacheDir = cacheDirFn(cc.gitRoot)
             out <- platformIO.withEC {
               for {
                 dec <- cc.decodedWithDepsFiltered(
                   colorize,
                   sourcePackageFilter,
-                  CompileOptions.Default
+                  CompileOptions.Default,
+                  cacheDir
                 )
                 ev = LibraryEvaluation(dec, BosatsuPredef.evalExternals)
                 (scope, value, tpe) <- moduleIOMonad.fromEither {
@@ -1598,6 +1674,7 @@ object Command {
             )
             .orFalse,
           Opts.option[P]("output", help = "output path").orNone,
+          compileCacheDirOpt,
           Colorize.optsConsoleDefault
         ).mapN {
           (
@@ -1609,6 +1686,7 @@ object Command {
               noOpt,
               jsonOut,
               output,
+              cacheDirFn,
               colorize
           ) =>
           val compileOptions =
@@ -1623,16 +1701,18 @@ object Command {
             }
           for {
             cc <- fcc
+            cacheDir = cacheDirFn(cc.gitRoot)
             out <- platformIO.withEC {
               for {
                 dec <- sourceFilterOpt match {
                   case None =>
-                    cc.decodedWithDeps(colorize, compileOptions)
+                    cc.decodedWithDeps(colorize, compileOptions, cacheDir)
                   case Some(sourceFilter) =>
                     cc.decodedWithDepsFiltered(
                       colorize,
                       sourceFilter,
-                      compileOptions
+                      compileOptions,
+                      cacheDir
                     )
                 }
                 ev = LibraryEvaluation(dec, BosatsuPredef.jvmExternals)
@@ -1672,11 +1752,17 @@ object Command {
               help = "include Bosatsu/Predef in generated docs"
             )
             .orFalse,
+          compileCacheDirOpt,
           Colorize.optsConsoleDefault
-        ).mapN { (fcc, outdir, includePredef, colorize) =>
+        ).mapN { (fcc, outdir, includePredef, cacheDirFn, colorize) =>
           for {
             cc <- fcc
-            docs <- cc.docPackages(colorize, outdir, includePredef)
+            docs <- cc.docPackages(
+              colorize,
+              outdir,
+              includePredef,
+              cacheDirFn(cc.gitRoot)
+            )
           } yield (Output.TranspileOut(docs): Output[P])
         }
       }
@@ -1745,8 +1831,9 @@ object Command {
             .orFalse,
           mainOpt,
           outputOpt,
+          compileCacheDirOpt,
           Colorize.optsConsoleDefault
-        ).mapN { (fcc, mode, yamlOut, target, output, colorize) =>
+        ).mapN { (fcc, mode, yamlOut, target, output, cacheDirFn, colorize) =>
           def showError[A](prefix: String, str: String, idx: Int): F[A] = {
             val errMsg0 = str.substring(idx + 1)
             val errMsg =
@@ -1820,9 +1907,14 @@ object Command {
 
           for {
             cc <- fcc
+            cacheDir = cacheDirFn(cc.gitRoot)
             out <- platformIO.withEC {
               for {
-                dec <- cc.decodedWithDeps(colorize, CompileOptions.Default)
+                dec <- cc.decodedWithDeps(
+                  colorize,
+                  CompileOptions.Default,
+                  cacheDir
+                )
                 ev = LibraryEvaluation(dec, BosatsuPredef.jvmExternals)
                 evaluated <- moduleIOMonad.fromEither {
                   target match {
@@ -2076,12 +2168,23 @@ object Command {
             ConfigConf.opts,
             mainPack,
             outputSpecOpt,
+            compileCacheDirOpt,
             ClangTranspiler.EmitMode.opts,
             ClangTranspiler.GenExternalsMode.opts
           ).tupled
 
         (buildArgs, Colorize.optsConsoleDefault).mapN {
-          case ((fcc, mainPackOpt, (outDirOpt, output), emit, gen), colorize) =>
+          case (
+                (
+                  fcc,
+                  mainPackOpt,
+                  (outDirOpt, output),
+                  cacheDirFn,
+                  emit,
+                  gen
+                ),
+                colorize
+              ) =>
             def mode(cc: ConfigConf): F[ClangTranspiler.Mode[F]] =
               mainPackOpt match {
                 case Some(m) =>
@@ -2120,7 +2223,11 @@ object Command {
                     platformIO
                   )
                 }
-                msg <- cc.build(colorize, trans)
+                msg <- cc.build(
+                  colorize,
+                  trans,
+                  compileCacheDirOpt = cacheDirFn(cc.gitRoot)
+                )
               } yield (Output.Basic(msg, None): Output[P])
 
             outDirOpt match {
@@ -2180,11 +2287,12 @@ object Command {
             clangOut,
             ClangTranspiler.EmitMode.opts,
             ClangTranspiler.GenExternalsMode.opts,
+            compileCacheDirOpt,
             Transpiler.outDir[P].orNone
           ).tupled
 
         (testArgs, Colorize.optsConsoleDefault).mapN {
-          case ((fcc, test, out, emit, gen, outDirOpt), colorize) =>
+          case ((fcc, test, out, emit, gen, cacheDirFn, outDirOpt), colorize) =>
             def runtimePreflight(
                 output: ClangTranspiler.Output[F, P]
             ): F[ClangTranspiler.Output[F, P]] =
@@ -2223,7 +2331,12 @@ object Command {
                 }
                 cc <- fcc
                 // build is the same as test, Transpiler controls the difference
-                msg <- cc.build(colorize, trans, test.filter)
+                msg <- cc.build(
+                  colorize,
+                  trans,
+                  test.filter,
+                  cacheDirFn(cc.gitRoot)
+                )
               } yield (Output.Basic(msg, None): Output[P])
             }
 
@@ -2259,6 +2372,7 @@ object Command {
           Colorize.optsConsoleDefault,
           gitShaOpt,
           Transpiler.outDir[P],
+          compileCacheDirOpt,
           Opts
             .option[String](
               long = "uri-base",
@@ -2266,7 +2380,16 @@ object Command {
               help = "uri prefix where all the libraries will be accessible."
             )
             .orNone
-        ).mapN { (readGitLibs, casDirFn, colorize, gitShaF, outDir, uriBaseOpt) =>
+        ).mapN {
+          (
+              readGitLibs,
+              casDirFn,
+              colorize,
+              gitShaF,
+              outDir,
+              cacheDirFn,
+              uriBaseOpt
+          ) =>
           for {
             gitRootlibs <- readGitLibs
             gitSha <- gitShaF
@@ -2274,10 +2397,14 @@ object Command {
             casDir = casDirFn(gitRoot)
             cas = new Cas(casDir, platformIO)
             allLibs <- libs.transform { case (name, (conf, path)) =>
-              val cc = ConfigConf(conf, cas, path)
+              val cc = ConfigConf(conf, cas, path, gitRoot)
               val libOut: P = libraryPath(outDir, name, conf.nextVersion)
               for {
-                protoLib <- cc.buildLibrary(vcsIdent = gitSha, colorize)
+                protoLib <- cc.buildLibrary(
+                  vcsIdent = gitSha,
+                  colorize = colorize,
+                  compileCacheDirOpt = cacheDirFn(gitRoot)
+                )
                 hashedLib = Hashed(
                   Algo[Algo.Blake3].hashBytes(protoLib.toByteArray),
                   protoLib

--- a/core/src/main/scala/dev/bosatsu/tool/CompilerApi.scala
+++ b/core/src/main/scala/dev/bosatsu/tool/CompilerApi.scala
@@ -113,6 +113,7 @@ object CompilerApi {
         cache,
         InferPhases.default
       )
+      _ <- cache.statsSnapshot.traverse_(platformIO.println)
       // TODO, we could use applicative, to report both duplicate packages and the other
       // errors
       res <-

--- a/core/src/test/scala/dev/bosatsu/ToolAndLibCommandTest.scala
+++ b/core/src/test/scala/dev/bosatsu/ToolAndLibCommandTest.scala
@@ -3407,6 +3407,126 @@ main = depBox
     }
   }
 
+  test("lib check --cache_dir writes cache artifacts and reuses them") {
+    val files = baseLibFiles("main = 1\n")
+    val cmd = List(
+      "lib",
+      "check",
+      "--repo_root",
+      "repo",
+      "--cache_dir",
+      "cache"
+    )
+
+    val result = for {
+      s0 <- MemoryMain.State.from[ErrorOr](files)
+      s1 <- runWithState(cmd, s0)
+      (state1, out1) = s1
+      s2 <- runWithState(cmd, state1)
+      (state2, out2) = s2
+    } yield (state1, state2, out1, out2)
+
+    result match {
+      case Left(err) =>
+        fail(err.getMessage)
+      case Right((state1, state2, out1, out2)) =>
+        val keyPrefix = Chain("cache", "keys", "blake3")
+        val casPrefix = Chain("cache", "cas", "blake3")
+        val keyFiles1 = filePathsUnder(state1, keyPrefix)
+        val casFiles1 = filePathsUnder(state1, casPrefix)
+
+        assert(keyFiles1.nonEmpty, "expected key cache files")
+        assert(casFiles1.nonEmpty, "expected cas cache files")
+        assertEquals(filePathsUnder(state2, keyPrefix), keyFiles1)
+        assertEquals(filePathsUnder(state2, casPrefix), casFiles1)
+        assertEquals(out1, Output.Basic(Doc.text(""), None))
+        assertEquals(out2, Output.Basic(Doc.text(""), None))
+    }
+  }
+
+  test(
+    "lib check without cache flags writes default cache artifacts and reuses them"
+  ) {
+    val files = baseLibFiles("main = 1\n")
+    val cmd = List(
+      "lib",
+      "check",
+      "--repo_root",
+      "repo"
+    )
+
+    val result = for {
+      s0 <- MemoryMain.State.from[ErrorOr](files)
+      s1 <- runWithState(cmd, s0)
+      (state1, out1) = s1
+      s2 <- runWithState(cmd, state1)
+      (state2, out2) = s2
+    } yield (state1, state2, out1, out2)
+
+    result match {
+      case Left(err) =>
+        fail(err.getMessage)
+      case Right((state1, state2, out1, out2)) =>
+        val keyPrefix =
+          Chain("repo", ".bosatsuc", "infer-cache", "keys", "blake3")
+        val casPrefix = Chain("repo", ".bosatsuc", "infer-cache", "cas", "blake3")
+        val keyFiles1 = filePathsUnder(state1, keyPrefix)
+        val casFiles1 = filePathsUnder(state1, casPrefix)
+
+        assert(keyFiles1.nonEmpty, "expected key cache files in default infer cache")
+        assert(casFiles1.nonEmpty, "expected cas cache files in default infer cache")
+        assertEquals(filePathsUnder(state2, keyPrefix), keyFiles1)
+        assertEquals(filePathsUnder(state2, casPrefix), casFiles1)
+        assertEquals(out1, Output.Basic(Doc.text(""), None))
+        assertEquals(out2, Output.Basic(Doc.text(""), None))
+    }
+  }
+
+  test("lib check --no_cache does not write infer cache artifacts") {
+    val files = baseLibFiles("main = 1\n")
+    val cmd = List(
+      "lib",
+      "check",
+      "--repo_root",
+      "repo",
+      "--no_cache"
+    )
+
+    val result = for {
+      s0 <- MemoryMain.State.from[ErrorOr](files)
+      s1 <- runWithState(cmd, s0)
+      (state1, _) = s1
+    } yield state1
+
+    result match {
+      case Left(err) =>
+        fail(err.getMessage)
+      case Right(state) =>
+        assertEquals(
+          filePathsUnder(state, Chain("repo", ".bosatsuc", "infer-cache")),
+          Set.empty
+        )
+    }
+  }
+
+  test("lib check rejects --cache_dir with --no_cache") {
+    val cmd = List(
+      "lib",
+      "check",
+      "--repo_root",
+      "repo",
+      "--cache_dir",
+      "cache",
+      "--no_cache"
+    )
+
+    module.run(cmd) match {
+      case Left(_)  => ()
+      case Right(_) =>
+        fail("expected parser error when both --cache_dir and --no_cache are supplied")
+    }
+  }
+
   test("lib deps list text output includes public and private sections") {
     val files = baseLibFiles("main = 1\n")
 

--- a/core/src/test/scala/dev/bosatsu/tool/CompileCacheTest.scala
+++ b/core/src/test/scala/dev/bosatsu/tool/CompileCacheTest.scala
@@ -30,13 +30,14 @@ class CompileCacheTest extends FunSuite {
 
   private def compilePackage(
       source: String,
+      depIfaces: List[Package.Interface] = Nil,
       compileOptions: CompileOptions = CompileOptions.Default
   ): Package.Inferred = {
     val parsed = parsePackage(source)
     val checked = Par.noParallelism {
       PackageMap.typeCheckParsed(
         cats.data.NonEmptyList.one((("test", LocationMap(source)), parsed)),
-        Nil,
+        depIfaces,
         "predef",
         compileOptions
       )
@@ -65,16 +66,29 @@ class CompileCacheTest extends FunSuite {
       pack: Package.Parsed,
       deps: SortedMap[PackageName, Package.Interface] = SortedMap.empty,
       compileOptions: CompileOptions = CompileOptions.Default
-  ): FsKey =
+  ): FsKey = {
+    val (stateAfterDepHashes, depHashes) =
+      deps.iterator.foldLeft(
+        (
+          MemoryMain.State.empty,
+          SortedMap.empty[PackageName, cache.DepHash]
+        )
+      ) { case ((state, hashes), (depName, depIface)) =>
+        val (nextState, depHash) = runF(cache.dependencyHash(depIface), state)
+        (nextState, hashes.updated(depName, depHash))
+      }
+
     runF(
       cache.generateKey(
         pack,
-        deps,
+        depHashes,
         compileOptions,
         "compiler-id",
         "phase-id"
-      )
+      ),
+      stateAfterDepHashes
     )._2
+  }
 
   test("sourceExprHash ignores statement regions") {
     val sourceA =
@@ -175,6 +189,61 @@ class CompileCacheTest extends FunSuite {
     )
   }
 
+  test("generateKey requires dependencyHash lookup for dependency interfaces") {
+    val consumerSource =
+      """package Cache/App
+        |from Cache/Dep import dep
+        |main = dep
+        |""".stripMargin
+    val depSource =
+      """package Cache/Dep
+        |export dep
+        |dep = 1
+        |""".stripMargin
+
+    val consumer = parsePackage(consumerSource)
+    val depIface = Package.interfaceOf(compilePackage(depSource))
+    val isolatedCache = CompileCache.filesystem(cacheDir, platform)
+    val depHashes = SortedMap(
+      depIface.name -> CompileCache.interfaceHash(depIface).getOrElse {
+        fail("failed to compute dependency interface hash")
+      }
+    )
+
+    val missingLookup =
+      isolatedCache
+        .generateKey(
+          consumer,
+          depHashes,
+          CompileOptions.Default,
+          "compiler-id",
+          "phase-id"
+        )
+        .run(MemoryMain.State.empty)
+    assert(missingLookup.isLeft)
+
+    val (stateWithLookup, _) = runF(isolatedCache.dependencyHash(depIface))
+    val seededKey =
+      runF(
+        isolatedCache.generateKey(
+          consumer,
+          depHashes,
+          CompileOptions.Default,
+          "compiler-id",
+          "phase-id"
+        ),
+        stateWithLookup
+      )._2
+
+    val helperKey =
+      compileKey(consumer, SortedMap(depIface.name -> depIface))
+
+    assertEquals(
+      CompileCache.keyHashHex(seededKey),
+      CompileCache.keyHashHex(helperKey)
+    )
+  }
+
   test("corrupt links and missing cas entries are treated as cache misses") {
     val source =
       """package Cache/Foo
@@ -217,5 +286,30 @@ class CompileCacheTest extends FunSuite {
 
     val (_, missFromMissingCas) = runF(cache.get(key), missingCasState)
     assertEquals(missFromMissingCas, None)
+  }
+
+  test("cached packages with imports decode on warm hits") {
+    val depSource =
+      """package Cache/Dep
+        |export dep
+        |dep = 1
+        |""".stripMargin
+    val appSource =
+      """package Cache/App
+        |from Cache/Dep import dep
+        |main = dep.add(1)
+        |""".stripMargin
+
+    val depCompiled = compilePackage(depSource)
+    val depIface = Package.interfaceOf(depCompiled)
+    val appParsed = parsePackage(appSource)
+    val appCompiled = compilePackage(appSource, depIfaces = depIface :: Nil)
+    val key = compileKey(appParsed, SortedMap(depIface.name -> depIface))
+
+    val (stateWithCache, _) = runF(cache.put(key, appCompiled))
+    val (_, warmHit) = runF(cache.get(key), stateWithCache)
+
+    assert(warmHit.nonEmpty, "expected warm cache hit for package with imports")
+    assertEquals(warmHit.map(_.name), Some(appParsed.name))
   }
 }


### PR DESCRIPTION
## Summary
- default compile/infer cache for `lib` compiler-invoking commands to `$repo/.bosatsuc/infer-cache`
- add `--no_cache` as an explicit opt-out and keep `--cache_dir` as an override
- enforce `--cache_dir | --no_cache` mutual exclusivity via Decline `.orElse`
- apply the same cache option behavior consistently across all `lib` subcommands that invoke compiler inference/typechecking:
  - `check`, `build`, `test`, `eval`, `show`, `doc`, `json`, `publish`
- refactor cache plumbing so noop cache has zero-cost dep-hash payload (`Unit`) and avoid computing dep-interface hash maps unless needed on cache miss
- expand tests to exercise:
  - default `lib check` cache writes/reuse under `.bosatsuc/infer-cache`
  - `lib check --no_cache` no cache writes
  - parser rejection when both `--cache_dir` and `--no_cache` are supplied

## Benchmarks
Latest benchmark summary is included in `cache_bench_summary.md`.

Median wall times (3 runs):

### `lib check`
- no_cache (`--no_cache`): **8.245s**
- cold_cache (`--cache_dir`, empty dir): **8.716s**
- warm_cache (`--cache_dir`, pre-warmed): **5.584s**
- warm vs no_cache: **1.48x faster** (~32.3% lower)

### `lib build`
- no_cache (`--no_cache`): **11.360s**
- cold_cache (`--cache_dir`, empty dir): **11.515s**
- warm_cache (`--cache_dir`, pre-warmed): **7.477s**
- warm vs no_cache: **1.52x faster** (~34.2% lower)

## Validation
- `sbt test:compile`
- `scripts/test_basic.sh`
- `sbt "coreJVM/testOnly dev.bosatsu.ToolAndLibCommandTest"`
