### PR TITLE
Fix eval --run exit code conversion for large Int values

### DIFF
--- a/core/src/main/scala/dev/bosatsu/tool/Output.scala
+++ b/core/src/main/scala/dev/bosatsu/tool/Output.scala
@@ -16,7 +16,6 @@ import dev.bosatsu.{
   Value,
   rankn
 }
-import java.math.BigInteger
 import org.typelevel.paiges.Doc
 import dev.bosatsu.LocationMap.Colorize
 import BInt.*
@@ -291,16 +290,10 @@ object Output {
   private def mainRunResult(
       run: PredefImpl.ProgRunResult
   ): (ExitCode, Option[Doc]) = {
-    val maxInt = BigInteger.valueOf(Int.MaxValue.toLong)
-    val minInt = BigInteger.valueOf(Int.MinValue.toLong)
-
     def asExitCode(value: Value): Either[String, ExitCode] =
       value match {
         case Value.ExternalValue(BInt(i)) =>
-          val bi = i.toBigInteger
-          if (bi.compareTo(minInt) >= 0 && bi.compareTo(maxInt) <= 0)
-            Right(ExitCode.fromInt(bi.intValue))
-          else Left(s"expected Main to return an Int exit code, found: $value")
+          Right(ExitCode.fromInt(i.toBigInteger.intValue))
         case other =>
           Left(s"expected Main to return an Int exit code, found: $other")
       }

--- a/core/src/test/scala/dev/bosatsu/ToolAndLibCommandTest.scala
+++ b/core/src/test/scala/dev/bosatsu/ToolAndLibCommandTest.scala
@@ -1538,6 +1538,70 @@ class ToolAndLibCommandTest extends FunSuite {
     }
   }
 
+  test("tool eval --run truncates Main exit code to low 32 bits") {
+    val progSrc =
+      """package Bosatsu/Prog
+|
+|export Prog(), Main(), pure
+|
+|enum Prog[e, a]:
+|  Pure(value: a)
+|  Raise(err: e)
+|
+|struct Main(run: List[String] -> Prog[String, Int])
+|
+|def pure(a):
+|  Pure(a)
+|""".stripMargin
+    val appSrc =
+      """package Tool/Foo
+|
+|from Bosatsu/Prog import Main, Prog, pure
+|
+|main = Main(_ -> pure(2147483648))
+|""".stripMargin
+    val files = List(
+      Chain("src", "Bosatsu", "Prog.bosatsu") -> progSrc,
+      Chain("src", "Tool", "Foo.bosatsu") -> appSrc
+    )
+
+    val result = for {
+      s0 <- MemoryMain.State.from[ErrorOr](files)
+      s1 <- runWithStateAndExit(
+        List(
+          "tool",
+          "eval",
+          "--run",
+          "--main",
+          "Tool/Foo",
+          "--package_root",
+          "src",
+          "--input",
+          "src/Bosatsu/Prog.bosatsu",
+          "--input",
+          "src/Tool/Foo.bosatsu"
+        ),
+        s0
+      )
+    } yield s1
+
+    result match {
+      case Left(err) =>
+        fail(err.getMessage)
+      case Right((state, out, exitCode)) =>
+        assertEquals(exitCode, ExitCode.fromInt(Int.MinValue))
+        val errOutput = state.stdErr.render(200)
+        assert(
+          !errOutput.contains("expected Main to return an Int exit code"),
+          errOutput
+        )
+        out match {
+          case Output.RunMainResult(_) => ()
+          case other                   => fail(s"unexpected output: $other")
+        }
+    }
+  }
+
   test("lib eval --run executes Bosatsu/Prog::Main and forwards trailing args") {
     val progSrc =
       """package Bosatsu/Prog


### PR DESCRIPTION
Reproduced issue #1890 by adding a regression in ToolAndLibCommandTest where Main returns 2147483648; before the fix this produced ExitCode.Error due to runtime range rejection. Updated Output.mainRunResult/asExitCode to always convert Bosatsu Int to Scala Int via intValue (low 32 bits) and map through ExitCode.fromInt, removing the overflow error path. Added assertions that no "expected Main to return an Int exit code" message is emitted for this case. Validation: sbt "coreJVM/testOnly dev.bosatsu.ToolAndLibCommandTest" and scripts/test_basic.sh both pass.

Fixes #1890