### PR TITLE
Fix malformed library config JSON errors to use CliException diagnostics

### DIFF
--- a/core/src/main/scala/dev/bosatsu/library/Command.scala
+++ b/core/src/main/scala/dev/bosatsu/library/Command.scala
@@ -35,6 +35,7 @@ import dev.bosatsu.{
   Identifier,
   Json,
   JsonEncodingError,
+  LocationMap,
   Package,
   PackageName,
   PackageMap,
@@ -170,12 +171,36 @@ object Command {
 
     def libsPath(root: P): P = platformIO.resolve(root, "bosatsu_libs.json")
 
+    def parseConfigJson(path: P, jsonString: String): F[Json] =
+      Json.parserFile.parseAll(jsonString) match {
+        case Right(json) => moduleIOMonad.pure(json)
+        case Left(err)   =>
+          val locations = LocationMap(jsonString)
+          val lineColSuffix =
+            locations
+              .toLineCol(err.failedAtOffset)
+              .map { case (line, col) => s":${line + 1}:${col + 1}" }
+              .getOrElse("")
+          val summary = show"config parse failed: $path$lineColSuffix"
+          val parseDoc = Parser.Error.showExpectations(
+            locations,
+            err.expected,
+            Colorize.None
+          )
+          val errDoc = Doc.intercalate(
+            Doc.hardLine,
+            List(Doc.text(summary), parseDoc)
+          )
+          moduleIOMonad.raiseError(CliException(summary, err = errDoc))
+      }
+
     def readJson[A: Json.Reader](path: P, onEmpty: => F[A]): F[A] =
       platformIO.fsDataType(path).flatMap {
         case None                             => onEmpty
         case Some(PlatformIO.FSDataType.File) =>
           platformIO
-            .parseUtf8(path, Json.parserFile)
+            .readUtf8(path)
+            .flatMap(parseConfigJson(path, _))
             .flatMap { json =>
               Json.Reader[A].read(Json.Path.Root, json) match {
                 case Right(a)          => moduleIOMonad.pure(a)

--- a/core/src/test/scala/dev/bosatsu/ToolAndLibCommandTest.scala
+++ b/core/src/test/scala/dev/bosatsu/ToolAndLibCommandTest.scala
@@ -4571,6 +4571,73 @@ main = 0
     }
   }
 
+  test("lib check malformed bosatsu_libs.json reports parse error without stack trace") {
+    val files = List(
+      Chain("repo", "bosatsu_libs.json") -> "{ bad json"
+    )
+
+    val result = for {
+      state0 <- MemoryMain.State.from[ErrorOr](files)
+      stateAndExit <- runAndReportWithState(
+        List("lib", "check", "--color", "none", "--repo_root", "repo"),
+        state0
+      )
+    } yield stateAndExit
+
+    result match {
+      case Left(err) =>
+        fail(err.getMessage)
+      case Right((state, exitCode)) =>
+        assertEquals(exitCode, ExitCode.Error)
+        val errOutput = state.stdErr.render(200)
+        assert(
+          errOutput.contains("config parse failed: repo/bosatsu_libs.json:1:3"),
+          errOutput
+        )
+        assert(errOutput.contains("expected"), errOutput)
+        assert(!errOutput.contains("unknown error"), errOutput)
+        assert(!errOutput.contains("java.lang.Exception"), errOutput)
+        assert(!errOutput.contains("\tat dev.bosatsu"), errOutput)
+    }
+  }
+
+  test("lib check malformed <lib>_conf.json reports parse error without stack trace") {
+    val libs = Libraries(SortedMap(Name("qa") -> "src"))
+    val files = List(
+      Chain("repo", "bosatsu_libs.json") -> renderJson(libs),
+      Chain("repo", "src", "qa_conf.json") -> "{ bad json",
+      Chain("repo", "src", "QA", "Foo.bosatsu") ->
+        """package QA/Foo
+          |
+          |x = 1
+          |""".stripMargin
+    )
+
+    val result = for {
+      state0 <- MemoryMain.State.from[ErrorOr](files)
+      stateAndExit <- runAndReportWithState(
+        List("lib", "check", "--color", "none", "--repo_root", "repo"),
+        state0
+      )
+    } yield stateAndExit
+
+    result match {
+      case Left(err) =>
+        fail(err.getMessage)
+      case Right((state, exitCode)) =>
+        assertEquals(exitCode, ExitCode.Error)
+        val errOutput = state.stdErr.render(200)
+        assert(
+          errOutput.contains("config parse failed: repo/src/qa_conf.json:1:3"),
+          errOutput
+        )
+        assert(errOutput.contains("expected"), errOutput)
+        assert(!errOutput.contains("unknown error"), errOutput)
+        assert(!errOutput.contains("java.lang.Exception"), errOutput)
+        assert(!errOutput.contains("\tat dev.bosatsu"), errOutput)
+    }
+  }
+
   test("lib fetch reports total fetched objects by default") {
     val files = baseLibFiles("main = 1\n")
 


### PR DESCRIPTION
Reproduced issue #1891 in `lib check` with malformed `bosatsu_libs.json` and malformed `<lib>_conf.json`; both cases previously emitted `unknown error` plus JVM stack traces.

Implemented fix in `core/src/main/scala/dev/bosatsu/library/Command.scala`:
- Added `parseConfigJson` to parse config JSON with `Json.parserFile.parseAll` and convert parse failures into `CliException`.
- Error summary now includes `config parse failed: <path>:<line>:<col>`.
- Used `LocationMap` + `Parser.Error.showExpectations(..., Colorize.None)` for deterministic, user-facing parse context and expectations.
- Updated `readJson` to use `readUtf8` + `parseConfigJson` instead of `PlatformIO.parseUtf8` (which raised a generic `Exception`).

Added regression tests in `core/src/test/scala/dev/bosatsu/ToolAndLibCommandTest.scala`:
- `lib check malformed bosatsu_libs.json reports parse error without stack trace`
- `lib check malformed <lib>_conf.json reports parse error without stack trace`
These assert no `unknown error`, no `java.lang.Exception`, and no JVM stack-frame output.

Validation:
- `sbt "coreJVM/testOnly dev.bosatsu.ToolAndLibCommandTest"` passed.
- Required pre-push command `scripts/test_basic.sh` passed.

Fixes #1891