### PR TITLE
Use inline call-by-name flow-control helpers

### DIFF
--- a/core/src/main/scala/dev/bosatsu/Kind.scala
+++ b/core/src/main/scala/dev/bosatsu/Kind.scala
@@ -136,8 +136,8 @@ object Kind {
       case _ => false
     }
 
-  def validApply[A](left: Kind, right: Kind, onTypeErr: => A)(
-      onSubsumeFail: Cons => A
+  final inline def validApply[A](left: Kind, right: Kind, inline onTypeErr: => A)(
+      inline onSubsumeFail: Cons => A
   ): Either[A, Kind] =
     left match {
       case cons @ Cons(Kind.Arg(_, lhs), res) =>

--- a/core/src/main/scala/dev/bosatsu/ProtoConverter.scala
+++ b/core/src/main/scala/dev/bosatsu/ProtoConverter.scala
@@ -67,7 +67,10 @@ object ProtoConverter {
       extends Exception(message)
 
   case class IdAssignment[A1, A2](mapping: Map[A1, Int], inOrder: Vector[A2]) {
-    def get(a1: A1, a2: => A2): Either[(IdAssignment[A1, A2], Int), Int] =
+    inline def get(
+        a1: A1,
+        inline a2: => A2
+    ): Either[(IdAssignment[A1, A2], Int), Int] =
       mapping.get(a1) match {
         case Some(id) => Right(id)
         case None     =>
@@ -96,17 +99,19 @@ object ProtoConverter {
       expressions: IdAssignment[TypedExpr[Any], proto.TypedExpr]
   ) {
 
-    def stringId(s: String): Either[(SerState, Int), Int] =
-      strings.get(s, s).left.map { case (next, id) =>
-        (copy(strings = next), id)
+    inline def stringId(s: String): Either[(SerState, Int), Int] =
+      strings.get(s, s) match {
+        case Right(id)         => Right(id)
+        case Left((next, id))  => Left((copy(strings = next), id))
       }
 
-    def typeId(
+    inline def typeId(
         t: Type,
-        protoType: => proto.Type
+        inline protoType: => proto.Type
     ): Either[(SerState, Int), Int] =
-      types.get(t, protoType).left.map { case (next, id) =>
-        (copy(types = next), id)
+      types.get(t, protoType) match {
+        case Right(id)         => Right(id)
+        case Left((next, id))  => Left((copy(types = next), id))
       }
   }
 
@@ -123,13 +128,18 @@ object ProtoConverter {
   type Tab[A] = StateT[Try, SerState, A]
 
   implicit class TabMethods[A](val self: Tab[A]) extends AnyVal {
-    def onFailPrint(message: => String): Tab[A] =
+    inline def onFailPrint(inline message: => String): Tab[A] =
       self.runF match {
         case Success(fn) =>
-          StateT(fn.andThen { next =>
-            if (next.isFailure) System.err.println(message)
-            next
-          })
+          def run(state: SerState): Try[(SerState, A)] =
+            fn(state) match {
+              case success @ Success(_) => success
+              case failure @ Failure(_) =>
+                System.err.println(message)
+                failure
+            }
+
+          StateT[Try, SerState, A](run)
 
         case Failure(_) =>
           System.err.println(message)
@@ -142,21 +152,27 @@ object ProtoConverter {
   private def tabPure[S, A](a: A): Tab[A] =
     Monad[Tab].pure(a)
 
-  private def get(fn: SerState => Either[(SerState, Int), Int]): Tab[Int] =
-    StateT
-      .get[Try, SerState]
-      .flatMap { ss =>
-        fn(ss) match {
-          case Right(idx)      => StateT.pure(idx + 1)
-          case Left((ss, idx)) =>
-            StateT.set[Try, SerState](ss).as(idx + 1)
-        }
+  private def getId(s: String): Tab[Int] =
+    def run(ss: SerState): Try[(SerState, Int)] =
+      ss.stringId(s) match {
+        case Right(idx) =>
+          Success((ss, idx + 1))
+        case Left((next, idx)) =>
+          Success((next, idx + 1))
       }
 
-  private def getId(s: String): Tab[Int] = get(_.stringId(s))
+    StateT[Try, SerState, Int](run)
 
-  private def getTypeId(t: Type, pt: => proto.Type): Tab[Int] =
-    get(_.typeId(t, pt))
+  private inline def getTypeId(t: Type, inline pt: => proto.Type): Tab[Int] =
+    def run(ss: SerState): Try[(SerState, Int)] =
+      ss.typeId(t, pt) match {
+        case Right(idx) =>
+          Success((ss, idx + 1))
+        case Left((next, idx)) =>
+          Success((next, idx + 1))
+      }
+
+    StateT[Try, SerState, Int](run)
 
   private def getProtoTypeTab(t: Type): Tab[Option[Int]] =
     StateT
@@ -206,7 +222,7 @@ object ProtoConverter {
       if ((0 <= idx) && (idx < strings.length)) Some(strings(idx))
       else None
 
-    def tryString(idx: Int, msg: => String): Try[String] =
+    inline def tryString(idx: Int, inline msg: => String): Try[String] =
       if ((0 <= idx) && (idx < strings.length)) Success(strings(idx))
       else Failure(new Exception(msg))
 
@@ -214,13 +230,13 @@ object ProtoConverter {
       if ((0 <= idx) && (idx < types.length)) Some(types(idx))
       else None
 
-    def tryType(idx: Int, msg: => String): Try[Type] =
+    inline def tryType(idx: Int, inline msg: => String): Try[Type] =
       if ((0 <= idx) && (idx < types.length)) Success(types(idx))
       else Failure(new Exception(msg))
 
-    def tryPattern(
+    inline def tryPattern(
         idx: Int,
-        msg: => String
+        inline msg: => String
     ): Try[Pattern[(PackageName, Constructor), Type]] =
       if ((0 <= idx) && (idx < patterns.length)) Success(patterns(idx))
       else Failure(new Exception(msg))
@@ -264,30 +280,53 @@ object ProtoConverter {
 
   type DTab[A] = ReaderT[Try, DecodeState, A]
 
-  private def find[A](idx: Int, context: => String)(
-      fn: (DecodeState, Int) => Option[A]
-  ): DTab[A] =
-    ReaderT { decodeState =>
-      fn(decodeState, idx - 1) match {
-        case Some(s) => Success(s)
-        case None => Failure(new Exception(s"invalid index: $idx in $context"))
-      }
-    }
-
-  private def lookup(idx: Int, context: => String): DTab[String] =
-    find(idx, context)(_.getString(_))
-
-  private def lookupType(idx: Int, context: => String): DTab[Type] =
-    find(idx, context)(_.getType(_))
-
-  private def lookupDts(
+  private inline def lookup(
       idx: Int,
-      context: => String
-  ): DTab[DefinedType[Kind.Arg]] =
-    find(idx, context)(_.getDt(_))
+      inline context: => String
+  ): DTab[String] =
+    def run(decodeState: DecodeState): Try[String] =
+      decodeState.getString(idx - 1) match {
+        case Some(s) => Success(s)
+        case None    => Failure(new Exception(s"invalid index: $idx in $context"))
+      }
 
-  private def lookupExpr(idx: Int, context: => String): DTab[TypedExpr[Unit]] =
-    find(idx, context)(_.getExpr(_))
+    ReaderT[Try, DecodeState, String](run)
+
+  private inline def lookupType(
+      idx: Int,
+      inline context: => String
+  ): DTab[Type] =
+    def run(decodeState: DecodeState): Try[Type] =
+      decodeState.getType(idx - 1) match {
+        case Some(t) => Success(t)
+        case None    => Failure(new Exception(s"invalid index: $idx in $context"))
+      }
+
+    ReaderT[Try, DecodeState, Type](run)
+
+  private inline def lookupDts(
+      idx: Int,
+      inline context: => String
+  ): DTab[DefinedType[Kind.Arg]] =
+    def run(decodeState: DecodeState): Try[DefinedType[Kind.Arg]] =
+      decodeState.getDt(idx - 1) match {
+        case Some(dt) => Success(dt)
+        case None     => Failure(new Exception(s"invalid index: $idx in $context"))
+      }
+
+    ReaderT[Try, DecodeState, DefinedType[Kind.Arg]](run)
+
+  private inline def lookupExpr(
+      idx: Int,
+      inline context: => String
+  ): DTab[TypedExpr[Unit]] =
+    def run(decodeState: DecodeState): Try[TypedExpr[Unit]] =
+      decodeState.getExpr(idx - 1) match {
+        case Some(exp) => Success(exp)
+        case None      => Failure(new Exception(s"invalid index: $idx in $context"))
+      }
+
+    ReaderT[Try, DecodeState, TypedExpr[Unit]](run)
 
   /** this is code to build tables of serialized dags. We use this for types,
     * patterns, expressions
@@ -470,9 +509,9 @@ object ProtoConverter {
       buildTable(pats.toArray)(patternFromProto)
     }
 
-  def recursionKindFromProto(
+  inline def recursionKindFromProto(
       rec: proto.RecursionKind,
-      context: => String
+      inline context: => String
   ): Try[RecursionKind] =
     rec match {
       case proto.RecursionKind.NotRec => Success(RecursionKind.NonRecursive)
@@ -674,27 +713,41 @@ object ProtoConverter {
       buildTable(exprs.toArray)(expressionFromProto)
     }
 
-  private def parsePack(pstr: String, context: => String): Try[PackageName] =
+  private inline def parsePack(
+      pstr: String,
+      inline context: => String
+  ): Try[PackageName] =
     PackageName.parse(pstr) match {
       case None =>
         Failure(new Exception(s"invalid package name: $pstr, in $context"))
       case Some(pack) => Success(pack)
     }
 
-  private def fullNameFromStr(
+  private inline def fullNameFromStr(
       pstr: String,
       tstr: String,
-      context: => String
+      inline context: => String
   ): Try[(PackageName, Constructor)] =
-    (parsePack(pstr, context), toConstructor(tstr)).tupled
+    parsePack(pstr, context) match {
+      case Success(pack) =>
+        toConstructor(tstr) match {
+          case Success(cons) => Success((pack, cons))
+          case failure: Failure[?] =>
+            failure.asInstanceOf[Try[(PackageName, Constructor)]]
+        }
+      case failure: Failure[?] =>
+        failure.asInstanceOf[Try[(PackageName, Constructor)]]
+    }
 
-  def typeConstFromStr(
+  inline def typeConstFromStr(
       pstr: String,
       tstr: String,
-      context: => String
+      inline context: => String
   ): Try[Type.Const.Defined] =
-    fullNameFromStr(pstr, tstr, context).map { case (p, c) =>
-      Type.Const.Defined(p, TypeName(c))
+    fullNameFromStr(pstr, tstr, context) match {
+      case Success((p, c)) => Success(Type.Const.Defined(p, TypeName(c)))
+      case failure: Failure[?] =>
+        failure.asInstanceOf[Try[Type.Const.Defined]]
     }
 
   def typeConstFromProto(p: proto.TypeConst): DTab[Type.Const.Defined] = {
@@ -1758,11 +1811,29 @@ object ProtoConverter {
   def toConstructor(str: String): Try[Identifier.Constructor] =
     tryParse(Identifier.consParser, str)
 
-  def lookupBindable(idx: Int, context: => String): DTab[Bindable] =
-    lookup(idx, context).flatMapF(toBindable)
+  inline def lookupBindable(
+      idx: Int,
+      inline context: => String
+  ): DTab[Bindable] =
+    def run(decodeState: DecodeState): Try[Bindable] =
+      decodeState.getString(idx - 1) match {
+        case Some(value) => toBindable(value)
+        case None        => Failure(new Exception(s"invalid index: $idx in $context"))
+      }
 
-  def lookupIdentifier(idx: Int, context: => String): DTab[Identifier] =
-    lookup(idx, context).flatMapF(toIdent)
+    ReaderT[Try, DecodeState, Bindable](run)
+
+  inline def lookupIdentifier(
+      idx: Int,
+      inline context: => String
+  ): DTab[Identifier] =
+    def run(decodeState: DecodeState): Try[Identifier] =
+      decodeState.getString(idx - 1) match {
+        case Some(value) => toIdent(value)
+        case None        => Failure(new Exception(s"invalid index: $idx in $context"))
+      }
+
+    ReaderT[Try, DecodeState, Identifier](run)
 
   def importedNameFromProto(
       loadDT: Type.Const => Try[DefinedType[Kind.Arg]],

--- a/core/src/main/scala/dev/bosatsu/UnusedLetCheck.scala
+++ b/core/src/main/scala/dev/bosatsu/UnusedLetCheck.scala
@@ -21,9 +21,9 @@ object UnusedLetCheck {
   private val empty: WriterChain[Set[Bindable]] =
     ap.pure(Set.empty)
 
-  private def checkArg(
+  private inline def checkArg(
       arg: Bindable,
-      reg: => Region,
+      inline reg: => Region,
       w: WriterChain[Set[Bindable]]
   ) =
     w.flatMap { free =>


### PR DESCRIPTION
## Summary
- switch call-by-name flow-control helpers to inline def patterns in ProtoConverter, Kind, and UnusedLetCheck
- rewrite several Either/Try helper paths in ProtoConverter from combinators to direct branching to reduce fast-path allocation pressure
- remove higher-order helper indirection in ProtoConverter (get/find) and use direct StateT/ReaderT transitions

## Validation
- sbt test:compile
- sbt "coreJVM/testOnly dev.bosatsu.ProtoConverterTest" "coreJS/testOnly dev.bosatsu.ProtoConverterTest"
