### PR TITLE
Add `--package-names` mode to `lib show`

### DIFF
--- a/core/src/main/scala/dev/bosatsu/library/Command.scala
+++ b/core/src/main/scala/dev/bosatsu/library/Command.scala
@@ -1663,6 +1663,12 @@ object Command {
             .orFalse,
           Opts
             .flag(
+              "package-names",
+              help = "show only package names in package entries"
+            )
+            .orFalse,
+          Opts
+            .flag(
               "no-opt",
               help = "disable normalization/optimization to inspect typed expressions before optimization"
             )
@@ -1683,6 +1689,7 @@ object Command {
               types,
               values,
               externalsOnly,
+              packageNamesOnly,
               noOpt,
               jsonOut,
               output,
@@ -1730,7 +1737,23 @@ object Command {
                 )
               } yield (
                 if (jsonOut)
-                  Output.JsonOutput(ShowEdn.showJson(packs, Nil), output)
+                  Output.JsonOutput(
+                    ShowEdn.showJson(
+                      packs,
+                      Nil,
+                      packageNamesOnly = packageNamesOnly
+                    ),
+                    output
+                  )
+                else if (packageNamesOnly)
+                  Output.Basic(
+                    ShowEdn.showDoc(
+                      packs,
+                      Nil,
+                      packageNamesOnly = true
+                    ),
+                    output
+                  )
                 else Output.ShowOutput(packs, Nil, output): Output[P]
               )
             }

--- a/core/src/main/scala/dev/bosatsu/tool/ShowEdn.scala
+++ b/core/src/main/scala/dev/bosatsu/tool/ShowEdn.scala
@@ -1539,6 +1539,9 @@ object ShowEdn {
     )
   }
 
+  private def encodePackageNameOnlyForShow(name: PackageName): Edn =
+    EList(List(sym("package"), kw("name"), nameAtom(name.asString)))
+
   private val showFormField = "$form"
   private val listField = "$list"
   private val vectorField = "$vec"
@@ -1704,7 +1707,8 @@ object ShowEdn {
 
   private def showEdnValue(
       packs: List[Package.Typed[Any]],
-      ifaces: List[Package.Interface]
+      ifaces: List[Package.Interface],
+      packageNamesOnly: Boolean
   ): Edn =
     EList(
       List(
@@ -1712,10 +1716,15 @@ object ShowEdn {
         kw("interfaces"),
         EVector(ifaces.map(encodeInterfaceForShow)),
         kw("packages"),
-        EVector(packs.map(p => normalizeForRoundTrip(p.void).fold(msg =>
-          EList(List(sym("show-error"), str(msg), str(p.name.asString))),
-          encodePackageForShow
-        )))
+        EVector(
+          if (packageNamesOnly)
+            packs.map(p => encodePackageNameOnlyForShow(p.name))
+          else
+            packs.map(p => normalizeForRoundTrip(p.void).fold(msg =>
+              EList(List(sym("show-error"), str(msg), str(p.name.asString))),
+              encodePackageForShow
+            ))
+        )
       )
     )
 
@@ -1732,13 +1741,15 @@ object ShowEdn {
 
   def showJson(
       packs: List[Package.Typed[Any]],
-      ifaces: List[Package.Interface]
+      ifaces: List[Package.Interface],
+      packageNamesOnly: Boolean = false
   ): Json =
-    ednToJson(showEdnValue(packs, ifaces))
+    ednToJson(showEdnValue(packs, ifaces, packageNamesOnly))
 
   def showDoc(
       packs: List[Package.Typed[Any]],
-      ifaces: List[Package.Interface]
+      ifaces: List[Package.Interface],
+      packageNamesOnly: Boolean = false
   ): Doc =
-    Edn.toDoc(showEdnValue(packs, ifaces))
+    Edn.toDoc(showEdnValue(packs, ifaces, packageNamesOnly))
 }

--- a/core/src/test/scala/dev/bosatsu/ToolAndLibCommandTest.scala
+++ b/core/src/test/scala/dev/bosatsu/ToolAndLibCommandTest.scala
@@ -687,6 +687,39 @@ class ToolAndLibCommandTest extends FunSuite {
         fail(s"expected show json object, found: $other")
     }
 
+  private def showJsonPackageFieldKeys(json: Json): List[Set[String]] =
+    def jsonListLike(value: Json): Option[Vector[Json]] =
+      value match {
+        case Json.JArray(items) => Some(items)
+        case Json.JObject(("$vec", Json.JArray(items)) :: Nil) =>
+          Some(items)
+        case _ => None
+      }
+
+    json match {
+      case Json.JObject(fields) =>
+        val byKey = fields.toMap
+        assertEquals(byKey.get("$form"), Some(Json.JString("show")))
+        byKey.get("packages") match {
+          case Some(packsJson) =>
+            val packs = jsonListLike(packsJson).getOrElse {
+              fail(s"expected show packages array, found: ${Some(packsJson)}")
+            }
+            packs.toList.map {
+              case Json.JObject(packFields) =>
+                val packMap = packFields.toMap
+                assertEquals(packMap.get("$form"), Some(Json.JString("package")))
+                packMap.keySet
+              case other =>
+                fail(s"expected package object, found: $other")
+            }
+          case None =>
+            fail("expected show packages array, found: None")
+        }
+      case other =>
+        fail(s"expected show json object, found: $other")
+    }
+
   private def withInjectedPublicDep(
       state: MemoryMain.State,
       previousLibPath: Chain[String],
@@ -847,6 +880,59 @@ class ToolAndLibCommandTest extends FunSuite {
     ) match {
       case Right(Output.JsonOutput(json, _)) =>
         assertEquals(showJsonPackageNames(json), List("MyLib/Foo"))
+      case Right(other) =>
+        fail(s"unexpected output: $other")
+      case Left(err) =>
+        fail(err.getMessage)
+    }
+  }
+
+  test("lib show --package-names only emits package names") {
+    val src =
+      """main = 42
+"""
+    val files = baseLibFiles(src)
+
+    module.runWith(files)(
+      List(
+        "lib",
+        "show",
+        "--repo_root",
+        "repo",
+        "--package",
+        "MyLib/Foo",
+        "--package-names"
+      )
+    ) match {
+      case Right(Output.Basic(doc, _)) =>
+        val rendered = doc.render(120)
+        assert(rendered.contains("(package :name MyLib/Foo)"), rendered)
+        assert(!rendered.contains(":imports"), rendered)
+        assert(!rendered.contains(":exports"), rendered)
+        assert(!rendered.contains(":types"), rendered)
+        assert(!rendered.contains(":defs"), rendered)
+        assert(!rendered.contains(":externals"), rendered)
+      case Right(other) =>
+        fail(s"unexpected output: $other")
+      case Left(err) =>
+        fail(err.getMessage)
+    }
+
+    module.runWith(files)(
+      List(
+        "lib",
+        "show",
+        "--repo_root",
+        "repo",
+        "--package",
+        "MyLib/Foo",
+        "--package-names",
+        "--json"
+      )
+    ) match {
+      case Right(Output.JsonOutput(json, _)) =>
+        assertEquals(showJsonPackageNames(json), List("MyLib/Foo"))
+        assertEquals(showJsonPackageFieldKeys(json), List(Set("$form", "name")))
       case Right(other) =>
         fail(s"unexpected output: $other")
       case Left(err) =>


### PR DESCRIPTION
Implemented issue #1899 with focused changes:
- Added a new `--package-names` flag to `lib show` in `core/src/main/scala/dev/bosatsu/library/Command.scala`.
- Extended show rendering in `core/src/main/scala/dev/bosatsu/tool/ShowEdn.scala` with a package-names-only mode (`showDoc`/`showJson` now support `packageNamesOnly`).
- Wired `lib show --package-names` so output keeps the same top-level show EDN/JSON format but each package entry contains only `:name`/`name`.
- Added tests in `core/src/test/scala/dev/bosatsu/ToolAndLibCommandTest.scala` to verify both EDN and JSON behavior for `lib show --package-names`.

Validation:
- Ran `sbt "coreJVM/test:compile"` successfully.
- Ran required pre-push command `scripts/test_basic.sh` successfully (all tests passed).

Fixes #1899