### PR TITLE
Fix `tool deps` parsing for valid source files with package declarations

### DIFF
--- a/core/src/main/scala/dev/bosatsu/tool/PackageResolver.scala
+++ b/core/src/main/scala/dev/bosatsu/tool/PackageResolver.scala
@@ -2,6 +2,7 @@ package dev.bosatsu.tool
 
 import cats.Traverse
 import cats.data.{Chain, NonEmptyList, Validated, ValidatedNel}
+import cats.parse.{Parser => P}
 import cats.syntax.all._
 import com.monovore.decline.Opts
 import dev.bosatsu.{LocationMap, Package, PackageName, PlatformIO}
@@ -148,9 +149,10 @@ sealed abstract class PackageResolver[IO[_], Path] {
     paths
       .traverse { path =>
         val defaultPack = packageNameFor(path)(platformIO)
+        val headerParser = Package.headerParser(defaultPack) <* P.anyChar.rep0
         platformIO.readUtf8(path).map { str =>
           PathParseError
-            .parseString(Package.headerParser(defaultPack), path, str)
+            .parseString(headerParser, path, str)
             .map { case (_, pp) => (path, pp) }
         }
       }

--- a/core/src/test/scala/dev/bosatsu/ToolAndLibCommandTest.scala
+++ b/core/src/test/scala/dev/bosatsu/ToolAndLibCommandTest.scala
@@ -2824,6 +2824,75 @@ main = depValue
     }
   }
 
+  test("tool deps parses explicit package declarations with body statements") {
+    val aSrc =
+      """package QA/A
+x = 1
+"""
+    val bSrc =
+      """package QA/B
+from QA/A import x
+y = x
+"""
+    val files = List(
+      Chain("src", "QA", "A.bosatsu") -> aSrc,
+      Chain("src", "QA", "B.bosatsu") -> bSrc
+    )
+
+    val result = for {
+      s0 <- MemoryMain.State.from[ErrorOr](files)
+      s1 <- runWithState(
+        List(
+          "tool",
+          "deps",
+          "--package_root",
+          "src",
+          "--input",
+          "src/QA/A.bosatsu",
+          "--input",
+          "src/QA/B.bosatsu",
+          "--graph_format",
+          "json",
+          "--output",
+          "out/deps.json"
+        ),
+        s0
+      )
+    } yield s1._1
+
+    result match {
+      case Left(err) =>
+        fail(err.getMessage)
+      case Right(state) =>
+        val jsonStr = readStringFile(state, Chain("out", "deps.json"))
+        Json.parserFile.parseAll(jsonStr) match {
+          case Right(Json.JArray(items)) =>
+            val packageDeps = items.toList.collect {
+              case Json.JObject(fields) =>
+                val pkg = fields.collectFirst {
+                  case ("package", Json.JString(p)) => p
+                } match {
+                  case Some(p) => p
+                  case None    => fail(show"missing package in output row: $fields")
+                }
+                val deps = fields
+                  .collectFirst { case ("dependsOn", Json.JArray(values)) =>
+                    values.toList.collect { case Json.JString(s) => s }
+                  }
+                  .getOrElse(Nil)
+                (pkg, deps)
+            }.toMap
+
+            assertEquals(packageDeps.get("QA/A"), Some(Nil))
+            assertEquals(packageDeps.get("QA/B"), Some(List("QA/A")))
+          case Right(other) =>
+            fail(show"expected deps json array output, found: $other")
+          case Left(err) =>
+            fail(show"failed to parse deps json output: $err")
+        }
+    }
+  }
+
   test(
     "tool assemble fails when previous public dependencies are not provided"
   ) {


### PR DESCRIPTION
Implemented a direct fix for issue #1903 in `tool deps`.

What changed:
- Updated `core/src/main/scala/dev/bosatsu/tool/PackageResolver.scala` in `parseHeaders`.
- `tool deps` was parsing with `Package.headerParser(...)` under a full-input parse (`parseAll`), which incorrectly required EOF immediately after the header/import/export section.
- Fixed by parsing the header and then consuming the remaining file content (`<* P.anyChar.rep0`), so valid source files with body statements now parse correctly for dependency extraction.

Regression coverage:
- Added `tool deps parses explicit package declarations with body statements` to `core/src/test/scala/dev/bosatsu/ToolAndLibCommandTest.scala`.
- The new test mirrors the issue report pattern (`package QA/A`, `x = 1`; `package QA/B`, `from QA/A import x`, `y = x`) and asserts successful JSON deps output with `QA/B -> QA/A`.
- This test failed before the fix with the same `expected end of file` parse error and passes after the fix.

Validation run:
- `sbt "coreJVM/testOnly dev.bosatsu.ToolAndLibCommandTest"` (pass)
- `scripts/test_basic.sh` (pass)

Fixes #1903