### PR TITLE
Use show-path rendering in source-map errors (fix JSUI Chain path)

### DIFF
--- a/core/src/main/scala/dev/bosatsu/PackageMap.scala
+++ b/core/src/main/scala/dev/bosatsu/PackageMap.scala
@@ -716,12 +716,12 @@ object PackageMap {
     )
   }
 
-  def buildSourceMap[F[_]: Foldable, A](
+  def buildSourceMap[F[_]: Foldable, A: Show](
       parsedFiles: F[((A, LocationMap), Package.Parsed)]
   ): Map[PackageName, (LocationMap, String)] =
     parsedFiles.foldLeft(Map.empty[PackageName, (LocationMap, String)]) {
       case (map, ((path, lm), pack)) =>
-        map.updated(pack.name, (lm, path.toString))
+        map.updated(pack.name, (lm, path.show))
     }
 
   /** typecheck a list of packages given a list of interface dependencies

--- a/core/src/main/scala/dev/bosatsu/tool/CompilerApi.scala
+++ b/core/src/main/scala/dev/bosatsu/tool/CompilerApi.scala
@@ -125,6 +125,7 @@ object CompilerApi {
               }
             moduleIOMonad.pure((p, pathToName))
           case Validated.Invalid(errs) =>
+            given cats.Show[Path] = platformIO.showPath
             val sourceMap = PackageMap.buildSourceMap(packs)
             moduleIOMonad.raiseError(
               PackageErrors(sourceMap, errs, errColor)

--- a/core/src/test/scala/dev/bosatsu/TestUtils.scala
+++ b/core/src/test/scala/dev/bosatsu/TestUtils.scala
@@ -449,6 +449,7 @@ object TestUtils {
 
       case Some(errs) if errs.collect(errFn).nonEmpty =>
         // make sure we can print the messages:
+        given cats.Show[String] = cats.Show.fromToString
         val sm = PackageMap.buildSourceMap(withPre)
         errs.toList.foreach(_.message(sm, LocationMap.Colorize.None))
         assert(true)

--- a/jsui/src/test/scala/dev/bosatsu/jsui/StoreTest.scala
+++ b/jsui/src/test/scala/dev/bosatsu/jsui/StoreTest.scala
@@ -77,4 +77,22 @@ class StoreTest extends munit.FunSuite {
         fail(s"expected Output.ShowOutput, got: $other")
     }
   }
+
+  test("evaluate error renders source paths with slash form") {
+    val reproSource =
+      """package Repro/Issue1
+        |
+        |test = Assertion(int_to_String(42) matches str, "msg")
+        |""".stripMargin
+
+    val (args, _) = Store.cmdHandler(Action.Cmd.Eval)
+    Store.memoryMain.runWith(files = Map(webDemoPath -> reproSource))(args) match {
+      case Left(err) =>
+        val msg = Option(err.getMessage).getOrElse(err.toString)
+        assert(msg.contains("in file: root/WebDemo"), msg)
+        assert(!msg.contains("Chain(root, WebDemo)"), msg)
+      case Right(output) =>
+        fail(s"expected evaluate to fail with type errors, got: $output")
+    }
+  }
 }


### PR DESCRIPTION
## Summary
- fix `PackageMap.buildSourceMap` to render source labels via `Show` instead of `toString`
- wire `CompilerApi` to provide `platformIO.showPath` when building source maps
- add a JSUI regression test for evaluate errors to ensure paths are shown as `root/WebDemo` (not `Chain(root, WebDemo)`)

## Repro covered
Using JSUI evaluate with:

```bosatsu
package Repro/Issue1

test = Assertion(int_to_String(42) matches str, "msg")
```

now reports `in file: root/WebDemo...` instead of `Chain(root, WebDemo)...`.

## Tests
- `sbt "jsuiJS/testOnly dev.bosatsu.jsui.StoreTest"`
- `sbt "coreJVM/testOnly dev.bosatsu.ErrorMessageTest"`
