### PR TITLE
Fix eval --run stdin handling in evaluator for tool/lib commands

### DIFF
--- a/core/src/main/scala/dev/bosatsu/Predef.scala
+++ b/core/src/main/scala/dev/bosatsu/Predef.scala
@@ -795,6 +795,7 @@ object PredefImpl {
   final case class ProgRuntimeState(
       stdin: Array[Byte],
       var stdinOffset: Int,
+      stdinStream: Option[InputStream],
       stdout: StringBuilder,
       stderr: StringBuilder
   )
@@ -917,29 +918,46 @@ object PredefImpl {
       runtime: ProgRuntimeState,
       count: Int
   ): Array[Byte] = {
-    val remaining = runtime.stdin.length - runtime.stdinOffset
-    if (count <= 0 || remaining <= 0) Array.emptyByteArray
-    else {
-      val toRead = if (count <= remaining) count else remaining
-      val out = java.util.Arrays.copyOfRange(
-        runtime.stdin,
-        runtime.stdinOffset,
-        runtime.stdinOffset + toRead
-      )
-      runtime.stdinOffset = runtime.stdinOffset + toRead
-      out
+    runtime.stdinStream match {
+      case Some(stream) =>
+        if (count <= 0) Array.emptyByteArray
+        else {
+          val buffer = new Array[Byte](count)
+          val readCount = stream.read(buffer, 0, count)
+          if (readCount <= 0) Array.emptyByteArray
+          else if (readCount == count) buffer
+          else java.util.Arrays.copyOf(buffer, readCount)
+        }
+      case None =>
+        val remaining = runtime.stdin.length - runtime.stdinOffset
+        if (count <= 0 || remaining <= 0) Array.emptyByteArray
+        else {
+          val toRead = if (count <= remaining) count else remaining
+          val out = java.util.Arrays.copyOfRange(
+            runtime.stdin,
+            runtime.stdinOffset,
+            runtime.stdinOffset + toRead
+          )
+          runtime.stdinOffset = runtime.stdinOffset + toRead
+          out
+        }
     }
   }
 
-  private def runtimeReadOne(runtime: ProgRuntimeState): Option[Byte] = {
-    val remaining = runtime.stdin.length - runtime.stdinOffset
-    if (remaining <= 0) None
-    else {
-      val b = runtime.stdin(runtime.stdinOffset)
-      runtime.stdinOffset = runtime.stdinOffset + 1
-      Some(b)
+  private def runtimeReadOne(runtime: ProgRuntimeState): Option[Byte] =
+    runtime.stdinStream match {
+      case Some(stream) =>
+        val value = stream.read()
+        if (value < 0) None else Some(value.toByte)
+      case None =>
+        val remaining = runtime.stdin.length - runtime.stdinOffset
+        if (remaining <= 0) None
+        else {
+          val b = runtime.stdin(runtime.stdinOffset)
+          runtime.stdinOffset = runtime.stdinOffset + 1
+          Some(b)
+        }
     }
-  }
 
   private def read_utf8_chunk(
       runtime: ProgRuntimeState,
@@ -2682,6 +2700,16 @@ object PredefImpl {
     Left(Str("unreachable"))
   }
 
+  private def runProgWithRuntime(
+      prog: Value,
+      runtime: ProgRuntimeState
+  ): ProgRunResult = {
+    val result = currentProgRuntime.withValue(Some(runtime)) {
+      run_prog(prog)
+    }
+    ProgRunResult(result, runtime.stdout.toString, runtime.stderr.toString)
+  }
+
   def runProg(
       prog: Value,
       stdin: String = ""
@@ -2690,14 +2718,27 @@ object PredefImpl {
       ProgRuntimeState(
         stdin = stdin.getBytes(StandardCharsets.UTF_8),
         stdinOffset = 0,
+        stdinStream = None,
         stdout = new StringBuilder,
         stderr = new StringBuilder
       )
 
-    val result = currentProgRuntime.withValue(Some(runtime)) {
-      run_prog(prog)
-    }
-    ProgRunResult(result, runtime.stdout.toString, runtime.stderr.toString)
+    runProgWithRuntime(prog, runtime)
+  }
+
+  private def runProgWithSystemStdin(
+      prog: Value
+  ): ProgRunResult = {
+    val runtime =
+      ProgRuntimeState(
+        stdin = Array.emptyByteArray,
+        stdinOffset = 0,
+        stdinStream = Some(System.in),
+        stdout = new StringBuilder,
+        stderr = new StringBuilder
+      )
+
+    runProgWithRuntime(prog, runtime)
   }
 
   private def unwrapMain(value: Value): Value =
@@ -2717,6 +2758,18 @@ object PredefImpl {
       case other       => other
     }
     runProg(prog, stdin)
+  }
+
+  def runProgMainWithSystemStdin(
+      main: Value,
+      args: List[String]
+  ): ProgRunResult = {
+    val argList = VList(args.map(Str(_)))
+    val prog = unwrapMain(main) match {
+      case fn: FnValue => callFn1(fn, argList)
+      case other       => other
+    }
+    runProgWithSystemStdin(prog)
   }
 
   final def shiftRight(a: BigInteger, b: BigInteger): BigInteger = {

--- a/core/src/main/scala/dev/bosatsu/library/Command.scala
+++ b/core/src/main/scala/dev/bosatsu/library/Command.scala
@@ -1616,7 +1616,7 @@ object Command {
                 out <- if (runMain) {
                   if (tpe == progMainType) {
                     val run =
-                      memoE.map(PredefImpl.runProgMain(_, runArgs))
+                      memoE.map(PredefImpl.runProgMainWithSystemStdin(_, runArgs))
                     moduleIOMonad.pure(Output.RunMainResult(run): Output[P])
                   } else {
                     val actual =

--- a/core/src/main/scala/dev/bosatsu/tool_command/EvalCommand.scala
+++ b/core/src/main/scala/dev/bosatsu/tool_command/EvalCommand.scala
@@ -31,7 +31,7 @@ object EvalCommand {
       args: List[String]
   ): Either[Exception & CliException, Output[Path]] =
     if (result.tpe == progMainType) {
-      val run = result.value.map(PredefImpl.runProgMain(_, args))
+      val run = result.value.map(PredefImpl.runProgMainWithSystemStdin(_, args))
       Right(Output.RunMainResult(run))
     } else {
       val actual = rankn.Type.fullyResolvedDocument.document(result.tpe).render(80)

--- a/core/src/test/scala/dev/bosatsu/ToolAndLibCommandTest.scala
+++ b/core/src/test/scala/dev/bosatsu/ToolAndLibCommandTest.scala
@@ -9,6 +9,8 @@ import dev.bosatsu.hashing.{Algo, Hashed}
 import dev.bosatsu.library.{LibConfig, Libraries, Name, Version}
 import dev.bosatsu.LocationMap.Colorize
 import dev.bosatsu.tool.{CliException, ExitCode, GraphOutput, Output, ShowEdn}
+import java.io.{ByteArrayInputStream, InputStream}
+import java.nio.charset.StandardCharsets
 import munit.FunSuite
 import org.typelevel.paiges.Doc
 import scala.collection.immutable.SortedMap
@@ -22,6 +24,18 @@ class ToolAndLibCommandTest extends FunSuite {
 
   private def renderJson[A: Json.Writer](value: A): String =
     Json.Writer.write(value).render
+
+  private def withSystemStdin[A](stdin: String)(fn: => A): A = {
+    val previous: InputStream = System.in
+    val next =
+      new ByteArrayInputStream(stdin.getBytes(StandardCharsets.UTF_8))
+    System.setIn(next)
+    try fn
+    finally {
+      System.setIn(previous)
+      next.close()
+    }
+  }
 
   private def runWithState(
       cmd: List[String],
@@ -1624,6 +1638,149 @@ class ToolAndLibCommandTest extends FunSuite {
     }
   }
 
+  test("tool eval --run reads stdin for IO/Std read_line and read_all_stdin") {
+    val ioCoreSrc =
+      """package Bosatsu/IO/Core
+|
+|from Bosatsu/Prog import Prog
+|from Bosatsu/IO/Error import IOError
+|
+|export (Handle, stdin, stdout, read_utf8, write_utf8, flush)
+|
+|external struct Handle
+|external stdin: Handle
+|external stdout: Handle
+|external def read_utf8(h: Handle, max_chars: Int) -> Prog[IOError, Option[String]]
+|external def write_utf8(h: Handle, s: String) -> Prog[IOError, Unit]
+|external def flush(h: Handle) -> Prog[IOError, Unit]
+|""".stripMargin
+    val ioStdSrc =
+      """package Bosatsu/IO/Std
+|
+|from Bosatsu/Prog import Prog, pure, await, recursive
+|from Bosatsu/IO/Error import IOError
+|from Bosatsu/IO/Core import stdin, stdout, read_utf8, write_utf8, flush
+|
+|export (println, read_line, read_all_stdin)
+|
+|def println(str: String) -> Prog[IOError, Unit]:
+|  (
+|    _ <- write_utf8(stdout, "${str}\n").await()
+|    flush(stdout)
+|  )
+|
+|def trim_trailing_cr(s: String) -> String:
+|  match s.rpartition_String("\r"):
+|    case Some((prefix, suffix)):
+|      if suffix matches "":
+|        prefix
+|      else:
+|        s
+|    case None:
+|      s
+|
+|def concat_rev_chunks(rev_chunks: List[String]) -> String:
+|  concat_String(rev_chunks.reverse())
+|
+|read_line: Prog[IOError, Option[String]] =
+|  recursive(rec -> rev_chunks ->
+|    read_utf8(stdin, 1).await(chunk ->
+|      match chunk:
+|        case None:
+|          if rev_chunks matches []:
+|            pure(None)
+|          else:
+|            pure(Some(trim_trailing_cr(concat_rev_chunks(rev_chunks))))
+|        case Some(piece):
+|          match piece.partition_String("\n"):
+|            case Some((before, _)):
+|              pure(Some(trim_trailing_cr(concat_rev_chunks([before, *rev_chunks]))))
+|            case None:
+|              rec([piece, *rev_chunks])
+|    )
+|  )([])
+|
+|read_all_stdin: Prog[IOError, String] =
+|  recursive(rec -> rev_chunks ->
+|    read_utf8(stdin, 4096).await(chunk ->
+|      match chunk:
+|        case None: pure(concat_rev_chunks(rev_chunks))
+|        case Some(piece): rec([piece, *rev_chunks])
+|    )
+|  )([])
+|""".stripMargin
+    val appSrc =
+      """package Tool/StdinEcho
+|
+|from Bosatsu/Prog import Prog, Main, pure, recover, await
+|from Bosatsu/IO/Error import IOError
+|from Bosatsu/IO/Std import read_line, read_all_stdin, println
+|
+|def render_opt_String(opt: Option[String]) -> String:
+|  match opt:
+|    case Some(s): s
+|    case None: "<none>"
+|
+|run_prog: Prog[IOError, Int] = (
+|  first <- read_line.await()
+|  _ <- println("line=${render_opt_String(first)}").await()
+|  rest <- read_all_stdin.await()
+|  _ <- println("rest=${rest}").await()
+|  pure(0)
+|)
+|
+|main = Main(_ -> recover(run_prog, _ -> pure(1)))
+|""".stripMargin
+
+    val files = List(
+      Chain("src", "Bosatsu", "Prog.bosatsu") -> minimalProgModuleSrc,
+      Chain("src", "Bosatsu", "IO", "Error.bosatsu") -> minimalIoErrorModuleSrc,
+      Chain("src", "Bosatsu", "IO", "Core.bosatsu") -> ioCoreSrc,
+      Chain("src", "Bosatsu", "IO", "Std.bosatsu") -> ioStdSrc,
+      Chain("src", "Tool", "StdinEcho.bosatsu") -> appSrc
+    )
+
+    val result = withSystemStdin("alpha\nbeta\ngamma") {
+      for {
+        s0 <- MemoryMain.State.from[ErrorOr](files)
+        s1 <- runWithStateAndExit(
+          List(
+            "tool",
+            "eval",
+            "--run",
+            "--main",
+            "Tool/StdinEcho",
+            "--package_root",
+            "src",
+            "--input",
+            "src/Bosatsu/Prog.bosatsu",
+            "--input",
+            "src/Bosatsu/IO/Error.bosatsu",
+            "--input",
+            "src/Bosatsu/IO/Core.bosatsu",
+            "--input",
+            "src/Bosatsu/IO/Std.bosatsu",
+            "--input",
+            "src/Tool/StdinEcho.bosatsu"
+          ),
+          s0
+        )
+      } yield s1
+    }
+
+    result match {
+      case Left(err) =>
+        fail(err.getMessage)
+      case Right((state, out, exitCode)) =>
+        assertEquals(exitCode, ExitCode.Success)
+        assertEquals(state.stdOut.render(200), "line=alpha\nrest=beta\ngamma\n\n")
+        out match {
+          case Output.RunMainResult(_) => ()
+          case other                   => fail(s"unexpected output: $other")
+        }
+    }
+  }
+
   test("tool eval --run truncates Main exit code to low 32 bits") {
     val progSrc =
       """package Bosatsu/Prog
@@ -1736,6 +1893,138 @@ class ToolAndLibCommandTest extends FunSuite {
         fail(err.getMessage)
       case Right((_, out, exitCode)) =>
         assertEquals(exitCode, ExitCode.fromInt(2))
+        out match {
+          case Output.RunMainResult(_) => ()
+          case other                   => fail(s"unexpected output: $other")
+        }
+    }
+  }
+
+  test("lib eval --run reads stdin for IO/Std read_line and read_all_stdin") {
+    val ioCoreSrc =
+      """package Bosatsu/IO/Core
+|
+|from Bosatsu/Prog import Prog
+|from Bosatsu/IO/Error import IOError
+|
+|export (Handle, stdin, stdout, read_utf8, write_utf8, flush)
+|
+|external struct Handle
+|external stdin: Handle
+|external stdout: Handle
+|external def read_utf8(h: Handle, max_chars: Int) -> Prog[IOError, Option[String]]
+|external def write_utf8(h: Handle, s: String) -> Prog[IOError, Unit]
+|external def flush(h: Handle) -> Prog[IOError, Unit]
+|""".stripMargin
+    val ioStdSrc =
+      """package Bosatsu/IO/Std
+|
+|from Bosatsu/Prog import Prog, pure, await, recursive
+|from Bosatsu/IO/Error import IOError
+|from Bosatsu/IO/Core import stdin, stdout, read_utf8, write_utf8, flush
+|
+|export (println, read_line, read_all_stdin)
+|
+|def println(str: String) -> Prog[IOError, Unit]:
+|  (
+|    _ <- write_utf8(stdout, "${str}\n").await()
+|    flush(stdout)
+|  )
+|
+|def trim_trailing_cr(s: String) -> String:
+|  match s.rpartition_String("\r"):
+|    case Some((prefix, suffix)):
+|      if suffix matches "":
+|        prefix
+|      else:
+|        s
+|    case None:
+|      s
+|
+|def concat_rev_chunks(rev_chunks: List[String]) -> String:
+|  concat_String(rev_chunks.reverse())
+|
+|read_line: Prog[IOError, Option[String]] =
+|  recursive(rec -> rev_chunks ->
+|    read_utf8(stdin, 1).await(chunk ->
+|      match chunk:
+|        case None:
+|          if rev_chunks matches []:
+|            pure(None)
+|          else:
+|            pure(Some(trim_trailing_cr(concat_rev_chunks(rev_chunks))))
+|        case Some(piece):
+|          match piece.partition_String("\n"):
+|            case Some((before, _)):
+|              pure(Some(trim_trailing_cr(concat_rev_chunks([before, *rev_chunks]))))
+|            case None:
+|              rec([piece, *rev_chunks])
+|    )
+|  )([])
+|
+|read_all_stdin: Prog[IOError, String] =
+|  recursive(rec -> rev_chunks ->
+|    read_utf8(stdin, 4096).await(chunk ->
+|      match chunk:
+|        case None: pure(concat_rev_chunks(rev_chunks))
+|        case Some(piece): rec([piece, *rev_chunks])
+|    )
+|  )([])
+|""".stripMargin
+    val appSrc =
+      """from Bosatsu/Prog import Prog, Main, pure, recover, await
+|
+|from Bosatsu/IO/Error import IOError
+|from Bosatsu/IO/Std import read_line, read_all_stdin, println
+|
+|def render_opt_String(opt: Option[String]) -> String:
+|  match opt:
+|    case Some(s): s
+|    case None: "<none>"
+|
+|run_prog: Prog[IOError, Int] = (
+|  first <- read_line.await()
+|  _ <- println("line=${render_opt_String(first)}").await()
+|  rest <- read_all_stdin.await()
+|  _ <- println("rest=${rest}").await()
+|  pure(0)
+|)
+|
+|main = Main(_ -> recover(run_prog, _ -> pure(1)))
+|""".stripMargin
+
+    val files =
+      baseLibFiles(appSrc) ++ List(
+        Chain("repo", "src", "Bosatsu", "Prog.bosatsu") -> minimalProgModuleSrc,
+        Chain("repo", "src", "Bosatsu", "IO", "Error.bosatsu") -> minimalIoErrorModuleSrc,
+        Chain("repo", "src", "Bosatsu", "IO", "Core.bosatsu") -> ioCoreSrc,
+        Chain("repo", "src", "Bosatsu", "IO", "Std.bosatsu") -> ioStdSrc
+      )
+
+    val result = withSystemStdin("alpha\nbeta\ngamma") {
+      for {
+        s0 <- MemoryMain.State.from[ErrorOr](files)
+        s1 <- runWithStateAndExit(
+          List(
+            "lib",
+            "eval",
+            "--repo_root",
+            "repo",
+            "--main",
+            "MyLib/Foo",
+            "--run"
+          ),
+          s0
+        )
+      } yield s1
+    }
+
+    result match {
+      case Left(err) =>
+        fail(err.getMessage)
+      case Right((state, out, exitCode)) =>
+        assertEquals(exitCode, ExitCode.Success)
+        assertEquals(state.stdOut.render(200), "line=alpha\nrest=beta\ngamma\n\n")
         out match {
           case Output.RunMainResult(_) => ()
           case other                   => fail(s"unexpected output: $other")


### PR DESCRIPTION
Implemented issue #1904 by wiring `eval --run` to consume live `System.in` instead of the evaluator’s default empty stdin buffer.

What changed:
- Updated evaluator runtime state in `core/src/main/scala/dev/bosatsu/Predef.scala` to support stdin from either:
  - in-memory bytes (existing behavior for explicit test inputs), or
  - a live `InputStream` (new path for CLI `--run`).
- Added `PredefImpl.runProgMainWithSystemStdin(main, args)` that executes `Bosatsu/Prog::Main` with live stdin while still capturing stdout/stderr.
- Switched both command entrypoints to use it:
  - `core/src/main/scala/dev/bosatsu/tool_command/EvalCommand.scala`
  - `core/src/main/scala/dev/bosatsu/library/Command.scala`
- Added regression tests in `core/src/test/scala/dev/bosatsu/ToolAndLibCommandTest.scala`:
  - `tool eval --run reads stdin for IO/Std read_line and read_all_stdin`
  - `lib eval --run reads stdin for IO/Std read_line and read_all_stdin`
  These tests inject stdin (`alpha\nbeta\ngamma`) and assert output matches expected non-EOF behavior.

Validation run:
- `sbt "coreJVM/testOnly dev.bosatsu.ToolAndLibCommandTest"` passed.
- Required pre-push command `scripts/test_basic.sh` passed.

Fixes #1904