### PR TITLE
Fix `tool json traverse` to support object-value traversal

### DIFF
--- a/core/src/main/scala/dev/bosatsu/tool_command/JsonCommand.scala
+++ b/core/src/main/scala/dev/bosatsu/tool_command/JsonCommand.scala
@@ -213,19 +213,65 @@ object JsonCommand {
                       json => json
                     )
                   case JsonMode.Traverse(in) =>
-                    process[Vector](
-                      in.read,
-                      {
-                        case Json.JArray(items) => moduleIOMonad.pure(items)
-                        case other              =>
-                          moduleIOMonad.raiseError(
-                            CliException.Basic(
-                              show"require an array or arrays for traverse, found: ${other.getClass.getName}"
+                    valueToJson.valueFnToJsonFn(res.tpe) match {
+                      case Left(unsup)           => unsupported(unsup)
+                      case Right((arity, fnGen)) =>
+                        fnGen(res.value.value) match {
+                          case Right(fn) =>
+                            def applyFnToArgArray(otherJson: Json): F[Json] =
+                              otherJson match {
+                                case ary @ Json.JArray(items)
+                                    if items.length == arity =>
+                                  fn(ary) match {
+                                    case Left(dataError) =>
+                                      moduleIOMonad.raiseError(
+                                        CliException.Basic(
+                                          show"invalid input json: $dataError"
+                                        )
+                                      )
+                                    case Right(json) =>
+                                      moduleIOMonad.pure(json)
+                                  }
+                                case invalid =>
+                                  moduleIOMonad.raiseError(
+                                    CliException.Basic(
+                                      show"required a json array of size $arity, found:\n\n${invalid.render}"
+                                    )
+                                  )
+                              }
+
+                            ioJson(in.read).flatMap {
+                              case Json.JArray(items) =>
+                                items
+                                  .traverse(applyFnToArgArray)
+                                  .map { out =>
+                                    outputFor(Json.JArray(out), yamlOut, outputOpt)
+                                  }
+                              case obj @ Json.JObject(_) =>
+                                obj.keys
+                                  .traverse { key =>
+                                    applyFnToArgArray(obj.toMap(key)).map(key -> _)
+                                  }
+                                  .map { out =>
+                                    outputFor(Json.JObject(out), yamlOut, outputOpt)
+                                  }
+                              case other =>
+                                moduleIOMonad.raiseError(
+                                  CliException.Basic(
+                                    show"require an array of argument arrays or an object of argument arrays for traverse, found: ${other.getClass.getName}"
+                                  )
+                                )
+                            }
+                          // $COVERAGE-OFF$ defensive fallback for ill-typed runtime values
+                          case Left(valueError) =>
+                            moduleIOMonad.raiseError(
+                              CliException.Basic(
+                                show"unexpected value error: $valueError"
+                              )
                             )
-                          )
-                      },
-                      items => Json.JArray(items)
-                    )
+                        // $COVERAGE-ON$
+                        }
+                    }
                 }
               }
           }

--- a/core/src/test/scala/dev/bosatsu/ToolAndLibCommandTest.scala
+++ b/core/src/test/scala/dev/bosatsu/ToolAndLibCommandTest.scala
@@ -3164,7 +3164,7 @@ main = depBox
     }
   }
 
-  test("tool json traverse rejects non-array inputs") {
+  test("tool json traverse supports object inputs") {
     val src =
       """main = (x) -> x.add(1)
 """
@@ -3182,14 +3182,49 @@ main = depBox
         "--main",
         "Json/Foo",
         "--json_string",
-        "{}"
+        """{"a":[1],"b":[4]}"""
+      )
+    ) match {
+      case Right(Output.JsonOutput(Json.JObject(items), _)) =>
+        assertEquals(items, List("a" -> Json.JNumberStr("2"), "b" -> Json.JNumberStr("5")))
+      case Right(out) =>
+        fail(s"expected traverse object output, got output: $out")
+      case Left(err) =>
+        fail(err.getMessage)
+    }
+  }
+
+  test("tool json traverse rejects non-array/object inputs") {
+    val src =
+      """main = (x) -> x.add(1)
+"""
+    val files = List(Chain("src", "Json", "Foo.bosatsu") -> src)
+
+    module.runWith(files)(
+      List(
+        "tool",
+        "json",
+        "traverse",
+        "--package_root",
+        "src",
+        "--input",
+        "src/Json/Foo.bosatsu",
+        "--main",
+        "Json/Foo",
+        "--json_string",
+        "1"
       )
     ) match {
       case Right(out) =>
         fail(s"expected traverse error, got output: $out")
       case Left(err) =>
         val msg = Option(err.getMessage).getOrElse(err.toString)
-        assert(msg.contains("require an array or arrays for traverse"), msg)
+        assert(
+          msg.contains(
+            "require an array of argument arrays or an object of argument arrays for traverse"
+          ),
+          msg
+        )
         assert(
           module.mainExceptionToString(err).nonEmpty,
           show"expected CliException: $msg"


### PR DESCRIPTION
Implemented issue #1906 by updating `tool json traverse` runtime behavior to match help text: object inputs are now supported by traversing each object value as an argument-array item and rebuilding a JSON object with the same keys. Array traversal behavior is unchanged, including per-item arity validation and data-conversion errors. Updated regression coverage in `core/src/test/scala/dev/bosatsu/ToolAndLibCommandTest.scala` to add a CLI-memory test that verifies object traversal output (`{"a":[1],"b":[4]}` -> `{"a":2,"b":5}` for `(x) -> x.add(1)`), and added a test that non-array/non-object roots are still rejected with a clear error. Validation run: `sbt "coreJVM/testOnly dev.bosatsu.ToolAndLibCommandTest"` passed; required pre-push command `scripts/test_basic.sh` passed.

Fixes #1906