### PR TITLE
Fix SyntaxParse ScalaCheck failure by re-normalizing generated string-pattern parts

### DIFF
--- a/core/src/test/scala/dev/bosatsu/Gen.scala
+++ b/core/src/test/scala/dev/bosatsu/Gen.scala
@@ -626,6 +626,57 @@ object Generators {
       useAnnotation = false
     )
 
+  private def strPartNames(part: Pattern.StrPart): Set[Identifier.Bindable] =
+    part match {
+      case Pattern.StrPart.NamedStr(n)  => Set(n)
+      case Pattern.StrPart.NamedChar(n) => Set(n)
+      case _                            => Set.empty
+    }
+
+  private def strPartNames(
+      parts: List[Pattern.StrPart]
+  ): Set[Identifier.Bindable] =
+    parts.iterator.flatMap(strPartNames(_)).toSet
+
+  private def isStringWild(part: Pattern.StrPart): Boolean =
+    part match {
+      case Pattern.StrPart.LitStr(_) | Pattern.StrPart.NamedChar(_) |
+          Pattern.StrPart.WildChar =>
+        false
+      case _ => true
+    }
+
+  private[bosatsu] def normalizeStrPatParts(
+      nel: NonEmptyList[Pattern.StrPart]
+  ): NonEmptyList[Pattern.StrPart] =
+    nel match {
+      case NonEmptyList(_, Nil) => nel
+      case NonEmptyList(h1, h2 :: t)
+          if strPartNames(h1).exists(strPartNames(h2 :: t).contains) =>
+        normalizeStrPatParts(NonEmptyList(h2, t))
+      case NonEmptyList(
+            Pattern.StrPart.LitStr(h1),
+            Pattern.StrPart.LitStr(h2) :: t
+          ) =>
+        normalizeStrPatParts(
+          NonEmptyList(Pattern.StrPart.LitStr(h1 + h2), t)
+        )
+      case NonEmptyList(h1, h2 :: t) =>
+        val tail = normalizeStrPatParts(NonEmptyList(h2, t))
+        if (isStringWild(tail.head) && isStringWild(h1)) {
+          tail
+        } else {
+          (h1, tail.head) match {
+            case (Pattern.StrPart.LitStr(s1), Pattern.StrPart.LitStr(s2)) =>
+              normalizeStrPatParts(
+                NonEmptyList(Pattern.StrPart.LitStr(s1 + s2), tail.tail)
+              )
+            case _ =>
+              h1 :: tail
+          }
+        }
+    }
+
   lazy val genStrPat: Gen[Pattern.StrPat] = {
     val recurse = Gen.lzy(genStrPat)
 
@@ -638,43 +689,10 @@ object Generators {
         Gen.const(Pattern.StrPart.WildChar)
       )
 
-    def isWild(p: Pattern.StrPart): Boolean =
-      p match {
-        case Pattern.StrPart.LitStr(_) | Pattern.StrPart.NamedChar(_) |
-            Pattern.StrPart.WildChar =>
-          false
-        case _ => true
-      }
-
-    def makeValid(
-        nel: NonEmptyList[Pattern.StrPart]
-    ): NonEmptyList[Pattern.StrPart] =
-      nel match {
-        case NonEmptyList(_, Nil) => nel
-        case NonEmptyList(h1, h2 :: t)
-            if Pattern
-              .StrPat(NonEmptyList.one(h1))
-              .names
-              .exists(Pattern.StrPat(NonEmptyList(h2, t)).names.toSet) =>
-          makeValid(NonEmptyList(h2, t))
-        case NonEmptyList(
-              Pattern.StrPart.LitStr(h1),
-              Pattern.StrPart.LitStr(h2) :: t
-            ) =>
-          makeValid(NonEmptyList(Pattern.StrPart.LitStr(h1 + h2), t))
-        case NonEmptyList(h1, h2 :: t) =>
-          val tail = makeValid(NonEmptyList(h2, t))
-          if (isWild(tail.head) && isWild(h1)) {
-            tail
-          } else {
-            h1 :: tail
-          }
-      }
-
     for {
       sz <- Gen.choose(1, 4) // don't get too giant, intersections blow up
       inner <- nonEmptyN(genPart, sz)
-      p0 = Pattern.StrPat(makeValid(inner))
+      p0 = Pattern.StrPat(normalizeStrPatParts(inner))
       notStr <- p0.toLiteralString.fold(Gen.const(p0))(_ => recurse)
     } yield notStr
   }

--- a/core/src/test/scala/dev/bosatsu/PatternTest.scala
+++ b/core/src/test/scala/dev/bosatsu/PatternTest.scala
@@ -158,6 +158,22 @@ class PatternTest extends munit.ScalaCheckSuite {
     }
   }
 
+  test("normalizeStrPatParts re-compacts literals after duplicate removal") {
+    val e = Identifier.Name("e")
+    val input = NonEmptyList.of(
+      Pattern.StrPart.LitStr("v"),
+      Pattern.StrPart.NamedStr(e),
+      Pattern.StrPart.LitStr("jptmabf"),
+      Pattern.StrPart.NamedStr(e)
+    )
+    val expected = NonEmptyList.of(
+      Pattern.StrPart.LitStr("vjptmabf"),
+      Pattern.StrPart.NamedStr(e)
+    )
+
+    assertEquals(Generators.normalizeStrPatParts(input), expected)
+  }
+
   test("definitelyTotal detects obvious total patterns") {
     val n = Identifier.Name("n")
 


### PR DESCRIPTION
Resolved issue #1910 by fixing `Generators.genStrPat` normalization so duplicate-name pruning cannot re-introduce adjacent `LitStr` segments.

What changed:
- Updated [core/src/test/scala/dev/bosatsu/Gen.scala](/Users/oscar/.local/share/mergexo/checkouts/johnynek/bosatsu/worker-04/core/src/test/scala/dev/bosatsu/Gen.scala) to extract and harden string-pattern normalization (`normalizeStrPatParts`).
- Added an extra boundary compaction step after recursive duplicate-name removal, which merges adjacent literals that can appear after dropping a repeated binding.
- Switched `genStrPat` to use the new normalization helper.
- Added deterministic regression coverage in [core/src/test/scala/dev/bosatsu/PatternTest.scala](/Users/oscar/.local/share/mergexo/checkouts/johnynek/bosatsu/worker-04/core/src/test/scala/dev/bosatsu/PatternTest.scala) for the exact failing shape (`LitStr("v"), NamedStr(e), LitStr("jptmabf"), NamedStr(e)`), asserting it normalizes to `LitStr("vjptmabf"), NamedStr(e)`.

Validation:
- `sbt "coreJVM/testOnly dev.bosatsu.PatternTest"` passed.
- `sbt "coreJVM/testOnly dev.bosatsu.SyntaxParseTest"` passed.
- Required pre-push command `scripts/test_basic.sh` passed.

Fixes #1910