### PR TITLE
Implement #1925 Lazy type across evaluator, Python externals, and C runtime

### DIFF
--- a/c_runtime/Makefile
+++ b/c_runtime/Makefile
@@ -46,7 +46,7 @@ endif
 ALL_CPPFLAGS := $(CPPFLAGS) $(GC_CFLAGS)
 ALL_LIBS := $(GC_LIBS) $(LIBS) -lm
 
-all: bosatsu_runtime.o test_out bosatsu_ext_Bosatsu_l_Predef.o bosatsu_ext_Bosatsu_l_Prog.o bosatsu_ext_Bosatsu_l_IO_l_Core.o bosatsu_ext_Bosatsu_l_IO_l_Bytes.o bosatsu_ext_Bosatsu_l_Collection_l_Array.o bosatsu_ext_Bosatsu_l_Num_l_Float64.o
+all: bosatsu_runtime.o test_out bosatsu_ext_Bosatsu_l_Predef.o bosatsu_ext_Bosatsu_l_Prog.o bosatsu_ext_Bosatsu_l_IO_l_Core.o bosatsu_ext_Bosatsu_l_IO_l_Bytes.o bosatsu_ext_Bosatsu_l_Collection_l_Array.o bosatsu_ext_Bosatsu_l_Num_l_Float64.o bosatsu_ext_Bosatsu_l_Lazy.o
 
 bosatsu_generated.h: typegen.py
 	python3 typegen.py impls > bosatsu_generated.h
@@ -89,11 +89,14 @@ bosatsu_ext_Bosatsu_l_Collection_l_Array.o: bosatsu_ext_Bosatsu_l_Collection_l_A
 bosatsu_ext_Bosatsu_l_Num_l_Float64.o: bosatsu_ext_Bosatsu_l_Num_l_Float64.c bosatsu_runtime.o
 	$(CC) $(ALL_CPPFLAGS) $(CFLAGS) -Wall -Werror -c bosatsu_ext_Bosatsu_l_Num_l_Float64.c
 
-bosatsu_platform.a: bosatsu_ext_Bosatsu_l_Predef.o bosatsu_ext_Bosatsu_l_Prog.o bosatsu_ext_Bosatsu_l_IO_l_Core.o bosatsu_ext_Bosatsu_l_IO_l_Bytes.o bosatsu_ext_Bosatsu_l_Collection_l_Array.o bosatsu_ext_Bosatsu_l_Num_l_Float64.o bosatsu_runtime.o
-	ar rcs bosatsu_platform.a bosatsu_ext_Bosatsu_l_Predef.o bosatsu_ext_Bosatsu_l_Prog.o bosatsu_ext_Bosatsu_l_IO_l_Core.o bosatsu_ext_Bosatsu_l_IO_l_Bytes.o bosatsu_ext_Bosatsu_l_Collection_l_Array.o bosatsu_ext_Bosatsu_l_Num_l_Float64.o bosatsu_runtime.o
+bosatsu_ext_Bosatsu_l_Lazy.o: bosatsu_ext_Bosatsu_l_Lazy.c bosatsu_runtime.o
+	$(CC) $(ALL_CPPFLAGS) $(CFLAGS) -Wall -Werror -c bosatsu_ext_Bosatsu_l_Lazy.c
+
+bosatsu_platform.a: bosatsu_ext_Bosatsu_l_Predef.o bosatsu_ext_Bosatsu_l_Prog.o bosatsu_ext_Bosatsu_l_IO_l_Core.o bosatsu_ext_Bosatsu_l_IO_l_Bytes.o bosatsu_ext_Bosatsu_l_Collection_l_Array.o bosatsu_ext_Bosatsu_l_Num_l_Float64.o bosatsu_ext_Bosatsu_l_Lazy.o bosatsu_runtime.o
+	ar rcs bosatsu_platform.a bosatsu_ext_Bosatsu_l_Predef.o bosatsu_ext_Bosatsu_l_Prog.o bosatsu_ext_Bosatsu_l_IO_l_Core.o bosatsu_ext_Bosatsu_l_IO_l_Bytes.o bosatsu_ext_Bosatsu_l_Collection_l_Array.o bosatsu_ext_Bosatsu_l_Num_l_Float64.o bosatsu_ext_Bosatsu_l_Lazy.o bosatsu_runtime.o
 
 boehm_example: boehm_example.c
 	$(CC) $(ALL_CPPFLAGS) $(CFLAGS) boehm_example.c $(LDFLAGS) $(ALL_LIBS) -o boehm_example
 
-install: bosatsu_platform.a bosatsu_decls_generated.h bosatsu_generated.h bosatsu_ext_Bosatsu_l_Predef.h bosatsu_ext_Bosatsu_l_Prog.h bosatsu_ext_Bosatsu_l_IO_l_Core.h bosatsu_ext_Bosatsu_l_IO_l_Bytes.h bosatsu_ext_Bosatsu_l_Collection_l_Array.h bosatsu_ext_Bosatsu_l_Num_l_Float64.h bosatsu_runtime.h
-	python3 install.py --root $(ROOTDIR) --include bosatsu_decls_generated.h --include bosatsu_generated.h --include bosatsu_ext_Bosatsu_l_Predef.h --include bosatsu_ext_Bosatsu_l_Prog.h --include bosatsu_ext_Bosatsu_l_IO_l_Core.h --include bosatsu_ext_Bosatsu_l_IO_l_Bytes.h --include bosatsu_ext_Bosatsu_l_Collection_l_Array.h --include bosatsu_ext_Bosatsu_l_Num_l_Float64.h --include bosatsu_runtime.h --lib bosatsu_platform.a --version $(VERSION) --cc="$(CC)" --cflags="$(CFLAGS)" --cppflags="$(ALL_CPPFLAGS)" --ldflags="$(LDFLAGS)" --libs="$(ALL_LIBS)" --pkg-config="$(PKG_CONFIG)" --profile="$(PROFILE)"
+install: bosatsu_platform.a bosatsu_decls_generated.h bosatsu_generated.h bosatsu_ext_Bosatsu_l_Predef.h bosatsu_ext_Bosatsu_l_Prog.h bosatsu_ext_Bosatsu_l_IO_l_Core.h bosatsu_ext_Bosatsu_l_IO_l_Bytes.h bosatsu_ext_Bosatsu_l_Collection_l_Array.h bosatsu_ext_Bosatsu_l_Num_l_Float64.h bosatsu_ext_Bosatsu_l_Lazy.h bosatsu_runtime.h
+	python3 install.py --root $(ROOTDIR) --include bosatsu_decls_generated.h --include bosatsu_generated.h --include bosatsu_ext_Bosatsu_l_Predef.h --include bosatsu_ext_Bosatsu_l_Prog.h --include bosatsu_ext_Bosatsu_l_IO_l_Core.h --include bosatsu_ext_Bosatsu_l_IO_l_Bytes.h --include bosatsu_ext_Bosatsu_l_Collection_l_Array.h --include bosatsu_ext_Bosatsu_l_Num_l_Float64.h --include bosatsu_ext_Bosatsu_l_Lazy.h --include bosatsu_runtime.h --lib bosatsu_platform.a --version $(VERSION) --cc="$(CC)" --cflags="$(CFLAGS)" --cppflags="$(ALL_CPPFLAGS)" --ldflags="$(LDFLAGS)" --libs="$(ALL_LIBS)" --pkg-config="$(PKG_CONFIG)" --profile="$(PROFILE)"

--- a/c_runtime/bosatsu_ext_Bosatsu_l_Lazy.c
+++ b/c_runtime/bosatsu_ext_Bosatsu_l_Lazy.c
@@ -1,0 +1,62 @@
+#include "bosatsu_ext_Bosatsu_l_Lazy.h"
+
+#include <gc.h>
+#include <stdatomic.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+typedef struct {
+  _Atomic _Bool forced;
+  _Atomic BValue thunk;
+  _Atomic BValue value;
+} BSTS_Lazy;
+
+static void bsts_lazy_free(void* ptr) {
+  (void)ptr;
+}
+
+static BSTS_Lazy* bsts_lazy_unbox(BValue lazy_value) {
+  return (BSTS_Lazy*)get_external(lazy_value);
+}
+
+static BValue bsts_lazy_wrap(BValue thunk) {
+  BSTS_Lazy* lazy = (BSTS_Lazy*)GC_malloc(sizeof(BSTS_Lazy));
+  if (lazy == NULL) {
+    perror("GC_malloc failure in bsts_lazy_wrap");
+    abort();
+  }
+
+  atomic_init(&lazy->forced, 0);
+  atomic_init(&lazy->thunk, thunk);
+  atomic_init(&lazy->value, bsts_unit_value());
+  return alloc_external(lazy, bsts_lazy_free);
+}
+
+BValue ___bsts_g_Bosatsu_l_Lazy_l_lazy(BValue fn) {
+  return bsts_lazy_wrap(fn);
+}
+
+BValue ___bsts_g_Bosatsu_l_Lazy_l_get__Lazy(BValue lazy_value) {
+  BSTS_Lazy* lazy = bsts_lazy_unbox(lazy_value);
+
+  if (atomic_load_explicit(&lazy->forced, memory_order_acquire)) {
+    return atomic_load_explicit(&lazy->value, memory_order_acquire);
+  }
+
+  BValue thunk = atomic_load_explicit(&lazy->thunk, memory_order_acquire);
+  if (thunk == bsts_unit_value()) {
+    return atomic_load_explicit(&lazy->value, memory_order_acquire);
+  }
+
+  BValue value = call_fn1(thunk, bsts_unit_value());
+
+  if (!atomic_load_explicit(&lazy->forced, memory_order_acquire)) {
+    atomic_store_explicit(&lazy->value, value, memory_order_relaxed);
+    atomic_store_explicit(&lazy->forced, 1, memory_order_release);
+    // Clearing the thunk reference lets the closure be reclaimed.
+    atomic_store_explicit(&lazy->thunk, bsts_unit_value(), memory_order_release);
+    return value;
+  }
+
+  return atomic_load_explicit(&lazy->value, memory_order_acquire);
+}

--- a/c_runtime/bosatsu_ext_Bosatsu_l_Lazy.h
+++ b/c_runtime/bosatsu_ext_Bosatsu_l_Lazy.h
@@ -1,0 +1,4 @@
+#include "bosatsu_runtime.h"
+
+BValue ___bsts_g_Bosatsu_l_Lazy_l_lazy(BValue fn);
+BValue ___bsts_g_Bosatsu_l_Lazy_l_get__Lazy(BValue lazy_value);

--- a/core/src/main/scala/dev/bosatsu/Predef.scala
+++ b/core/src/main/scala/dev/bosatsu/Predef.scala
@@ -37,6 +37,7 @@ import java.nio.file.{
   StandardOpenOption
 }
 import java.util.Locale
+import java.util.concurrent.atomic.AtomicReference
 import scala.util.control.NonFatal
 import scala.util.DynamicVariable
 object Predef {
@@ -65,6 +66,8 @@ object Predef {
     PackageName.parts("Bosatsu", "IO", "Bytes")
   private def ioCorePackageName: PackageName =
     PackageName.parts("Bosatsu", "IO", "Core")
+  private def lazyPackageName: PackageName =
+    PackageName.parts("Bosatsu", "Lazy")
 
   private def addIoBytesExternals(externals: Externals): Externals =
     externals
@@ -420,6 +423,12 @@ object Predef {
         "int_to_Float64",
         FfiCall.Fn1(PredefImpl.int_to_Float64(_))
       )
+      .add(lazyPackageName, "lazy", FfiCall.Fn1(PredefImpl.lazy_Lazy(_)))
+      .add(
+        lazyPackageName,
+        "get_Lazy",
+        FfiCall.Fn1(PredefImpl.get_Lazy(_))
+      )
       .add(progPackageName, "pure", FfiCall.Fn1(PredefImpl.prog_pure(_)))
       .add(
         progPackageName,
@@ -466,6 +475,8 @@ object PredefImpl {
     Require(len >= 0, s"len must be >= 0: $len")
     Require(offset + len <= data.length, s"invalid view ($offset, $len)")
   }
+
+  final case class LazyCell(state: AtomicReference[Either[Value, Value]])
 
   private val EmptyArrayData: Array[Value] = Array.empty[Value]
   private val EmptyArrayRepr: ArrayValue = ArrayValue(EmptyArrayData, 0, 0)
@@ -630,11 +641,41 @@ object PredefImpl {
       // $COVERAGE-ON$
     }
 
+  private def asLazy(a: Value): LazyCell =
+    a.asExternal.toAny match {
+      case lazyCell: LazyCell => lazyCell
+      case other              =>
+        // $COVERAGE-OFF$
+        sys.error(s"expected lazy external value, found: $other")
+      // $COVERAGE-ON$
+    }
+
   private def normalizeByte(intValue: Value.BosatsuInt): Byte =
     (Value.intToBigInteger(intValue).intValue() & 0xff).toByte
 
   private def byteToIntValue(byte: Byte): Value =
     VInt(byte.toInt & 0xff)
+
+  def lazy_Lazy(fn: Value): Value =
+    ExternalValue(LazyCell(new AtomicReference(Left(fn))))
+
+  def get_Lazy(cellValue: Value): Value = {
+    val cell = asLazy(cellValue)
+
+    @annotation.tailrec
+    def loop: Value =
+      cell.state.get() match {
+        case Right(value) =>
+          value
+        case left @ Left(thunk) =>
+          val value = callFn1(thunk, UnitValue)
+          // If another thread wins the race, read the stored value.
+          if (cell.state.compareAndSet(left, Right(value))) value
+          else loop
+      }
+
+    loop
+  }
 
   def add(a: Value, b: Value): Value =
     ExternalValue(addInt(intRaw(a), intRaw(b)))

--- a/core/src/test/scala/dev/bosatsu/EvaluationTest.scala
+++ b/core/src/test/scala/dev/bosatsu/EvaluationTest.scala
@@ -1,5 +1,6 @@
 package dev.bosatsu
 
+import cats.data.NonEmptyList
 import Value._
 
 import scala.concurrent.duration.DurationInt
@@ -3092,6 +3093,70 @@ tests = TestSuite("bytes eval", [
       "Bosatsu/IO/Bytes",
       14
     )
+  }
+
+  test("lazy externals evaluate") {
+    runBosatsuTest(
+      List(
+        """
+package Bosatsu/Lazy
+
+export (Lazy, lazy, get_Lazy)
+
+external struct Lazy[a: +*]
+
+external def lazy[a](fn: Unit -> a) -> Lazy[a]
+external def get_Lazy[a](l: Lazy[a]) -> a
+""",
+        """
+package LazyEval
+
+from Bosatsu/Lazy import Lazy, lazy, get_Lazy
+
+def force_twice[a](l: Lazy[a]) -> (a, a):
+  (get_Lazy(l), get_Lazy(l))
+
+tests = TestSuite("lazy eval", [
+  Assertion(get_Lazy(lazy(_ -> 1)) matches 1, "force"),
+  Assertion(force_twice(lazy(_ -> 2)) matches (2, 2), "force twice"),
+  Assertion(get_Lazy(lazy(_ -> (1, "x"))) matches (1, "x"), "tuple"),
+])
+"""
+      ),
+      "LazyEval",
+      3
+    )
+  }
+
+  test("lazy runtime memoizes and is non-strict") {
+    var calls = 0
+    val thunk = FnValue { case NonEmptyList(_, _) =>
+      calls += 1
+      VInt(42)
+    }
+
+    val lazyValue = PredefImpl.lazy_Lazy(thunk)
+    assertEquals(calls, 0)
+    assertEquals(PredefImpl.get_Lazy(lazyValue), VInt(42))
+    assertEquals(calls, 1)
+    assertEquals(PredefImpl.get_Lazy(lazyValue), VInt(42))
+    assertEquals(calls, 1)
+  }
+
+  test("lazy runtime retries after failed force") {
+    var calls = 0
+    val thunk = FnValue { case NonEmptyList(_, _) =>
+      calls += 1
+      if (calls == 1) throw new RuntimeException("boom")
+      else VInt(7)
+    }
+
+    val lazyValue = PredefImpl.lazy_Lazy(thunk)
+    val _ = intercept[RuntimeException](PredefImpl.get_Lazy(lazyValue))
+    assertEquals(calls, 1)
+    assertEquals(PredefImpl.get_Lazy(lazyValue), VInt(7))
+    assertEquals(PredefImpl.get_Lazy(lazyValue), VInt(7))
+    assertEquals(calls, 2)
   }
 
   if (Platform.isScalaJvm)

--- a/test_workspace/Bosatsu/Lazy.bosatsu
+++ b/test_workspace/Bosatsu/Lazy.bosatsu
@@ -1,0 +1,25 @@
+package Bosatsu/Lazy
+
+export (
+  Lazy,
+  lazy,
+  get_Lazy,
+)
+
+external struct Lazy[a: +*]
+
+external def lazy[a](fn: Unit -> a) -> Lazy[a]
+external def get_Lazy[a](l: Lazy[a]) -> a
+
+########
+## test code below
+########
+
+def force_twice[a](l: Lazy[a]) -> (a, a):
+  (get_Lazy(l), get_Lazy(l))
+
+tests = TestSuite("Lazy tests", [
+  Assertion(get_Lazy(lazy(_ -> 1)) matches 1, "force int"),
+  Assertion(force_twice(lazy(_ -> 2)) matches (2, 2), "force twice"),
+  Assertion(get_Lazy(lazy(_ -> (1, "x"))) matches (1, "x"), "force tuple"),
+])

--- a/test_workspace/Prog.bosatsu_externals
+++ b/test_workspace/Prog.bosatsu_externals
@@ -52,5 +52,9 @@
     utf8_bytes_from_String: ProgExt.utf8_bytes_from_String,
     utf8_bytes_to_String: ProgExt.utf8_bytes_to_String,
     utf8_Char_at: ProgExt.utf8_Char_at
+  },
+  Bosatsu/Lazy: {
+    lazy: ProgExt.lazy,
+    get_Lazy: ProgExt.get_Lazy
   }
 }

--- a/test_workspace/ProgExt.py
+++ b/test_workspace/ProgExt.py
@@ -109,6 +109,19 @@ def _ioerror_from_errno(err: Optional[int], context: str):
 _none = (0,)
 def _some(value): return (1, value)
 
+class _BosatsuLazy:
+    __slots__ = ("_thunk", "_value", "_forced")
+
+    def __init__(self, thunk):
+        self._thunk = thunk
+        self._value = None
+        self._forced = False
+
+def _as_bosatsu_lazy(value):
+    if isinstance(value, _BosatsuLazy):
+        return value
+    return None
+
 class _BosatsuBytes:
     __slots__ = ("data", "offset", "length")
 
@@ -310,6 +323,23 @@ def _kind_from_lstat(st):
     if _stat.S_ISLNK(mode):
         return (2,)  # Symlink
     return (3,)      # Other
+
+# Bosatsu/Lazy externals
+def lazy(fn):
+    return _BosatsuLazy(fn)
+
+def get_Lazy(lazy_value):
+    l = _as_bosatsu_lazy(lazy_value)
+    if l is None:
+        raise ValueError(f"invalid Lazy value: {lazy_value!r}")
+    if l._forced:
+        return l._value
+
+    value = l._thunk(())
+    l._value = value
+    l._forced = True
+    l._thunk = None
+    return value
 
 # Bosatsu/IO/Bytes externals
 empty_Bytes = _BosatsuBytes(b"", 0, 0)

--- a/test_workspace/core_alpha_conf.json
+++ b/test_workspace/core_alpha_conf.json
@@ -1,7 +1,7 @@
 {
   "name": "core_alpha",
   "repo_uri": "https://github.com/johnynek/bosatsu.git",
-  "next_version": "4.0.3",
+  "next_version": "4.1.0",
   "previous": {
       "version": "4.0.2",
       "hashes": [ "blake3:07ae9205acac7794d2c35418df96cf34a1f275a7f1a0585a6591a163e8df26a5" ],
@@ -11,7 +11,7 @@
   "exported_packages": [ "Bosatsu/Bool", "Bosatsu/Char", "Bosatsu/Collection/Array",
       "Bosatsu/Collection/Queue", "Bosatsu/Collection/TreeList", "Bosatsu/Dict", "Bosatsu/IO/Error",
       "Bosatsu/IO/Bytes", "Bosatsu/IO/Core", "Bosatsu/IO/Std", "Bosatsu/Num/Binary", "Bosatsu/List",
-      "Bosatsu/Num/Nat", "Bosatsu/Num/BinNat", "Bosatsu/Nothing", "Bosatsu/Option", "Bosatsu/Json",
+      "Bosatsu/Lazy", "Bosatsu/Num/Nat", "Bosatsu/Num/BinNat", "Bosatsu/Nothing", "Bosatsu/Option", "Bosatsu/Json",
       "Bosatsu/Prog", "Bosatsu/Rand", "Bosatsu/Testing/Properties", "Bosatsu/Num/Float64" ],
   "all_packages": [ ".*" ]
 }


### PR DESCRIPTION
Implemented `Bosatsu/Lazy` as an external package with `Lazy[a: +*]`, `lazy`, and `get_Lazy` in `test_workspace/Bosatsu/Lazy.bosatsu` (including package tests). Added evaluator wiring in `Predef.evalExternals` and a memoized runtime cell in `PredefImpl` backed by `AtomicReference[Either[Value, Value]]`, with non-strict construction, memoized successful force, and retry-after-failure behavior. Added evaluation coverage in `EvaluationTest` for package-level usage plus direct runtime semantics (non-strictness, memoization, and failure retry). Added Python transpile runtime support (`Prog.bosatsu_externals`, `ProgExt.py`) with `_BosatsuLazy`, `lazy`, and `get_Lazy`, clearing the thunk after first successful force. Added C runtime externals (`c_runtime/bosatsu_ext_Bosatsu_l_Lazy.c` and `.h`) and wired them into `c_runtime/Makefile` build/install targets, including forced-state caching and thunk release. Updated `test_workspace/core_alpha_conf.json` to export `Bosatsu/Lazy` and bumped `next_version` to `4.1.0` to satisfy library versioning rules for added exported API. Validation run: `sbt -batch "coreJVM/test:compile"`, `make -C c_runtime all`, `./test_python.sh`, and required `scripts/test_basic.sh` all pass.

Fixes #1925

Implements design doc: [docs/design/1925-lazy-type.md](https://github.com/johnynek/bosatsu/blob/main/docs/design/1925-lazy-type.md)

Design source PR: https://github.com/johnynek/bosatsu/pull/1926