### PR TITLE
Fix RingOpt repeated-add optimization regression (issue #1932)

### DIFF
--- a/core/src/main/scala/dev/bosatsu/RingOpt.scala
+++ b/core/src/main/scala/dev/bosatsu/RingOpt.scala
@@ -2301,18 +2301,45 @@ object RingOpt {
         val sumProd = SumProd[A](leftA :: rightA :: Nil).normalize(W)
 
         // Preserve repeated-add structure when it is cheaper than term-wise
-        // decomposition. This avoids losing opportunities like 2 * (x + y).
-        if (Hash[Expr[A]].eqv(leftA, rightA)) {
-          val doubled = Expr.checkMult(Integer(2), leftA)
-          val costDouble = W.cost(doubled)
-          val costSumProd = W.cost(sumProd)
-          if (costDouble < costSumProd) doubled
-          else if (
-            costDouble == costSumProd && Order[Expr[A]].lt(doubled, sumProd)
-          )
-            doubled
-          else sumProd
-        } else sumProd
+        // decomposition. This avoids losing opportunities like n * (x + y).
+        def repeatedAdds(expr: Expr[A]): Option[(BigInt, Expr[A])] = {
+          def loop(e0: Expr[A]): (BigInt, Expr[A]) =
+            e0 match {
+              case Add(x, y) =>
+                val xA: Expr[A] = x
+                val yA: Expr[A] = y
+                val (cx, tx) = loop(xA)
+                val (cy, ty) = loop(yA)
+                if (Hash[Expr[A]].eqv(tx, ty)) (cx + cy, tx)
+                else (BigInt(1), e0)
+              case _ =>
+                (BigInt(1), e0)
+            }
+
+          loop(expr) match {
+            case (cnt, term) if cnt > 1 => Some((cnt, term))
+            case _                       => None
+          }
+        }
+
+        val repeatedForms =
+          repeatedAdds(Add(leftA, rightA)).toList :::
+            repeatedAdds(e).toList
+
+        repeatedForms
+          .map { case (cnt, term) =>
+            Expr.checkMult(Integer(cnt), term)
+          }
+          .foldLeft(sumProd) { (best, candidate) =>
+            val bestCost = W.cost(best)
+            val candidateCost = W.cost(candidate)
+            if (candidateCost < bestCost) candidate
+            else if (
+              (candidateCost == bestCost) && Order[Expr[A]].lt(candidate, best)
+            )
+              candidate
+            else best
+          }
 
       case Mult(a, b) =>
         val aA: Expr[A] = a

--- a/core/src/test/scala/dev/bosatsu/RingOptLaws.scala
+++ b/core/src/test/scala/dev/bosatsu/RingOptLaws.scala
@@ -1209,6 +1209,33 @@ class RingOptLaws extends munit.ScalaCheckSuite {
           2,
           Weights(3, 1, 1)
         ) ::
+        (
+          // issue #1932
+          Add(
+            Mult(
+              Add(
+                One,
+                Add(
+                  Symbol(BigInt("-9223372036854775808")),
+                  Symbol(BigInt("-1"))
+                )
+              ),
+              Integer(BigInt("-9223372036854775809"))
+            ),
+            Mult(
+              Integer(BigInt("-9327526714483220380375219972304915541328013433")),
+              Add(
+                Symbol(BigInt("-19744576984966573129269796274849165441")),
+                Add(
+                  Symbol(BigInt("-3219933437254141254")),
+                  Symbol(BigInt("-1"))
+                )
+              )
+            )
+          ),
+          5,
+          Weights(4, 2, 1)
+        ) ::
         Nil
 
     regressions.foreach { case (e, c, w) => law(e, c, w) }


### PR DESCRIPTION
Reproduced the reported failure by adding the exact seed-derived counterexample from issue #1932 into `RingOptLaws` regressions; before the fix, `repeated adds are optimized if better` failed with `costAdd > costMult`.

Implemented the fix in `core/src/main/scala/dev/bosatsu/RingOpt.scala` within `norm` for `Add`:
- Replaced the narrow `x + x` special-case with repeated-add detection that collapses additive trees of identical subexpressions into `(count, term)`.
- Built factored candidates via `Expr.checkMult(Integer(count), term)` from both the undistributed and original add form.
- Chose the cheapest candidate against the existing `SumProd` normalization result (tie-broken by expression ordering), preserving correctness while preventing higher-cost rewrites.

Added/updated regression coverage in `core/src/test/scala/dev/bosatsu/RingOptLaws.scala`:
- Added explicit issue #1932 regression case (`cnt = 5`, `Weights(4,2,1)`) in `repeated adds are optimized if better`.

Validation:
- `sbt "coreJVM/testOnly dev.bosatsu.RingOptLaws"` passes.
- Required pre-push command `scripts/test_basic.sh` passes.

Fixes #1932