### PR TITLE
Fix C `cmp_String` normalization mismatch between `lib eval` and `lib test`

### DIFF
--- a/c_runtime/bosatsu_runtime.c
+++ b/c_runtime/bosatsu_runtime.c
@@ -660,13 +660,9 @@ int bsts_string_cmp(BValue left, BValue right) {
   size_t rlen = rview.len;
   size_t min_len = (llen <= rlen) ? llen : rlen;
   int cmp = memcmp(lview.bytes, rview.bytes, min_len);
-
-  if (cmp == 0) {
-    return (llen < rlen) ? -1 : ((llen > rlen) ? 1 : 0);
-  }
-  else {
-    return cmp;
-  }
+  if (cmp < 0) return -1;
+  if (cmp > 0) return 1;
+  return (llen < rlen) ? -1 : ((llen > rlen) ? 1 : 0);
 }
 
 int bsts_utf8_code_point_bytes(const char* utf8data, int offset, int len) {

--- a/c_runtime/bosatsu_runtime.h
+++ b/c_runtime/bosatsu_runtime.h
@@ -95,7 +95,7 @@ BValue bsts_string_from_utf8_bytes_static_null_term(const char* bytes);
 int bsts_string_code_point_to_utf8(int codepoint, char* bytes);
 // (&String, &String) -> Bool
 _Bool bsts_string_equals(BValue left, BValue right);
-// (&String, &String) -> int 
+// (&String, &String) -> int in {-1, 0, 1}
 int bsts_string_cmp(BValue left, BValue right);
 // &String -> int (length in bytes)
 size_t bsts_string_utf8_len_ref(const BValue* str);

--- a/c_runtime/test.c
+++ b/c_runtime/test.c
@@ -371,6 +371,17 @@ void test_runtime_strings() {
   }
 
   {
+    BValue barbara = bsts_string_from_utf8_bytes_static(7, "BARBARA");
+    BValue linda = bsts_string_from_utf8_bytes_static(5, "LINDA");
+    BValue a = bsts_string_from_utf8_bytes_static(1, "A");
+    BValue c = bsts_string_from_utf8_bytes_static(1, "C");
+    assert(bsts_string_cmp(barbara, linda) == -1, "cmp BARBARA < LINDA normalized");
+    assert(bsts_string_cmp(linda, barbara) == 1, "cmp LINDA > BARBARA normalized");
+    assert(bsts_string_cmp(a, c) == -1, "cmp A < C normalized");
+    assert(bsts_string_cmp(c, a) == 1, "cmp C > A normalized");
+  }
+
+  {
     BValue long_s = bsts_string_from_utf8_bytes_static(10, "0123456789");
     BValue mid = bsts_string_substring(long_s, 3, 7);
     BValue tail = bsts_string_substring_tail(long_s, 8);

--- a/test_workspace/PredefTests.bosatsu
+++ b/test_workspace/PredefTests.bosatsu
@@ -108,6 +108,91 @@ test_int = TestSuite("Int tests", [
       Assertion(string_to_Int("-2147483649z") matches None, "-2147483649z string_to_Int"),
     ])
 
+def cmp_to_int(c: Comparison) -> Int:
+  match c:
+    case LT: -1
+    case EQ: 0
+    case GT: 1
+
+def cmp_char(left: Char, right: Char) -> Comparison:
+  cmp_Int(char_to_Int(left), char_to_Int(right))
+
+def cmp_string_model(left: String, right: String) -> Comparison:
+  recur (left, right):
+    case ("", ""): EQ
+    case ("", _): LT
+    case (_, ""): GT
+    case ("$.{left_head}${left_tail}", "$.{right_head}${right_tail}"):
+      head_cmp = cmp_char(left_head, right_head)
+      match head_cmp:
+        case LT: LT
+        case EQ: cmp_string_model(left_tail, right_tail)
+        case GT: GT
+
+def cmp_string_matches_model(left: String, right: String) -> Bool:
+  cmp_Int(
+    cmp_to_int(cmp_String(left, right)),
+    cmp_to_int(cmp_string_model(left, right))
+  ) matches EQ
+
+def cmp_string_row_law(left: String, rights: List[String]) -> Bool:
+  recur rights:
+    case []: True
+    case [right, *tail]:
+      if cmp_string_matches_model(left, right):
+        cmp_string_row_law(left, tail)
+      else:
+        False
+
+def cmp_string_matrix_law(lefts: List[String], rights: List[String]) -> Bool:
+  recur lefts:
+    case []: True
+    case [left, *tail]:
+      if cmp_string_row_law(left, rights):
+        cmp_string_matrix_law(tail, rights)
+      else:
+        False
+
+cmp_string_samples = [
+  "",
+  "A",
+  "B",
+  "BARBARA",
+  "LINDA",
+  "alpha",
+  "alphabet",
+  "alphabeta",
+  "bar",
+  "baz",
+  "foo",
+  "food",
+  "fool",
+  "z",
+  "zz",
+  "0",
+  "2",
+  "9",
+  "10",
+  "hello",
+  "hello!",
+  "hello?",
+  "Hello",
+  "é",
+  "ê",
+  "Ω",
+  "δ",
+  "👋",
+  "👋a",
+  "a👋",
+  "日本",
+  "日本語",
+  "~tilde",
+  "{brace}",
+  "|pipe",
+  "🙂",
+  "🙃",
+]
+
 test_string = TestSuite("String tests", [
   Assertion("foo".partition_String("f") matches Some(("", "oo")), "foo partition_String f"),
   Assertion("foo".partition_String("") matches None, "foo partition_String \"\""),
@@ -126,6 +211,10 @@ test_string = TestSuite("String tests", [
   Assertion(tail_or_empty_String("") matches "", "tail_or_empty empty"),
   Assertion(tail_or_empty_String("abc") matches "bc", "tail_or_empty ascii"),
   Assertion(tail_or_empty_String("éa") matches "a", "tail_or_empty unicode"),
+  Assertion(cmp_String("BARBARA", "LINDA") matches LT, "cmp_String BARBARA vs LINDA"),
+  Assertion(
+    cmp_string_matrix_law(cmp_string_samples, cmp_string_samples),
+    "cmp_String agrees with recursive model on sample matrix"),
 
   Assertion(notb("bbb" matches "ab${_}"), "literal prefix not found"),
   Assertion(notb("zabq" matches "ab${_}"), "literal found later is not a prefix"),

--- a/test_workspace/core_alpha_conf.json
+++ b/test_workspace/core_alpha_conf.json
@@ -1,7 +1,7 @@
 {
   "name": "core_alpha",
   "repo_uri": "https://github.com/johnynek/bosatsu.git",
-  "next_version": "4.1.1",
+  "next_version": "4.2.0",
   "previous": {
       "version": "4.1.0",
       "hashes": [ "blake3:8b7b12951a35990fbcabfb57b582eebee72ae57a67faa2d47734c424810df70c" ],


### PR DESCRIPTION
Implemented a direct fix for issue #1941 in the C runtime path and added broad regressions.

What changed:
- Fixed `bsts_string_cmp` in `c_runtime/bosatsu_runtime.c` to return normalized `-1/0/1` (instead of raw `memcmp` deltas), which is what the `cmp_String` enum mapping expects.
- Updated the runtime API comment in `c_runtime/bosatsu_runtime.h` to document the normalized return contract.
- Added C runtime regression coverage in `c_runtime/test.c` with explicit cases that previously broke (`"BARBARA" < "LINDA"`, `"A" < "C"`) and reverse-order checks.
- Added extensive cross-platform predef regressions in `test_workspace/PredefTests.bosatsu`:
  - explicit assertion for `cmp_String("BARBARA", "LINDA") == LT`
  - a larger matrix law over many sample strings (ASCII + Unicode) comparing `cmp_String` against an independent recursive model.
- Supporting update: bumped `test_workspace/core_alpha_conf.json` `next_version` from `4.1.1` to `4.2.0` so required repo test gating can pass (current API diff already requires 4.2.0).

Issue reproduction:
- Reproduced before fix using the reported repro module:
  - `lib eval` returned `LT`
  - `lib test` returned failure message `GT`
- After fix:
  - `lib eval` remains `LT`
  - `lib test` passes.

Validation run:
- `make -C c_runtime test_out` passed.
- Required command `scripts/test_basic.sh` passed (after the `next_version` gating correction above).

Fixes #1941