### PR TITLE
Fix doc formatting for `Unit -> a` signatures

### DIFF
--- a/core/src/main/scala/dev/bosatsu/TypeParser.scala
+++ b/core/src/main/scala/dev/bosatsu/TypeParser.scala
@@ -139,12 +139,19 @@ abstract class TypeParser[A] {
         val args = if (ins.tail.isEmpty) {
           val in0 = ins.head
           val din = toDoc(in0)
-          unapplyFn(in0)
-            .orElse(unapplyUniversal(in0))
-            .orElse(unapplyExistential(in0))
-            .orElse(unapplyTuple(in0)) match {
-            case Some(_) => par(din)
-            case None    => din
+          unapplyTuple(in0) match {
+            case Some(Nil) =>
+              // Unit arguments are already rendered as `()`.
+              din
+            case Some(_) =>
+              par(din)
+            case None    =>
+              unapplyFn(in0)
+                .orElse(unapplyUniversal(in0))
+                .orElse(unapplyExistential(in0)) match {
+                case Some(_) => par(din)
+                case None    => din
+              }
           }
         } else {
           // there is more than 1 arg so parens are always used: (a, b) -> c

--- a/core/src/test/scala/dev/bosatsu/ToolAndLibCommandTest.scala
+++ b/core/src/test/scala/dev/bosatsu/ToolAndLibCommandTest.scala
@@ -2744,6 +2744,43 @@ build = (a, b, c, d, e, f, g, h, i, j, k) -> Massive(a, b, c, d, e, f, g, h, i, 
     }
   }
 
+  test("tool doc renders Unit -> a as () -> a in external signatures") {
+    val src =
+      """export apply_default
+external def apply_default[a](default: Unit -> a) -> a
+"""
+    val files = List(Chain("src", "UnitFn", "Main.bosatsu") -> src)
+
+    val result = for {
+      s0 <- MemoryMain.State.from[ErrorOr](files)
+      s1 <- runWithState(
+        List(
+          "tool",
+          "doc",
+          "--package_root",
+          "src",
+          "--input",
+          "src/UnitFn/Main.bosatsu",
+          "--outdir",
+          "docs"
+        ),
+        s0
+      )
+    } yield s1
+
+    result match {
+      case Left(err) =>
+        fail(err.getMessage)
+      case Right((state, _)) =>
+        val markdown = readStringFile(state, Chain("docs", "UnitFn", "Main.md"))
+        assert(
+          markdown.contains("def apply_default[a](default: () -> a) -> a"),
+          markdown
+        )
+        assert(!markdown.contains("default: (()) -> a"), markdown)
+    }
+  }
+
   test("tool doc --include_predef includes Bosatsu/Predef markdown") {
     val src =
       """export main,

--- a/core/src/test/scala/dev/bosatsu/rankn/TypeRenderingTest.scala
+++ b/core/src/test/scala/dev/bosatsu/rankn/TypeRenderingTest.scala
@@ -1,0 +1,13 @@
+package dev.bosatsu.rankn
+
+import cats.data.NonEmptyList
+import munit.FunSuite
+
+class TypeRenderingTest extends FunSuite {
+  test("rendering Unit function arguments uses () without extra parens") {
+    val a = Type.TyVar(Type.Var.Bound("a"))
+    val tpe = Type.Fun(NonEmptyList.one(Type.UnitType), a)
+    val rendered = Type.fullyResolvedDocument.document(tpe).render(80)
+    assertEquals(rendered, "() -> a")
+  }
+}


### PR DESCRIPTION
Implemented the fix in `TypeParser.toDoc` so single-argument function types no longer add an extra pair of parentheses when the argument is `Unit`. This changes rendering from `(()) -> a` to `() -> a` in generated docs.

Added regression coverage:
- `ToolAndLibCommandTest`: new integration test `tool doc renders Unit -> a as () -> a in external signatures` verifies `tool doc` output contains `default: () -> a` and not `default: (()) -> a`.
- `TypeRenderingTest`: focused unit test asserting `Type.fullyResolvedDocument` renders `Unit -> a` as `() -> a`.

Validation run:
- `sbt "coreJVM/testOnly dev.bosatsu.ToolAndLibCommandTest"`
- `sbt "coreJVM/testOnly dev.bosatsu.rankn.TypeRenderingTest"`
- `scripts/test_basic.sh` (required)

Fixes #1951