### PR TITLE
Add parser hints for `match`/`matches` keyword swaps

### DIFF
--- a/core/src/main/scala/dev/bosatsu/ParserHints.scala
+++ b/core/src/main/scala/dev/bosatsu/ParserHints.scala
@@ -15,6 +15,7 @@ object ParserHints {
     elseIfRule ::
       elseifSpellingRule ::
       assignmentInConditionRule ::
+      matchesHeaderKeywordRule ::
       missingColonAfterHeaderRule ::
       Nil
 
@@ -202,10 +203,48 @@ object ParserHints {
                 tail.startsWith("=") && !tail.startsWith("==") =>
             // Handled by assignmentInConditionRule with a more specific message.
             None
+          case Some((keyword, _))
+              if (keyword == "if" || keyword == "elif") &&
+                wordAtOrAfter(source, pos).exists { case (word, _, _) =>
+                  word == "match"
+                } =>
+            Some(
+              Doc.text(
+                "hint: this condition uses 'match'. It looks like you meant 'matches'."
+              )
+            )
           case Some((k, _)) =>
             Some(Doc.text(s"hint: missing ':' after $k header."))
           case None =>
             None
+        }
+      }
+    }
+  }
+
+  private def matchesHeaderKeywordRule(
+      source: String,
+      locations: LocationMap,
+      error: ParseFailure
+  ): Option[Doc] = {
+    val pos = error.position
+    if (pos < 0 || pos > source.length) {
+      None
+    } else {
+      lineInfo(locations, pos).flatMap { case (_, col, line) =>
+        val words = wordsIn(line)
+        val wordAtError =
+          words.find { case (_, start, end) => start <= col && col < end }
+        val wordBeforeError =
+          words.takeWhile { case (_, _, end) => end <= col }.lastOption
+
+        (wordAtError.toList ::: wordBeforeError.toList).collectFirst {
+          case ("matches", start, end)
+              if startsExpressionLikePrefix(line, start) &&
+                line.drop(end).contains(':') =>
+            Doc.text(
+              "hint: match headers start with 'match', not 'matches'. It looks like you meant 'match'."
+            )
         }
       }
     }
@@ -274,6 +313,12 @@ object ParserHints {
 
   private def isWordChar(c: Char): Boolean =
     c == '_' || c.isLetterOrDigit
+
+  private def startsExpressionLikePrefix(line: String, wordStart: Int): Boolean = {
+    val prevSignificant =
+      line.take(wordStart).reverseIterator.find(!_.isWhitespace)
+    prevSignificant.forall("=([{,:".contains(_))
+  }
 
   private val intLiteralRegex =
     raw"""[+-]?(?:0|[1-9][0-9_]*|0[bB][01_]+|0[oO][0-7_]+|0[xX][0-9a-fA-F_]+)""".r

--- a/core/src/test/scala/dev/bosatsu/ParserHintsTest.scala
+++ b/core/src/test/scala/dev/bosatsu/ParserHintsTest.scala
@@ -162,6 +162,41 @@ class ParserHintsTest extends munit.FunSuite {
     )
   }
 
+  test("using match in a condition suggests matches") {
+    val source =
+      """package Foo
+        |
+        |x = (
+        |  if value match Foo: 1
+        |  else: 0
+        |)
+        |""".stripMargin
+
+    val pf = parseFailure(source)
+    val hints = ParserHints.hints(source, pf.locations, pf).map(_.render(120))
+    assert(
+      hints.exists(_.contains("meant 'matches'")),
+      hints.mkString("\n")
+    )
+  }
+
+  test("using matches as a match header suggests match") {
+    val source =
+      """package Foo
+        |
+        |x = matches value:
+        |  case _: 1
+        |""".stripMargin
+
+    val pf = parseFailure(source)
+    val hints = ParserHints.hints(source, pf.locations, pf).map(_.render(120))
+    val shown = pf.showContext(LocationMap.Colorize.None).render(120)
+    assert(
+      hints.exists(_.contains("meant 'match'")),
+      hints.mkString("\n") + "\n" + shown
+    )
+  }
+
   test("zero-arg defs are supported") {
     val source =
       """package Foo


### PR DESCRIPTION
Implemented issue #1965 with focused parser-hint changes in `ParserHints`.

Changes made:
- Added a specific hint for `if`/`elif` headers when users write `match` where a condition likely intended `matches`.
- Added a new hint rule for `matches ...:` used in expression/header position, suggesting `match` for match headers.
- Kept existing generic missing-colon and assignment hints intact, with the new wording only in the targeted swap scenarios.
- Added regression tests in `ParserHintsTest` for both directions:
  - `if ... match ...` suggests `matches`
  - `matches ...:` suggests `match`

Validation:
- Ran focused tests: `sbt "coreJVM/testOnly dev.bosatsu.ParserHintsTest"` (pass)
- Ran required pre-push command: `scripts/test_basic.sh` (pass)

Fixes #1965