### PR TITLE
Add source links to `lib doc` output and disable Paradox markdown backlinks for generated core_alpha docs

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -88,6 +88,13 @@ lazy val docs = (project in file("docs"))
       val paradoxGeneratedRoot =
         (Compile / sourceDirectory).value / "paradox" / "generated" / "core_alpha"
       val generatedDocsRoot = repoRoot / "core_alpha_docs"
+      val sourceRepoUrl = "https://github.com/johnynek/bosatsu/blob/main"
+      val disableParadoxSourceMarkdownLink =
+        """---
+          |github.base_url=
+          |---
+          |
+          |""".stripMargin
 
       // Ensure bosatsuj has an up-to-date CLI assembly before generating docs.
       val _ = (cli / assembly).value
@@ -107,7 +114,9 @@ lazy val docs = (project in file("docs"))
         "doc",
         "--outdir",
         "core_alpha_docs",
-        "--include_predef"
+        "--include_predef",
+        "--source_repo_url",
+        sourceRepoUrl
       )
       log.info(docCmd.mkString("running: ", " ", ""))
       val docExit = Process(docCmd, repoRoot).!
@@ -157,7 +166,7 @@ lazy val docs = (project in file("docs"))
         s"""# Core Alpha API
            |
            |This section is generated from `test_workspace` using:
-           |`./bosatsuj lib doc --outdir core_alpha_docs --include_predef`
+           |`./bosatsuj lib doc --outdir core_alpha_docs --include_predef --source_repo_url $sourceRepoUrl`
            |
            |@@@ index
            |${tocLinkLines.mkString("\n")}
@@ -168,7 +177,13 @@ lazy val docs = (project in file("docs"))
            |${pageLinkLines.mkString("\n")}
            |""".stripMargin
 
-      IO.write(paradoxGeneratedRoot / "index.md", generatedIndex)
+      markdownFiles.foreach { file =>
+        IO.write(file, disableParadoxSourceMarkdownLink + IO.read(file))
+      }
+      IO.write(
+        paradoxGeneratedRoot / "index.md",
+        disableParadoxSourceMarkdownLink + generatedIndex
+      )
       log.info(
         s"generated ${markdownFiles.size} markdown files into $paradoxGeneratedRoot"
       )

--- a/core/src/main/scala/dev/bosatsu/library/Command.scala
+++ b/core/src/main/scala/dev/bosatsu/library/Command.scala
@@ -642,6 +642,7 @@ object Command {
           colorize: Colorize,
           outdir: P,
           includePredef: Boolean,
+          sourceRepoUrlOpt: Option[String],
           compileCacheDirOpt: Option[P] = None
       ): F[List[(P, Doc)]] =
         for {
@@ -670,6 +671,34 @@ object Command {
             )
           }
           (compiled, sourcePaths) = checked
+          sourceLinksByPackage = sourceRepoUrlOpt match {
+            case Some(sourceRepoUrl) =>
+              val normalizedRepoUrl =
+                if (sourceRepoUrl.endsWith("/")) sourceRepoUrl
+                else sourceRepoUrl + "/"
+              sourcePaths.toList
+                .foldLeft(Map.empty[PackageName, List[(String, String)]]) {
+                  case (acc, (path, packageName)) =>
+                    platformIO.relativize(gitRoot, path) match {
+                      case Some(relPath) =>
+                        val relPathString =
+                          platformIO.pathToString(relPath).replace('\\', '/')
+                        val sourceLink =
+                          (relPathString, normalizedRepoUrl + relPathString)
+                        acc.updated(
+                          packageName,
+                          sourceLink :: acc.getOrElse(packageName, Nil)
+                        )
+                      case None =>
+                        acc
+                    }
+                }
+                .view
+                .mapValues(_.distinct.sortBy(_._1))
+                .toMap
+            case None =>
+              Map.empty[PackageName, List[(String, String)]]
+          }
           compiledPacks = {
             val packs0 = compiled.toMap.values.toList
             if (includePredef) packs0
@@ -680,7 +709,8 @@ object Command {
             compiledPacks,
             sourcePaths.toList,
             outdir,
-            colorize
+            colorize,
+            sourceLinksByPackage
           )
         } yield docs
 
@@ -1804,15 +1834,31 @@ object Command {
               help = "include Bosatsu/Predef in generated docs"
             )
             .orFalse,
+          Opts
+            .option[String](
+              "source_repo_url",
+              help =
+                "optional URL to the repo root used to generate source code links in docs"
+            )
+            .orNone,
           compileCacheDirOpt,
           Colorize.optsConsoleDefault
-        ).mapN { (fcc, outdir, includePredef, cacheDirFn, colorize) =>
+        ).mapN {
+          (
+              fcc,
+              outdir,
+              includePredef,
+              sourceRepoUrlOpt,
+              cacheDirFn,
+              colorize
+          ) =>
           for {
             cc <- fcc
             docs <- cc.docPackages(
               colorize,
               outdir,
               includePredef,
+              sourceRepoUrlOpt,
               cacheDirFn(cc.gitRoot)
             )
           } yield (Output.TranspileOut(docs): Output[P])

--- a/core/src/main/scala/dev/bosatsu/tool/MarkdownDoc.scala
+++ b/core/src/main/scala/dev/bosatsu/tool/MarkdownDoc.scala
@@ -623,7 +623,29 @@ object MarkdownDoc {
       Some(Doc.text("public dependencies: ") + list)
     }
 
-  private def packageDoc(pack: Package.Typed[Any], docs: SourceDocs): Doc = {
+  private def sourceCodeLinksDoc(
+      sourceLinks: List[(String, String)]
+  ): Option[Doc] =
+    if (sourceLinks.isEmpty) None
+    else {
+      val list =
+        Doc.intercalate(
+          Doc.hardLine,
+          sourceLinks.map { case (path, url) =>
+            Doc.text(show"- [`${path.replace("`", "\\`")}`]($url)")
+          }
+        )
+
+      Some(
+        Doc.text("source code:") + Doc.hardLine + list
+      )
+    }
+
+  private def packageDoc(
+      pack: Package.Typed[Any],
+      docs: SourceDocs,
+      sourceLinks: List[(String, String)]
+  ): Doc = {
     val ctx = TypeRenderer.Context(pack.name, localTypeNames(pack))
     val values = valueDocs(pack)
     val types = typeDocs(pack)
@@ -685,7 +707,9 @@ object MarkdownDoc {
     val header = Doc.text("# ") + inlineCode(pack.name.asString)
     Doc.intercalate(
       Doc.hardLine + Doc.hardLine,
-      header :: dependenciesDoc(deps).toList ::: body :: Nil
+      header ::
+        sourceCodeLinksDoc(sourceLinks).toList :::
+        dependenciesDoc(deps).toList ::: body :: Nil
     )
   }
 
@@ -743,7 +767,8 @@ object MarkdownDoc {
       packages: List[Package.Typed[Any]],
       sourcePaths: List[(Path, PackageName)],
       outdir: Path,
-      color: dev.bosatsu.LocationMap.Colorize
+      color: dev.bosatsu.LocationMap.Colorize,
+      sourceLinksByPackage: Map[PackageName, List[(String, String)]] = Map.empty
   ): F[List[(Path, Doc)]] = {
     import platformIO.moduleIOMonad
 
@@ -753,7 +778,7 @@ object MarkdownDoc {
           .map { pack =>
             val path = outputPath(platformIO, outdir, pack.name)
             val docs = packageDocs.getOrElse(pack.name, SourceDocs.empty)
-            (path, packageDoc(pack, docs))
+            (path, packageDoc(pack, docs, sourceLinksByPackage.getOrElse(pack.name, Nil)))
           }
       }
   }

--- a/core/src/test/scala/dev/bosatsu/ToolAndLibCommandTest.scala
+++ b/core/src/test/scala/dev/bosatsu/ToolAndLibCommandTest.scala
@@ -2727,6 +2727,7 @@ mk = (x) -> Thing(x)
         assert(markdown.contains("# `MyLib/Foo`"), markdown)
         assert(markdown.contains("Thing docs."), markdown)
         assert(markdown.contains("Mk docs."), markdown)
+        assert(!markdown.contains("source code:"), markdown)
         assert(!markdown.contains("public dependencies:"), markdown)
         assert(
           markdown.indexOf("## Types") < markdown.indexOf("## Values"),
@@ -2737,6 +2738,53 @@ mk = (x) -> Thing(x)
         assert(!markdown.contains("Bosatsu/Predef::Int"), markdown)
         assert(markdown.contains("## Values"), markdown)
         assert(markdown.contains("## Types"), markdown)
+    }
+  }
+
+  test("lib doc --source_repo_url includes source code links") {
+    val src =
+      """export Thing(), mk
+
+# Thing docs.
+struct Thing(v: Int)
+
+# Mk docs.
+mk = (x) -> Thing(x)
+"""
+    val files = baseLibFiles(src)
+
+    val result = for {
+      s0 <- MemoryMain.State.from[ErrorOr](files)
+      s1 <- runWithState(
+        List(
+          "lib",
+          "doc",
+          "--repo_root",
+          "repo",
+          "--name",
+          "mylib",
+          "--outdir",
+          "outdocs",
+          "--source_repo_url",
+          "https://example.com/repo/blob/main"
+        ),
+        s0
+      )
+    } yield s1
+
+    result match {
+      case Left(err) =>
+        fail(err.getMessage)
+      case Right((state, _)) =>
+        val markdown =
+          readStringFile(state, Chain("outdocs", "MyLib", "Foo.md"))
+        assert(markdown.contains("source code:"), markdown)
+        assert(
+          markdown.contains(
+            "[`src/MyLib/Foo.bosatsu`](https://example.com/repo/blob/main/src/MyLib/Foo.bosatsu)"
+          ),
+          markdown
+        )
     }
   }
 


### PR DESCRIPTION
Implemented issue #1976 with focused changes:
- Added optional `--source_repo_url` to `lib doc` in `core/src/main/scala/dev/bosatsu/library/Command.scala`.
- Wired source-path collection (relative to `--repo_root`) into markdown generation and rendered per-package `source code:` links in `core/src/main/scala/dev/bosatsu/tool/MarkdownDoc.scala`.
- Updated docs generation task in `build.sbt` to pass `--source_repo_url https://github.com/johnynek/bosatsu/blob/main` when generating `core_alpha` docs.
- Disabled Paradox’s generated HTML->markdown source link for these generated pages by prepending front-matter override (`github.base_url=`) to `docs/src/main/paradox/generated/core_alpha/*.md` and generated index.
- Added/updated tests in `core/src/test/scala/dev/bosatsu/ToolAndLibCommandTest.scala`:
  - default `lib doc` output does not include source links
  - `lib doc --source_repo_url ...` includes expected source link.

Validation run:
- `scripts/test_basic.sh` (required): passed
- `sbt "doc; paradox"` (per docs/paradox guideline): passed

Fixes #1976