### PR TITLE
Improve recursive type mismatch diagnostics and unknown-type rendering (#1981)

### DIFF
--- a/core/src/main/scala/dev/bosatsu/PackageError.scala
+++ b/core/src/main/scala/dev/bosatsu/PackageError.scala
@@ -16,15 +16,110 @@ sealed abstract class PackageError {
 }
 
 object PackageError {
+  final case class ShownTypes(
+      typeDocs: Map[Type, Doc],
+      unknownTypeVars: List[(String, Kind)]
+  ) extends (Type => Doc) {
+    def apply(tpe: Type): Doc = typeDocs(tpe)
+
+    private def unknownTypeVarDoc(name: String, kind: Kind): Doc =
+      if (kind == Kind.Type) Doc.text(name)
+      else Doc.text(name) + Doc.text(": ") + Kind.toDoc(kind)
+
+    val unknownTypesDoc: Doc =
+      unknownTypeVars match {
+        case Nil =>
+          Doc.empty
+        case (name, kind) :: Nil =>
+          Doc.hardLine + Doc.text("where ") + unknownTypeVarDoc(
+            name,
+            kind
+          ) + Doc.text(" is an unknown type.")
+        case many =>
+          val docs = many.map { case (name, kind) =>
+            unknownTypeVarDoc(name, kind)
+          }
+          Doc.hardLine + Doc.text("where unknown types are ") +
+            Doc.intercalate(Doc.text(",") + Doc.space, docs) +
+            Doc.char('.')
+      }
+
+    def withUnknownTypes(doc: Doc): Doc =
+      doc + unknownTypesDoc
+  }
+
+  private def renameTypeMetas(
+      tpe: Type,
+      renameMeta: Map[Type.Meta, Type.Var.Bound]
+  ): Type = {
+    def renameLeaf(leaf: Type.Leaf): Type.Leaf =
+      leaf match {
+        case Type.TyMeta(meta) =>
+          renameMeta.get(meta) match {
+            case Some(bound) => Type.TyVar(bound)
+            case None        => leaf
+          }
+        case _ =>
+          leaf
+      }
+
+    def renameLeafApply(
+        in: Type.Leaf | Type.TyApply
+    ): Type.Leaf | Type.TyApply =
+      in match {
+        case leaf: Type.Leaf     => renameLeaf(leaf)
+        case Type.TyApply(on, a) =>
+          Type.TyApply(renameLeafApply(on), renameType(a))
+      }
+
+    def renameRho(rho: Type.Rho): Type.Rho =
+      rho match {
+        case leaf: Type.Leaf        => renameLeaf(leaf)
+        case Type.TyApply(on, a)    =>
+          Type.TyApply(renameLeafApply(on), renameType(a))
+        case Type.Exists(vars, in1) =>
+          Type.Exists(vars, renameLeafApply(in1))
+      }
+
+    def renameType(in: Type): Type =
+      in match {
+        case rho: Type.Rho         => renameRho(rho)
+        case Type.ForAll(vars, in) => Type.ForAll(vars, renameRho(in))
+      }
+
+    renameType(tpe)
+  }
+
   def showTypes(
       pack: PackageName,
       tpes: List[Type],
       localTypeNames: Set[TypeName] = Set.empty
-  ): Map[Type, Doc] = {
+  ): ShownTypes = {
     // TODO: we should use the imports in each package to talk about (https://github.com/johnynek/bosatsu/issues/4)
     // types in ways that are local to that package
     Require(pack ne null)
-    TypeRenderer.documents(tpes, TypeRenderer.Context(pack, localTypeNames), 80)
+    val usedBounds: Set[Type.Var.Bound] =
+      Type.tyVarBinders(tpes) ++ Type.freeTyVars(tpes).collect {
+        case b: Type.Var.Bound => b
+      }
+    val metaToBound: List[(Type.Meta, Type.Var.Bound)] =
+      Type.alignBinders(Type.metaTvs(tpes).toList, usedBounds.contains)
+    val metaSubs = metaToBound.toMap
+    val ctx = TypeRenderer.Context(pack, localTypeNames)
+    val rendered =
+      tpes.iterator
+        .map { tpe =>
+          val shown =
+            if (metaSubs.isEmpty) tpe
+            else renameTypeMetas(tpe, metaSubs)
+          tpe -> TypeRenderer.document(shown, ctx, 80)
+        }
+        .toMap
+
+    ShownTypes(
+      rendered,
+      metaToBound.map { case (meta, bound) => (bound.name, meta.kind) }
+    )
   }
 
   def nearest[A](
@@ -551,14 +646,19 @@ object PackageError {
           orient(left, right, direction)
         }
 
-      def mismatchEvidenceRegion(
+      def mismatchEvidenceRegions(
           tpeErr: Infer.Error.Single
-      ): Option[Region] =
+      ): List[Region] =
         tpeErr match {
           case te: Infer.Error.TypeError =>
-            expectedFound(te).map(_._1._2)
+            expectedFound(te)
+              .map { case ((_, expectedRegion), (_, foundRegion)) =>
+                if (expectedRegion === foundRegion) expectedRegion :: Nil
+                else expectedRegion :: foundRegion :: Nil
+              }
+              .getOrElse(Nil)
           case _ =>
-            None
+            Nil
         }
 
       def dedupKey(
@@ -617,7 +717,7 @@ object PackageError {
             .empty[(Infer.Error.Single, List[Region])]
 
         singles.foreach { single =>
-          val evidence = mismatchEvidenceRegion(single).toList
+          val evidence = mismatchEvidenceRegions(single)
           dedupKey(single) match {
             case Some(key) =>
               keyToIdx.get(key) match {
@@ -656,6 +756,27 @@ object PackageError {
           case _ =>
             None
         }
+
+      def evidenceDocOrDefault(
+          evidenceRegions: List[Region],
+          baselineRegions: List[Region],
+          defaultDoc: Doc
+      ): Doc = {
+        val distinctEvidence = evidenceRegions.distinct.sortBy(_.start)
+        val distinctBaseline = baselineRegions.distinct.sortBy(_.start)
+        val extraEvidence = distinctEvidence.filterNot(distinctBaseline.contains)
+
+        if (extraEvidence.nonEmpty) {
+          val docs = (distinctBaseline ::: extraEvidence)
+            .distinct
+            .sortBy(_.start)
+            .map(contextDoc)
+          Doc.text("evidence sites:") + Doc.hardLine +
+            Doc.intercalate(Doc.hardLine + Doc.hardLine, docs)
+        } else {
+          defaultDoc
+        }
+      }
 
       def isUseBeforeDef(name: Identifier, region: Region): Boolean =
         name match {
@@ -722,6 +843,7 @@ object PackageError {
                   }
 
                 (
+                  tmap.withUnknownTypes(
                   Doc.text(
                     s"type mismatch in call to $fnLabel, argument ${appSite.argIndex + 1} of ${appSite.argCount}:"
                   ) + Doc.hardLine +
@@ -730,6 +852,7 @@ object PackageError {
                     Doc.text("function type: ") + tmap(appSite.functionType) +
                     Doc.hardLine + Doc.text("argument site:") + Doc.hardLine +
                     contextDoc(appSite.argumentRegion) + fnContext,
+                  ),
                   Some(appSite.argumentRegion)
                 )
 
@@ -760,6 +883,7 @@ object PackageError {
                   }
 
                 (
+                  tmap.withUnknownTypes(
                   Doc.text("pattern type mismatch:") + Doc.hardLine +
                     Doc.text("pattern: ") + Doc.text(
                       patternDoc
@@ -772,6 +896,7 @@ object PackageError {
                     ) + Doc.hardLine +
                     Doc.text("pattern site:") + Doc.hardLine +
                     contextDoc(patSite.patternRegion) + scrutineeContext,
+                  ),
                   Some(patSite.patternRegion)
                 )
             }
@@ -810,20 +935,16 @@ object PackageError {
 
             val tmap =
               showTypes(pack, List(expectedType, foundType), localTypeNames)
-            val evidenceDocs =
-              evidenceRegions.distinct.sortBy(_.start).map(contextDoc)
-            val evidenceDoc =
-              if (evidenceDocs.lengthCompare(1) > 0) {
-                Doc.text("evidence sites:") + Doc.hardLine +
-                  Doc.intercalate(Doc.hardLine + Doc.hardLine, evidenceDocs)
-              } else {
-                context1
-              }
-            val doc =
+            val evidenceDoc = evidenceDocOrDefault(
+              evidenceRegions,
+              expectedRegion :: foundRegion :: Nil,
+              context1
+            )
+            val doc = tmap.withUnknownTypes(
               Doc.text("type error: expected type ") + tmap(expectedType) +
                 context0 + Doc.text("but found type ") + tmap(foundType) +
                 Doc.hardLine + fnHint + evidenceDoc
-
+            )
             (doc, Some(expectedRegion))
 
           case Infer.Error.VarNotInScope((_, name), scope, region) =>
@@ -925,15 +1046,11 @@ object PackageError {
 
             val tmap =
               showTypes(pack, List(expectedType, foundType), localTypeNames)
-            val evidenceDocs =
-              evidenceRegions.distinct.sortBy(_.start).map(contextDoc)
-            val evidenceDoc =
-              if (evidenceDocs.lengthCompare(1) > 0) {
-                Doc.text("evidence sites:") + Doc.hardLine +
-                  Doc.intercalate(Doc.hardLine + Doc.hardLine, evidenceDocs)
-              } else {
-                context1
-              }
+            val evidenceDoc = evidenceDocOrDefault(
+              evidenceRegions,
+              foundRegion :: expectedRegion :: Nil,
+              context1
+            )
             val kindHints = List(
               kindHintDoc("found type", foundType),
               kindHintDoc("expected type", expectedType)
@@ -941,12 +1058,14 @@ object PackageError {
             val kindHintSection =
               if (kindHints.isEmpty) Doc.empty
               else Doc.hardLine + Doc.intercalate(Doc.hardLine, kindHints)
-            val doc = Doc.text("type ") + tmap(foundType) + context0 +
+            val doc = tmap.withUnknownTypes(
+              Doc.text("type ") + tmap(foundType) + context0 +
               Doc.text("does not subsume expected type ") + tmap(
                 expectedType
               ) + Doc.hardLine +
               evidenceDoc +
               kindHintSection
+            )
 
             (doc, Some(foundRegion))
 
@@ -977,22 +1096,26 @@ object PackageError {
           case Infer.Error.KindCannotTyApply(applied, region) =>
             val tmap = showTypes(pack, applied :: Nil, localTypeNames)
             val context = contextDoc(region)
-            val doc = Doc.text("kind error: for kind of the left of ") +
+            val doc = tmap.withUnknownTypes(
+              Doc.text("kind error: for kind of the left of ") +
               tmap(applied) + Doc.text(
                 " is *. Cannot apply to kind *."
               ) + Doc.hardLine +
               context
+            )
 
             (doc, Some(region))
 
           case Infer.Error.KindExpectedType(tpe, kind, region) =>
             val tmap = showTypes(pack, tpe :: Nil, localTypeNames)
             val context = contextDoc(region)
-            val doc = Doc.text("expected type ") +
+            val doc = tmap.withUnknownTypes(
+              Doc.text("expected type ") +
               tmap(tpe) + Doc.text(
                 " to have kind *, which is to say be a valid value, but it is kind "
               ) + Kind.toDoc(kind) + Doc.hardLine +
               context
+            )
 
             (doc, Some(region))
 
@@ -1005,7 +1128,8 @@ object PackageError {
               localTypeNames
             )
             val context = contextDoc(region)
-            val doc = Doc.text("kind error: ") + Doc.text("the type: ") + tmap(
+            val doc = tmap.withUnknownTypes(
+              Doc.text("kind error: ") + Doc.text("the type: ") + tmap(
               applied
             ) +
               Doc.text(" is invalid because the left ") + tmap(leftT) + Doc
@@ -1016,6 +1140,7 @@ object PackageError {
               Doc.text(s" but left cannot accept the kind of the right:") +
               Doc.hardLine +
               context
+            )
 
             (doc, Some(region))
 
@@ -1038,7 +1163,7 @@ object PackageError {
                 Doc.empty
               }
 
-            val doc =
+            val doc = tmap.withUnknownTypes(
               Doc.text("kind error: ") + Doc.text("the type: ") + tmap(meta) +
                 Doc.text(" of kind: ") + Kind.toDoc(metaK) + Doc.text(
                   " at: "
@@ -1048,6 +1173,7 @@ object PackageError {
                 Doc.text(" of kind: ") + Kind.toDoc(rightK) + context1 +
                 Doc.hardLine +
                 Doc.text("because the first kind does not subsume the second.")
+            )
 
             (doc, Some(metaR))
 
@@ -1064,7 +1190,7 @@ object PackageError {
                 Doc.empty
               }
 
-            val doc =
+            val doc = tmap.withUnknownTypes(
               Doc.text("Unexpected unknown: the type: ") + tmap(tymeta) +
                 Doc.text(" of kind: ") + Kind.toDoc(meta.kind) + Doc.text(
                   " at: "
@@ -1075,6 +1201,7 @@ object PackageError {
                 Doc.text(
                   "this sometimes happens when a function arg has been omitted, or an illegal recursive type or function."
                 )
+            )
 
             (doc, Some(metaR))
 
@@ -1083,9 +1210,11 @@ object PackageError {
             val context = contextDoc(region)
 
             (
+              tmap.withUnknownTypes(
               Doc.text("the type ") + tmap(tpe) + Doc.text(
                 " is not polymorphic enough"
               ) + Doc.hardLine + context,
+              ),
               Some(region)
             )
 
@@ -1222,7 +1351,7 @@ object PackageError {
           singleToDoc(
             s,
             occurrences = 1,
-            evidenceRegions = mismatchEvidenceRegion(s).toList
+            evidenceRegions = mismatchEvidenceRegions(s)
           )
         case c @ Infer.Error.Combine(_, _) =>
           val twoLines = Doc.hardLine + Doc.hardLine

--- a/core/src/main/scala/dev/bosatsu/rankn/Infer.scala
+++ b/core/src/main/scala/dev/bosatsu/rankn/Infer.scala
@@ -2284,13 +2284,20 @@ object Infer {
               case notAnnotated =>
                 newMeta // the kind of a let value is a Type
                   .flatMap { rhsTpe =>
+                    val recursiveRegion =
+                      notAnnotated match {
+                        case Expr.Lambda(_, result, _) =>
+                          region(notAnnotated) - region(result)
+                        case _ =>
+                          region(notAnnotated)
+                      }
                     extendEnv(name, rhsTpe) {
                       for {
                         // the type variable needs to be unified with varT
                         // note, varT could be a sigma type, it is not a Tau or Rho
                         typedRhs <- inferSigmaMeta(
                           notAnnotated,
-                          Some((name, rhsTpe, region(notAnnotated)))
+                          Some((name, rhsTpe, recursiveRegion))
                         )
                         varT = typedRhs.getType
                         // we need to overwrite the metavariable now with the full type
@@ -2939,6 +2946,14 @@ object Infer {
         e: Expr[A],
         meta: Option[(Identifier, Type.TyMeta, Region)]
     ): Infer[TypedExpr[A]] = {
+      def recursiveBindingRegion(expr: Expr[A]): Region =
+        expr match {
+          case Expr.Lambda(_, result, _) =>
+            region(expr) - region(result)
+          case _ =>
+            region(expr)
+        }
+
       def unifySelf(rho: Type.Rho): Infer[Map[Name, Type]] =
         meta match {
           case None             => getEnv
@@ -2946,7 +2961,7 @@ object Infer {
             (unifyRho(
               rho,
               m,
-              region(e),
+              recursiveBindingRegion(e),
               r,
               Error.Direction.ExpectRight
             ) *> getEnv).map { envTys =>

--- a/core/src/test/scala/dev/bosatsu/ErrorMessageTest.scala
+++ b/core/src/test/scala/dev/bosatsu/ErrorMessageTest.scala
@@ -1893,14 +1893,15 @@ struct Id(a)
 def makeFoo(v: Int): Foo(Id(v))
 
 """)) { case kie: PackageError.TypeErrorIn =>
-      assertEquals(
-        kie.message(Map.empty, Colorize.None),
-        """in file: <unknown source>, package Foo
-kind error: the type: ?0 of kind: (* -> *) -> * at: 
-[183, 188)
-
-cannot be unified with the type Id of kind: +* -> *
-because the first kind does not subsume the second."""
+      val message = kie.message(Map.empty, Colorize.None)
+      assert(
+        message.contains("kind error: the type: a of kind: (* -> *) -> *"),
+        message
+      )
+      assert(message.contains("cannot be unified with the type Id"), message)
+      assert(
+        message.contains("where a: (* -> *) -> * is an unknown type."),
+        message
       )
       ()
     }
@@ -1944,18 +1945,57 @@ def quick_sort0(cmp, left, right):
         bigs = quick_sort0(cmp, tail)
         [*smalls, *bigs]
 """)) { case kie: PackageError.TypeErrorIn =>
-      assertEquals(
-        kie.message(Map.empty, Colorize.None),
-        """in file: <unknown source>, package QS
-type error: expected type Fn2
-[835, 842)
-but found type Fn3[(?17, ?9) -> Comparison]
-hint: the first type is a function with 2 arguments and the second is a function with 3 arguments.
-[403, 414)"""
+      val message = kie.message(Map.empty, Colorize.None)
+      assert(message.contains("type error: expected type Fn2"), message)
+      assert(message.contains("but found type Fn3[("), message)
+      assert(message.contains("-> Comparison]"), message)
+      assert(
+        message.contains(
+          "hint: the first type is a function with 2 arguments and the second is a function with 3 arguments."
+        ),
+        message
       )
+      assert(message.contains("where unknown types are a, b."), message)
+      assert(!"\\?[0-9]+".r.findFirstIn(message).isDefined, message)
       ()
     }
 
+  }
+
+  test("recursive local function mismatch points at definition and names unknowns") {
+    evalFail(List("""
+package RecOrder
+
+enum Tree:
+  Single(a: a)
+  Branch(size: Int, head: a, left: Tree[a], right: Tree[a])
+
+struct TreeList(trees: List[Tree[a]])
+
+operator - = sub
+
+def get(TreeList(trees): TreeList[a], idx: Int) -> Option[a]:
+  def go(trees, idx):
+    loop (idx, trees):
+      case _ if cmp_Int(idx, 0) matches LT: None
+      case (_, []): None
+      case (idx, [Single(h), *rest]):
+        if eq_Int(idx, 0): Some(h)
+        else: go(idx - 1, rest)
+      case (_, [Branch(s, _, t1, t2), *rest]):
+        match cmp_Int(idx, s):
+          case LT: go(idx - 1, [t1, t2, *rest])
+          case _: go(idx - s, rest)
+  go(trees, idx)
+""")) { case kie: PackageError.TypeErrorIn =>
+      val message = kie.message(Map.empty, Colorize.None)
+      assert(message.contains("type error: expected type Int but found type"), message)
+      assert(message.contains("type a[b]"), message)
+      assert(message.contains("[227, 250)"), message)
+      assert(message.contains("where unknown type"), message)
+      assert(!"\\?[0-9]+".r.findFirstIn(message).isDefined, message)
+      ()
+    }
   }
 
   test("error early on a bad type in a recursive function") {


### PR DESCRIPTION
Implemented a focused fix for issue #1981 in the type error reporter and recursive inference path.

Changes made:
- Updated `PackageError.showTypes` to render unsolved type metas as fresh readable names (`a`, `b`, ...), instead of raw `?N` ids.
- Added explicit unknown-type legend text (e.g. `where unknown types are a, b.`), including kind annotations when a meta is not kind `*`.
- Improved mismatch evidence collection to track both expected and found regions for type errors, so deduplicated combined errors can show richer evidence sites.
- In recursive let inference (`Infer`), narrowed recursive-binding regions for lambdas to the definition/signature span, avoiding broad body-wide highlights.
- Added/updated regression coverage in `ErrorMessageTest` for:
  - readable unknown-type variable rendering,
  - unknown-type legend output,
  - recursive local mismatch behavior with the focused definition-region reporting.

Validation run:
- `sbt "coreJVM/test:compile"` (pass)
- `sbt "coreJVM/testOnly dev.bosatsu.ErrorMessageTest"` (pass)
- `scripts/test_basic.sh` (pass)

Fixes #1981