### PR TITLE
Implement issue #1977: 62-bit C small-int representation and runtime/codegen updates

### DIFF
--- a/c_runtime/bench.c
+++ b/c_runtime/bench.c
@@ -163,6 +163,9 @@ int main(int argc, char** argv) {
   BValue small_neg = bsts_integer_from_int(-1);
   BValue small_10 = bsts_integer_from_int(10);
   BValue small_mask = bsts_integer_from_int(0x12345678);
+  BValue small62_pos = bsts_integer_from_int64((INT64_C(1) << 40) + 12345);
+  BValue small62_neg = bsts_integer_from_int64(-((INT64_C(1) << 40) + 12345));
+  BValue small62_mask = bsts_integer_from_int64((INT64_C(1) << 40) + 0x12345678);
   BValue shift_left = bsts_integer_from_int(5);
   BValue shift_right = bsts_integer_from_int(-5);
 
@@ -177,11 +180,18 @@ int main(int argc, char** argv) {
   printf("iters=%zu\n", iters);
   bench_add_big_small("add_big_small_pos", iters, big_pos, small_pos, small_neg);
   bench_add_big_small("add_big_small_neg", iters, big_neg, small_pos, small_neg);
+  bench_add_big_small("add_big_small62_pos", iters, big_pos, small62_pos, small62_neg);
+  bench_add_big_small("add_big_small62_neg", iters, big_neg, small62_pos, small62_neg);
   bench_mul_big_small("mul_big_small_pos", iters, big_pos, small_10);
   bench_mul_big_small("mul_big_small_neg", iters, big_neg, small_10);
+  bench_mul_big_small("mul_big_small62_pos", iters, big_pos, small62_pos);
+  bench_mul_big_small("mul_big_small62_neg", iters, big_neg, small62_pos);
   bench_bitwise("and_neg_mixed", iters, big_neg, small_mask, '&');
   bench_bitwise("or_neg_mixed", iters, big_neg, small_mask, '|');
   bench_bitwise("xor_neg_mixed", iters, big_neg, small_mask, '^');
+  bench_bitwise("and_neg_mixed62", iters, big_neg, small62_mask, '&');
+  bench_bitwise("or_neg_mixed62", iters, big_neg, small62_mask, '|');
+  bench_bitwise("xor_neg_mixed62", iters, big_neg, small62_mask, '^');
   bench_shift("shift_neg_left", iters, big_neg, shift_left);
   bench_shift("shift_neg_right", iters, big_neg, shift_right);
   bench_string_static_ctor("str_ctor_static_heap", iters, "abcdefghijklmnopqrstuvwx");

--- a/c_runtime/bosatsu_ext_Bosatsu_l_IO_l_Core.c
+++ b/c_runtime/bosatsu_ext_Bosatsu_l_IO_l_Core.c
@@ -284,34 +284,6 @@ static BValue bsts_core_make_handle(
   return alloc_external(h, bsts_core_handle_free);
 }
 
-static BValue bsts_integer_from_int64_local(int64_t value)
-{
-  if ((value >= INT32_MIN) && (value <= INT32_MAX))
-  {
-    return bsts_integer_from_int((int32_t)value);
-  }
-
-  uint64_t mag;
-  _Bool pos;
-  if (value >= 0)
-  {
-    pos = 1;
-    mag = (uint64_t)value;
-  }
-  else
-  {
-    pos = 0;
-    mag = (uint64_t)(-(value + 1));
-    mag += 1;
-  }
-
-  uint32_t words[2];
-  words[0] = (uint32_t)(mag & 0xFFFFFFFFULL);
-  words[1] = (uint32_t)((mag >> 32) & 0xFFFFFFFFULL);
-  size_t size = (words[1] == 0U) ? 1U : 2U;
-  return bsts_integer_from_words_copy(pos, size, words);
-}
-
 static char *bsts_string_to_cstr(BValue str)
 {
   BSTS_String_View view = bsts_string_view_ref(&str);
@@ -1791,7 +1763,7 @@ static BValue bsts_core_stat_effect(BValue path_value)
   }
 
   BValue kind = alloc_enum0((ENUM_TAG)kind_tag);
-  BValue size_bytes = bsts_integer_from_int64_local((int64_t)st.st_size);
+  BValue size_bytes = bsts_integer_from_int64((int64_t)st.st_size);
 
 #if defined(__APPLE__)
   int64_t sec = (int64_t)st.st_mtimespec.tv_sec;
@@ -1801,7 +1773,7 @@ static BValue bsts_core_stat_effect(BValue path_value)
   long nsec = st.st_mtim.tv_nsec;
 #endif
 
-  BValue sec_i = bsts_integer_from_int64_local(sec);
+  BValue sec_i = bsts_integer_from_int64(sec);
   BValue billion = bsts_integer_from_int(1000000000);
   BValue nsec_i = bsts_integer_from_int((int32_t)nsec);
   BValue mtime = bsts_integer_add(bsts_integer_times(sec_i, billion), nsec_i);
@@ -1959,7 +1931,7 @@ static BValue bsts_core_now_wall_effect(BValue unit)
         bsts_ioerror_from_errno_default(errno, "reading wall clock"));
   }
 
-  BValue sec_i = bsts_integer_from_int64_local((int64_t)ts.tv_sec);
+  BValue sec_i = bsts_integer_from_int64((int64_t)ts.tv_sec);
   BValue billion = bsts_integer_from_int(1000000000);
   BValue nsec_i = bsts_integer_from_int((int32_t)ts.tv_nsec);
   BValue nanos = bsts_integer_add(bsts_integer_times(sec_i, billion), nsec_i);
@@ -1976,7 +1948,7 @@ static BValue bsts_core_now_mono_effect(BValue unit)
         bsts_ioerror_from_errno_default(errno, "reading monotonic clock"));
   }
 
-  BValue sec_i = bsts_integer_from_int64_local((int64_t)ts.tv_sec);
+  BValue sec_i = bsts_integer_from_int64((int64_t)ts.tv_sec);
   BValue billion = bsts_integer_from_int(1000000000);
   BValue nsec_i = bsts_integer_from_int((int32_t)ts.tv_nsec);
   BValue nanos = bsts_integer_add(bsts_integer_times(sec_i, billion), nsec_i);

--- a/c_runtime/bosatsu_ext_Bosatsu_l_Num_l_Float64.c
+++ b/c_runtime/bosatsu_ext_Bosatsu_l_Num_l_Float64.c
@@ -26,15 +26,7 @@ static BValue bsts_some(BValue value) {
 }
 
 static BValue bsts_uint64_to_int(uint64_t bits) {
-  uint32_t words[2] = {
-    (uint32_t)(bits & UINT32_C(0xffffffff)),
-    (uint32_t)((bits >> 32) & UINT32_C(0xffffffff))
-  };
-
-  if (words[1] == 0 && words[0] <= INT32_MAX) {
-    return bsts_integer_from_int((int32_t)words[0]);
-  }
-  return bsts_integer_from_words_copy(1, words[1] == 0 ? 1 : 2, words);
+  return bsts_integer_from_uint64(bits);
 }
 
 static double bsts_round_ties_even(double d) {

--- a/c_runtime/bosatsu_runtime.c
+++ b/c_runtime/bosatsu_runtime.c
@@ -15,6 +15,7 @@ _Static_assert(sizeof(void*) == 8, "Bosatsu runtime currently requires 64-bit po
 _Static_assert(sizeof(uintptr_t) == 8, "Bosatsu runtime assumes 64-bit uintptr_t");
 _Static_assert(sizeof(size_t) == 8, "Bosatsu runtime assumes 64-bit size_t");
 _Static_assert(sizeof(BSTS_String) == 24, "BSTS_String should remain 24 bytes on 64-bit platforms");
+_Static_assert(BSTS_SMALL_INT_PAYLOAD_BITS == 62, "small-int payload bits must remain 62");
 
 /*
 There are a few kinds of values:
@@ -40,7 +41,7 @@ Char values are stored as tiny UTF-8 strings (1..4 bytes) in type-directed conte
 String values are either pointers to BSTS_String objects or tiny strings packed
 directly into the BValue word in type-directed contexts.
 
-Integer values are either pure values (signed values packed into 63 bits),
+Integer values are either pure values (signed values packed into 62 payload bits),
 or gced big integers
 */
 #define TAG_MASK ((uintptr_t)0x3)
@@ -284,26 +285,47 @@ typedef struct {
 
 // Helper macros and functions
 #define IS_SMALL(v) IS_PURE_VALUE(v)
-#define GET_SMALL_INT(v) (int32_t)(PURE_VALUE(v))
 #define GET_BIG_INT(v) BSTS_PTR(BSTS_Integer, (v))
 
-void bsts_load_op_from_small(int32_t value, uint32_t* words, BSTS_Int_Operand* op) {
+static inline int64_t bsts_small_int_decode(BValue value) {
+  return ((int64_t)value) >> 2;
+}
+
+static inline _Bool bsts_small_int_fits_int64(int64_t value) {
+  return (value >= BSTS_SMALL_INT_MIN) && (value <= BSTS_SMALL_INT_MAX);
+}
+
+static inline BValue bsts_small_int_from_int64_unchecked(int64_t value) {
+  return (BValue)((((uint64_t)value) << 2) | PURE_VALUE_TAG);
+}
+
+static inline BValue bsts_small_int_from_int64_maybe(int64_t value) {
+  if (!bsts_small_int_fits_int64(value)) return BSTS_BVALUE_NULL;
+  return bsts_small_int_from_int64_unchecked(value);
+}
+
+static inline uint64_t bsts_abs_i64(int64_t value) {
+  if (value >= 0) return (uint64_t)value;
+  uint64_t abs_value = (uint64_t)(-(value + 1));
+  return abs_value + UINT64_C(1);
+}
+
+static inline size_t bsts_u64_to_words(uint64_t magnitude, uint32_t* words) {
+  words[0] = (uint32_t)(magnitude & UINT32_C(0xffffffff));
+  words[1] = (uint32_t)((magnitude >> 32) & UINT32_C(0xffffffff));
+  return (words[1] == 0U) ? 1U : 2U;
+}
+
+static inline size_t bsts_small_twos_word_len(int64_t value) {
+  return (bsts_abs_i64(value) >> 32) == 0U ? 1U : 2U;
+}
+
+#define GET_SMALL_INT(v) bsts_small_int_decode((v))
+
+void bsts_load_op_from_small(int64_t value, uint32_t* words, BSTS_Int_Operand* op) {
     op->sign = value < 0;
     op->words = words;
-    int64_t bigger = (int64_t)value;
-    int64_t abs_bigger = (bigger < 0 ? -bigger : bigger);
-    uint32_t low = (uint32_t)(abs_bigger & 0xFFFFFFFF);
-    uint32_t high = (uint32_t)((abs_bigger >> 32) & 0xFFFFFFFF);
-    if (high == 0) {
-      words[0] = low;
-      op->len = 1;
-    }
-    else {
-      // TODO: this branch should be unreachable, remove it
-      words[0] = low;
-      words[1] = high;
-      op->len = 2;
-    }
+    op->len = bsts_u64_to_words(bsts_abs_i64(value), words);
 }
  
 void bsts_integer_load_op(BValue v, uint32_t* buffer, BSTS_Int_Operand* operand) {
@@ -949,12 +971,16 @@ void bsts_string_print(BValue v) {
 }
 
 BValue bsts_integer_from_int(int32_t small_int) {
-    return TO_PURE_VALUE(small_int);
+    return bsts_small_int_from_int64_unchecked((int64_t)small_int);
 }
 
 int32_t bsts_integer_to_int32(BValue bint) {
     if (IS_SMALL(bint)) {
-        return GET_SMALL_INT(bint);
+        int64_t small = GET_SMALL_INT(bint);
+        if (small < INT32_MIN) {
+            return INT32_MIN;
+        }
+        return (int32_t)small;
     }
 
     BSTS_Integer* bi = GET_BIG_INT(bint);
@@ -988,15 +1014,55 @@ BSTS_Integer* bsts_integer_alloc(size_t size) {
     return integer; // Low bit is 0 since it's a pointer
 }
 
-BValue bsts_maybe_small_int(_Bool pos, uint32_t small_result);
+static BValue bsts_maybe_small_int_words(_Bool is_pos, size_t size, const uint32_t* words) {
+    if (size == 0) {
+      return bsts_small_int_from_int64_unchecked(0);
+    }
+    while ((size > 1) && (words[size - 1] == 0U)) {
+      size--;
+    }
+    if (size > 2) {
+      return BSTS_BVALUE_NULL;
+    }
+
+    uint64_t magnitude = (uint64_t)words[0];
+    if (size == 2) {
+      uint32_t high = words[1];
+      // Any high bits above payload bit 61 cannot fit in small-int form.
+      if (high > UINT32_C(0x20000000)) {
+        return BSTS_BVALUE_NULL;
+      }
+      magnitude |= ((uint64_t)high << 32);
+    }
+
+    if (magnitude == 0U) {
+      return bsts_small_int_from_int64_unchecked(0);
+    }
+
+    if (is_pos) {
+      if (magnitude > (uint64_t)BSTS_SMALL_INT_MAX) {
+        return BSTS_BVALUE_NULL;
+      }
+      return bsts_small_int_from_int64_unchecked((int64_t)magnitude);
+    }
+
+    uint64_t min_mag = UINT64_C(1) << 61;
+    if (magnitude > min_mag) {
+      return BSTS_BVALUE_NULL;
+    }
+    if (magnitude == min_mag) {
+      return bsts_small_int_from_int64_unchecked(BSTS_SMALL_INT_MIN);
+    }
+    return bsts_small_int_from_int64_unchecked(-(int64_t)magnitude);
+}
 
 BValue bsts_integer_from_words_copy(_Bool is_pos, size_t size, uint32_t* words) {
     // remove any leading 0 words
     while ((size > 1) && (words[size - 1] == 0)) {
       size--;
     }
-    if (size == 1) {
-      BValue maybe = bsts_maybe_small_int(is_pos, words[0]);
+    {
+      BValue maybe = bsts_maybe_small_int_words(is_pos, size, words);
       if (maybe) return maybe;
     }
     BSTS_Integer* integer = bsts_integer_alloc(size);
@@ -1006,53 +1072,22 @@ BValue bsts_integer_from_words_copy(_Bool is_pos, size_t size, uint32_t* words) 
 }
 
 BValue bsts_integer_from_int64(int64_t result) {
-  // Check if result fits in small integer
-  if ((INT32_MIN <= result) && (result <= INT32_MAX)) {
-      return bsts_integer_from_int((int32_t)result);
-  } else {
-      // Promote to big integer
-      _Bool is_positive = result >= 0;
-      uint64_t abs_result = is_positive ? result : -result;
-      uint32_t low = (uint32_t)(abs_result & 0xFFFFFFFF);
-      uint32_t high = (uint32_t)((abs_result >> 32) & 0xFFFFFFFF);
-      if (high == 0) {
-        BSTS_Integer* result = bsts_integer_alloc(1);
-        result->sign = !is_positive;
-        result->words[0] = low;
-        return BSTS_VALUE_FROM_PTR(result);
-      }
-      else {
-        BSTS_Integer* result = bsts_integer_alloc(2);
-        result->sign = !is_positive;
-        result->words[0] = low;
-        result->words[1] = high;
-        return BSTS_VALUE_FROM_PTR(result);
-      }
+  BValue maybe = bsts_small_int_from_int64_maybe(result);
+  if (maybe != BSTS_BVALUE_NULL) {
+      return maybe;
   }
+  uint32_t words[2];
+  size_t size = bsts_u64_to_words(bsts_abs_i64(result), words);
+  return bsts_integer_from_words_copy(result >= 0, size, words);
 }
 
 BValue bsts_integer_from_uint64(uint64_t result) {
-  // Check if result fits in small integer
-  if (result <= INT32_MAX) {
-      return bsts_integer_from_int((int32_t)result);
-  } else {
-      // Promote to big integer
-      uint32_t low = (uint32_t)(result & 0xFFFFFFFF);
-      uint32_t high = (uint32_t)((result >> 32) & 0xFFFFFFFF);
-      if (high == 0) {
-        BSTS_Integer* result = bsts_integer_alloc(1);
-        result->sign = 0;
-        result->words[0] = low;
-        return BSTS_VALUE_FROM_PTR(result);
-      }
-      else {
-        BSTS_Integer* result = bsts_integer_alloc(2);
-        result->sign = 0;
-        result->words[0] = low;
-        result->words[1] = high;
-        return BSTS_VALUE_FROM_PTR(result);
-      }
+  if (result <= (uint64_t)BSTS_SMALL_INT_MAX) {
+      return bsts_small_int_from_int64_unchecked((int64_t)result);
   }
+  uint32_t words[2];
+  size_t size = bsts_u64_to_words(result, words);
+  return bsts_integer_from_words_copy(1, size, words);
 }
 
 uint64_t bsts_integer_to_low_uint64(BValue bint) {
@@ -1219,31 +1254,6 @@ BValue bsts_integral_float64_to_integer(double d) {
   return bsts_integer_from_words_copy(!is_negative, size, words);
 }
 
-BValue bsts_maybe_small_int(_Bool pos, uint32_t small_result) {
-  if (!pos) {
-    if (small_result <= 0x80000000) {
-      // this fits in int32_t
-      if (small_result == 0x80000000) {
-        return bsts_integer_from_int(INT32_MIN);
-      }
-      else {
-        return bsts_integer_from_int(-((int32_t)small_result));
-      }
-    }
-    else {
-      return BSTS_BVALUE_NULL;
-    }
-  }
-  else if (small_result <= INT32_MAX) {
-    // it is a small positive
-    return bsts_integer_from_int(((int32_t)small_result));
-  }
-  else {
-    // positive number > INT32_MAX
-    return BSTS_BVALUE_NULL;
-  }
-}
-
 // Function to check equality between two BValues
 _Bool bsts_integer_equals(BValue left, BValue right) {
     if (left == right) { return 1; }
@@ -1284,7 +1294,7 @@ _Bool bsts_integer_equals(BValue left, BValue right) {
         }
 
         // Extract small integer value
-        int32_t small_int_value = GET_SMALL_INT(left);
+        int64_t small_int_value = GET_SMALL_INT(left);
         BSTS_Integer* big_int = GET_BIG_INT(right);
 
         // Check sign
@@ -1293,19 +1303,23 @@ _Bool bsts_integer_equals(BValue left, BValue right) {
         if (big_int_sign != small_int_sign) {
             return 0; // Different signs
         }
-        // they are both positive
-        if (big_int->len > 1) {
-          // the big int is bigger
-          return 0;
-        }
         if (big_int->len == 0) {
           return small_int_value == 0;
         }
-        // else len == 1
-        int64_t small64 = (int64_t)small_int_value;
-        int64_t big64 = big_int_sign ? -(int64_t)big_int->words[0] : (int64_t)big_int->words[0];
 
-        return big64 == small64;
+        uint32_t small_words[2];
+        BSTS_Int_Operand small_operand;
+        bsts_load_op_from_small(small_int_value, small_words, &small_operand);
+
+        if (big_int->len != small_operand.len) {
+          return 0;
+        }
+        for (size_t i = 0; i < big_int->len; i++) {
+          if (big_int->words[i] != small_operand.words[i]) {
+            return 0;
+          }
+        }
+        return 1;
     }
 }
 
@@ -1329,166 +1343,64 @@ int compare_abs(size_t len_a, uint32_t* words_a, size_t len_b, uint32_t* words_b
     }
 }
 
-static inline uint64_t bsts_abs_i32(int32_t v) {
-  return (v < 0) ? (uint64_t)(-(int64_t)v) : (uint64_t)v;
+#if !defined(__SIZEOF_INT128__)
+static _Bool bsts_mul_i64_overflow(int64_t left, int64_t right, int64_t* out) {
+#if defined(__has_builtin)
+#if __has_builtin(__builtin_mul_overflow)
+    return __builtin_mul_overflow(left, right, out);
+#endif
+#endif
+#if defined(__GNUC__) || defined(__clang__)
+    return __builtin_mul_overflow(left, right, out);
+#else
+    if ((left == 0) || (right == 0)) {
+      *out = 0;
+      return 0;
+    }
+    if (left == -1) {
+      if (right == INT64_MIN) return 1;
+      *out = -right;
+      return 0;
+    }
+    if (right == -1) {
+      if (left == INT64_MIN) return 1;
+      *out = -left;
+      return 0;
+    }
+
+    if (left > 0) {
+      if (right > 0) {
+        if (left > (INT64_MAX / right)) return 1;
+      } else {
+        if (right < (INT64_MIN / left)) return 1;
+      }
+    } else {
+      if (right > 0) {
+        if (left < (INT64_MIN / right)) return 1;
+      } else {
+        if (left < (INT64_MAX / right)) return 1;
+      }
+    }
+    *out = left * right;
+    return 0;
+#endif
 }
-
-static BValue bsts_integer_add_big_small(BValue bigv, int32_t small) {
-    if (small == 0) {
-        return bigv;
-    }
-    BSTS_Integer* big = GET_BIG_INT(bigv);
-    _Bool big_sign = big->sign;
-    _Bool small_sign = (small < 0);
-    uint64_t abs_small = bsts_abs_i32(small);
-
-    if (big_sign == small_sign) {
-        // same sign: add magnitudes
-        size_t len = big->len;
-        size_t result_len = len + 1;
-        BSTS_Integer* result = bsts_integer_alloc(result_len);
-
-        uint64_t sum = (uint64_t)big->words[0] + abs_small;
-        result->words[0] = (uint32_t)(sum & 0xFFFFFFFF);
-        uint64_t carry = sum >> 32;
-
-        for (size_t i = 1; i < len; i++) {
-            sum = (uint64_t)big->words[i] + carry;
-            result->words[i] = (uint32_t)(sum & 0xFFFFFFFF);
-            carry = sum >> 32;
-        }
-        if (carry) {
-            result->words[len] = (uint32_t)carry;
-        }
-
-        size_t out_len = carry ? (len + 1) : len;
-        while (out_len > 1 && result->words[out_len - 1] == 0) {
-            out_len--;
-        }
-        if (out_len == 1) {
-            BValue maybe = bsts_maybe_small_int(!big_sign, result->words[0]);
-            if (maybe) return maybe;
-        }
-        result->len = out_len;
-        result->sign = big_sign;
-        return BSTS_VALUE_FROM_PTR(result);
-    }
-    else {
-        // different signs: subtract magnitudes
-        size_t len = big->len;
-        if (len > 1) {
-            // big magnitude is larger than abs_small
-            BSTS_Integer* result = bsts_integer_alloc(len);
-            uint64_t w0 = big->words[0];
-            uint64_t diff = w0 - abs_small;
-            uint32_t borrow = (w0 < abs_small) ? 1u : 0u;
-            result->words[0] = (uint32_t)(diff & 0xFFFFFFFF);
-
-            for (size_t i = 1; i < len; i++) {
-                uint32_t w = big->words[i];
-                if (borrow) {
-                    if (w == 0) {
-                        result->words[i] = 0xFFFFFFFFu;
-                        borrow = 1;
-                    } else {
-                        result->words[i] = w - 1;
-                        borrow = 0;
-                    }
-                } else {
-                    result->words[i] = w;
-                }
-            }
-
-            size_t out_len = len;
-            while (out_len > 1 && result->words[out_len - 1] == 0) {
-                out_len--;
-            }
-            if (out_len == 1) {
-                BValue maybe = bsts_maybe_small_int(!big_sign, result->words[0]);
-                if (maybe) return maybe;
-            }
-            result->len = out_len;
-            result->sign = big_sign;
-            return BSTS_VALUE_FROM_PTR(result);
-        } else {
-            uint32_t bw = big->words[0];
-            if (bw == abs_small) {
-                return bsts_integer_from_int(0);
-            }
-            if (bw > abs_small) {
-                uint32_t diff = (uint32_t)(bw - abs_small);
-                BValue maybe = bsts_maybe_small_int(!big_sign, diff);
-                if (maybe) return maybe;
-                BSTS_Integer* result = bsts_integer_alloc(1);
-                result->words[0] = diff;
-                result->len = 1;
-                result->sign = big_sign;
-                return BSTS_VALUE_FROM_PTR(result);
-            } else {
-                uint32_t diff = (uint32_t)(abs_small - bw);
-                _Bool result_sign = small_sign;
-                BValue maybe = bsts_maybe_small_int(!result_sign, diff);
-                if (maybe) return maybe;
-                BSTS_Integer* result = bsts_integer_alloc(1);
-                result->words[0] = diff;
-                result->len = 1;
-                result->sign = result_sign;
-                return BSTS_VALUE_FROM_PTR(result);
-            }
-        }
-    }
-}
-
-static BValue bsts_integer_mul_big_small(BValue bigv, int32_t small) {
-    if (small == 0) return bsts_integer_from_int(0);
-    if (small == 1) return bigv;
-    if (small == -1) return bsts_integer_negate(bigv);
-
-    BSTS_Integer* big = GET_BIG_INT(bigv);
-    size_t len = big->len;
-    uint64_t abs_small = bsts_abs_i32(small);
-    _Bool result_sign = big->sign ^ (small < 0);
-
-    size_t result_len = len + 1;
-    BSTS_Integer* result = bsts_integer_alloc(result_len);
-    uint64_t carry = 0;
-    for (size_t i = 0; i < len; i++) {
-        uint64_t prod = (uint64_t)big->words[i] * abs_small + carry;
-        result->words[i] = (uint32_t)(prod & 0xFFFFFFFF);
-        carry = prod >> 32;
-    }
-    result->words[len] = (uint32_t)carry;
-
-    size_t out_len = result_len;
-    while (out_len > 1 && result->words[out_len - 1] == 0) {
-        out_len--;
-    }
-    if (out_len == 1) {
-        BValue maybe = bsts_maybe_small_int(!result_sign, result->words[0]);
-        if (maybe) return maybe;
-    }
-    result->len = out_len;
-    result->sign = result_sign;
-    return BSTS_VALUE_FROM_PTR(result);
-}
+#endif
 
 BValue bsts_integer_add(BValue l, BValue r) {
     _Bool l_is_small = IS_SMALL(l);
     _Bool r_is_small = IS_SMALL(r);
 
-    // Case 1: Both are small integers
     if (l_is_small && r_is_small) {
-        int64_t l_int = (int64_t)GET_SMALL_INT(l);
-        int64_t r_int = (int64_t)GET_SMALL_INT(r);
+        int64_t l_int = GET_SMALL_INT(l);
+        int64_t r_int = GET_SMALL_INT(r);
         return bsts_integer_from_int64(l_int + r_int);
-    } else if (l_is_small && !r_is_small) {
-        return bsts_integer_add_big_small(r, GET_SMALL_INT(l));
-    } else if (!l_is_small && r_is_small) {
-        return bsts_integer_add_big_small(l, GET_SMALL_INT(r));
     } else if (l == (BValue)PURE_VALUE_TAG) {
         // sub(x, y) is encoded as add(x, negate(y)), and in Bosatsu code
         // -y is encoded as 0 - y. We should have a negate in Predef, but don't currently.
         return r;
+    } else if (r == (BValue)PURE_VALUE_TAG) {
+        return l;
     } else {
         // At least one operand is a big integer
 
@@ -1532,21 +1444,8 @@ BValue bsts_integer_add(BValue l, BValue r) {
                 result_len--;
             }
 
-            // Check for small integer representation
-            if (result_len == 1) {
-                BValue maybe_result = bsts_maybe_small_int(!result_sign, result_words[0]);
-                if (maybe_result) {
-                  result = maybe_result;
-                  free(result_words);
-                }
-                else {
-                  result = bsts_integer_from_words_copy(!result_sign, result_len, result_words);
-                  free(result_words);
-                }
-            } else {
-                result = bsts_integer_from_words_copy(!result_sign, result_len, result_words);
-                free(result_words);
-            }
+            result = bsts_integer_from_words_copy(!result_sign, result_len, result_words);
+            free(result_words);
         } else {
             // Subtraction
             // (-a) + b if |a| > |b|, then -(a - b)
@@ -1596,21 +1495,8 @@ BValue bsts_integer_add(BValue l, BValue r) {
                     result_len--;
                 }
 
-                // Check for small integer representation
-                if (result_len == 1) {
-                    BValue maybe_result = bsts_maybe_small_int(!result_sign, result_words[0]);
-                    if (maybe_result) {
-                      result = maybe_result;
-                      free(result_words);
-                    }
-                    else {
-                      result = bsts_integer_from_words_copy(!result_sign, result_len, result_words);
-                      free(result_words);
-                    }
-                } else {
-                    result = bsts_integer_from_words_copy(!result_sign, result_len, result_words);
-                    free(result_words);
-                }
+                result = bsts_integer_from_words_copy(!result_sign, result_len, result_words);
+                free(result_words);
             }
         }
 
@@ -1621,13 +1507,8 @@ BValue bsts_integer_add(BValue l, BValue r) {
 // Function to negate a BValue
 BValue bsts_integer_negate(BValue v) {
     if (IS_SMALL(v)) {
-        int32_t small = GET_SMALL_INT(v);
-        if (small != INT32_MIN) {
-            return bsts_integer_from_int(-small);
-        } else {
-            uint32_t words[1] = { 0x80000000 };
-            return bsts_integer_from_words_copy(1, 1, words);
-        }
+        int64_t small = GET_SMALL_INT(v);
+        return bsts_integer_from_int64(-small);
     } else {
         // Negate big integer
         BSTS_Integer* integer = GET_BIG_INT(v);
@@ -1677,11 +1558,11 @@ uint32_t bigint_divide_by_10(uint32_t* words, size_t len, uint32_t* quotient_wor
 // &Integer -> String
 BValue bsts_integer_to_string(BValue v) {
     if (IS_SMALL(v)) {
-        int value = GET_SMALL_INT(v);
+        int64_t value = GET_SMALL_INT(v);
 
         // Convert small integer to string
         char buffer[32]; // Enough for 64-bit integer
-        int length = snprintf(buffer, sizeof(buffer), "%d", value);
+        int length = snprintf(buffer, sizeof(buffer), "%lld", (long long)value);
 
         if (length < 0) {
             // snprintf error
@@ -1801,32 +1682,32 @@ BValue bsts_string_to_integer(BValue v) {
   // at least 1 character
 
   int64_t acc = 0;
-  BValue bacc = 0;
+  _Bool use_big_acc = 0;
+  BValue bacc = BSTS_BVALUE_NULL;
+  BValue ten = bsts_integer_from_int(10);
   while(pos < slen) {
     int32_t digit = (int32_t)(bytes[pos] - '0');
     if ((digit < 0) || (9 < digit)) return alloc_enum0(0);
-    if (pos >= 10) {
-      if (pos == 10) {
-        // we could be overflowing an int32_t at this point
-        bacc = bsts_integer_from_int64(((int64_t)acc) * 10L);
+
+    if (!use_big_acc) {
+      // Keep an int64 accumulator until the next decimal step would overflow.
+      if (acc > (INT64_MAX - digit) / 10) {
+        use_big_acc = 1;
+        bacc = bsts_integer_from_int64(acc);
+      } else {
+        acc = acc * 10 + digit;
+        pos++;
+        continue;
       }
-      else {
-        bacc = bsts_integer_times(bacc, bsts_integer_from_int(10));
-      }
-      bacc = bsts_integer_add(bacc, bsts_integer_from_int(digit)); 
     }
-    else {
-      acc = acc * 10 + digit;
-    }
+    bacc = bsts_integer_add(bsts_integer_times(bacc, ten), bsts_integer_from_int(digit));
     pos++;
   }
-  if (slen < 11) {
-    // acc should hold the number
+
+  if (!use_big_acc) {
     return alloc_enum1(1, bsts_integer_from_int64(sign ? -acc : acc));
   }
-  else {
-    return alloc_enum1(1, sign ? bsts_integer_negate(bacc) : bacc);
-  }
+  return alloc_enum1(1, sign ? bsts_integer_negate(bacc) : bacc);
 }
 
 // Function to convert sign-magnitude to two's complement representation
@@ -1900,13 +1781,17 @@ void twos_complement_to_sign_magnitude(size_t len, uint32_t* words, _Bool* sign,
     }
 }
 
-void bsts_integer_small_to_twos(int32_t value, uint32_t* target, size_t max_len) {
-  memcpy(target, &value, sizeof(int32_t));
-  if (value < 0) {
-    // fill with -1 all the rest
-    for (size_t i = 1; i < max_len; i++) {
-      target[i] = 0xFFFFFFFF;
-    }
+void bsts_integer_small_to_twos(int64_t value, uint32_t* target, size_t max_len) {
+  uint64_t bits = (uint64_t)value;
+  if (max_len > 0) {
+    target[0] = (uint32_t)(bits & UINT32_C(0xffffffff));
+  }
+  if (max_len > 1) {
+    target[1] = (uint32_t)((bits >> 32) & UINT32_C(0xffffffff));
+  }
+  uint32_t fill = (value < 0) ? UINT32_C(0xffffffff) : UINT32_C(0x00000000);
+  for (size_t i = 2; i < max_len; i++) {
+    target[i] = fill;
   }
 }
 
@@ -1918,13 +1803,10 @@ BValue bsts_integer_from_twos(size_t max_len, uint32_t* result_twos) {
     twos_complement_to_sign_magnitude(max_len, result_twos, &result_sign, &result_len, result->words);
     free(result_twos);
 
-    // Check if result can be represented as small integer
-    if (result_len == 1) {
-        // Attempt to pack into small integer
-        BValue maybe = bsts_maybe_small_int(!result_sign, result->words[0]);
-        if (maybe) {
-          return maybe;
-        }
+    // Canonicalize to immediate if the normalized magnitude fits 62 bits.
+    BValue maybe = bsts_maybe_small_int_words(!result_sign, result_len, result->words);
+    if (maybe) {
+      return maybe;
     }
     result->len = result_len;
     result->sign = result_sign;
@@ -1936,13 +1818,15 @@ BValue bsts_integer_and(BValue l, BValue r) {
     _Bool l_is_small = IS_SMALL(l);
     _Bool r_is_small = IS_SMALL(r);
 
-    if (l_is_small & r_is_small) {
-      return bsts_integer_from_int(GET_SMALL_INT(l) & GET_SMALL_INT(r));
+    if (l_is_small && r_is_small) {
+      int64_t lv = GET_SMALL_INT(l);
+      int64_t rv = GET_SMALL_INT(r);
+      return bsts_integer_from_int64(lv & rv);
     }
     // Determine maximum length in words
     // we need to leave space for maybe 1 extra word if we have -MAX
-    size_t l_len = l_is_small ? 1 : (GET_BIG_INT(l)->len + 1);
-    size_t r_len = r_is_small ? 1 : (GET_BIG_INT(r)->len + 1);
+    size_t l_len = l_is_small ? bsts_small_twos_word_len(GET_SMALL_INT(l)) : (GET_BIG_INT(l)->len + 1);
+    size_t r_len = r_is_small ? bsts_small_twos_word_len(GET_SMALL_INT(r)) : (GET_BIG_INT(r)->len + 1);
     size_t max_len = (l_len > r_len) ? l_len : r_len;
 
     // Ensure at least one word
@@ -2000,84 +1884,121 @@ BValue bsts_integer_times(BValue left, BValue right) {
     _Bool left_is_small = IS_SMALL(left);
     _Bool right_is_small = IS_SMALL(right);
 
-    if (left_is_small & right_is_small) {
-        // Both are small integers
-        int32_t l_int = GET_SMALL_INT(left);
-        int32_t r_int = GET_SMALL_INT(right);
-        // Multiply and check for overflow
-        int64_t result = (int64_t)l_int * (int64_t)r_int;
-        return bsts_integer_from_int64(result);
-    } else if (left_is_small && !right_is_small) {
-        return bsts_integer_mul_big_small(right, GET_SMALL_INT(left));
-    } else if (!left_is_small && right_is_small) {
-        return bsts_integer_mul_big_small(left, GET_SMALL_INT(right));
-    } else {
-        // At least one operand is big integer
-        uint32_t left_temp[2];
-        uint32_t right_temp[2];
-        BSTS_Int_Operand l_operand;
-        BSTS_Int_Operand r_operand;
-
-        // Prepare left operand
-        bsts_integer_load_op(left, left_temp, &l_operand);
-        // Prepare right operand
-        bsts_integer_load_op(right, right_temp, &r_operand);
-
-        // Multiply operands
-        size_t result_len = l_operand.len + r_operand.len;
-        uint32_t* result_words = (uint32_t*)calloc(result_len, sizeof(uint32_t));
-        if (result_words == NULL) {
-            perror("failed to malloc result_words in bsts_integer_times");
-            abort();
+    if (left_is_small && right_is_small) {
+        int64_t l_int = GET_SMALL_INT(left);
+        int64_t r_int = GET_SMALL_INT(right);
+#if defined(__SIZEOF_INT128__)
+        __int128 wide = ((__int128)l_int) * ((__int128)r_int);
+        if ((wide >= (__int128)BSTS_SMALL_INT_MIN) && (wide <= (__int128)BSTS_SMALL_INT_MAX)) {
+            return bsts_small_int_from_int64_unchecked((int64_t)wide);
+        }
+        unsigned __int128 mag = (wide < 0) ? (unsigned __int128)(-wide) : (unsigned __int128)wide;
+        uint32_t words[4] = { 0, 0, 0, 0 };
+        size_t size = 0;
+        while (mag != 0) {
+            words[size++] = (uint32_t)(mag & UINT32_C(0xffffffff));
+            mag >>= 32;
+        }
+        if (size == 0) {
+            words[0] = 0;
+            size = 1;
+        }
+        return bsts_integer_from_words_copy(wide >= 0, size, words);
+#else
+        int64_t result = 0;
+        if (!bsts_mul_i64_overflow(l_int, r_int, &result)) {
+            return bsts_integer_from_int64(result);
         }
 
-        for (size_t i = 0; i < l_operand.len; i++) {
+        uint32_t left_words[2];
+        uint32_t right_words[2];
+        size_t left_len = bsts_u64_to_words(bsts_abs_i64(l_int), left_words);
+        size_t right_len = bsts_u64_to_words(bsts_abs_i64(r_int), right_words);
+        uint32_t result_words[4] = { 0, 0, 0, 0 };
+        size_t result_len = left_len + right_len;
+        for (size_t i = 0; i < left_len; i++) {
             uint64_t carry = 0;
-            uint64_t a = l_operand.words[i];
-            for (size_t j = 0; j < r_operand.len; j++) {
-                uint64_t b = r_operand.words[j];
+            uint64_t a = left_words[i];
+            for (size_t j = 0; j < right_len; j++) {
+                uint64_t b = right_words[j];
                 uint64_t sum = (uint64_t)result_words[i + j] + a * b + carry;
-                result_words[i + j] = (uint32_t)(sum & 0xFFFFFFFF);
+                result_words[i + j] = (uint32_t)(sum & UINT32_C(0xffffffff));
                 carry = sum >> 32;
             }
-            result_words[i + r_operand.len] += (uint32_t)carry;
+            result_words[i + right_len] += (uint32_t)carry;
         }
-
-        // Determine sign of result
-        _Bool result_sign = !(l_operand.sign == r_operand.sign);
-
-        // Normalize result
-        while (result_len > 1 && result_words[result_len - 1] == 0) {
+        while ((result_len > 1) && (result_words[result_len - 1] == 0U)) {
             result_len--;
         }
-
-        // Check if result fits in small integer
-        if (result_len == 1) {
-            BValue maybe_res = bsts_maybe_small_int(!result_sign, result_words[0]);
-            if (maybe_res) {
-              free(result_words);
-              return maybe_res;
-            }
-        }
-        // if we make it here we have to fit into big
-        BValue result = bsts_integer_from_words_copy(!result_sign, result_len, result_words);
-        free(result_words);
-        return result;
+        return bsts_integer_from_words_copy((l_int < 0) == (r_int < 0), result_len, result_words);
+#endif
     }
+
+    if (left_is_small) {
+      int64_t lv = GET_SMALL_INT(left);
+      if (lv == 0) return bsts_integer_from_int(0);
+      if (lv == 1) return right;
+      if (lv == -1) return bsts_integer_negate(right);
+    }
+    if (right_is_small) {
+      int64_t rv = GET_SMALL_INT(right);
+      if (rv == 0) return bsts_integer_from_int(0);
+      if (rv == 1) return left;
+      if (rv == -1) return bsts_integer_negate(left);
+    }
+
+    // At least one operand is big integer.
+    uint32_t left_temp[2];
+    uint32_t right_temp[2];
+    BSTS_Int_Operand l_operand;
+    BSTS_Int_Operand r_operand;
+
+    bsts_integer_load_op(left, left_temp, &l_operand);
+    bsts_integer_load_op(right, right_temp, &r_operand);
+
+    size_t result_len = l_operand.len + r_operand.len;
+    uint32_t* result_words = (uint32_t*)calloc(result_len, sizeof(uint32_t));
+    if (result_words == NULL) {
+        perror("failed to malloc result_words in bsts_integer_times");
+        abort();
+    }
+
+    for (size_t i = 0; i < l_operand.len; i++) {
+        uint64_t carry = 0;
+        uint64_t a = l_operand.words[i];
+        for (size_t j = 0; j < r_operand.len; j++) {
+            uint64_t b = r_operand.words[j];
+            uint64_t sum = (uint64_t)result_words[i + j] + a * b + carry;
+            result_words[i + j] = (uint32_t)(sum & UINT32_C(0xffffffff));
+            carry = sum >> 32;
+        }
+        result_words[i + r_operand.len] += (uint32_t)carry;
+    }
+
+    _Bool result_sign = !(l_operand.sign == r_operand.sign);
+    while (result_len > 1 && result_words[result_len - 1] == 0) {
+        result_len--;
+    }
+
+    BValue result = bsts_integer_from_words_copy(!result_sign, result_len, result_words);
+    free(result_words);
+    return result;
 }
 
 // Function to perform bitwise OR on two BValues
 BValue bsts_integer_or(BValue l, BValue r) {
     _Bool l_is_small = IS_SMALL(l);
     _Bool r_is_small = IS_SMALL(r);
-    if (l_is_small & r_is_small) {
-      return bsts_integer_from_int(GET_SMALL_INT(l) | GET_SMALL_INT(r));
+    if (l_is_small && r_is_small) {
+      int64_t lv = GET_SMALL_INT(l);
+      int64_t rv = GET_SMALL_INT(r);
+      return bsts_integer_from_int64(lv | rv);
     }
 
     // Determine maximum length in words
     // we need to leave space for maybe 1 extra word if we have -MAX
-    size_t l_len = l_is_small ? 1 : (GET_BIG_INT(l)->len + 1);
-    size_t r_len = r_is_small ? 1 : (GET_BIG_INT(r)->len + 1);
+    size_t l_len = l_is_small ? bsts_small_twos_word_len(GET_SMALL_INT(l)) : (GET_BIG_INT(l)->len + 1);
+    size_t r_len = r_is_small ? bsts_small_twos_word_len(GET_SMALL_INT(r)) : (GET_BIG_INT(r)->len + 1);
     size_t max_len = (l_len > r_len) ? l_len : r_len;
 
     // Ensure at least one word
@@ -2133,14 +2054,16 @@ BValue bsts_integer_or(BValue l, BValue r) {
 BValue bsts_integer_xor(BValue l, BValue r) {
     _Bool l_is_small = IS_SMALL(l);
     _Bool r_is_small = IS_SMALL(r);
-    if (l_is_small & r_is_small) {
-      return bsts_integer_from_int(GET_SMALL_INT(l) ^ GET_SMALL_INT(r));
+    if (l_is_small && r_is_small) {
+      int64_t lv = GET_SMALL_INT(l);
+      int64_t rv = GET_SMALL_INT(r);
+      return bsts_integer_from_int64(lv ^ rv);
     }
 
     // Determine maximum length in words
     // we need to leave space for maybe 1 extra word if we have -MAX
-    size_t l_len = l_is_small ? 1 : (GET_BIG_INT(l)->len + 1);
-    size_t r_len = r_is_small ? 1 : (GET_BIG_INT(r)->len + 1);
+    size_t l_len = l_is_small ? bsts_small_twos_word_len(GET_SMALL_INT(l)) : (GET_BIG_INT(l)->len + 1);
+    size_t r_len = r_is_small ? bsts_small_twos_word_len(GET_SMALL_INT(r)) : (GET_BIG_INT(r)->len + 1);
     size_t max_len = (l_len > r_len) ? l_len : r_len;
 
     // Ensure at least one word
@@ -2205,8 +2128,8 @@ int bsts_integer_cmp(BValue l, BValue r) {
 
     if (l_is_small && r_is_small) {
         // Both are small integers, but not equal (we already compared)
-        int32_t l_int = GET_SMALL_INT(l);
-        int32_t r_int = GET_SMALL_INT(r);
+        int64_t l_int = GET_SMALL_INT(l);
+        int64_t r_int = GET_SMALL_INT(r);
         return (l_int < r_int) ? -1 : 1;
     } else if (!l_is_small && !r_is_small) {
         // Both are big integers
@@ -2250,7 +2173,7 @@ int bsts_integer_cmp(BValue l, BValue r) {
         }
 
         // Now 'l' is big, 'r' is small
-        int32_t r_int = GET_SMALL_INT(r);
+        int64_t r_int = GET_SMALL_INT(r);
         BSTS_Integer* l_big = GET_BIG_INT(l);
 
         // Compare signs
@@ -2299,10 +2222,14 @@ _Bool bsts_integer_lt_zero(BValue v) {
   }
 }
 
-static BValue bsts_integer_shift_twos(BValue l, int32_t shift_amount) {
+static BValue bsts_integer_shift_twos(BValue l, int64_t shift_amount) {
     _Bool l_is_small = IS_SMALL(l);
-    size_t l_len = l_is_small ? 1 : (GET_BIG_INT(l)->len + 1);
+    size_t l_len = l_is_small ? bsts_small_twos_word_len(GET_SMALL_INT(l)) : (GET_BIG_INT(l)->len + 1);
     uint32_t* l_twos = (uint32_t*)calloc(l_len, sizeof(uint32_t));
+    if (l_twos == NULL) {
+        perror("failed to calloc l_twos in bsts_integer_shift_left");
+        abort();
+    }
     // Convert left operand to two's complement
     if (l_is_small) {
         bsts_integer_small_to_twos(GET_SMALL_INT(l), l_twos, l_len);
@@ -2313,17 +2240,30 @@ static BValue bsts_integer_shift_twos(BValue l, int32_t shift_amount) {
 
     // Determine direction of shift
     _Bool shift_left = shift_amount > 0;
-    intptr_t shift_abs = shift_left ? shift_amount : -shift_amount;
+    uint64_t shift_abs_u64 = shift_left ? (uint64_t)shift_amount : bsts_abs_i64(shift_amount);
 
     // Perform shifting on operand.words
     if (shift_left) {
         // Left shift
-        size_t word_shift = shift_abs / 32;
-        size_t bit_shift = shift_abs % 32;
+        uint64_t word_shift_u64 = shift_abs_u64 / 32U;
+        size_t bit_shift = (size_t)(shift_abs_u64 % 32U);
+
+        if (word_shift_u64 > (uint64_t)(SIZE_MAX - l_len - 1U)) {
+            free(l_twos);
+            perror("shift amount too large in bsts_integer_shift_left");
+            abort();
+        }
+        size_t word_shift = (size_t)word_shift_u64;
 
         size_t new_len = l_len + word_shift + 1; // +1 for possible carry
+        if (new_len > (SIZE_MAX / sizeof(uint32_t))) {
+            free(l_twos);
+            perror("shift allocation too large in bsts_integer_shift_left");
+            abort();
+        }
         uint32_t* new_words = (uint32_t*)calloc(new_len, sizeof(uint32_t));
         if (new_words == NULL) {
+            free(l_twos);
             perror("failed to calloc new_words in bsts_integer_shift_left");
             abort();
         }
@@ -2337,17 +2277,20 @@ static BValue bsts_integer_shift_twos(BValue l, int32_t shift_amount) {
             carry = shifted >> 32;
         }
         // make sure the top bits are negative
-        uint32_t high_bits = bsts_integer_lt_zero(l) ? ((0xFFFFFFFF >> bit_shift) << bit_shift) : 0;
+        uint32_t high_bits =
+            bsts_integer_lt_zero(l)
+                ? ((UINT32_C(0xffffffff) >> bit_shift) << bit_shift)
+                : UINT32_C(0x00000000);
         new_words[l_len + word_shift] = ((uint32_t)carry) | high_bits;
 
         free(l_twos);
         return bsts_integer_from_twos(new_len, new_words);
     } else {
         // Right shift
-        size_t word_shift = shift_abs / 32;
-        size_t bit_shift = shift_abs % 32;
+        uint64_t word_shift_u64 = shift_abs_u64 / 32U;
+        size_t bit_shift = (size_t)(shift_abs_u64 % 32U);
 
-        if (word_shift >= l_len) {
+        if (word_shift_u64 >= l_len) {
             // All bits are shifted out
             if (bsts_integer_lt_zero(l)) {
                 // Negative number, result is -1
@@ -2360,15 +2303,18 @@ static BValue bsts_integer_shift_twos(BValue l, int32_t shift_amount) {
             }
         }
 
+        size_t word_shift = (size_t)word_shift_u64;
         size_t new_len = l_len - word_shift;
         uint32_t* new_words = (uint32_t*)calloc(new_len, sizeof(uint32_t));
         if (new_words == NULL) {
+            free(l_twos);
             perror("failed to calloc new_words in bsts_integer_shift_left");
             abort();
         }
 
         _Bool operand_sign = bsts_integer_lt_zero(l);
-        uint32_t sign_extension = operand_sign ? 0xFFFFFFFF : 0x00000000;
+        uint32_t sign_extension =
+            operand_sign ? UINT32_C(0xffffffff) : UINT32_C(0x00000000);
 
         for (size_t i = 0; i < new_len; i++) {
             uint64_t high = (i + word_shift + 1 < l_len) ? l_twos[i + word_shift + 1] : sign_extension;
@@ -2395,7 +2341,7 @@ BValue bsts_integer_shift_left(BValue l, BValue r) {
     }
 
     // Get the shift amount
-    int32_t shift_amount = GET_SMALL_INT(r);
+    int64_t shift_amount = GET_SMALL_INT(r);
 
     // If shift_amount is zero, return l as is
     if (shift_amount == 0) {
@@ -2585,7 +2531,7 @@ _Bool bsts_integer_is_zero(BValue v) {
 BValue bsts_integer_div_mod(BValue l, BValue r) {
     _Bool r_is_small = IS_SMALL(r);
     if (r_is_small) {
-      int32_t rs = GET_SMALL_INT(r);
+      int64_t rs = GET_SMALL_INT(r);
       if (rs == 0) {
         // we define division by zero as (0, l)
         return alloc_struct2(bsts_integer_from_int(0), l);
@@ -2600,10 +2546,10 @@ BValue bsts_integer_div_mod(BValue l, BValue r) {
       }
       if (IS_SMALL(l)) {
         // normal integer division works
-        int32_t ls = GET_SMALL_INT(l);
+        int64_t ls = GET_SMALL_INT(l);
         // C rounds to 0, but bosatsu and python round to -inf
-        int32_t div = ls / rs;
-        int32_t mod = ls % rs;
+        int64_t div = ls / rs;
+        int64_t mod = ls % rs;
         _Bool lpos = ls >= 0;
         _Bool rpos = rs >= 0;
         if ((mod != 0) & (lpos ^ rpos)) {
@@ -2613,7 +2559,7 @@ BValue bsts_integer_div_mod(BValue l, BValue r) {
           div = div - 1;
           mod = mod + rs;
         }
-        return alloc_struct2(bsts_integer_from_int(div), bsts_integer_from_int(mod));
+        return alloc_struct2(bsts_integer_from_int64(div), bsts_integer_from_int64(mod));
       }
     }
     if (bsts_integer_is_zero(r)) {

--- a/c_runtime/bosatsu_runtime.h
+++ b/c_runtime/bosatsu_runtime.h
@@ -29,6 +29,10 @@ static inline const void* bsts_bvalue_to_const_ptr(BValue value) {
 #define BSTS_STRING_INLINE16_FLAG (((size_t)1) << 63)
 #define BSTS_STRING_MAX_LEN ((size_t)(BSTS_STRING_INLINE16_FLAG - 1))
 
+#define BSTS_SMALL_INT_PAYLOAD_BITS 62
+#define BSTS_SMALL_INT_MIN (-(INT64_C(1) << 61))
+#define BSTS_SMALL_INT_MAX ((INT64_C(1) << 61) - 1)
+
 typedef struct BSTS_String_View {
   size_t len;
   const char* bytes;
@@ -140,6 +144,9 @@ BValue bsts_char_from_code_point(int codepoint);
 int bsts_char_code_point_from_value(BValue ch);
 
 BValue bsts_integer_from_int(int32_t small_int);
+// Construct from 64-bit values, using immediate representation when possible.
+BValue bsts_integer_from_int64(int64_t value);
+BValue bsts_integer_from_uint64(uint64_t value);
 int32_t bsts_integer_to_int32(BValue bint);
 BValue bsts_integer_from_words_copy(_Bool is_pos, size_t size, uint32_t* words);
 _Bool bsts_integer_equals(BValue left, BValue right);

--- a/c_runtime/test.c
+++ b/c_runtime/test.c
@@ -66,6 +66,20 @@ void assert_u64_equals(uint64_t got, uint64_t expected, const char* message) {
   }
 }
 
+void assert_is_small_int(BValue value, const char* message) {
+  if ((value & (BValue)0x3) != (BValue)0x1) {
+    printf("%s\nexpected small-int immediate\n", message);
+    exit(1);
+  }
+}
+
+void assert_is_big_int(BValue value, const char* message) {
+  if ((value & (BValue)0x3) != (BValue)0x0) {
+    printf("%s\nexpected heap-backed integer\n", message);
+    exit(1);
+  }
+}
+
 #if !defined(_WIN32)
 typedef void (*VoidFn)(void);
 
@@ -137,6 +151,19 @@ void test_integer() {
   uint32_t i64_words[2] = { 0x9abcdef0, 0x12345678 };
   BValue i64_pos = bsts_integer_from_words_copy(1, 2, i64_words);
   BValue i64_neg = bsts_integer_from_words_copy(0, 2, i64_words);
+  BValue i61_max = bsts_integer_from_int64((INT64_C(1) << 61) - 1);
+  BValue i61_min = bsts_integer_from_int64(-(INT64_C(1) << 61));
+
+  uint32_t i61_max_mag_words[2] = { 0xffffffff, 0x1fffffff };
+  uint32_t i61_min_mag_words[2] = { 0x00000000, 0x20000000 };
+  uint32_t i61_under_mag_words[2] = { 0x00000001, 0x20000000 };
+  BValue i61_max_from_words = bsts_integer_from_words_copy(1, 2, i61_max_mag_words);
+  BValue i61_min_from_words = bsts_integer_from_words_copy(0, 2, i61_min_mag_words);
+  BValue i61_over = bsts_integer_from_words_copy(1, 2, i61_min_mag_words);
+  BValue i61_under = bsts_integer_from_words_copy(0, 2, i61_under_mag_words);
+  BValue s62_pos = bsts_integer_from_int64((INT64_C(1) << 40) + 1234);
+  BValue s62_neg = bsts_integer_from_int64(-((INT64_C(1) << 40) + 1234));
+  BValue pow40 = bsts_integer_from_int64(INT64_C(1) << 40);
 
   uint32_t i128_words[4] = { 0x9abcdef0, 0x12345678, 0x9abcdef0, 0x12345678 };
   BValue i128_pos = bsts_integer_from_words_copy(1, 4, i128_words);
@@ -151,8 +178,25 @@ void test_integer() {
   assert_int_string(i32_min, "-2147483648", "i32_min to_string");
   assert_int_string(i64_pos, "1311768467463790320", "i64_pos to_string");
   assert_int_string(i64_neg, "-1311768467463790320", "i64_neg to_string");
+  assert_int_string(i61_max, "2305843009213693951", "i61_max to_string");
+  assert_int_string(i61_min, "-2305843009213693952", "i61_min to_string");
+  assert_int_string(i61_over, "2305843009213693952", "i61_over to_string");
+  assert_int_string(i61_under, "-2305843009213693953", "i61_under to_string");
+  assert_int_string(s62_pos, "1099511629010", "s62_pos to_string");
+  assert_int_string(s62_neg, "-1099511629010", "s62_neg to_string");
   assert_int_string(i128_pos, "24197857203266734864793317670504947440", "i128_pos to_string");
   assert_int_string(i128_neg, "-24197857203266734864793317670504947440", "i128_neg to_string");
+
+  assert_is_small_int(i64_pos, "i64_pos should be immediate");
+  assert_is_small_int(i64_neg, "i64_neg should be immediate");
+  assert_is_small_int(i61_max, "i61_max should be immediate");
+  assert_is_small_int(i61_min, "i61_min should be immediate");
+  assert_is_small_int(i61_max_from_words, "i61_max_from_words should canonicalize to immediate");
+  assert_is_small_int(i61_min_from_words, "i61_min_from_words should canonicalize to immediate");
+  assert_is_small_int(s62_pos, "s62_pos should be immediate");
+  assert_is_small_int(s62_neg, "s62_neg should be immediate");
+  assert_is_big_int(i61_over, "i61_over should spill to big-int");
+  assert_is_big_int(i61_under, "i61_under should spill to big-int");
 
   assert(bsts_integer_equals(i32_pos, i32_pos), "i32_pos equals self");
   assert(bsts_integer_equals(i32_pos, i32_pos_big), "i32_pos equals big");
@@ -169,12 +213,24 @@ void test_integer() {
   assert_int_string(bsts_integer_negate(i128_neg), "24197857203266734864793317670504947440", "negate i128_neg");
   assert_int_string(bsts_integer_negate(i32_min), "2147483648", "negate i32_min");
 
+  BValue add_i61_over = bsts_integer_add(i61_max, bsts_integer_from_int(1));
+  BValue sub_i61_under = bsts_integer_add(i61_min, bsts_integer_from_int(-1));
+  BValue neg_i61_min = bsts_integer_negate(i61_min);
+  assert_int_string(add_i61_over, "2305843009213693952", "add i61_max 1");
+  assert_int_string(sub_i61_under, "-2305843009213693953", "sub i61_min 1");
+  assert_int_string(neg_i61_min, "2305843009213693952", "negate i61_min");
+  assert_is_big_int(add_i61_over, "add i61_max 1 should spill to big-int");
+  assert_is_big_int(sub_i61_under, "sub i61_min 1 should spill to big-int");
+  assert_is_big_int(neg_i61_min, "negate i61_min should spill to big-int");
+
   assert(bsts_integer_to_int32(i32_pos) == 305419896, "to_int32 i32_pos");
   assert(bsts_integer_to_int32(i32_neg) == -305419896, "to_int32 i32_neg");
   assert(bsts_integer_to_int32(i32_pos_big) == 305419896, "to_int32 i32_pos_big");
   assert(bsts_integer_to_int32(neg_small_big) == -123, "to_int32 neg_small_big");
   assert(bsts_integer_to_int32(i64_pos) == -1698898192, "to_int32 i64_pos trunc");
   assert(bsts_integer_to_int32(i64_neg) == INT32_MIN, "to_int32 i64_neg sentinel");
+  assert(bsts_integer_to_int32(i61_max) == -1, "to_int32 i61_max trunc");
+  assert(bsts_integer_to_int32(i61_min) == INT32_MIN, "to_int32 i61_min sentinel");
 
   struct IntBinCase { const char* name; BValue a; BValue b; const char* expected; };
   struct IntBinCase add_cases[] = {
@@ -197,10 +253,22 @@ void test_integer() {
     assert_int_string(bsts_integer_times(mul_cases[i].a, mul_cases[i].b), mul_cases[i].expected, mul_cases[i].name);
   }
 
+  BValue mul_small_small = bsts_integer_times(
+      bsts_integer_from_int64(INT64_C(1) << 30),
+      bsts_integer_from_int64(INT64_C(1) << 20));
+  BValue mul_small_over = bsts_integer_times(
+      bsts_integer_from_int64(INT64_C(1) << 31),
+      bsts_integer_from_int64(INT64_C(1) << 31));
+  assert_int_string(mul_small_small, "1125899906842624", "mul small range stays immediate");
+  assert_int_string(mul_small_over, "4611686018427387904", "mul small overflow spills");
+  assert_is_small_int(mul_small_small, "mul small range should stay immediate");
+  assert_is_big_int(mul_small_over, "mul small overflow should spill to big-int");
+
   struct IntBinCase and_cases[] = {
     { "and i32_pos i32_neg", i32_pos, i32_neg, "8" },
     { "and i64_pos i64_neg", i64_pos, i64_neg, "16" },
     { "and i128_pos i64_pos", i128_pos, i64_pos, "1311768467463790320" },
+    { "and s62_pos s62_neg", s62_pos, s62_neg, "2" },
   };
   for (size_t i = 0; i < sizeof(and_cases) / sizeof(and_cases[0]); i++) {
     assert_int_string(bsts_integer_and(and_cases[i].a, and_cases[i].b), and_cases[i].expected, and_cases[i].name);
@@ -210,6 +278,7 @@ void test_integer() {
     { "or i32_pos i32_neg", i32_pos, i32_neg, "-8" },
     { "or i64_pos i64_neg", i64_pos, i64_neg, "-16" },
     { "or i128_pos i64_pos", i128_pos, i64_pos, "24197857203266734864793317670504947440" },
+    { "or s62_pos s62_neg", s62_pos, s62_neg, "-2" },
   };
   for (size_t i = 0; i < sizeof(or_cases) / sizeof(or_cases[0]); i++) {
     assert_int_string(bsts_integer_or(or_cases[i].a, or_cases[i].b), or_cases[i].expected, or_cases[i].name);
@@ -219,6 +288,7 @@ void test_integer() {
     { "xor i32_pos i32_neg", i32_pos, i32_neg, "-16" },
     { "xor i64_pos i64_neg", i64_pos, i64_neg, "-32" },
     { "xor i128_pos i64_pos", i128_pos, i64_pos, "24197857203266734863481549203041157120" },
+    { "xor s62_pos s62_neg", s62_pos, s62_neg, "-4" },
   };
   for (size_t i = 0; i < sizeof(xor_cases) / sizeof(xor_cases[0]); i++) {
     assert_int_string(bsts_integer_xor(xor_cases[i].a, xor_cases[i].b), xor_cases[i].expected, xor_cases[i].name);
@@ -230,6 +300,8 @@ void test_integer() {
     { "shift i32_neg >> 5", i32_neg, -5, "-9544372" },
     { "shift i64_pos << 17", i64_pos, 17, "171936116567413924823040" },
     { "shift i64_neg >> 17", i64_neg, -17, "-10007999171935" },
+    { "shift pow40 << 5", pow40, 5, "35184372088832" },
+    { "shift pow40 << 30", pow40, 30, "1180591620717411303424" },
     { "shift i128_pos << 33", i128_pos, 33, "207858010642617301217980562388315306121997844480" },
     { "shift i128_neg >> 33", i128_neg, -33, "-2817001333840509744453397309" },
   };
@@ -237,6 +309,12 @@ void test_integer() {
     BValue shift = bsts_integer_from_int(shift_cases[i].shift);
     assert_int_string(bsts_integer_shift_left(shift_cases[i].value, shift), shift_cases[i].expected, shift_cases[i].name);
   }
+
+  BValue shift_twos_small = bsts_integer_shift_left(bsts_integer_from_int(1), bsts_integer_from_int(40));
+  BValue shift_twos_big = bsts_integer_shift_left(pow40, bsts_integer_from_int(30));
+  assert_int_string(shift_twos_small, "1099511627776", "shift twos small canonicalization");
+  assert_is_small_int(shift_twos_small, "shift twos small should stay immediate");
+  assert_is_big_int(shift_twos_big, "shift pow40 << 30 should spill to big-int");
 
   struct IntCmpCase { const char* name; BValue a; BValue b; int expected; };
   struct IntCmpCase cmp_cases[] = {
@@ -261,6 +339,8 @@ void test_integer() {
     { "divmod i32_pos 7", i32_pos, bsts_integer_from_int(7), "43631413", "5" },
     { "divmod i32_neg 7", i32_neg, bsts_integer_from_int(7), "-43631414", "2" },
     { "divmod i64_pos -12345", i64_pos, bsts_integer_from_int(-12345), "-106259090114524", "-8460" },
+    { "divmod i61_max 7", i61_max, bsts_integer_from_int(7), "329406144173384850", "1" },
+    { "divmod i61_min 7", i61_min, bsts_integer_from_int(7), "-329406144173384851", "5" },
     { "divmod i128_neg i64_pos", i128_neg, i64_pos, "-18446744073709551617", "0" },
     { "divmod i64_pos 0", i64_pos, bsts_integer_from_int(0), "0", "1311768467463790320" },
   };
@@ -280,6 +360,10 @@ void test_integer() {
     { "stoi i32_min", "-2147483648", "-2147483648" },
     { "stoi i64_pos", "1311768467463790320", "1311768467463790320" },
     { "stoi i64_neg", "-1311768467463790320", "-1311768467463790320" },
+    { "stoi i61_max", "2305843009213693951", "2305843009213693951" },
+    { "stoi i61_min", "-2305843009213693952", "-2305843009213693952" },
+    { "stoi i61_over", "2305843009213693952", "2305843009213693952" },
+    { "stoi i61_under", "-2305843009213693953", "-2305843009213693953" },
     { "stoi i128_pos", "24197857203266734864793317670504947440", "24197857203266734864793317670504947440" },
     { "stoi i128_neg", "-24197857203266734864793317670504947440", "-24197857203266734864793317670504947440" },
   };

--- a/core/src/main/scala/dev/bosatsu/codegen/clang/ClangGen.scala
+++ b/core/src/main/scala/dev/bosatsu/codegen/clang/ClangGen.scala
@@ -544,29 +544,40 @@ class ClangGen[K](ns: CompilationNamespace[K]) {
               pv(Code.Ident("bsts_integer_from_int")(Code.IntLiteral(iv)))
             } catch {
               case _: ArithmeticException =>
-                // emit the uint32 words and sign
-                val isPos = toBigInteger.signum >= 0
-                var current = if (isPos) toBigInteger else toBigInteger.negate()
-                val two32 = BigInteger.ONE.shiftLeft(32)
-                val bldr = List.newBuilder[Code.IntLiteral]
-                while (current.compareTo(BigInteger.ZERO) > 0) {
-                  bldr += Code.IntLiteral(current.mod(two32).longValue())
-                  current = current.shiftRight(32)
-                }
-                val lits = bldr.result()
-                // call:
-                // bsts_integer_from_words_copy(_Bool is_pos, size_t size, int32_t* words);
-                newLocalName("int").map { ident =>
-                  Code.DeclareArray(
-                    Code.TypeIdent.UInt32,
-                    ident,
-                    Right(lits)
-                  ) +:
-                    Code.Ident("bsts_integer_from_words_copy")(
-                      if (isPos) Code.TrueLit else Code.FalseLit,
-                      Code.IntLiteral(lits.length),
-                      ident
+                try {
+                  val lv = toBigInteger.longValueExact()
+                  pv(
+                    Code.Ident("bsts_integer_from_int64")(
+                      Code.IntLiteral(BigInt(lv))
                     )
+                  )
+                } catch {
+                  case _: ArithmeticException =>
+                    // emit the uint32 words and sign
+                    val isPos = toBigInteger.signum >= 0
+                    var current =
+                      if (isPos) toBigInteger else toBigInteger.negate()
+                    val two32 = BigInteger.ONE.shiftLeft(32)
+                    val bldr = List.newBuilder[Code.IntLiteral]
+                    while (current.compareTo(BigInteger.ZERO) > 0) {
+                      bldr += Code.IntLiteral(current.mod(two32).longValue())
+                      current = current.shiftRight(32)
+                    }
+                    val lits = bldr.result()
+                    // call:
+                    // bsts_integer_from_words_copy(_Bool is_pos, size_t size, int32_t* words);
+                    newLocalName("int").map { ident =>
+                      Code.DeclareArray(
+                        Code.TypeIdent.UInt32,
+                        ident,
+                        Right(lits)
+                      ) +:
+                        Code.Ident("bsts_integer_from_words_copy")(
+                          if (isPos) Code.TrueLit else Code.FalseLit,
+                          Code.IntLiteral(lits.length),
+                          ident
+                        )
+                    }
                 }
             }
 

--- a/core/src/test/scala/dev/bosatsu/codegen/clang/ClangGenTest.scala
+++ b/core/src/test/scala/dev/bosatsu/codegen/clang/ClangGenTest.scala
@@ -450,6 +450,28 @@ main = 1.5
     }
   }
 
+  test("int literals in int64 range use bsts_integer_from_int64") {
+    TestUtils.checkPackageMap("""
+main = 4294967296
+""") { pm =>
+      val renderedE = Par.withEC {
+        ClangGen(pm).renderMain(
+          TestUtils.testPackage,
+          Identifier.Name("main"),
+          Code.Ident("run_main")
+        )
+      }
+      renderedE match {
+        case Left(err) =>
+          fail(err.toString)
+        case Right(doc) =>
+          val rendered = doc.render(80)
+          assert(rendered.contains("bsts_integer_from_int64(4294967296)"))
+          assert(!rendered.contains("bsts_integer_from_words_copy"))
+      }
+    }
+  }
+
   test("float literals with sign bit use unsigned bit literals") {
     TestUtils.checkPackageMap("""
 main = -0.0


### PR DESCRIPTION
Implemented the accepted design for issue #1977 across runtime, extern C modules, tests, benchmarks, and C codegen.

What changed:
- `c_runtime/bosatsu_runtime.h`
  - Added shared small-int constants: `BSTS_SMALL_INT_PAYLOAD_BITS`, `BSTS_SMALL_INT_MIN`, `BSTS_SMALL_INT_MAX`.
  - Exposed `bsts_integer_from_int64` and `bsts_integer_from_uint64` in the public runtime API.

- `c_runtime/bosatsu_runtime.c`
  - Switched small-int decode/encode internals to signed 62-bit immediates via centralized helpers (`int64_t` decode, fit checks, checked/unchecked encoding).
  - Updated small-int operand loading to `int64_t` and 1–2 word magnitude handling.
  - Reworked canonicalization with a 1–2 word helper (`bsts_maybe_small_int_words`) and applied it in:
    - `bsts_integer_from_words_copy`
    - `bsts_integer_from_twos`
    - add/sub/mul result paths via `bsts_integer_from_words_copy`
  - Updated integer fast paths to `int64_t` where required:
    - `bsts_integer_to_int32` (keeps existing sentinel behavior for negative out-of-int32 values)
    - `bsts_integer_add`
    - `bsts_integer_negate`
    - `bsts_integer_times`
    - `bsts_integer_and` / `or` / `xor`
    - `bsts_integer_cmp`
    - `bsts_integer_shift_left`
    - small-path logic in `bsts_integer_div_mod`
  - Added overflow-safe small*small multiply:
    - preferred `__int128` path
    - non-`__int128` fallback with checked multiply + word multiply
  - Added left-shift guardrails for huge shifts to prevent `size_t` overflow/allocation overflow.
  - Improved `bsts_string_to_integer` accumulation so it stays in int64 until overflow risk, then promotes.
  - Updated small integer formatting in `bsts_integer_to_string` to print full 64-bit values.

- Extern modules
  - `c_runtime/bosatsu_ext_Bosatsu_l_IO_l_Core.c`: removed local int64 conversion helper; now uses runtime `bsts_integer_from_int64`.
  - `c_runtime/bosatsu_ext_Bosatsu_l_Num_l_Float64.c`: `uint64 -> Int` now uses runtime `bsts_integer_from_uint64`.

- Benchmarks
  - `c_runtime/bench.c`: added >32-bit and <62-bit small-int scenarios for add/mul/bitwise benches.

- Runtime tests
  - `c_runtime/test.c`: added explicit 62-bit boundary and crossover coverage, including:
    - construction/roundtrip for `2^61-1`, `-2^61`, `2^61`, `-(2^61+1)`
    - representation assertions (immediate vs heap-backed) around boundary values
    - add/negate crossover checks at bounds
    - multiplication in-range vs overflow crossover
    - bitwise checks with >32-bit immediates
    - shift canonicalization and overflow crossover checks
    - div/mod checks for new small-int boundary values
    - `bsts_integer_to_int32` compatibility checks for now-small out-of-int32 values
    - string-to-int boundary parsing cases

- Codegen
  - `core/src/main/scala/dev/bosatsu/codegen/clang/ClangGen.scala`: added integer literal path that emits `bsts_integer_from_int64` for literals that fit int64 but not int32.
  - `core/src/test/scala/dev/bosatsu/codegen/clang/ClangGenTest.scala`: added test verifying int64-range literals use `bsts_integer_from_int64` (not word-array construction).

Validation run:
- Required command passed: `scripts/test_basic.sh`.
- Additional runtime validation passed: `cd c_runtime && make PROFILE=debug` (includes runtime C tests with `-Wall -Werror`).

Fixes #1977

Implements design doc: [docs/design/1977-improve-c-small-int.md](https://github.com/johnynek/bosatsu/blob/main/docs/design/1977-improve-c-small-int.md)

Design source PR: https://github.com/johnynek/bosatsu/pull/1979