### PR TITLE
Refactor SMT normalization/path implication into SmtExpr + strong ScalaCheck tests

### DIFF
--- a/core/src/main/scala/dev/bosatsu/TypedExprRecursionCheck.scala
+++ b/core/src/main/scala/dev/bosatsu/TypedExprRecursionCheck.scala
@@ -800,52 +800,10 @@ object TypedExprRecursionCheck {
           expr
       }
 
-    private def asNegativeConstMul(expr: SmtExpr.IntExpr): Option[BigInt] =
-      expr match {
-        case SmtExpr.Mul(args) =>
-          args.toList match {
-            case SmtExpr.IntConst(negOne) :: SmtExpr.IntConst(n) :: Nil
-                if (negOne == BigInt(-1)) && (n > 0) =>
-              Some(n)
-            case SmtExpr.IntConst(n) :: SmtExpr.IntConst(negOne) :: Nil
-                if (negOne == BigInt(-1)) && (n > 0) =>
-              Some(n)
-            case _ =>
-              None
-          }
-        case _ =>
-          None
-      }
-
-    private def asNegativeConst(expr: SmtExpr.IntExpr): Option[BigInt] =
-      expr match {
-        case SmtExpr.IntConst(n) if n < 0 =>
-          Some(-n)
-        case _ =>
-          None
-      }
-
-    private def asSubByPositiveConst(
-        expr: SmtExpr.IntExpr
-    ): Option[(SmtExpr.IntExpr, BigInt)] =
-      expr match {
-        case SmtExpr.Add(args) =>
-          args.toList match {
-            case left :: right :: Nil =>
-              asNegativeConstMul(right)
-                .orElse(asNegativeConst(right))
-                .map((left, _))
-                .orElse(
-                  asNegativeConstMul(left)
-                    .orElse(asNegativeConst(left))
-                    .map((right, _))
-                )
-            case _ =>
-              None
-          }
-        case _ =>
-          None
-      }
+    private def renderBoolForSolver(expr: SmtExpr.BoolExpr): String =
+      SmtLibRender
+        .renderExpr(SmtExpr.normalizeBoolForSolver(expr))
+        .render(120)
 
     private def comparisonInDomain(
         term: SmtExpr.IntExpr
@@ -1223,14 +1181,7 @@ object TypedExprRecursionCheck {
               )
             case Some(Identifier.Name("sub")) =>
               lowerBinaryInt(args, state)((left, right) =>
-                SmtExpr.Add(
-                  Vector(
-                    left,
-                    SmtExpr.Mul(
-                      Vector(SmtExpr.IntConst(BigInt(-1)), right)
-                    )
-                  )
-                )
+                SmtExpr.Sub(Vector(left, right))
               )
             case Some(Identifier.Name("mul")) =>
               lowerBinaryInt(args, state)((left, right) =>
@@ -1667,58 +1618,8 @@ object TypedExprRecursionCheck {
     private def buildPathCondition(state: SmtBranchState): SmtExpr.BoolExpr =
       mkAnd(state.pathFacts)
 
-    private def pathImplies(
-        goal: SmtExpr.BoolExpr,
-        state: SmtBranchState
-    ): Boolean = {
-      // Cheap implication checks for common facts avoid unnecessary solver calls.
-      val goal1 = simplifyBoolExpr(goal)
-      val facts = state.pathFacts.map(simplifyBoolExpr)
-
-      def hasFact(p: SmtExpr.BoolExpr => Boolean): Boolean =
-        facts.exists(p)
-
-      def hasGte(base: SmtExpr.IntExpr, lower: BigInt): Boolean =
-        hasFact {
-          case SmtExpr.Gte(l, SmtExpr.IntConst(c)) => (l == base) && (c >= lower)
-          case SmtExpr.Gt(l, SmtExpr.IntConst(c))  => (l == base) && (c >= (lower - 1))
-          case SmtExpr.EqInt(l, SmtExpr.IntConst(c)) => (l == base) && (c >= lower)
-          case _                                    => false
-        }
-
-      facts.contains(goal1) ||
-      (goal1 match {
-        case SmtExpr.Gte(left, right) =>
-          hasFact {
-            case SmtExpr.Gt(l1, r1)    => (l1 == left) && (r1 == right)
-            case SmtExpr.EqInt(l1, r1) => (l1 == left) && (r1 == right)
-            case _                     => false
-          } ||
-            (right match {
-              case SmtExpr.IntConst(zero) if zero == BigInt(0) =>
-                asSubByPositiveConst(left).exists { case (base, by) =>
-                  hasGte(base, by)
-                }
-              case _ =>
-                false
-            })
-        case SmtExpr.Lte(left, right) =>
-          hasFact {
-            case SmtExpr.Lt(l1, r1)    => (l1 == left) && (r1 == right)
-            case SmtExpr.EqInt(l1, r1) => (l1 == left) && (r1 == right)
-            case _                     => false
-          }
-        case SmtExpr.Lt(left, right)  =>
-          asSubByPositiveConst(left).exists { case (base, by) =>
-            (base == right) && (by > 0)
-          }
-        case _ =>
-          false
-      })
-    }
-
     private def renderPathCondition(state: SmtBranchState): String =
-      SmtLibRender.renderExpr(buildPathCondition(state)).render(120)
+      renderBoolForSolver(buildPathCondition(state))
 
     private def renderModel(model: Option[Vector[SExpr]]): Option[String] =
       model.map(SExpr.renderAll(_))
@@ -1727,9 +1628,11 @@ object TypedExprRecursionCheck {
         goal: SmtExpr.BoolExpr,
         state: SmtBranchState
     ): ProofOutcome = {
-      if (pathImplies(goal, state)) {
+      if (SmtExpr.pathImplies(goal, state.pathFacts)) {
         ProofOutcome.Proved
       } else {
+        val goal1 = SmtExpr.normalizeBoolForSolver(goal)
+        val pathCondition1 = SmtExpr.normalizeBoolForSolver(buildPathCondition(state))
         val declarations = state.declarations.toList.sortBy(_._1).map {
           case (name, sort) =>
             SmtCommand.DeclareConst(name, sort)
@@ -1738,8 +1641,8 @@ object TypedExprRecursionCheck {
           Vector(SmtCommand.SetLogic("QF_LIA")) ++
             declarations ++
             Vector(
-              SmtCommand.Assert(buildPathCondition(state)),
-              SmtCommand.Assert(SmtExpr.Not(goal)),
+              SmtCommand.Assert(pathCondition1),
+              SmtCommand.Assert(SmtExpr.Not(goal1)),
               SmtCommand.CheckSat
             )
         )
@@ -1872,7 +1775,7 @@ object TypedExprRecursionCheck {
       RecursionCheck.IntRecursionObligationFailed(
         fnname,
         target.paramName,
-        SmtLibRender.renderExpr(obligation).render(120),
+        renderBoolForSolver(obligation),
         renderPathCondition(state),
         model,
         detail,

--- a/core/src/main/scala/dev/bosatsu/smt/SmtExpr.scala
+++ b/core/src/main/scala/dev/bosatsu/smt/SmtExpr.scala
@@ -51,4 +51,280 @@ object SmtExpr {
       extends SmtExpr[SmtSort.BoolSort]
   final case class Implies(left: BoolExpr, right: BoolExpr)
       extends SmtExpr[SmtSort.BoolSort]
+
+  private def mkAnd(args: Vector[BoolExpr]): BoolExpr =
+    args.size match {
+      case 0 => BoolConst.True
+      case 1 => args.head
+      case _ => And(args)
+    }
+
+  private def mkOr(args: Vector[BoolExpr]): BoolExpr =
+    args.size match {
+      case 0 => BoolConst.False
+      case 1 => args.head
+      case _ => Or(args)
+    }
+
+  private def simplifyBoolExpr(expr: BoolExpr): BoolExpr =
+    expr match {
+      case BoolConst(_) | EqInt(_, _) | Lt(_, _) |
+          Lte(_, _) | Gt(_, _) | Gte(_, _) =>
+        expr
+      case Not(in) =>
+        simplifyBoolExpr(in) match {
+          case BoolConst(value) => BoolConst(!value)
+          case Not(in1)         => in1
+          case other            => Not(other)
+        }
+      case And(args) =>
+        val simp = args.map(simplifyBoolExpr)
+        if (simp.contains(BoolConst.False)) BoolConst.False
+        else mkAnd(simp.filterNot(_ == BoolConst.True))
+      case Or(args)  =>
+        val simp = args.map(simplifyBoolExpr)
+        if (simp.contains(BoolConst.True)) BoolConst.True
+        else mkOr(simp.filterNot(_ == BoolConst.False))
+      case Ite(cond, ifTrue, ifFalse) =>
+        val c = simplifyBoolExpr(cond)
+        val t = simplifyBoolExpr(ifTrue)
+        val f = simplifyBoolExpr(ifFalse)
+        (c, t, f) match {
+          case (_, BoolConst.True, BoolConst.False) =>
+            c
+          case (_, BoolConst.False, BoolConst.True) =>
+            simplifyBoolExpr(Not(c))
+          case (BoolConst.True, _, _) =>
+            t
+          case (BoolConst.False, _, _) =>
+            f
+          case _ if t == f =>
+            t
+          case _ =>
+            Ite(c, t, f)
+        }
+      case _ =>
+        expr
+    }
+
+  private def asNegativeConstMul(expr: IntExpr): Option[BigInt] =
+    expr match {
+      case Mul(args) =>
+        args.toList match {
+          case IntConst(negOne) :: IntConst(n) :: Nil
+              if (negOne == BigInt(-1)) && (n > 0) =>
+            Some(n)
+          case IntConst(n) :: IntConst(negOne) :: Nil
+              if (negOne == BigInt(-1)) && (n > 0) =>
+            Some(n)
+          case _ =>
+            None
+        }
+      case _ =>
+        None
+    }
+
+  private def asNegativeConst(expr: IntExpr): Option[BigInt] =
+    expr match {
+      case IntConst(n) if n < 0 =>
+        Some(-n)
+      case _ =>
+        None
+    }
+
+  private def asSubByPositiveConst(expr: IntExpr): Option[(IntExpr, BigInt)] =
+    expr match {
+      case Add(args) =>
+        args.toList match {
+          case left :: right :: Nil =>
+            asNegativeConstMul(right)
+              .orElse(asNegativeConst(right))
+              .map((left, _))
+              .orElse(
+                asNegativeConstMul(left)
+                  .orElse(asNegativeConst(left))
+                  .map((right, _))
+              )
+          case _ =>
+            None
+        }
+      case Sub(args) =>
+        args.toList match {
+          case left :: IntConst(n) :: Nil if n > 0 =>
+            Some((left, n))
+          case _ =>
+            None
+        }
+      case _ =>
+        None
+    }
+
+  private def asNegatedTermForNormalization(expr: IntExpr): Option[IntExpr] =
+    expr match {
+      case Mul(args) =>
+        args.toList match {
+          case IntConst(negOne) :: term :: Nil if negOne == BigInt(-1) =>
+            Some(term)
+          case term :: IntConst(negOne) :: Nil if negOne == BigInt(-1) =>
+            Some(term)
+          case _ =>
+            None
+        }
+      case IntConst(n) if n < 0 =>
+        Some(IntConst(-n))
+      case _ =>
+        None
+    }
+
+  def normalizeIntForSolver(expr: IntExpr): IntExpr = {
+    val normalized: IntExpr =
+      expr match {
+        case Add(args) =>
+          Add(args.map(normalizeIntForSolver))
+        case Sub(args) =>
+          Sub(args.map(normalizeIntForSolver))
+        case Mul(args) =>
+          Mul(args.map(normalizeIntForSolver))
+        case Div(num, den) =>
+          Div(
+            normalizeIntForSolver(num),
+            normalizeIntForSolver(den)
+          )
+        case Mod(num, den) =>
+          Mod(
+            normalizeIntForSolver(num),
+            normalizeIntForSolver(den)
+          )
+        case Ite(cond, ifTrue, ifFalse) =>
+          Ite(
+            normalizeBoolForSolver(cond),
+            normalizeIntForSolver(ifTrue),
+            normalizeIntForSolver(ifFalse)
+          )
+        case other =>
+          other
+      }
+
+    normalized match {
+      case Add(args) =>
+        args.toList match {
+          case left :: right :: Nil =>
+            asNegatedTermForNormalization(right)
+              .map(term => Sub(Vector(left, normalizeIntForSolver(term))))
+              .orElse(
+                asNegatedTermForNormalization(left)
+                  .map(term => Sub(Vector(right, normalizeIntForSolver(term))))
+              )
+              .getOrElse(normalized)
+          case _ =>
+            normalized
+        }
+      case _ =>
+        normalized
+    }
+  }
+
+  def normalizeBoolForSolver(expr: BoolExpr): BoolExpr =
+    expr match {
+      case EqInt(left, right) =>
+        EqInt(
+          normalizeIntForSolver(left),
+          normalizeIntForSolver(right)
+        )
+      case EqBool(left, right) =>
+        EqBool(
+          normalizeBoolForSolver(left),
+          normalizeBoolForSolver(right)
+        )
+      case Lt(left, right) =>
+        Lt(
+          normalizeIntForSolver(left),
+          normalizeIntForSolver(right)
+        )
+      case Lte(left, right) =>
+        Lte(
+          normalizeIntForSolver(left),
+          normalizeIntForSolver(right)
+        )
+      case Gt(left, right) =>
+        Gt(
+          normalizeIntForSolver(left),
+          normalizeIntForSolver(right)
+        )
+      case Gte(left, right) =>
+        Gte(
+          normalizeIntForSolver(left),
+          normalizeIntForSolver(right)
+        )
+      case Not(inner) =>
+        Not(normalizeBoolForSolver(inner))
+      case And(args) =>
+        And(args.map(normalizeBoolForSolver))
+      case Or(args)  =>
+        Or(args.map(normalizeBoolForSolver))
+      case Xor(left, right) =>
+        Xor(
+          normalizeBoolForSolver(left),
+          normalizeBoolForSolver(right)
+        )
+      case Implies(left, right) =>
+        Implies(
+          normalizeBoolForSolver(left),
+          normalizeBoolForSolver(right)
+        )
+      case Ite(cond, ifTrue, ifFalse) =>
+        Ite(
+          normalizeBoolForSolver(cond),
+          normalizeBoolForSolver(ifTrue),
+          normalizeBoolForSolver(ifFalse)
+        )
+      case other =>
+        other
+    }
+
+  def pathImplies(goal: BoolExpr, facts0: Iterable[BoolExpr]): Boolean = {
+    val goal1 = simplifyBoolExpr(goal)
+    val facts = facts0.iterator.map(simplifyBoolExpr).toVector
+
+    def hasFact(p: BoolExpr => Boolean): Boolean =
+      facts.exists(p)
+
+    def hasGte(base: IntExpr, lower: BigInt): Boolean =
+      hasFact {
+        case Gte(l, IntConst(c)) => (l == base) && (c >= lower)
+        case Gt(l, IntConst(c))  => (l == base) && (c >= (lower - 1))
+        case EqInt(l, IntConst(c)) => (l == base) && (c >= lower)
+        case _                    => false
+      }
+
+    facts.contains(goal1) ||
+    (goal1 match {
+      case Gte(left, right) =>
+        hasFact {
+          case Gt(l1, r1)    => (l1 == left) && (r1 == right)
+          case EqInt(l1, r1) => (l1 == left) && (r1 == right)
+          case _             => false
+        } ||
+          (right match {
+            case IntConst(zero) if zero == BigInt(0) =>
+              asSubByPositiveConst(left).exists { case (base, by) =>
+                hasGte(base, by)
+              }
+            case _ =>
+              false
+          })
+      case Lte(left, right) =>
+        hasFact {
+          case Lt(l1, r1)    => (l1 == left) && (r1 == right)
+          case EqInt(l1, r1) => (l1 == left) && (r1 == right)
+          case _             => false
+        }
+      case Lt(left, right)  =>
+        asSubByPositiveConst(left).exists { case (base, by) =>
+          (base == right) && (by > 0)
+        }
+      case _ =>
+        false
+    })
+  }
 }

--- a/core/src/test/scala/dev/bosatsu/TypedExprRecursionCheckTest.scala
+++ b/core/src/test/scala/dev/bosatsu/TypedExprRecursionCheckTest.scala
@@ -328,6 +328,8 @@ def bad(i: Int) -> Int:
       i
 """) { msg =>
       assert(clue(msg).contains("cannot prove Int recursion obligation for bad: (>= "))
+      assert(clue(msg).contains("(- "))
+      assert(!clue(msg).contains("(* (- 1)"))
       assert(clue(msg).contains("recur target: i"))
       assert(clue(msg).contains("path condition:"))
     }

--- a/core/src/test/scala/dev/bosatsu/smt/SmtExprNormalizeAndPathImpliesTest.scala
+++ b/core/src/test/scala/dev/bosatsu/smt/SmtExprNormalizeAndPathImpliesTest.scala
@@ -1,0 +1,371 @@
+package dev.bosatsu.smt
+
+import org.scalacheck.Gen
+import org.scalacheck.Prop.forAll
+
+class SmtExprNormalizeAndPathImpliesTest extends munit.ScalaCheckSuite {
+  import SmtExpr.*
+
+  private val varNames: Vector[String] =
+    Vector("x", "y", "z", "a", "b", "u", "v")
+
+  private val intVarGen: Gen[IntExpr] =
+    Gen.oneOf(varNames).map(Var[SmtSort.IntSort](_))
+
+  private val intConstGen: Gen[IntExpr] =
+    Gen.chooseNum(-30, 30).map(n => IntConst(BigInt(n)))
+
+  private val boolConstGen: Gen[BoolExpr] =
+    Gen.oneOf(true, false).map(BoolConst(_))
+
+  private def intExprGen(depth: Int): Gen[IntExpr] = {
+    val leaf = Gen.frequency(
+      4 -> intConstGen,
+      3 -> intVarGen
+    )
+
+    if (depth <= 0) leaf
+    else {
+      val recInt = intExprGen(depth - 1)
+      val recBool = boolExprGen(depth - 1)
+
+      val add2 = for {
+        left <- recInt
+        right <- recInt
+      } yield Add(Vector(left, right))
+
+      val addN = for {
+        size <- Gen.choose(0, 4)
+        args <- Gen.listOfN(size, recInt)
+      } yield Add(args.toVector)
+
+      val sub2 = for {
+        left <- recInt
+        right <- recInt
+      } yield Sub(Vector(left, right))
+
+      val mul2 = for {
+        left <- recInt
+        right <- recInt
+      } yield Mul(Vector(left, right))
+
+      val negMul = recInt.map(expr => Mul(Vector(IntConst(BigInt(-1)), expr)))
+
+      val ite = for {
+        cond <- recBool
+        ifTrue <- recInt
+        ifFalse <- recInt
+      } yield Ite(cond, ifTrue, ifFalse)
+
+      Gen.frequency(
+        8 -> leaf,
+        4 -> add2,
+        2 -> addN,
+        3 -> sub2,
+        3 -> mul2,
+        2 -> negMul,
+        2 -> ite
+      )
+    }
+  }
+
+  private def boolExprGen(depth: Int): Gen[BoolExpr] = {
+    val leaf = boolConstGen
+
+    if (depth <= 0) leaf
+    else {
+      val recInt = intExprGen(depth - 1)
+      val recBool = boolExprGen(depth - 1)
+
+      val cmp = Gen.oneOf(
+        for {
+          l <- recInt
+          r <- recInt
+        } yield Lt(l, r),
+        for {
+          l <- recInt
+          r <- recInt
+        } yield Lte(l, r),
+        for {
+          l <- recInt
+          r <- recInt
+        } yield Gt(l, r),
+        for {
+          l <- recInt
+          r <- recInt
+        } yield Gte(l, r),
+        for {
+          l <- recInt
+          r <- recInt
+        } yield EqInt(l, r),
+        for {
+          l <- recBool
+          r <- recBool
+        } yield EqBool(l, r)
+      )
+
+      val andExpr = for {
+        size <- Gen.choose(0, 4)
+        args <- Gen.listOfN(size, recBool)
+      } yield And(args.toVector)
+
+      val orExpr = for {
+        size <- Gen.choose(0, 4)
+        args <- Gen.listOfN(size, recBool)
+      } yield Or(args.toVector)
+
+      val xorExpr = for {
+        l <- recBool
+        r <- recBool
+      } yield Xor(l, r)
+
+      val impliesExpr = for {
+        l <- recBool
+        r <- recBool
+      } yield Implies(l, r)
+
+      val iteExpr = for {
+        c <- recBool
+        t <- recBool
+        f <- recBool
+      } yield Ite(c, t, f)
+
+      Gen.frequency(
+        4 -> leaf,
+        4 -> cmp,
+        2 -> recBool.map(Not(_)),
+        2 -> andExpr,
+        2 -> orExpr,
+        1 -> xorExpr,
+        1 -> impliesExpr,
+        1 -> iteExpr
+      )
+    }
+  }
+
+  private val envGen: Gen[Map[String, BigInt]] =
+    Gen
+      .listOfN(varNames.size, Gen.chooseNum(-20, 20))
+      .map(values => varNames.iterator.zip(values.iterator.map(BigInt(_))).toMap)
+
+  private def evalInt(expr: IntExpr, env: Map[String, BigInt]): BigInt =
+    expr match {
+      case IntConst(v) => v
+      case Var(name)   => env.getOrElse(name, BigInt(0))
+      case Add(args)   => args.iterator.map(evalInt(_, env)).sum
+      case Sub(args)   =>
+        args.toList match {
+          case Nil          => BigInt(0)
+          case head :: Nil  => -evalInt(head, env)
+          case head :: tail => tail.foldLeft(evalInt(head, env))(_ - evalInt(_, env))
+        }
+      case Mul(args) =>
+        args.toList match {
+          case Nil  => BigInt(1)
+          case list => list.map(evalInt(_, env)).product
+        }
+      case Div(_, _) | Mod(_, _) =>
+        throw new IllegalArgumentException("generator excludes Div/Mod")
+      case Ite(cond, ifTrue, ifFalse) =>
+        if (evalBool(cond, env)) evalInt(ifTrue, env)
+        else evalInt(ifFalse, env)
+      case App(name, _) =>
+        throw new IllegalArgumentException(s"generator excludes App: $name")
+    }
+
+  private def evalBool(expr: BoolExpr, env: Map[String, BigInt]): Boolean =
+    expr match {
+      case BoolConst(v)     => v
+      case EqInt(l, r)      => evalInt(l, env) == evalInt(r, env)
+      case EqBool(l, r)     => evalBool(l, env) == evalBool(r, env)
+      case Lt(l, r)         => evalInt(l, env) < evalInt(r, env)
+      case Lte(l, r)        => evalInt(l, env) <= evalInt(r, env)
+      case Gt(l, r)         => evalInt(l, env) > evalInt(r, env)
+      case Gte(l, r)        => evalInt(l, env) >= evalInt(r, env)
+      case Not(inner)       => !evalBool(inner, env)
+      case And(args)        => args.forall(evalBool(_, env))
+      case Or(args)         => args.exists(evalBool(_, env))
+      case Xor(l, r)        => evalBool(l, env) ^ evalBool(r, env)
+      case Implies(l, r)    => !evalBool(l, env) || evalBool(r, env)
+      case Ite(c, t, f)     => if (evalBool(c, env)) evalBool(t, env) else evalBool(f, env)
+      case Var(name)        =>
+        throw new IllegalArgumentException(s"unexpected bool var: $name")
+      case App(name, _)     =>
+        throw new IllegalArgumentException(s"generator excludes bool App: $name")
+    }
+
+  private def isNegatedTerm(expr: IntExpr): Boolean =
+    expr match {
+      case Mul(args) =>
+        args.toList match {
+          case IntConst(n) :: _ :: Nil if n == BigInt(-1) => true
+          case _                                           => false
+        }
+      case IntConst(n) if n < 0 =>
+        true
+      case _ =>
+        false
+    }
+
+  private def hasNegAddPair(expr: IntExpr): Boolean =
+    expr match {
+      case Add(args) =>
+        val atNode =
+          args.toList match {
+            case left :: right :: Nil =>
+              isNegatedTerm(left) || isNegatedTerm(right)
+            case _ =>
+              false
+          }
+        atNode || args.exists(hasNegAddPair)
+      case Sub(args) =>
+        args.exists(hasNegAddPair)
+      case Mul(args) =>
+        args.exists(hasNegAddPair)
+      case Div(num, den) =>
+        hasNegAddPair(num) || hasNegAddPair(den)
+      case Mod(num, den) =>
+        hasNegAddPair(num) || hasNegAddPair(den)
+      case Ite(cond, ifTrue, ifFalse) =>
+        hasNegAddPairInBool(cond) || hasNegAddPair(ifTrue) || hasNegAddPair(ifFalse)
+      case _ =>
+        false
+    }
+
+  private def hasNegAddPairInBool(expr: BoolExpr): Boolean =
+    expr match {
+      case EqInt(l, r)   => hasNegAddPair(l) || hasNegAddPair(r)
+      case EqBool(l, r)  => hasNegAddPairInBool(l) || hasNegAddPairInBool(r)
+      case Lt(l, r)      => hasNegAddPair(l) || hasNegAddPair(r)
+      case Lte(l, r)     => hasNegAddPair(l) || hasNegAddPair(r)
+      case Gt(l, r)      => hasNegAddPair(l) || hasNegAddPair(r)
+      case Gte(l, r)     => hasNegAddPair(l) || hasNegAddPair(r)
+      case Not(inner)    => hasNegAddPairInBool(inner)
+      case And(args)     => args.exists(hasNegAddPairInBool)
+      case Or(args)      => args.exists(hasNegAddPairInBool)
+      case Xor(l, r)     => hasNegAddPairInBool(l) || hasNegAddPairInBool(r)
+      case Implies(l, r) => hasNegAddPairInBool(l) || hasNegAddPairInBool(r)
+      case Ite(c, t, f)  =>
+        hasNegAddPairInBool(c) || hasNegAddPairInBool(t) || hasNegAddPairInBool(f)
+      case _             => false
+    }
+
+  test("normalizeIntForSolver is idempotent") {
+    forAll(intExprGen(5)) { expr =>
+      val once = normalizeIntForSolver(expr)
+      val twice = normalizeIntForSolver(once)
+      assertEquals(twice, once)
+    }
+  }
+
+  test("normalizeBoolForSolver is idempotent") {
+    forAll(boolExprGen(5)) { expr =>
+      val once = normalizeBoolForSolver(expr)
+      val twice = normalizeBoolForSolver(once)
+      assertEquals(twice, once)
+    }
+  }
+
+  test("normalizeIntForSolver removes two-term add-with-negative patterns") {
+    forAll(intExprGen(5)) { expr =>
+      val normalized = normalizeIntForSolver(expr)
+      assert(!hasNegAddPair(normalized))
+    }
+  }
+
+  test("normalizeBoolForSolver removes two-term add-with-negative patterns from Int subterms") {
+    forAll(boolExprGen(5)) { expr =>
+      val normalized = normalizeBoolForSolver(expr)
+      assert(!hasNegAddPairInBool(normalized))
+    }
+  }
+
+  test("normalizeIntForSolver preserves evaluation semantics on generated Int expressions") {
+    forAll(intExprGen(5), envGen) { (expr, env) =>
+      val normalized = normalizeIntForSolver(expr)
+      assertEquals(evalInt(normalized, env), evalInt(expr, env))
+    }
+  }
+
+  test("normalizeBoolForSolver preserves evaluation semantics on generated Bool expressions") {
+    forAll(boolExprGen(5), envGen) { (expr, env) =>
+      val normalized = normalizeBoolForSolver(expr)
+      assertEquals(evalBool(normalized, env), evalBool(expr, env))
+    }
+  }
+
+  test("pathImplies holds when the goal fact is present") {
+    forAll(boolExprGen(5), Gen.listOf(boolExprGen(4))) { (goal, extra) =>
+      assert(pathImplies(goal, goal :: extra))
+    }
+  }
+
+  test("pathImplies accepts stronger direct comparisons") {
+    forAll(Gen.oneOf(varNames), Gen.chooseNum(-20, 20)) { (name, c) =>
+      val left = Var[SmtSort.IntSort](name)
+      val right = IntConst(BigInt(c))
+      assert(pathImplies(Gte(left, right), List(Gt(left, right))))
+      assert(pathImplies(Gte(left, right), List(EqInt(left, right))))
+      assert(pathImplies(Lte(left, right), List(Lt(left, right))))
+      assert(pathImplies(Lte(left, right), List(EqInt(left, right))))
+    }
+  }
+
+  test("pathImplies proves decrement non-negativity from lower bounds for both canonical and legacy forms") {
+    forAll(Gen.oneOf(varNames), Gen.chooseNum(1, 20)) { (name, by) =>
+      val base = Var[SmtSort.IntSort](name)
+      val byConst = IntConst(BigInt(by))
+      val facts = List(Gte(base, byConst))
+      val canonicalGoal = Gte(Sub(Vector(base, byConst)), IntConst(BigInt(0)))
+      val legacyGoal =
+        Gte(
+          Add(
+            Vector(
+              base,
+              Mul(Vector(IntConst(BigInt(-1)), byConst))
+            )
+          ),
+          IntConst(BigInt(0))
+        )
+      assert(pathImplies(canonicalGoal, facts))
+      assert(pathImplies(legacyGoal, facts))
+    }
+  }
+
+  test("pathImplies proves strict decrease for positive constant decrements") {
+    forAll(Gen.oneOf(varNames), Gen.chooseNum(1, 20)) { (name, by) =>
+      val base = Var[SmtSort.IntSort](name)
+      val byConst = IntConst(BigInt(by))
+      assert(pathImplies(Lt(Sub(Vector(base, byConst)), base), Nil))
+      assert(
+        pathImplies(
+          Lt(
+            Add(Vector(base, Mul(Vector(IntConst(BigInt(-1)), byConst)))),
+            base
+          ),
+          Nil
+        )
+      )
+    }
+  }
+
+  test("pathImplies does not over-claim when the lower bound is insufficient") {
+    forAll(Gen.oneOf(varNames), Gen.chooseNum(0, 20)) { (name, by) =>
+      val base = Var[SmtSort.IntSort](name)
+      val byConst = IntConst(BigInt(by))
+      val facts = List(Gte(base, byConst))
+      val tooLarge = IntConst(BigInt(by + 1))
+      val goal = Gte(Sub(Vector(base, tooLarge)), IntConst(BigInt(0)))
+      assert(!pathImplies(goal, facts))
+    }
+  }
+
+  test("pathImplies is monotonic with respect to added facts") {
+    forAll(boolExprGen(5), Gen.listOf(boolExprGen(4)), boolExprGen(4)) {
+      (goal, facts, extraFact) =>
+        val before = pathImplies(goal, facts)
+        val after = pathImplies(goal, facts :+ extraFact)
+        assert(!before || after)
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- move SMT solver-normalization helpers into `dev.bosatsu.smt.SmtExpr`
  - add `normalizeIntForSolver` and `normalizeBoolForSolver`
- move fast-path implication helper into `SmtExpr` as `pathImplies(goal, facts: Iterable[BoolExpr])`
- update recursion checking to consume the shared helpers
  - diagnostics rendering and solver assertions now use the same normalized forms
  - keep `sub` lowering as `SmtExpr.Sub(Vector(left, right))`
- add a new ScalaCheck suite with strong property coverage:
  - normalization idempotence (int/bool)
  - normalization shape guarantees (eliminate two-term add-with-negative subtraction patterns)
  - semantic preservation over randomized environments (int/bool evaluators)
  - `pathImplies` properties: direct fact containment, stronger-comparison implication, decrement non-negativity/decrease, monotonicity, and non-overclaiming
- keep existing recursion-check message-shape assertion for subtraction display

## Testing
- `sbt 'coreJVM/testOnly dev.bosatsu.smt.SmtExprNormalizeAndPathImpliesTest'`
- `sbt 'coreJVM/testOnly dev.bosatsu.TypedExprRecursionCheckTest'`
