### PR TITLE
Fix RingOpt +0 normalization regression from issue #1997

### DIFF
--- a/core/src/main/scala/dev/bosatsu/RingOpt.scala
+++ b/core/src/main/scala/dev/bosatsu/RingOpt.scala
@@ -1723,14 +1723,21 @@ object RingOpt {
     // inside. It helps with the repeatedAdd normalization in corner cases
     // but doesn't seem to frustrate undistribute much for the a*b + a*c
     // cases we want to work (although, probably some nesting of those doesn't)
-    // work well, I would imagine
-    // strip obvious top-level additive no-ops without flattening the full tree,
-    // since flattening can hide useful factorization structure.
-    val e =
-      e0 match {
-        case Add(x, y) => Expr.checkAdd[A](x, y)
-        case other     => other
+    // work well, I would imagine.
+    //
+    // Strip obvious top-level additive no-ops without flattening the full tree,
+    // since flattening can hide useful factorization structure. We do this
+    // repeatedly so normalize(a + 0) and normalize(a) start from the same root
+    // even when a itself is Add(_, 0).
+    @annotation.tailrec
+    def stripTopLevelAddNoOps(expr: Expr[A]): Expr[A] =
+      expr match {
+        case Add(x, y) if x.isZero => stripTopLevelAddNoOps(y)
+        case Add(x, y) if y.isZero => stripTopLevelAddNoOps(x)
+        case other                 => other
       }
+
+    val e = stripTopLevelAddNoOps(e0)
     loop(e, W.cost(e), HashSet.empty[Expr[A]].add(e), 0)
   }
 

--- a/core/src/test/scala/dev/bosatsu/RingOptLaws.scala
+++ b/core/src/test/scala/dev/bosatsu/RingOptLaws.scala
@@ -787,6 +787,55 @@ class RingOptLaws extends munit.ScalaCheckSuite {
       ),
       Weights(9, 4, 1)
     )
+    // issue #1997
+    law(
+      Add(
+        Neg(
+          Mult(
+            Neg(Neg(Neg(One))),
+            Add(
+              Add(
+                Symbol(BigInt("-1")),
+                Neg(Add(One, Symbol(BigInt("-2147483649"))))
+              ),
+              Mult(
+                Neg(One),
+                Add(
+                  Symbol(BigInt("9223372036854775808")),
+                  Symbol(BigInt("9223372036854775808"))
+                )
+              )
+            )
+          )
+        ),
+        Mult(
+          Neg(
+            Mult(
+              Symbol(
+                BigInt(
+                  "227735723830261017356624072586187250173053607080767410257500007075375160416"
+                )
+              ),
+              Zero
+            )
+          ),
+          Add(
+            Add(
+              Neg(Symbol(BigInt("-2958422629478306252"))),
+              Neg(Add(Zero, Integer(BigInt("2147483648"))))
+            ),
+            Mult(
+              Neg(One),
+              Add(
+                Integer(BigInt("2147483648")),
+                Mult(Symbol(BigInt("8849351773351790999")), One)
+              )
+            )
+          )
+        )
+      ),
+      Weights(21, 10, 9)
+    )
     forAll((a: Expr[BigInt], w: Weights) => law(a, w))
   }
   property("multiplication by 1 is always simplified") {


### PR DESCRIPTION
Implemented a direct fix for issue #1997 in `RingOpt.normalize` and added a deterministic regression case.

What changed:
- `core/src/main/scala/dev/bosatsu/RingOpt.scala`
  - Replaced one-shot top-level `Add` no-op stripping with a tail-recursive `stripTopLevelAddNoOps` helper.
  - This repeatedly removes top-level `+ 0`/`0 +` shells so `normalize(a + 0)` and `normalize(a)` start from the same root, including nested top-level add-zero shapes.
- `core/src/test/scala/dev/bosatsu/RingOptLaws.scala`
  - Added the exact issue #1997 counterexample (expression + `Weights(21, 10, 9)`) to the `addition by 0 is always simplified` regression set.

Reproduction and validation:
- Reproduced failure before the fix via the new regression (same failing shape as reported in the issue).
- Verified after fix:
  - `sbt "coreJVM/testOnly dev.bosatsu.RingOptLaws"` passes.
  - Required pre-push command `scripts/test_basic.sh` passes.

Fixes #1997