### PR TITLE
Print SMT-LIB when pathImplies z3 call traps

### DIFF
--- a/core/src/test/scala/dev/bosatsu/smt/SmtExprNormalizeAndPathImpliesTest.scala
+++ b/core/src/test/scala/dev/bosatsu/smt/SmtExprNormalizeAndPathImpliesTest.scala
@@ -323,12 +323,19 @@ class SmtExprNormalizeAndPathImpliesTest extends munit.ScalaCheckSuite {
           CheckSat
         )
     )
+    val smt2 = SmtLibRender.renderScript(script)
 
     Z3Api.run(script, parseModel = false, liveRunner) match {
       case Right(res) =>
         res.status == Z3Api.Status.Unsat
       case Left(err)  =>
-        fail(s"unexpected z3 failure while checking pathImplies soundness: ${err.message}")
+        val showSmt2 = err.message.toLowerCase.contains("trap")
+        val detail =
+          if (showSmt2) s"\nSMT-LIB sent to z3:\n$smt2"
+          else ""
+        fail(
+          s"unexpected z3 failure while checking pathImplies soundness: ${err.message}$detail"
+        )
     }
   }
 


### PR DESCRIPTION
## Summary
- update `SmtExprNormalizeAndPathImpliesTest.z3Implies` to render SMT-LIB before invoking Z3
- when Z3 fails with a trap-style message, append the full SMT-LIB script to the assertion failure message
- keep existing failure behavior unchanged for non-trap errors

## Why
Embedded `z3.wasm` trap failures are hard to reproduce in `scalawasiz3` without the exact SMT2 payload. This change makes the failing test output directly copyable into a minimal reproduction.

## Validation
- `sbt "coreJVM/testOnly dev.bosatsu.smt.SmtExprNormalizeAndPathImpliesTest"`
