### PR TITLE
Fix tree-sitter comment detection for comment-only lines (#2016)

### DIFF
--- a/syntax/tree-sitter-bosatsu/src/scanner.c
+++ b/syntax/tree-sitter-bosatsu/src/scanner.c
@@ -126,12 +126,6 @@ static inline uint16_t count_indentation(TSLexer *lexer) {
   return indent;
 }
 
-static inline void skip_comment(TSLexer *lexer) {
-  while (!lexer->eof(lexer) && lexer->lookahead != '\n' && lexer->lookahead != '\r') {
-    lexer->advance(lexer, true);
-  }
-}
-
 bool tree_sitter_bosatsu_external_scanner_scan(
     void *payload,
     TSLexer *lexer,
@@ -162,11 +156,7 @@ bool tree_sitter_bosatsu_external_scanner_scan(
   if (scanner->at_line_start && (valid_symbols[INDENT] || valid_symbols[DEDENT])) {
     uint16_t indent = count_indentation(lexer);
 
-    if (lexer->lookahead == '#') {
-      skip_comment(lexer);
-    }
-
-    if (!(lexer->lookahead == '\n' || lexer->lookahead == '\r' || lexer->eof(lexer))) {
+    if (!(lexer->lookahead == '\n' || lexer->lookahead == '\r' || lexer->lookahead == '#' || lexer->eof(lexer))) {
       uint16_t current = current_indent(scanner);
       if (indent > current && valid_symbols[INDENT]) {
         if (scanner->indent_count < MAX_INDENTS) {
@@ -215,6 +205,8 @@ bool tree_sitter_bosatsu_external_scanner_scan(
     }
   }
 
-  scanner->at_line_start = false;
+  if (lexer->lookahead != '#') {
+    scanner->at_line_start = false;
+  }
   return false;
 }

--- a/syntax/tree-sitter-bosatsu/test/corpus/test_workspace.txt
+++ b/syntax/tree-sitter-bosatsu/test/corpus/test_workspace.txt
@@ -228,6 +228,7 @@ ignore = y
         (identifier))
       (line_item
         (punctuation))))
+  (comment)
   (simple_statement
     (line_items
       (line_item
@@ -244,6 +245,7 @@ ignore = y
         (punctuation))
       (line_item
         (identifier))))
+  (comment)
   (simple_statement
     (line_items
       (line_item
@@ -351,3 +353,52 @@ external def partition_String(arg: String, sep: String) -> Option[(String, Strin
                 (punctuation))
               (line_item
                 (type_identifier)))))))))
+
+==================
+Comment Detection
+==================
+
+x = 1
+# top-level comment
+
+def f(x: Int) -> Int:
+  # indented comment
+  x
+
+---
+
+(source_file
+  (simple_statement
+    (line_items
+      (line_item
+        (identifier))
+      (line_item
+        (punctuation))
+      (line_item
+        (number))))
+  (comment)
+  (simple_statement
+    (line_items
+      (line_item
+        (keyword))
+      (line_item
+        (identifier))
+      (line_item
+        (tuple
+          (line_item
+            (identifier))
+          (line_item
+            (punctuation))
+          (line_item
+            (type_identifier))))
+      (line_item
+        (operator))
+      (line_item
+        (type_identifier))
+      (line_item
+        (punctuation))))
+  (comment)
+  (simple_statement
+    (line_items
+      (line_item
+        (identifier)))))


### PR DESCRIPTION
Reproduced issue #2016 in `syntax/tree-sitter-bosatsu`: inline comments produced `(comment)` nodes, but full-line comments (top-level and indented) were swallowed by the external scanner, so they were not available for highlighting.

Implemented fix:
- Updated `syntax/tree-sitter-bosatsu/src/scanner.c` to stop consuming `#...` in the external scanner.
- Treated `#` at line start like a blank-line boundary for indent/dedent decisions, so comment-only lines no longer affect indentation state.
- Preserved `at_line_start` when lookahead is `#` so comment tokens can be emitted by the grammar and matched by highlight queries.

Regression tests:
- Updated `syntax/tree-sitter-bosatsu/test/corpus/test_workspace.txt`:
  - `Foo Fixture` now expects comment nodes where comment-only lines occur.
  - Added new `Comment Detection` corpus case covering top-level and indented comment-only lines.

Validation run:
- `syntax/tree-sitter-bosatsu`: `tree-sitter test` (via local CLI) passed.
- Required pre-push command `scripts/test_basic.sh` passed (`cli` and `coreJVM` suites).

Fixes #2016