### PR TITLE
Fix singleton parametric constructor inference in recur matches

### DIFF
--- a/core/src/main/scala/dev/bosatsu/TypedExprRecursionCheck.scala
+++ b/core/src/main/scala/dev/bosatsu/TypedExprRecursionCheck.scala
@@ -73,10 +73,8 @@ object TypedExprRecursionCheck {
     type RecurTarget = NonEmptyList[RecurTargetItem]
     type TypedPattern = Pattern[(PackageName, Identifier.Constructor), Type]
 
-    enum SingletonCtor derives CanEqual {
-      case EmptyList
-      case NamedConstructor(cons: Identifier.Constructor)
-    }
+    case class SingletonCtor(pack: PackageName, cons: Identifier.Constructor)
+        derives CanEqual
 
     type TopLevelLowerableAliases = Map[(PackageName, Bindable), TopLevelAlias]
     type TopLevelPredefAliases = Map[(PackageName, Bindable), Identifier.Name]
@@ -97,6 +95,8 @@ object TypedExprRecursionCheck {
           Left(Z3Api.RunError.ExecutionFailure(msg, stdout, stderr))
       }
     }
+    private val emptyListSingletonCtor =
+      SingletonCtor(PackageName.PredefName, Identifier.Constructor("EmptyList"))
 
     case class SmtBranchState(
         intBindings: Map[Bindable, SmtExpr.IntExpr],
@@ -585,28 +585,48 @@ object TypedExprRecursionCheck {
           target.map(_ => Set.empty[Bindable])
       }
 
-    private def singletonCtorFromParsedPart(
-        part: Pattern.Parsed
+    private def isTupleConstructor(
+        pack: PackageName,
+        cons: Identifier.Constructor,
+        arity: Int
+    ): Boolean =
+      (pack == PackageName.PredefName) &&
+        (cons.asString == s"Tuple$arity")
+
+    private def targetPatternPartsFromTyped(
+        targetLength: Int,
+        branchPat: TypedPattern
+    ): Option[List[TypedPattern]] =
+      if (targetLength == 1) Some(branchPat :: Nil)
+      else
+        unwrapNamedAnnotation(branchPat) match {
+          case Pattern.PositionalStruct((pack, cons), parts)
+              if (parts.length == targetLength) &&
+                isTupleConstructor(pack, cons, targetLength) =>
+            Some(parts)
+          case _ =>
+            None
+        }
+
+    private def singletonCtorFromTypedPart(
+        part: TypedPattern
     ): Option[SingletonCtor] =
       unwrapNamedAnnotation(part) match {
         case Pattern.ListPat(Nil) =>
-          Some(SingletonCtor.EmptyList)
-        case Pattern.PositionalStruct(
-              Pattern.StructKind.Named(cons, _),
-              Nil
-            ) =>
-          Some(SingletonCtor.NamedConstructor(cons))
+          Some(emptyListSingletonCtor)
+        case Pattern.PositionalStruct((pack, cons), Nil) =>
+          Some(SingletonCtor(pack, cons))
         case _ =>
           None
       }
 
-    private def singletonCtorByTargetFromParsed(
+    private def singletonCtorByTargetFromTyped(
         target: RecurTarget,
-        branchPat: Pattern.Parsed
+        branchPat: TypedPattern
     ): NonEmptyList[Option[SingletonCtor]] =
-      targetPatternPartsFromParsed(target.length, branchPat) match {
+      targetPatternPartsFromTyped(target.length, branchPat) match {
         case Some(parts) =>
-          NonEmptyList.fromListUnsafe(parts.map(singletonCtorFromParsedPart))
+          NonEmptyList.fromListUnsafe(parts.map(singletonCtorFromTypedPart))
         case None        =>
           target.map(_ => None)
       }
@@ -1896,16 +1916,16 @@ object TypedExprRecursionCheck {
     ): Option[SingletonCtor] = {
       unwrapDeclExpr(arg.tag) match {
         case Declaration.ListDecl(ListLang.Cons(Nil)) =>
-          Some(SingletonCtor.EmptyList)
+          Some(emptyListSingletonCtor)
         case _                                         =>
           stripExprWrappers(arg) match {
             case TypedExpr.Global(
-                  _,
+                  pack,
                   cons: Identifier.Constructor,
                   _,
                   _
                 ) =>
-              Some(SingletonCtor.NamedConstructor(cons))
+              Some(SingletonCtor(pack, cons))
             case _ =>
               None
           }
@@ -2795,7 +2815,7 @@ object TypedExprRecursionCheck {
                             val equalAliases =
                               equalAliasesByTargetFromParsed(irr.target, sourcePat)
                             val singletonCtor =
-                              singletonCtorByTargetFromParsed(irr.target, sourcePat)
+                              singletonCtorByTargetFromTyped(irr.target, compiledPat)
                             val reachable = allowed.iterator.flatMap(_.iterator).toSet
                             val smtState0 =
                               addPatternFactsAndBindings(

--- a/core/src/main/scala/dev/bosatsu/rankn/Infer.scala
+++ b/core/src/main/scala/dev/bosatsu/rankn/Infer.scala
@@ -2653,54 +2653,6 @@ object Infer {
           expectedType: Type,
           innerBindings: List[(Bindable, Type)]
       ): Infer[Type] = {
-        def renameTypeMetas(
-            tpe: Type,
-            renameMeta: Map[Type.Meta, Type.Var.Bound],
-            renameSkolem: Map[Type.Var.Skolem, Type.Var.Bound]
-        ): Type = {
-          def renameLeaf(leaf: Type.Leaf): Type.Leaf =
-            leaf match {
-              case Type.TyMeta(meta) =>
-                renameMeta.get(meta) match {
-                  case Some(bound) => Type.TyVar(bound)
-                  case None        => leaf
-                }
-              case Type.TyVar(sk: Type.Var.Skolem) =>
-                renameSkolem.get(sk) match {
-                  case Some(bound) => Type.TyVar(bound)
-                  case None        => leaf
-                }
-              case _ =>
-                leaf
-            }
-
-          def renameLeafApply(
-              in: Type.Leaf | Type.TyApply
-          ): Type.Leaf | Type.TyApply =
-            in match {
-              case leaf: Type.Leaf     => renameLeaf(leaf)
-              case Type.TyApply(on, a) =>
-                Type.TyApply(renameLeafApply(on), renameType(a))
-            }
-
-          def renameRho(rho: Type.Rho): Type.Rho =
-            rho match {
-              case leaf: Type.Leaf        => renameLeaf(leaf)
-              case Type.TyApply(on, a)    =>
-                Type.TyApply(renameLeafApply(on), renameType(a))
-              case Type.Exists(vars, in1) =>
-                Type.Exists(vars, renameLeafApply(in1))
-            }
-
-          def renameType(in: Type): Type =
-            in match {
-              case rho: Type.Rho         => renameRho(rho)
-              case Type.ForAll(vars, in) => Type.ForAll(vars, renameRho(in))
-            }
-
-          renameType(tpe)
-        }
-
         if (!singletonParametricPattern(innerPattern)) pure(expectedType)
         else {
           val innerBindingTypes = innerBindings.map(_._2)
@@ -2743,7 +2695,12 @@ object Infer {
               alignedSkolems.iterator.toMap
             val renamedExpected =
               if (metaToBound.isEmpty && skolemToBound.isEmpty) expectedType
-              else renameTypeMetas(expectedType, metaToBound, skolemToBound)
+              else
+                Type.renameMetaAndSkolemsToBounds(
+                  expectedType,
+                  metaToBound,
+                  skolemToBound
+                )
             val quantifiers =
               freeBounds.map(_ -> Kind.Type) ++
                 alignedMetas.map { case (tm, b) => (b, tm.kind) } ++
@@ -2792,17 +2749,12 @@ object Infer {
               Infer.pure((GenPattern.Annotation(pat, t), List((n, t))))
           }
         case GenPattern.Named(n, p) =>
+          val Expected.Check((t0, _)) = sigma
           for {
             pair0 <- typeCheckPattern(p, sigma, reg)
             (p0, ts0) = pair0
-            t1 <- sigma match {
-              case Expected.Check((t, _)) =>
-                maybeWidenNamedBindingType(p0, t, ts0)
-            }
-            p1 = sigma match {
-              case Expected.Check((t, _)) =>
-                GenPattern.Annotation(GenPattern.Named(n, p0), t)
-            }
+            t1 <- maybeWidenNamedBindingType(p0, t0, ts0)
+            p1 = GenPattern.Annotation(GenPattern.Named(n, p0), t0)
           } yield (p1, (n, t1) :: ts0)
         case GenPattern.StrPat(items) =>
           val tpe = Type.StrType

--- a/core/src/main/scala/dev/bosatsu/rankn/Type.scala
+++ b/core/src/main/scala/dev/bosatsu/rankn/Type.scala
@@ -846,8 +846,57 @@ object Type {
       case c @ TyConst(_) => c
     }
 
+  def renameMetaAndSkolemsToBounds(
+      tpe: Type,
+      renameMeta: Map[Type.Meta, Type.Var.Bound],
+      renameSkolem: Map[Type.Var.Skolem, Type.Var.Bound]
+  ): Type = {
+    def renameLeaf(leaf: Type.Leaf): Type.Leaf =
+      leaf match {
+        case Type.TyMeta(meta) =>
+          renameMeta.get(meta) match {
+            case Some(bound) => Type.TyVar(bound)
+            case None        => leaf
+          }
+        case Type.TyVar(sk: Type.Var.Skolem) =>
+          renameSkolem.get(sk) match {
+            case Some(bound) => Type.TyVar(bound)
+            case None        => leaf
+          }
+        case _ =>
+          leaf
+      }
+
+    def renameLeafApply(
+        in: Type.Leaf | Type.TyApply
+    ): Type.Leaf | Type.TyApply =
+      in match {
+        case leaf: Type.Leaf     => renameLeaf(leaf)
+        case Type.TyApply(on, a) =>
+          Type.TyApply(renameLeafApply(on), renameType(a))
+      }
+
+    def renameRho(rho: Type.Rho): Type.Rho =
+      rho match {
+        case leaf: Type.Leaf        => renameLeaf(leaf)
+        case Type.TyApply(on, a)    =>
+          Type.TyApply(renameLeafApply(on), renameType(a))
+        case Type.Exists(vars, in1) =>
+          Type.Exists(vars, renameLeafApply(in1))
+      }
+
+    def renameType(in: Type): Type =
+      in match {
+        case rho: Type.Rho         => renameRho(rho)
+        case Type.ForAll(vars, in) => Type.ForAll(vars, renameRho(in))
+      }
+
+    if (renameMeta.isEmpty && renameSkolem.isEmpty) tpe
+    else renameType(tpe)
+  }
+
   /** A successful instantiation result from [[instantiate]].
-    *
+   *
     * `frees` are variables from the left side that remain universally
     * quantified. The mapped bound variable is the name that must appear on the
     * right side after alpha-renaming.

--- a/core/src/test/scala/dev/bosatsu/TypedExprRecursionCheckTest.scala
+++ b/core/src/test/scala/dev/bosatsu/TypedExprRecursionCheckTest.scala
@@ -251,6 +251,32 @@ def step(rem: Nat, current: LL[a], pending: List[LL[a]]) -> Int:
 """)
   }
 
+  test("tuple recur allows mixing [] and EmptyList singleton forms") {
+    allowed("""#
+enum Nat:
+  Z
+  S(prev: Nat)
+
+enum LL[a]:
+  Empty
+  Cons(head: a, tail: LL[a])
+  Mapped[b](source: LL[b], fn: b -> a)
+
+def step(rem: Nat, current: LL[a], pending: List[LL[a]]) -> Int:
+  recur (rem, pending, current):
+    case (_, _, Cons(_, tail)):
+      step(rem, tail, pending)
+    case (_, [], Mapped(source, _)):
+      step(rem, source, EmptyList)
+    case (_, EmptyList, Empty):
+      0
+    case (_, [next, *rest], Empty):
+      step(rem, next, rest)
+    case _:
+      0
+""")
+  }
+
   test("tuple recur allows custom singleton constructor literal in unchanged earlier component") {
     allowed("""#
 enum Nat:

--- a/core/src/test/scala/dev/bosatsu/rankn/TypeTest.scala
+++ b/core/src/test/scala/dev/bosatsu/rankn/TypeTest.scala
@@ -726,6 +726,49 @@ class TypeTest extends munit.ScalaCheckSuite {
     assertEquals(Type.freeBoundTyVars(sub :: Nil), List(a))
   }
 
+  test("renameMetaAndSkolemsToBounds rewrites through quantifiers") {
+    import Type.Var.Bound
+
+    val a = Bound("a")
+    val b = Bound("b")
+    val x = Bound("x")
+    val y = Bound("y")
+    val meta =
+      Type.Meta(
+        Kind.Type,
+        100001L,
+        existential = false,
+        RefSpace.constRef(Option.empty)
+      )
+    val skolem = Type.Var.Skolem("sk", Kind.Type, existential = false, 100002L)
+
+    val tpe =
+      Type.forAll(
+        NonEmptyList.one((a, Kind.Type)),
+        Type.existsRho(
+          NonEmptyList.one((b, Kind.Type)),
+          Type.TyApply(Type.TyVar(skolem), Type.TyMeta(meta))
+        )
+      )
+
+    val renamed =
+      Type.renameMetaAndSkolemsToBounds(
+        tpe,
+        Map(meta -> x),
+        Map(skolem -> y)
+      )
+    val expected =
+      Type.forAll(
+        NonEmptyList.one((a, Kind.Type)),
+        Type.existsRho(
+          NonEmptyList.one((b, Kind.Type)),
+          Type.TyApply(Type.TyVar(y), Type.TyVar(x))
+        )
+      )
+
+    assertEquals(renamed, expected)
+  }
+
   test("types are well ordered") {
     forAll(NTypeGen.genDepth03, NTypeGen.genDepth03, NTypeGen.genDepth03) {
       dev.bosatsu.OrderingLaws.law(_, _, _)


### PR DESCRIPTION
## Summary
- preserve and use branch-local singleton constructor equality facts during recur lexicographic checking
- treat alias names from singleton patterns as equal to the recur target when validating recursive calls
- widen named singleton-pattern bindings during type inference when the constructor carries no type evidence
- add regression tests for `[]`/`[] as e` and custom `EList`/`EList as e` tuple-recur cases

## Testing
- `sbt "coreJVM/testOnly dev.bosatsu.TypedExprRecursionCheckTest"`
- `./scripts/test_basic.sh`

Fixes #2015
