### PR TITLE
Bump scalawasiz3 to 0.0.11 and add -O2 native-image option

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -266,6 +266,7 @@ lazy val cli = (project in file("cli"))
     nativeImageOptions ++= List(
       "--no-fallback",
       "--verbose",
+      "-O2",
       "-J-Xmx12g",
       "-H:IncludeResources=dev/bosatsu/scalawasiz3/aot/.*\\.meta",
       "-H:+RemoveUnusedSymbols"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -28,6 +28,6 @@ object Dependencies {
   lazy val paiges = Def.setting("org.typelevel" %%% "paiges-core" % "0.4.4")
   lazy val scalaCheck =
     Def.setting("org.scalacheck" %%% "scalacheck" % "1.19.0")
-  lazy val scalawasiz3 = Def.setting("dev.bosatsu" %%% "scalawasiz3" % "0.0.10")
+  lazy val scalawasiz3 = Def.setting("dev.bosatsu" %%% "scalawasiz3" % "0.0.11")
   lazy val slf4jNop = Def.setting("org.slf4j" % "slf4j-nop" % "2.0.17")
 }


### PR DESCRIPTION
## Summary
- bump dev.bosatsu:scalawasiz3 from 0.0.10 to 0.0.11
- add -O2 to cli nativeImageOptions

## Validation
- sbt "show cli/nativeImageOptions"
