### PR TITLE
Improve parse error hint when a local `def` has no trailing expression

### DIFF
--- a/core/src/main/scala/dev/bosatsu/ParserHints.scala
+++ b/core/src/main/scala/dev/bosatsu/ParserHints.scala
@@ -17,6 +17,7 @@ object ParserHints {
       assignmentInConditionRule ::
       matchesHeaderKeywordRule ::
       missingColonAfterHeaderRule ::
+      missingTrailingExpressionAfterDefRule ::
       Nil
 
   def hints(
@@ -250,6 +251,28 @@ object ParserHints {
     }
   }
 
+  private def missingTrailingExpressionAfterDefRule(
+      source: String,
+      locations: LocationMap,
+      error: ParseFailure
+  ): Option[Doc] = {
+    val pos = error.position
+    if (pos < 0 || pos > source.length) {
+      None
+    } else {
+      for {
+        expectedIndent <- expectedIndentationAt(error.expected, pos)
+        (row, col, line) <- lineInfo(locations, pos)
+        if col <= expectedIndent.length
+        actualIndent = leadingIndent(line)
+        if actualIndent.length < expectedIndent.length
+        _ <- nearestUnclosedDefLineBefore(locations, row, expectedIndent)
+      } yield Doc.text(
+        "hint: this def ended without a final expression at its indentation level. Add a trailing expression before dedenting."
+      )
+    }
+  }
+
   private def expectsColonAt(
       expected: NonEmptyList[P.Expectation],
       position: Int
@@ -270,6 +293,72 @@ object ParserHints {
       case _ =>
         false
     }
+
+  private def expectedIndentationAt(
+      expected: NonEmptyList[P.Expectation],
+      position: Int
+  ): Option[String] =
+    expected.toList
+      .flatMap(expectationIndentationAt(_, position))
+      .filter(isIndentString)
+      .sortBy(_.length)
+      .lastOption
+
+  private def expectationIndentationAt(
+      e: P.Expectation,
+      position: Int
+  ): Option[String] =
+    e match {
+      case P.Expectation.OneOfStr(offset, strs: List[String])
+          if math.abs(offset - position) <= 1 =>
+        strs.filter(isIndentString).sortBy(_.length).lastOption
+      case P.Expectation.WithContext(_, inner) =>
+        expectationIndentationAt(inner, position)
+      case _ =>
+        None
+    }
+
+  private def isIndentString(s: String): Boolean =
+    s.nonEmpty && s.forall(c => c == ' ' || c == '\t')
+
+  private def leadingIndent(line: String): String = {
+    var i = 0
+    while (i < line.length && (line.charAt(i) == ' ' || line.charAt(i) == '\t')) {
+      i = i + 1
+    }
+    line.substring(0, i)
+  }
+
+  private def isSignificantLine(line: String): Boolean = {
+    val trimmed = line.trim
+    trimmed.nonEmpty && !trimmed.startsWith("#")
+  }
+
+  private def nearestUnclosedDefLineBefore(
+      locations: LocationMap,
+      row: Int,
+      indent: String
+  ): Option[Int] = {
+    @annotation.tailrec
+    def loop(r: Int): Option[Int] =
+      if (r < 0) None
+      else {
+        locations.getLine(r) match {
+          case Some(line) if isSignificantLine(line) =>
+            val leading = leadingIndent(line)
+            if (leading.startsWith(indent) && leading.length > indent.length) {
+              loop(r - 1)
+            } else if (leading == indent) {
+              if (line.drop(indent.length).startsWith("def ")) Some(r)
+              else None
+            } else None
+          case _ =>
+            loop(r - 1)
+        }
+      }
+
+    loop(row - 1)
+  }
 
   private def lineInfo(
       locations: LocationMap,

--- a/core/src/test/scala/dev/bosatsu/ParserHintsTest.scala
+++ b/core/src/test/scala/dev/bosatsu/ParserHintsTest.scala
@@ -253,4 +253,42 @@ class ParserHintsTest extends munit.FunSuite {
       hints.mkString("\n")
     )
   }
+
+  test("missing trailing expression after nested def gets hint") {
+    val source =
+      """package Foo
+        |
+        |def flat_map(ll: LazyList[a], fn: a -> LazyList[b]) -> LazyList[b]:
+        |    def loop(first: Int, ll):
+        |        match (first, ll):
+        |            case (_, Empty): Empty
+        |            case (_, Cons(h, t)):
+        |                match fn(get_Lazy(h)):
+        |                    case Empty: todo(())
+        |                    case not_empty:
+        |                        Concat(not_empty, lazy(() -> flat_map(get_Lazy(t), fn)))
+        |            case (_, Concat(first, second)):
+        |                concat_lazy(flat_map(first, fn), lazy(() -> flat_map(get_Lazy(second), fn)))
+        |            case (f, Mapped(ll, fn1)):
+        |                if cmp_Int(f, 0) matches GT:
+        |                    loop(0, run_map(ll, fn1))
+        |                else:
+        |                    Empty
+        |
+        |# invariant: neither current nor pending should be empty
+        |def uncons_step(rem: Int, current: LazyList[a], pending: List[LazyList[a]]) -> Option[(Lazy[a], LazyList[a])]:
+        |""".stripMargin
+
+    val pf = parseFailure(source)
+    val hints = ParserHints.hints(source, pf.locations, pf).map(_.render(120))
+    val shown = pf.showContext(LocationMap.Colorize.None).render(120)
+    assert(
+      hints.exists(_.contains("def ended without a final expression")),
+      hints.mkString("\n") + "\n" + shown
+    )
+    assert(
+      shown.contains("def ended without a final expression"),
+      shown
+    )
+  }
 }


### PR DESCRIPTION
Implemented a parser hint fix for issue #2020 by adding a new `ParserHints` rule that detects dedenting while a local `def` is still expecting a same-indentation continuation expression. When this pattern is detected, parse errors now include a targeted hint: the `def` likely ended without a final expression before dedent, instead of only showing `expected ... whitespace`.

What changed:
- Updated `core/src/main/scala/dev/bosatsu/ParserHints.scala`:
  - Added `missingTrailingExpressionAfterDefRule` to the hint rule pipeline.
  - Added helpers to extract indentation expectations from parse expectations and to detect an unclosed local `def` context from surrounding lines.
  - Handles the parse-offset vs expectation-offset off-by-one case seen in this failure mode.
- Added regression coverage in `core/src/test/scala/dev/bosatsu/ParserHintsTest.scala`:
  - New test `missing trailing expression after nested def gets hint` reproduces the issue shape from the report and asserts the new hint appears both in `ParserHints.hints(...)` and in `ParseFailure.showContext(...)` output.

Validation:
- `sbt "coreJVM/testOnly dev.bosatsu.ParserHintsTest"` passed.
- Required pre-push command `scripts/test_basic.sh` passed.

Fixes #2020