### PR TITLE
Fix unused-value span for nested local defs

### DIFF
--- a/core/src/main/scala/dev/bosatsu/UnusedLetCheck.scala
+++ b/core/src/main/scala/dev/bosatsu/UnusedLetCheck.scala
@@ -45,19 +45,26 @@ object UnusedLetCheck {
         args.toList.foldRight(loop(expr)) { (arg, res) =>
           checkArg(arg._1, HasRegion.region(e), res)
         }
-      case Let(arg, expr, in, rec, _) =>
+      case Let(arg, expr, in, rec, tag) =>
         val exprCheck = loop(expr)
         val exprRes =
           // if it is recursive, it is definitely used, because
           // that is automatically applied in source conversions
           if (rec.isRecursive) exprCheck.map(_ - arg) else exprCheck
         // the region of the let isn't directly tracked, but
-        // it would start with the whole region starts and end at expr
+        // it starts with the whole let start and ends at rhs.
+        // Nested defs encode the rhs body region in the declaration tag.
         val inCheck = checkArg(
           arg, {
             val wholeRegion = HasRegion.region(e)
-            val endRegion = HasRegion.region(expr)
-            val bindRegion = wholeRegion.withEnd(endRegion.end)
+            val bindEnd =
+              tag match {
+                case Declaration.DefFn(defStmt) =>
+                  defStmt.result._1.get.region.end
+                case _ =>
+                  HasRegion.region(expr).end
+              }
+            val bindRegion = wholeRegion.withEnd(bindEnd)
             bindRegion
           },
           loop(in)

--- a/core/src/test/scala/dev/bosatsu/ErrorMessageTest.scala
+++ b/core/src/test/scala/dev/bosatsu/ErrorMessageTest.scala
@@ -89,6 +89,31 @@ class ErrorMessageTest extends munit.FunSuite with ParTest {
     )
   }
 
+  test("unused local def points to only that def body") {
+    val source =
+      """package A
+        |
+        |main = (
+        |  limit = 10
+        |
+        |  def fuel_for_take(rem: Int) -> Int:
+        |    rem.add(1)
+        |
+        |  def step(rem: Int) -> Int:
+        |    rem
+        |
+        |  step(limit)
+        |)
+        |""".stripMargin
+
+    val message = unusedLetMessage(source)
+    assert(message.contains("unused value 'fuel_for_take'"), message)
+    assert(message.contains("def fuel_for_take(rem: Int) -> Int:"), message)
+    assert(message.contains("rem.add(1)"), message)
+    assert(!message.contains("def step(rem: Int) -> Int:"), message)
+    assert(!message.contains("step(limit)"), message)
+  }
+
   test("matches identifier binding is reported as a source-converter error") {
     evalFail(List("""
 package MatchesBinding


### PR DESCRIPTION
Resolved issue #2023 by tightening the region used for unused-let diagnostics in `UnusedLetCheck`. For `Expr.Let` nodes tagged with `Declaration.DefFn`, the error span now ends at the nested def body end (`defStmt.result._1.get.region.end`) instead of using the RHS expr tag region, which could include subsequent bindings and statements. Added a regression test in `ErrorMessageTest` (`unused local def points to only that def body`) that reproduces the reported behavior and verifies the message excludes following defs/expressions. Validation: `sbt "coreJVM/testOnly dev.bosatsu.ErrorMessageTest"` and required `scripts/test_basic.sh` both pass.

Fixes #2023