### PR TITLE
Fix #2028: report unexpected indentation for over-indented lines

### DIFF
--- a/core/src/main/scala/dev/bosatsu/ParserHints.scala
+++ b/core/src/main/scala/dev/bosatsu/ParserHints.scala
@@ -17,6 +17,7 @@ object ParserHints {
       assignmentInConditionRule ::
       matchesHeaderKeywordRule ::
       missingColonAfterHeaderRule ::
+      unexpectedIndentationRule ::
       missingTrailingExpressionAfterDefRule ::
       Nil
 
@@ -273,6 +274,50 @@ object ParserHints {
     }
   }
 
+  private def unexpectedIndentationRule(
+      source: String,
+      locations: LocationMap,
+      error: ParseFailure
+  ): Option[Doc] = {
+    val pos = error.position
+    if (
+      pos < 0 || pos >= source.length || !isIndentChar(source.charAt(pos))
+    ) {
+      None
+    } else {
+      for {
+        (_, col, line) <- lineInfo(locations, pos)
+        if isSignificantLine(line)
+        actualIndent = leadingIndent(line)
+        if col <= actualIndent.length
+        expected <- expectedIndentColumnsAt(error.expected, pos, col, actualIndent)
+        if actualIndent.length > expected
+      } yield {
+        val actual = actualIndent.length
+        Doc.text(
+          s"hint: unexpected indentation. This line is indented $actual spaces, but this block expects $expected."
+        )
+      }
+    }
+  }
+
+  private def expectedIndentColumnsAt(
+      expected: NonEmptyList[P.Expectation],
+      position: Int,
+      column: Int,
+      actualIndent: String
+  ): Option[Int] =
+    expectedIndentationAt(expected, position)
+      .map(_.length)
+      .filter(actualIndent.take(_).forall(isIndentChar))
+      .orElse {
+        // Sometimes block indentation has already been consumed and the parser
+        // is expecting either a comment (`#`) or an expression token.
+        Option.when(
+          expectsCharNear(expected, position, '#') && (column < actualIndent.length)
+        )(column)
+      }
+
   private def expectsColonAt(
       expected: NonEmptyList[P.Expectation],
       position: Int
@@ -290,6 +335,31 @@ object ParserHints {
         (offset == position) && (lower == ':') && (upper == ':')
       case P.Expectation.WithContext(_, inner) =>
         expectationMentionsColonAt(inner, position)
+      case _ =>
+        false
+    }
+
+  private def expectsCharNear(
+      expected: NonEmptyList[P.Expectation],
+      position: Int,
+      char: Char
+  ): Boolean =
+    expected.exists(expectationMentionsCharNear(_, position, char))
+
+  private def expectationMentionsCharNear(
+      e: P.Expectation,
+      position: Int,
+      char: Char
+  ): Boolean =
+    e match {
+      case P.Expectation.InRange(offset, lower, upper) =>
+        (math.abs(offset - position) <= 1) &&
+          (lower == char) && (upper == char)
+      case P.Expectation.OneOfStr(offset, strs: List[String]) =>
+        (math.abs(offset - position) <= 1) &&
+          strs.exists(s => (s.length == 1) && (s.charAt(0) == char))
+      case P.Expectation.WithContext(_, inner) =>
+        expectationMentionsCharNear(inner, position, char)
       case _ =>
         false
     }
@@ -320,6 +390,9 @@ object ParserHints {
 
   private def isIndentString(s: String): Boolean =
     s.nonEmpty && s.forall(c => c == ' ' || c == '\t')
+
+  private def isIndentChar(c: Char): Boolean =
+    c == ' ' || c == '\t'
 
   private def leadingIndent(line: String): String = {
     var i = 0

--- a/core/src/test/scala/dev/bosatsu/ParserHintsTest.scala
+++ b/core/src/test/scala/dev/bosatsu/ParserHintsTest.scala
@@ -291,4 +291,30 @@ class ParserHintsTest extends munit.FunSuite {
       shown
     )
   }
+
+  test("unexpected indentation in def body gets dedicated hint") {
+    val source =
+      """package Foo
+        |
+        |def map(ll: LazyList[a], fn: a -> b) -> LazyList[b]:
+        |    LazyList(sz, vll) = ll
+        |    vll1 = match vll:
+        |        case Empty: Empty
+        |        case Mapped(mll, fn1): Mapped(mll, x -> fn(fn1(x)))
+        |        case notEmptyMapped: Mapped(notEmptyMapped, fn)
+        |     LazyList(sz, vll1)
+        |""".stripMargin
+
+    val pf = parseFailure(source)
+    val hints = ParserHints.hints(source, pf.locations, pf).map(_.render(120))
+    val shown = pf.showContext(LocationMap.Colorize.None).render(120)
+    assert(
+      hints.exists(_.contains("unexpected indentation")),
+      hints.mkString("\n") + "\n" + shown
+    )
+    assert(
+      shown.contains("unexpected indentation"),
+      shown
+    )
+  }
 }


### PR DESCRIPTION
Implemented a parser-hint fix for bad indentation in declaration bodies.

Changes made:
- Added `unexpectedIndentationRule` to `ParserHints` so parse failures that occur on leading whitespace now produce a dedicated hint when a line is indented deeper than the current block expects.
- Covered both expectation shapes seen in this failure mode:
  - direct expected-indentation expectations,
  - and the case where indentation was already consumed and the parser is expecting `#` (comment) or an expression token.
- Added helper logic to infer expected indentation columns safely from parser expectations and current line/column context.
- Added regression test `unexpected indentation in def body gets dedicated hint` in `ParserHintsTest` using the issue’s code pattern (final expression indented one extra space).
- The new test verifies both `ParserHints.hints(...)` and rendered `showContext(...)` include `unexpected indentation`.

Reproduction and validation:
- Reproduced by adding the regression test first (it failed on current behavior).
- After the fix, test passes.
- Ran required pre-push command successfully: `scripts/test_basic.sh`.
- Also ran focused suite: `sbt "coreJVM/testOnly dev.bosatsu.ParserHintsTest"`.

Fixes #2028