### PR TITLE
Fix confusing destructuring-match type errors by reporting scrutinee vs pattern types

### DIFF
--- a/core/src/main/scala/dev/bosatsu/rankn/Infer.scala
+++ b/core/src/main/scala/dev/bosatsu/rankn/Infer.scala
@@ -2903,7 +2903,19 @@ object Infer {
           } yield (p1, binds)
         case GenPattern.PositionalStruct(nm, args) =>
           for {
+            foundPatternType <- constructorPatternType(nm, reg)
             params <- instDataCon(nm, sigma.value._1, reg, sigma.value._2)
+              .mapError { err =>
+                contextualTypeError(
+                  Error.MismatchSite.MatchPattern(
+                    pat,
+                    sigma.value._1,
+                    foundPatternType,
+                    sigma.value._2,
+                    reg
+                  )
+                )(err)
+              }
             // we need to do a pattern linting phase and probably error
             // if the pattern arity does not match the arity of the constructor
             // but we don't want to error type-checking since we want to show
@@ -2957,6 +2969,17 @@ object Infer {
         reg: Region
     ): Infer[(Pattern, List[(Bindable, Type)])] =
       typeCheckPattern(pat, Expected.Check((sigma, reg)), reg)
+
+    def constructorPatternType(
+        consName: (PackageName, Constructor),
+        reg: Region
+    ): Infer[Type] =
+      GetDataCons(consName, reg).map { case (args, _, _, tpeName) =>
+        Type.applyAll(
+          Type.TyConst(tpeName),
+          args.map { case (tparam, _) => Type.TyVar(tparam) }
+        )
+      }
 
     /** To do this, Infer will need to know the names of the type constructors
       * in scope.

--- a/core/src/test/scala/dev/bosatsu/ErrorMessageTest.scala
+++ b/core/src/test/scala/dev/bosatsu/ErrorMessageTest.scala
@@ -1706,6 +1706,31 @@ main = under_twenty(3)
     }
   }
 
+  test("destructuring binding mismatch reports scrutinee and pattern types") {
+    val src = """
+package A
+
+struct Lazy[a](value: a)
+struct LazyList[a](bound: Int, list: a)
+
+def bad(tail: Lazy[LazyList[Int]], size: Int) -> LazyList[Int]:
+  if size matches 0:
+    LazyList(0, 0)
+  else:
+    LazyList(tail_size, tailv) = tail
+    LazyList(tail_size, tailv)
+"""
+
+    evalFail(List(src)) { case te: PackageError.TypeErrorIn =>
+      val msg = te.message(Map.empty, Colorize.None)
+      assert(msg.contains("pattern type mismatch"), msg)
+      assert(msg.contains("expected scrutinee type: Lazy[LazyList[Int]]"), msg)
+      assert(msg.contains("found pattern type: LazyList["), msg)
+      assert(!msg.contains("match branch result type mismatch"), msg)
+      ()
+    }
+  }
+
   test(
     "match branch mismatch reports expected and inferred branch result types"
   ) {
@@ -2138,8 +2163,9 @@ def go(rem: Int, current: Int, pending: Int) -> Int:
 
     evalFail(List(testCode)) { case kie: PackageError.TypeErrorIn =>
       val message = kie.message(Map.empty, Colorize.None)
-      assert(message.contains("expected type Tuple3"), message)
-      assert(message.contains("but found type Tuple2"), message)
+      assert(message.contains("pattern type mismatch"), message)
+      assert(message.contains("expected scrutinee type: (Int, Int, Int)"), message)
+      assert(message.contains("found pattern type: ("), message)
       assert(message.contains(s"[$start, $end)"), message)
       assertEquals(testCode.substring(start, end), pattern)
       ()


### PR DESCRIPTION
Implemented issue #2033 by changing inference error contextualization for constructor/positional patterns so mismatches are reported as `pattern type mismatch` instead of leaking as outer `match branch result type mismatch`.

What changed:
- `Infer.typeCheckPattern` now wraps `PositionalStruct` constructor-instantiation failures with `MismatchSite.MatchPattern` context.
- Added `constructorPatternType` helper in `Infer` to build an explicit pattern type (e.g. `LazyList[a]`) for clearer diagnostics.
- Added regression test: `destructuring binding mismatch reports scrutinee and pattern types` in `ErrorMessageTest` to reproduce the reported pattern-binding case and assert the improved message.
- Updated an existing tuple-pattern diagnostic test to match the new, more specific `pattern type mismatch` format.

Reproduction/verification:
- Before fix, the new regression failed with the confusing message (`match branch result type mismatch`, `expected branch type: LazyList[Int]`, `found branch type: LazyList`).
- After fix, targeted tests pass.
- Required pre-push command passed: `scripts/test_basic.sh`.
- Also ran: `sbt "coreJVM/testOnly dev.bosatsu.ErrorMessageTest"`.

Fixes #2033