### PR TITLE
Deduplicate duplicate union-pattern mismatch diagnostics (#2039)

### DIFF
--- a/core/src/main/scala/dev/bosatsu/PackageError.scala
+++ b/core/src/main/scala/dev/bosatsu/PackageError.scala
@@ -666,13 +666,52 @@ object PackageError {
       ): Option[(String, Int, String, String)] =
         tpeErr match {
           case c @ Infer.Error.ContextualTypeError(site, _, _) =>
+            val (siteKey, siteHash) =
+              site match {
+                case Infer.Error.MismatchSite.AppArg(
+                      _,
+                      _,
+                      _,
+                      _,
+                      _,
+                      functionRegion,
+                      argumentRegion,
+                      callRegion
+                    ) =>
+                  (
+                    "context:app-arg",
+                    (functionRegion, argumentRegion, callRegion).hashCode
+                  )
+                case Infer.Error.MismatchSite.MatchPattern(
+                      _,
+                      _,
+                      _,
+                      scrutineeRegion,
+                      patternRegion
+                    ) =>
+                  (
+                    "context:match-pattern",
+                    (scrutineeRegion, patternRegion).hashCode
+                  )
+                case Infer.Error.MismatchSite.MatchBranchResult(
+                      _,
+                      _,
+                      scrutineeRegion,
+                      patternRegion,
+                      branchRegion
+                    ) =>
+                  (
+                    "context:match-branch-result",
+                    (scrutineeRegion, patternRegion, branchRegion).hashCode
+                  )
+              }
             val (expectedKey, foundKey) =
               expectedFound(c)
                 .map { case ((exp, _), (found, _)) =>
                   (renderedTypeKey(exp), renderedTypeKey(found))
                 }
                 .getOrElse(("", ""))
-            Some((s"context:$site", site.hashCode, expectedKey, foundKey))
+            Some((siteKey, siteHash, expectedKey, foundKey))
           case e @ Infer.Error.NotUnifiable(_, _, r0, r1, _) =>
             val (expectedKey, foundKey) =
               expectedFound(e)

--- a/core/src/test/scala/dev/bosatsu/ErrorMessageTest.scala
+++ b/core/src/test/scala/dev/bosatsu/ErrorMessageTest.scala
@@ -1731,6 +1731,33 @@ def bad(tail: Lazy[LazyList[Int]], size: Int) -> LazyList[Int]:
     }
   }
 
+  test("union destructuring mismatch is not duplicated") {
+    val src = """
+package A
+
+struct Lazy[a](value: a)
+enum LazyList[a]:
+  LazyList1(bound: Int, list: a), LazyList2(bound: Int, list: a)
+
+def bad(tail: Lazy[LazyList[Int]], size: Int) -> LazyList[Int]:
+  if size matches 0:
+    LazyList1(0, 0)
+  else:
+    LazyList1(tail_size, tailv) | LazyList2(tail_size, tailv) = tail
+    LazyList1(tail_size, tailv)
+"""
+
+    evalFail(List(src)) { case te: PackageError.TypeErrorIn =>
+      val msg = te.message(Map.empty, Colorize.None)
+      val mismatchCount =
+        "pattern type mismatch".r.findAllMatchIn(msg).length
+      assertEquals(mismatchCount, 1, msg)
+      assert(msg.contains("expected scrutinee type: Lazy[LazyList[Int]]"), msg)
+      assert(msg.contains("found pattern type: LazyList["), msg)
+      ()
+    }
+  }
+
   test(
     "match branch mismatch reports expected and inferred branch result types"
   ) {


### PR DESCRIPTION
Implemented a direct fix for issue #2039 by tightening `TypeErrorIn` de-duplication for contextual type errors in `core/src/main/scala/dev/bosatsu/PackageError.scala`. The de-dup key for `Infer.Error.ContextualTypeError` now uses normalized mismatch-site identity (regions for `AppArg`, `MatchPattern`, and `MatchBranchResult`) plus expected/found rendered types, instead of relying on the full `site` case-class hash. This prevents union branches that share the same mismatch site and types from printing duplicate errors.

Added a regression test in `core/src/test/scala/dev/bosatsu/ErrorMessageTest.scala` named `union destructuring mismatch is not duplicated`, using the exact issue scenario (`LazyList1(...) | LazyList2(...) = tail`) and asserting only one `pattern type mismatch` appears.

Reproduction and verification:
- Reproduced pre-fix failure with the new test (observed duplicate mismatch messages, count = 2).
- Verified post-fix targeted test passes.
- Ran full `ErrorMessageTest` suite (pass).
- Ran required pre-push command `scripts/test_basic.sh` (pass).

Fixes #2039