### PR TITLE
Rewrite leading wildcard guard matches and lower bool selectors directly to If

### DIFF
--- a/core/src/main/scala/dev/bosatsu/Matchless.scala
+++ b/core/src/main/scala/dev/bosatsu/Matchless.scala
@@ -4546,6 +4546,53 @@ object Matchless {
       // orthogonal cases before falling back.
       val orthoThreshold = 4
 
+      def boolSelectorBranches(
+          bs: NonEmptyList[MatchBranch]
+      ): Option[(Expr[B], Expr[B])] = {
+        val truePat: Pattern[(PackageName, Constructor), Type] =
+          Pattern.PositionalStruct(
+            (PackageName.PredefName, Constructor("True")),
+            Nil
+          )
+        val falsePat: Pattern[(PackageName, Constructor), Type] =
+          Pattern.PositionalStruct(
+            (PackageName.PredefName, Constructor("False")),
+            Nil
+          )
+
+        def normalizedNoNames(
+            p: Pattern[(PackageName, Constructor), Type]
+        ): Option[Pattern[(PackageName, Constructor), Type]] = {
+          val p1 = normalizePattern(p)
+          if (p1.names.isEmpty) Some(p1)
+          else None
+        }
+
+        def isTrue(p: Pattern[(PackageName, Constructor), Type]): Boolean =
+          p == truePat
+
+        def isFalseOrWild(
+            p: Pattern[(PackageName, Constructor), Type]
+        ): Boolean =
+          (p == falsePat) || (p == Pattern.WildCard)
+
+        bs.toList match {
+          case MatchBranch(p1, None, ifTrue) :: MatchBranch(p2, None, ifFalse) :: Nil =>
+            (normalizedNoNames(p1), normalizedNoNames(p2)) match {
+              case (Some(np1), Some(np2)) if isTrue(np1) && isFalseOrWild(np2) =>
+                Some((ifTrue, ifFalse))
+              case (Some(np1), Some(np2)) if (np1 == falsePat) && (
+                    (np2 == truePat) || (np2 == Pattern.WildCard)
+                  ) =>
+                Some((ifFalse, ifTrue))
+              case _ =>
+                None
+            }
+          case _ =>
+            None
+        }
+      }
+
       def maybeMatrix(
           arg: CheapExpr[B],
           branches: NonEmptyList[MatchBranch],
@@ -4561,24 +4608,29 @@ object Matchless {
           branches: NonEmptyList[MatchBranch],
           rootInlined: Option[InlinedStructRoot]
       ): F[Expr[B]] = {
-        val (orthoPrefix, nonOrthoSuffix) =
-          branches.toList.span(branch => !isNonOrthogonal(branch.pattern))
-        val maybeNonOrthoSuffix = NonEmptyList.fromList(nonOrthoSuffix)
-
-        maybeNonOrthoSuffix match {
+        boolSelectorBranches(branches) match {
+          case Some((ifTrue, ifFalse)) =>
+            Monad[F].pure(If(isTrueExpr(arg), ifTrue, ifFalse))
           case None =>
-            maybeMatrix(arg, branches, rootInlined)
-          case Some(suffixNel) if orthoPrefix.length >= orthoThreshold =>
-            matchExprOrderedCheap(arg, suffixNel, rootInlined).flatMap {
-              fallbackExpr =>
-                val combinedNel = NonEmptyList.ofInitLast(
-                  orthoPrefix,
-                  MatchBranch(Pattern.WildCard, None, fallbackExpr)
-                )
-                compileWithCheapArg(arg, combinedNel, rootInlined)
+            val (orthoPrefix, nonOrthoSuffix) =
+              branches.toList.span(branch => !isNonOrthogonal(branch.pattern))
+            val maybeNonOrthoSuffix = NonEmptyList.fromList(nonOrthoSuffix)
+
+            maybeNonOrthoSuffix match {
+              case None =>
+                maybeMatrix(arg, branches, rootInlined)
+              case Some(suffixNel) if orthoPrefix.length >= orthoThreshold =>
+                matchExprOrderedCheap(arg, suffixNel, rootInlined).flatMap {
+                  fallbackExpr =>
+                    val combinedNel = NonEmptyList.ofInitLast(
+                      orthoPrefix,
+                      MatchBranch(Pattern.WildCard, None, fallbackExpr)
+                    )
+                    compileWithCheapArg(arg, combinedNel, rootInlined)
+                }
+              case _ =>
+                matchExprOrderedCheap(arg, branches, rootInlined)
             }
-          case _ =>
-            matchExprOrderedCheap(arg, branches, rootInlined)
         }
       }
 

--- a/core/src/main/scala/dev/bosatsu/TypedExprNormalization.scala
+++ b/core/src/main/scala/dev/bosatsu/TypedExprNormalization.scala
@@ -1493,6 +1493,27 @@ object TypedExprNormalization {
         val totalityCheck =
           TotalityCheck(ev.substituteCo[[x] =>> TypeEnv[x]](typeEnv))
 
+        def rewriteLeadingWildcardGuard(
+            arg1: TypedExpr[A],
+            bs: NonEmptyList[Branch[A]]
+        ): Option[TypedExpr[A]] =
+          bs.toList match {
+            case Branch(Pattern.WildCard, Some(g), e1) :: tail =>
+              NonEmptyList.fromList(tail).map { tailNel =>
+                val fallback = Match(arg1, tailNel, tag)
+                Match(
+                  g,
+                  NonEmptyList.of(
+                    Branch(TruePattern, None, e1),
+                    Branch(FalsePattern, None, fallback)
+                  ),
+                  g.tag
+                )
+              }
+            case _ =>
+              None
+          }
+
         def rewriteTrailingGuardPair(
             bs: NonEmptyList[Branch[A]]
         ): Option[NonEmptyList[Branch[A]]] =
@@ -1522,26 +1543,31 @@ object TypedExprNormalization {
           }
 
         val a1 = normalize1(None, arg, scope, typeEnv).get
-        if (changed1 == 0) {
-          val m1 = Match(a1, branches, tag)
-          Impl.maybeEvalMatch(m1, scope) match {
-            case None =>
-              // if only the arg changes, there
-              // is no need to rerun the normalization
-              // because normalization of branches
-              // does not depend on the arg
-              if (a1 eq arg) None
-              else Some(m1)
-            case Some(m2) =>
-              // TODO: we may not have a proof that m2 is smaller
-              // than m1. requiring m2.size < m1.size fails some tests
-              // we can possibly simplify this now:
-              normalize1(namerec, m2, scope, typeEnv)
-          }
-        } else {
-          // there has been some change, so
-          // see if that unlocked any new changes
-          normalize1(namerec, Match(a1, branches1a, tag), scope, typeEnv)
+        rewriteLeadingWildcardGuard(a1, branches1a) match {
+          case Some(rewritten) =>
+            normalize1(namerec, rewritten, scope, typeEnv)
+          case None =>
+            if (changed1 == 0) {
+              val m1 = Match(a1, branches, tag)
+              Impl.maybeEvalMatch(m1, scope) match {
+                case None =>
+                  // if only the arg changes, there
+                  // is no need to rerun the normalization
+                  // because normalization of branches
+                  // does not depend on the arg
+                  if (a1 eq arg) None
+                  else Some(m1)
+                case Some(m2) =>
+                  // TODO: we may not have a proof that m2 is smaller
+                  // than m1. requiring m2.size < m1.size fails some tests
+                  // we can possibly simplify this now:
+                  normalize1(namerec, m2, scope, typeEnv)
+              }
+            } else {
+              // there has been some change, so
+              // see if that unlocked any new changes
+              normalize1(namerec, Match(a1, branches1a, tag), scope, typeEnv)
+            }
         }
     }
   }

--- a/core/src/test/scala/dev/bosatsu/MatchlessTests.scala
+++ b/core/src/test/scala/dev/bosatsu/MatchlessTests.scala
@@ -783,6 +783,61 @@ x = 1
     }
   }
 
+  test("Matchless lowers bool selector matches directly to If") {
+    val cond = Identifier.Name("cond")
+    val boolType = rankn.Type.BoolType
+    val truePat: Pattern[(PackageName, Constructor), rankn.Type] =
+      Pattern.PositionalStruct(
+        (PackageName.PredefName, Constructor("True")),
+        Nil
+      )
+    val falsePat: Pattern[(PackageName, Constructor), rankn.Type] =
+      Pattern.PositionalStruct(
+        (PackageName.PredefName, Constructor("False")),
+        Nil
+      )
+    val typed = TypedExpr.AnnotatedLambda(
+      NonEmptyList.one((cond, boolType)),
+      TypedExpr.Match(
+        TypedExpr.Local(cond, boolType, ()),
+        NonEmptyList.of(
+          TypedExpr.Branch(truePat, None, intLit(1)),
+          TypedExpr.Branch(falsePat, None, intLit(0))
+        ),
+        ()
+      ),
+      ()
+    )
+
+    val boolFn: Fn = {
+      val base = fnFromTypeEnv(rankn.TypeEnv.empty)
+      {
+        case (PackageName.PredefName, Constructor("False")) =>
+          Some(DataRepr.Enum(0, 0, 0 :: 0 :: Nil))
+        case (PackageName.PredefName, Constructor("True")) =>
+          Some(DataRepr.Enum(1, 0, 0 :: 0 :: Nil))
+        case (pn, cons) =>
+          base(pn, cons)
+      }
+    }
+
+    val lowered =
+      Matchless.fromLet(
+        (),
+        Identifier.Name("select"),
+        RecursionKind.NonRecursive,
+        typed
+      )(boolFn)
+
+    lowered match {
+      case Matchless.Lambda(_, None, _, Matchless.If(_, thenExpr, elseExpr)) =>
+        assertEquals(thenExpr, Matchless.Literal(Lit(1)))
+        assertEquals(elseExpr, Matchless.Literal(Lit(0)))
+      case other =>
+        fail(s"expected direct If lowering for bool selector, found: $other")
+    }
+  }
+
   test("Matchless.applyArgs pushes through If and Always") {
     val left = Identifier.Name("left")
     val right = Identifier.Name("right")

--- a/core/src/test/scala/dev/bosatsu/TypedExprTest.scala
+++ b/core/src/test/scala/dev/bosatsu/TypedExprTest.scala
@@ -1083,6 +1083,56 @@ foo = _ -> 1
   }
 
   test(
+    "normalization rewrites leading wildcard guards to a bool selector match"
+  ) {
+    val x = varTE("x", intTpe)
+    val guardExpr =
+      TypedExpr.App(PredefEqInt, NonEmptyList.of(x, int(0)), boolTpe, ())
+    val truePat: Pattern[(PackageName, Constructor), Type] =
+      Pattern.PositionalStruct((PackageName.PredefName, Constructor("True")), Nil)
+    val falsePat: Pattern[(PackageName, Constructor), Type] =
+      Pattern.PositionalStruct((PackageName.PredefName, Constructor("False")), Nil)
+
+    val guardedLeading = TypedExpr.Match(
+      x,
+      NonEmptyList.of(
+        TypedExpr.Branch(Pattern.WildCard, Some(guardExpr), int(10)),
+        TypedExpr.Branch(Pattern.Literal(Lit.fromInt(1)), None, int(11)),
+        TypedExpr.Branch(Pattern.WildCard, None, int(12))
+      ),
+      ()
+    )
+
+    TypedExprNormalization.normalize(guardedLeading) match {
+      case Some(TypedExpr.Match(arg1, branches1, _)) =>
+        assertEquals(arg1, guardExpr)
+        assertEquals(branches1.length, 2)
+        assertEquals(branches1.head.pattern, truePat)
+        assertEquals(branches1.head.guard, None)
+        assertEquals(branches1.head.expr, int(10))
+
+        branches1.tail.head match {
+          case TypedExpr.Branch(
+                `falsePat`,
+                None,
+                TypedExpr.Match(innerArg, innerBranches, _)
+              ) =>
+            assertEquals(innerArg, x)
+            assertEquals(innerBranches.length, 2)
+            assertEquals(
+              innerBranches.head.pattern,
+              Pattern.Literal(Lit.fromInt(1))
+            )
+            assertEquals(innerBranches.last.pattern, Pattern.WildCard)
+          case other =>
+            fail(s"expected False branch to contain tail match, got: $other")
+        }
+      case other =>
+        fail(s"expected rewritten bool selector match, got: $other")
+    }
+  }
+
+  test(
     "normalization rewrites let substitutions in guard and branch body consistently"
   ) {
     val xName = Identifier.Name("x")


### PR DESCRIPTION
Implemented issue #2054 with focused changes in normalization and lowering. In `TypedExprNormalization`, added a rewrite for matches that start with `case _ if guard` so they become a Bool selector match (`True`/`False`) where the `False` branch re-matches the original scrutinee against the remaining branches. In `Matchless`, added a direct bool-selector fast path so 2-branch `True`/`False` (and `True`/`_`, `False`/`_`) matches lower straight to `If`. Added targeted tests in `TypedExprTest` and `MatchlessTests` for both behaviors. Ran the required pre-push command `scripts/test_basic.sh`, and it passed.

Fixes #2054