### PR TITLE
Fix markdown link rendering in generated doc signatures

### DIFF
--- a/core/src/main/scala/dev/bosatsu/tool/MarkdownDoc.scala
+++ b/core/src/main/scala/dev/bosatsu/tool/MarkdownDoc.scala
@@ -298,6 +298,21 @@ object MarkdownDoc {
   private def markdownCodeLink(label: String, href: String): Doc =
     Doc.text(show"[`${label.replace("`", "\\`")}`]($href)")
 
+  private def escapeMarkdownLiteral(str: String): String = {
+    val out = new StringBuilder(str.length)
+    var idx = 0
+    while (idx < str.length) {
+      str.charAt(idx) match {
+        case '[' =>
+          out.append("\\[")
+        case ch =>
+          out.append(ch)
+      }
+      idx += 1
+    }
+    out.result()
+  }
+
   private def anchorSlug(raw: String): String = {
     val lowered = raw.toLowerCase(Locale.ROOT)
     val mapped = lowered.map { ch =>
@@ -390,7 +405,7 @@ object MarkdownDoc {
 
       def flushText(): Unit =
         if (text.length > 0) {
-          pieces += Doc.text(text.result())
+          pieces += Doc.text(escapeMarkdownLiteral(text.result()))
           text.clear()
         }
 

--- a/core/src/test/scala/dev/bosatsu/ToolAndLibCommandTest.scala
+++ b/core/src/test/scala/dev/bosatsu/ToolAndLibCommandTest.scala
@@ -2914,6 +2914,50 @@ external def apply_default[a](default: Unit -> a) -> a
     }
   }
 
+  test("tool doc escapes linked type argument brackets in type signatures") {
+    val src =
+      """export flatten
+flatten = (deps: List[Dict[String, Int]]) -> deps
+"""
+    val files = List(Chain("src", "LinkSig", "Main.bosatsu") -> src)
+
+    val result = for {
+      s0 <- MemoryMain.State.from[ErrorOr](files)
+      s1 <- runWithState(
+        List(
+          "tool",
+          "doc",
+          "--package_root",
+          "src",
+          "--input",
+          "src/LinkSig/Main.bosatsu",
+          "--outdir",
+          "docs"
+        ),
+        s0
+      )
+    } yield s1
+
+    result match {
+      case Left(err) =>
+        fail(err.getMessage)
+      case Right((state, _)) =>
+        val markdown = readStringFile(state, Chain("docs", "LinkSig", "Main.md"))
+        assert(
+          markdown.contains(
+            "[`List`](../Bosatsu/Predef.md#type-list)\\[[`Dict`](../Bosatsu/Predef.md#type-dict)\\[[`String`](../Bosatsu/Predef.md#type-string), [`Int`](../Bosatsu/Predef.md#type-int)]]"
+          ),
+          markdown
+        )
+        assert(
+          !markdown.contains(
+            "[`List`](../Bosatsu/Predef.md#type-list)[[`Dict`](../Bosatsu/Predef.md#type-dict)"
+          ),
+          markdown
+        )
+    }
+  }
+
   test("tool doc --include_predef includes Bosatsu/Predef markdown") {
     val src =
       """export main,


### PR DESCRIPTION
Reproduced issue #2060 by running `sbt "docs/paradox"` and inspecting generated HTML (for example `generated/core_alpha/BazelDepsApi.html`), where generic type signatures produced malformed encoded `href` fragments from adjacent markdown links and `[` type-argument delimiters.

Implemented fix in `MarkdownDoc` by escaping literal `[` characters in non-link text segments during linked type rendering, so generated markdown stays parser-safe (emits `\[` between linked generic arguments).

Added regression coverage in `ToolAndLibCommandTest` with `tool doc escapes linked type argument brackets in type signatures`, asserting the escaped form is present and the old broken pattern is absent.

Validation run:
- `sbt "coreJVM/testOnly dev.bosatsu.ToolAndLibCommandTest -- --log=failure"`
- `sbt "docs/paradox"` (manual HTML verification)
- `scripts/test_basic.sh` (required, passes)

Fixes #2060