### PR TITLE
Clarify core_alpha docs for total division and Float64 ordering

### DIFF
--- a/core/src/main/resources/bosatsu/predef.bosatsu
+++ b/core/src/main/resources/bosatsu/predef.bosatsu
@@ -225,7 +225,7 @@ external def add(a: Int, b: Int) -> Int
 external def sub(a: Int, b: Int) -> Int
 # Integer multiplication.
 external def mul(a: Int, b: Int) -> Int
-# Integer division.
+# Integer division rounded toward negative infinity; total with `div(a, 0) == 0`.
 external def div(a: Int, b: Int) -> Int
 # Integer equality.
 external def eq_Int(a: Int, b: Int) -> Bool
@@ -233,7 +233,7 @@ external def eq_Int(a: Int, b: Int) -> Bool
 external def gcd_Int(a: Int, b: Int) -> Int
 # Total integer comparison.
 external def cmp_Int(a: Int, b: Int) -> Comparison
-# Integer modulus.
+# Integer modulus paired with `div`; total with `mod_Int(a, 0) == a`.
 external def mod_Int(a: Int, mod: Int) -> Int
 # Bitwise left shift.
 external def shift_left_Int(arg: Int, shift: Int) -> Int
@@ -253,9 +253,9 @@ external def addf(a: Float64, b: Float64) -> Float64
 external def subf(a: Float64, b: Float64) -> Float64
 # Floating-point multiplication.
 external def timesf(a: Float64, b: Float64) -> Float64
-# Floating-point division.
+# IEEE754 floating-point division; unlike `div`, dividing by `0.0` yields `∞`, `-∞`, or `.NaN`.
 external def divf(a: Float64, b: Float64) -> Float64
-# Total Float64 comparison.
+# Total Float64 comparison where all `.NaN` values are equal and ordered before non-`.NaN` values.
 external def cmp_Float64(a: Float64, b: Float64) -> Comparison
 
 # Loop until the returned Int is <= 0 or >= intValue.

--- a/core/src/test/scala/dev/bosatsu/ToolAndLibCommandTest.scala
+++ b/core/src/test/scala/dev/bosatsu/ToolAndLibCommandTest.scala
@@ -3068,6 +3068,22 @@ main = 1
         assert(predefDoc.contains("intValue: Int"), predefDoc)
         assert(predefDoc.contains("state: a"), predefDoc)
         assert(predefDoc.contains("fn: (Int, a) -> (Int, a)"), predefDoc)
+        assert(
+          predefDoc.contains("div(a, 0) == 0"),
+          predefDoc
+        )
+        assert(
+          predefDoc.contains("mod_Int(a, 0) == a"),
+          predefDoc
+        )
+        assert(
+          predefDoc.contains("all `.NaN` values are equal"),
+          predefDoc
+        )
+        assert(
+          predefDoc.contains("dividing by `0.0` yields `∞`, `-∞`, or `.NaN`"),
+          predefDoc
+        )
     }
   }
 


### PR DESCRIPTION
Implemented a focused docs fix for issue #2063 in the predef API surface used by generated core_alpha docs.

Changes made:
- Updated exported-value comments in `core/src/main/resources/bosatsu/predef.bosatsu` for:
  - `div` (documents total integer division behavior: `div(a, 0) == 0`)
  - `mod_Int` (documents total modulus behavior: `mod_Int(a, 0) == a`)
  - `divf` (documents IEEE754 zero-division results: `∞`, `-∞`, `.NaN`)
  - `cmp_Float64` (documents lawful total ordering behavior for `.NaN` values)
- Added regression assertions in `core/src/test/scala/dev/bosatsu/ToolAndLibCommandTest.scala` under the `tool doc --include_predef includes Bosatsu/Predef markdown` test to ensure generated docs include the new explanations.

Validation:
- Ran required command `scripts/test_basic.sh` successfully (after a clean rebuild to refresh compile-time embedded predef text).

Fixes #2063