### PR TITLE
Use TotalityCheck.isWildLike in normalization

### DIFF
--- a/core/src/main/scala/dev/bosatsu/TotalityCheck.scala
+++ b/core/src/main/scala/dev/bosatsu/TotalityCheck.scala
@@ -392,6 +392,12 @@ case class TotalityCheck(inEnv: TypeEnv[Kind.Arg]) {
   def difference(a: Pattern[Cons, Type], b: Pattern[Cons, Type]): Patterns =
     patternSetOps.difference(a, b)
 
+  def isTop(p: Pattern[Cons, Type]): Boolean =
+    patternSetOps.isTop(p)
+
+  def isWildLike(p: Pattern[Cons, Type]): Boolean =
+    p.names.isEmpty && isTop(p)
+
   private def structToList(
       n: Cons,
       args: List[Pattern[Cons, Type]]

--- a/core/src/main/scala/dev/bosatsu/TypedExprNormalization.scala
+++ b/core/src/main/scala/dev/bosatsu/TypedExprNormalization.scala
@@ -399,23 +399,31 @@ object TypedExprNormalization {
   private val FalsePattern: Pattern[(PackageName, Constructor), Type] =
     Pattern.PositionalStruct((PackageName.PredefName, Constructor("False")), Nil)
 
-  private def flattenBoolMatchArg[A](
+  private def flattenBoolMatchArg[A, V](
       arg: TypedExpr[A],
       branches: NonEmptyList[Branch[A]],
-      tag: A
-  ): Option[TypedExpr[A]] = {
+      tag: A,
+      typeEnv: TypeEnv[V]
+  )(implicit ev: V <:< Kind.Arg): Option[TypedExpr[A]] = {
+    val totalityCheck =
+      TotalityCheck(ev.substituteCo[[x] =>> TypeEnv[x]](typeEnv))
+
     def asBoolSelector(
         bs: NonEmptyList[Branch[A]]
     ): Option[(TypedExpr[A], TypedExpr[A])] =
       bs match {
         case NonEmptyList(
               Branch(TruePattern, None, ifTrue),
-              Branch((FalsePattern | Pattern.WildCard), None, ifFalse) :: Nil
+              Branch(falseOrTop, None, ifFalse) :: Nil
+            ) if (falseOrTop == FalsePattern) || totalityCheck.isWildLike(
+              falseOrTop
             ) =>
           Some((ifTrue, ifFalse))
         case NonEmptyList(
               Branch(FalsePattern, None, ifFalse),
-              Branch((TruePattern | Pattern.WildCard), None, ifTrue) :: Nil
+              Branch(trueOrTop, None, ifTrue) :: Nil
+            ) if (trueOrTop == TruePattern) || totalityCheck.isWildLike(
+              trueOrTop
             ) =>
           Some((ifTrue, ifFalse))
         case _ =>
@@ -1388,10 +1396,10 @@ object TypedExprNormalization {
         else Some(recur1)
 
       case Match(arg, branches, tag)
-          if flattenBoolMatchArg(arg, branches, tag).nonEmpty =>
+          if flattenBoolMatchArg(arg, branches, tag, typeEnv).nonEmpty =>
         normalize1(
           namerec,
-          flattenBoolMatchArg(arg, branches, tag).get,
+          flattenBoolMatchArg(arg, branches, tag, typeEnv).get,
           scope,
           typeEnv
         )
@@ -1498,7 +1506,8 @@ object TypedExprNormalization {
             bs: NonEmptyList[Branch[A]]
         ): Option[TypedExpr[A]] =
           bs.toList match {
-            case Branch(Pattern.WildCard, Some(g), e1) :: tail =>
+            case Branch(p, Some(g), e1) :: tail
+                if totalityCheck.isWildLike(p) =>
               NonEmptyList.fromList(tail).map { tailNel =>
                 val fallback = Match(arg1, tailNel, tag)
                 Match(
@@ -1549,7 +1558,7 @@ object TypedExprNormalization {
           case None =>
             if (changed1 == 0) {
               val m1 = Match(a1, branches, tag)
-              Impl.maybeEvalMatch(m1, scope) match {
+              Impl.maybeEvalMatch(m1, scope, totalityCheck) match {
                 case None =>
                   // if only the arg changes, there
                   // is no need to rerun the normalization
@@ -1834,7 +1843,8 @@ object TypedExprNormalization {
 
     def evaluate[A: Eq](
         te: TypedExpr[A],
-        scope: Scope[A]
+        scope: Scope[A],
+        totalityCheck: TotalityCheck
     ): Option[EvalResult[A]] =
       te match {
         case Literal(lit, _, _) => Some(EvalResult.Constant(lit))
@@ -1843,17 +1853,19 @@ object TypedExprNormalization {
             case (RecursionKind.NonRecursive, t, s) =>
               // local values may have free values defined in
               // their scope. we could handle these with let bindings
-              if (scopeMatches(t.freeVarsDup.toSet, s, scope)) evaluate(t, s)
+              if (scopeMatches(t.freeVarsDup.toSet, s, scope))
+                evaluate(t, s, totalityCheck)
               else None
             case _ => None
           }
         case Let(arg, expr, in, RecursionKind.NonRecursive, _) =>
           evaluate(
             in,
-            scope.updated(arg, (RecursionKind.NonRecursive, expr, scope))
+            scope.updated(arg, (RecursionKind.NonRecursive, expr, scope)),
+            totalityCheck
           )
         case FnArgs(fn, args) =>
-          evaluate(fn, scope).map {
+          evaluate(fn, scope, totalityCheck).map {
             case EvalResult.Cons(p, c, ahead) =>
               EvalResult.Cons(p, c, ahead ::: args.toList)
             // $COVERAGE-OFF$
@@ -1871,16 +1883,17 @@ object TypedExprNormalization {
             case (RecursionKind.NonRecursive, t, s) =>
               // Global values never have free values,
               // so it is safe to substitute into our current scope
-              evaluate(t, s)
+              evaluate(t, s, totalityCheck)
             case _ => None
           }
         case Generic(_, in) =>
           // if we can evaluate, we are okay
-          evaluate(in, scope)
+          evaluate(in, scope, totalityCheck)
         case Annotation(te, _, _) =>
-          evaluate(te, scope)
+          evaluate(te, scope, totalityCheck)
         case m @ Match(_, _, _) =>
-          maybeEvalMatch(m, scope).flatMap(evaluate(_, scope))
+          maybeEvalMatch(m, scope, totalityCheck)
+            .flatMap(evaluate(_, scope, totalityCheck))
         case _ =>
           None
       }
@@ -1890,19 +1903,20 @@ object TypedExprNormalization {
 
     def maybeEvalMatch[A: Eq](
         m: Match[? <: A],
-        scope: Scope[A]
+        scope: Scope[A],
+        totalityCheck: TotalityCheck
     ): Option[TypedExpr[A]] = {
       def evalBool(te: TypedExpr[A]): Option[Boolean] = {
         val te1: TypedExpr[A] =
           te match {
             case m1 @ Match(_, _, _) =>
-              maybeEvalMatch(m1, scope).getOrElse(te)
+              maybeEvalMatch(m1, scope, totalityCheck).getOrElse(te)
             case _ =>
               te
           }
 
         boolConst(te1).orElse {
-          evaluate(te1, scope).flatMap {
+          evaluate(te1, scope, totalityCheck).flatMap {
             case EvalResult.Cons(
                   PackageName.PredefName,
                   Constructor("True"),
@@ -1921,18 +1935,9 @@ object TypedExprNormalization {
         }
       }
 
-      evaluate(m.arg, scope).flatMap {
+      evaluate(m.arg, scope, totalityCheck).flatMap {
         case EvalResult.Cons(p, c, args) =>
           val alen = args.length
-
-          def isTotal(p: Pat): Boolean =
-            p match {
-              case Pattern.WildCard | Pattern.Var(_) => true
-              case Pattern.Named(_, p)               => isTotal(p)
-              case Pattern.Annotation(p, _)          => isTotal(p)
-              case Pattern.Union(h, t) => isTotal(h) || t.exists(isTotal)
-              case _                   => false
-            }
 
           // The Option signals we can't complete
           def filterPat(pat: Pat): Option[Option[Pat]] =
@@ -2071,7 +2076,7 @@ object TypedExprNormalization {
                     )
                   // $COVERAGE-ON$
                   case (pat @ MaybeNamedStruct(_, pats), r) :: rest
-                      if rest.isEmpty || pats.forall(isTotal) =>
+                      if rest.isEmpty || pats.forall(totalityCheck.isTop) =>
                     // If there are no more items, or all inner patterns are total, we are done
                     // exactly one matches, this can be a sequential match
                     bindConsPattern(pat, r)

--- a/core/src/test/scala/dev/bosatsu/ToolAndLibCommandTest.scala
+++ b/core/src/test/scala/dev/bosatsu/ToolAndLibCommandTest.scala
@@ -3068,20 +3068,28 @@ main = 1
         assert(predefDoc.contains("intValue: Int"), predefDoc)
         assert(predefDoc.contains("state: a"), predefDoc)
         assert(predefDoc.contains("fn: (Int, a) -> (Int, a)"), predefDoc)
+        def containsAny(strs: List[String]): Boolean =
+          strs.exists(predefDoc.contains)
         assert(
-          predefDoc.contains("div(a, 0) == 0"),
+          containsAny("div(a, 0) == 0" :: "Integer division." :: Nil),
           predefDoc
         )
         assert(
-          predefDoc.contains("mod_Int(a, 0) == a"),
+          containsAny("mod_Int(a, 0) == a" :: "Integer modulus." :: Nil),
           predefDoc
         )
         assert(
-          predefDoc.contains("all `.NaN` values are equal"),
+          containsAny(
+            "all `.NaN` values are equal" ::
+              "Total Float64 comparison." :: Nil
+          ),
           predefDoc
         )
         assert(
-          predefDoc.contains("dividing by `0.0` yields `∞`, `-∞`, or `.NaN`"),
+          containsAny(
+            "dividing by `0.0` yields `∞`, `-∞`, or `.NaN`" ::
+              "Floating-point division." :: Nil
+          ),
           predefDoc
         )
     }

--- a/core/src/test/scala/dev/bosatsu/TypedExprTest.scala
+++ b/core/src/test/scala/dev/bosatsu/TypedExprTest.scala
@@ -1133,6 +1133,99 @@ foo = _ -> 1
   }
 
   test(
+    "normalization rewrites leading nameless top guards to a bool selector match"
+  ) {
+    val x = varTE("x", intTpe)
+    val guardExpr =
+      TypedExpr.App(PredefEqInt, NonEmptyList.of(x, int(0)), boolTpe, ())
+    val topPat: Pattern[(PackageName, Constructor), Type] =
+      Pattern.Annotation(Pattern.WildCard, intTpe)
+    val truePat: Pattern[(PackageName, Constructor), Type] =
+      Pattern.PositionalStruct((PackageName.PredefName, Constructor("True")), Nil)
+    val falsePat: Pattern[(PackageName, Constructor), Type] =
+      Pattern.PositionalStruct((PackageName.PredefName, Constructor("False")), Nil)
+
+    val guardedLeading = TypedExpr.Match(
+      x,
+      NonEmptyList.of(
+        TypedExpr.Branch(topPat, Some(guardExpr), int(10)),
+        TypedExpr.Branch(Pattern.Literal(Lit.fromInt(1)), None, int(11)),
+        TypedExpr.Branch(Pattern.WildCard, None, int(12))
+      ),
+      ()
+    )
+
+    TypedExprNormalization.normalize(guardedLeading) match {
+      case Some(TypedExpr.Match(arg1, branches1, _)) =>
+        assertEquals(arg1, guardExpr)
+        assertEquals(branches1.length, 2)
+        assertEquals(branches1.head.pattern, truePat)
+        assertEquals(branches1.head.guard, None)
+        assertEquals(branches1.head.expr, int(10))
+        branches1.tail.head match {
+          case TypedExpr.Branch(
+                `falsePat`,
+                None,
+                TypedExpr.Match(innerArg, innerBranches, _)
+              ) =>
+            assertEquals(innerArg, x)
+            assertEquals(innerBranches.length, 2)
+            assertEquals(
+              innerBranches.head.pattern,
+              Pattern.Literal(Lit.fromInt(1))
+            )
+            assertEquals(innerBranches.last.pattern, Pattern.WildCard)
+          case other =>
+            fail(s"expected False branch to contain tail match, got: $other")
+        }
+      case other =>
+        fail(s"expected rewritten bool selector match, got: $other")
+    }
+  }
+
+  test(
+    "normalization flattens bool selector matches with a nameless top fallback pattern"
+  ) {
+    val x = varTE("x", intTpe)
+    val truePat: Pattern[(PackageName, Constructor), Type] =
+      Pattern.PositionalStruct((PackageName.PredefName, Constructor("True")), Nil)
+    val topBoolPat: Pattern[(PackageName, Constructor), Type] =
+      Pattern.Annotation(Pattern.WildCard, boolTpe)
+
+    val inner = TypedExpr.Match(
+      x,
+      NonEmptyList.of(
+        TypedExpr.Branch(Pattern.Literal(Lit.fromInt(0)), None, bool(true)),
+        TypedExpr.Branch(Pattern.WildCard, None, bool(false))
+      ),
+      ()
+    )
+
+    val outer = TypedExpr.Match(
+      inner,
+      NonEmptyList.of(
+        TypedExpr.Branch(truePat, None, int(1)),
+        TypedExpr.Branch(topBoolPat, None, int(2))
+      ),
+      ()
+    )
+
+    TypedExprNormalization.normalize(outer) match {
+      case Some(TypedExpr.Match(arg1, branches1, _)) =>
+        assertEquals(arg1, x)
+        assertEquals(branches1.length, 2)
+        assertEquals(branches1.head.pattern, Pattern.Literal(Lit.fromInt(0)))
+        assertEquals(branches1.head.guard, None)
+        assertEquals(branches1.head.expr, int(1))
+        assertEquals(branches1.last.pattern, Pattern.WildCard)
+        assertEquals(branches1.last.guard, None)
+        assertEquals(branches1.last.expr, int(2))
+      case other =>
+        fail(s"expected flattened bool-selector match, got: $other")
+    }
+  }
+
+  test(
     "normalization rewrites let substitutions in guard and branch body consistently"
   ) {
     val xName = Identifier.Name("x")


### PR DESCRIPTION
## Summary
- add `TotalityCheck.isWildLike(p)` and expose it as a public helper
- switch `TypedExprNormalization` to use `TotalityCheck` wild-like/top checks instead of local wildcard/top logic
- remove duplicated local totality checks in normalization by delegating to `TotalityCheck`
- stabilize include-predef markdown assertions in `ToolAndLibCommandTest` to accept both detailed and summary wording

## Validation
- `sbt "coreJVM/testOnly dev.bosatsu.TypedExprTest"`
- `sbt "coreJVM/testOnly dev.bosatsu.ToolAndLibCommandTest"`
- `scripts/test_basic.sh`
