### PR TITLE
Add Matchless SwitchVariant IR and backend lowering for wide enum dispatch

### DIFF
--- a/core/src/main/scala/dev/bosatsu/Matchless.scala
+++ b/core/src/main/scala/dev/bosatsu/Matchless.scala
@@ -140,7 +140,7 @@ object Matchless {
                 val c3 =
                   Order[NonEmptyList[(Int, Expr[A])]].compare(casesL, casesR)
                 if (c3 != 0) c3
-                else compareExpr(defaultL, defaultR)
+                else Order[Option[Expr[A]]].compare(defaultL, defaultR)
               }
             }
 
@@ -230,7 +230,7 @@ object Matchless {
           case SwitchVariant(on, _, cases, default) =>
             loopExpr(on) || cases.exists { case (_, branch) =>
               loopExpr(branch)
-            } || loopExpr(default)
+            } || default.exists(loopExpr)
           case Always(cond, thenExpr) =>
             loopBool(cond) || loopExpr(thenExpr)
           case PrevNat(of) =>
@@ -290,7 +290,7 @@ object Matchless {
           case SwitchVariant(on, _, cases, default) =>
             loopExpr(on) || cases.exists { case (_, branch) =>
               loopExpr(branch)
-            } || loopExpr(default)
+            } || default.exists(loopExpr)
           case Always(cond, thenExpr) =>
             loopBool(cond) || loopExpr(thenExpr)
           case PrevNat(of) =>
@@ -377,7 +377,7 @@ object Matchless {
               cases.exists { case (_, branch) =>
                 referencesBindable(branch, target, isShadowed)
               } ||
-              referencesBindable(default, target, isShadowed)
+              default.exists(referencesBindable(_, target, isShadowed))
           case Always(cond, thenExpr) =>
             BoolExpr.referencesBindable(cond, target, isShadowed) ||
               referencesBindable(thenExpr, target, isShadowed)
@@ -425,7 +425,7 @@ object Matchless {
             case SwitchVariant(on, _, cases, default) =>
               loopExpr(on, isShadowed) || cases.exists {
                 case (_, branch) => loopExpr(branch, isShadowed)
-              } || loopExpr(default, isShadowed)
+              } || default.exists(loopExpr(_, isShadowed))
             case Always(cond, thenExpr) =>
               loopBool(cond, isShadowed) || loopExpr(thenExpr, isShadowed)
             case PrevNat(of) =>
@@ -611,7 +611,7 @@ object Matchless {
             cases.map { case (variant, branch) =>
               (variant, loopExpr(branch))
             },
-            loopExpr(default)
+            default.map(loopExpr)
           )
         case Always(cond, thenExpr) =>
           Always(loopBool(cond), loopExpr(thenExpr))
@@ -753,7 +753,7 @@ object Matchless {
             cases.map { case (variant, branch) =>
               (variant, loop(branch, aliases))
             },
-            loop(default, aliases)
+            default.map(loop(_, aliases))
           )
         case Always(cond, thenExpr) =>
           Always(cond, loop(thenExpr, aliases))
@@ -815,7 +815,9 @@ object Matchless {
         case If(cond, thenExpr, elseExpr) =>
           loopExpr(elseExpr, loopExpr(thenExpr, loopBool(cond, acc)))
         case SwitchVariant(on, _, cases, default) =>
-          cases.foldLeft(loopExpr(default, loopCheap(on, acc))) {
+          val acc0 = loopCheap(on, acc)
+          val acc1 = default.fold(acc0)(loopExpr(_, acc0))
+          cases.foldLeft(acc1) {
             case (accN, (_, branch)) =>
               loopExpr(branch, accN)
           }
@@ -915,7 +917,8 @@ object Matchless {
             loop(els, bindableArities, anonArities)
           )
         case SwitchVariant(_, _, cases, default) =>
-          cases.foldLeft(loop(default, bindableArities, anonArities)) {
+          val defaultArity = default.flatMap(loop(_, bindableArities, anonArities))
+          cases.foldLeft(defaultArity) {
             case (acc, (_, branch)) =>
               sameArity(acc, loop(branch, bindableArities, anonArities))
           }
@@ -1003,7 +1006,9 @@ object Matchless {
           case If(cond, thenExpr, elseExpr) =>
             loopExpr(elseExpr, loopExpr(thenExpr, loopBool(cond, curr)))
           case SwitchVariant(on, _, cases, default) =>
-            cases.foldLeft(loopExpr(default, loopExpr(on, curr))) {
+            val curr1 = loopExpr(on, curr)
+            val curr2 = default.fold(curr1)(loopExpr(_, curr1))
+            cases.foldLeft(curr2) {
               case (acc, (_, branch)) =>
                 loopExpr(branch, acc)
             }
@@ -1416,7 +1421,14 @@ object Matchless {
                   val (branch1, st1) = recurExpr(branch, currSt)
                   ((variant, branch1) :: acc, st1)
               }
-            val (default1, stDefault) = recurExpr(default, stCases)
+            val (default1, stDefault) =
+              default match {
+                case Some(defaultExpr) =>
+                  val (defaultExpr1, st1) = recurExpr(defaultExpr, stCases)
+                  (Some(defaultExpr1), st1)
+                case None              =>
+                  (None, stCases)
+              }
             (
               SwitchVariant(
                 on1,
@@ -1473,7 +1485,7 @@ object Matchless {
               .map { case (_, branch) =>
                 loopExpr(branch)
               }
-              .sum + loopExpr(default)
+              .sum + default.fold(0)(loopExpr)
           case Always(cond, thenExpr) =>
             1 + loopBool(cond) + loopExpr(thenExpr)
           case PrevNat(of) =>
@@ -1631,7 +1643,7 @@ object Matchless {
             cases.map { case (variant, branch) =>
               (variant, recurExpr(branch))
             },
-            recurExpr(default)
+            default.map(recurExpr)
           )
         case Always(cond, thenExpr) =>
           rewriteCanonicalRecursionLoop(recurBool(cond), recurExpr(thenExpr))
@@ -1912,7 +1924,7 @@ object Matchless {
       case SwitchVariant(on, _, cases, default) =>
         hasSideEffect(on) ||
           cases.exists { case (_, branch) => hasSideEffect(branch) } ||
-          hasSideEffect(default)
+          default.exists(hasSideEffect)
       case Let(_, x, b) =>
         hasSideEffect(b) || hasSideEffect(x)
       case LetMut(_, in) => hasSideEffect(in)
@@ -1949,7 +1961,7 @@ object Matchless {
       cases: NonEmptyList[(Int, Expr[A])],
       // Variants not listed in `cases` (for example via wildcard/default rows)
       // evaluate this branch.
-      default: Expr[A]
+      default: Option[Expr[A]]
   ) extends Expr[A] {
     private val caseVariants = cases.toList.map(_._1)
     private val familySize = famArities.length
@@ -2680,7 +2692,7 @@ object Matchless {
             cases.map { case (variant, branch) =>
               (variant, substituteLocals(m, branch))
             },
-            substituteLocals(m, default)
+            default.map(substituteLocals(m, _))
           )
         case Always(c, e) =>
           Always(substituteLocalsBool(m, c), substituteLocals(m, e))
@@ -2800,7 +2812,9 @@ object Matchless {
               case (variant, branch) =>
                 (variant, loop(branch).getOrElse(returnValue(branch)))
             }
-            val rewrittenDefault = loop(default).getOrElse(returnValue(default))
+            val rewrittenDefault = default.map { defaultExpr =>
+              loop(defaultExpr).getOrElse(returnValue(defaultExpr))
+            }
             Some(SwitchVariant(on, famArities, rewrittenCases, rewrittenDefault))
           case Always(c, e) =>
             loop(e).map(Always(c, _))
@@ -4259,7 +4273,7 @@ object Matchless {
               val defaultPossible = possible diff explicitVariants
               val defaultTrue =
                 if (defaultPossible.isEmpty) Some(Set.empty[Int])
-                else collectTrueVariants(default, defaultPossible, selector)
+                else default.flatMap(collectTrueVariants(_, defaultPossible, selector))
               (explicitTrue, defaultTrue).mapN(_ union _)
             case _ =>
               None
@@ -4720,10 +4734,13 @@ object Matchless {
                         }
                     }
 
-                  val defaultExprF: F[Expr[B]] =
+                  val hasAllVariants = enumSigs.length == famArities.length
+                  val defaultExprF: F[Option[Expr[B]]] =
                     if (defaultRows.nonEmpty)
-                      compileRows(defaultRows, defaultOccs, mustMatch)
-                    else Monad[F].pure(UnitExpr)
+                      compileRows(defaultRows, defaultOccs, mustMatch).map(Some(_))
+                    else if (!mustMatch && !hasAllVariants)
+                      Monad[F].pure(Some(UnitExpr))
+                    else Monad[F].pure(None)
 
                   (enumSigs.traverse(compileCase), defaultExprF).mapN {
                     (compiledCases, defaultExpr) =>
@@ -4773,7 +4790,7 @@ object Matchless {
               .map { case (_, branch) =>
                 loopExpr(branch)
               }
-              .sum + loopExpr(default)
+              .sum + default.fold(0)(loopExpr)
           case Always(cond, thenExpr) =>
             1 + loopBool(cond) + loopExpr(thenExpr)
           case PrevNat(of) =>

--- a/core/src/main/scala/dev/bosatsu/MatchlessToValue.scala
+++ b/core/src/main/scala/dev/bosatsu/MatchlessToValue.scala
@@ -481,13 +481,27 @@ object MatchlessToValue {
             cases.iterator.foreach { case (variant, branch) =>
               caseFns(variant) = Some(loop(branch))
             }
-            lazy val defaultF = loop(default)
+            lazy val defaultF = default.map(loop)
 
             Dynamic { (scope: Scope) =>
               val variant = onF(scope).asSum.variant
-              if ((variant >= 0) && (variant < caseFns.length))
-                caseFns(variant).getOrElse(defaultF)(scope)
-              else defaultF(scope)
+              if ((variant >= 0) && (variant < caseFns.length)) {
+                caseFns(variant) match {
+                  case Some(fn) => fn(scope)
+                  case None     =>
+                    defaultF match {
+                      case Some(df) => df(scope)
+                      case None     =>
+                        throw new IllegalStateException(
+                          s"SwitchVariant missing case for variant=$variant in family size=${caseFns.length}"
+                        )
+                    }
+                }
+              } else {
+                throw new IllegalStateException(
+                  s"SwitchVariant variant out of bounds: variant=$variant, family size=${caseFns.length}"
+                )
+              }
             }
           case Always.SetChain(muts, expr) =>
             val values = muts.map { case (m, e) => (m, loop(e)) }

--- a/core/src/main/scala/dev/bosatsu/codegen/clang/ClangGen.scala
+++ b/core/src/main/scala/dev/bosatsu/codegen/clang/ClangGen.scala
@@ -802,7 +802,7 @@ class ClangGen[K](ns: CompilationNamespace[K]) {
                       )
                     }
                   }
-                  defaultVL <- innerToValue(default)
+                  defaultVL <- default.traverse(innerToValue)
                 } yield {
                   val variantGetter =
                     if (famArities.forall(_ == 0)) "get_variant_value"
@@ -812,7 +812,7 @@ class ClangGen[K](ns: CompilationNamespace[K]) {
                     Code.Switch(
                       variantName,
                       caseBlocks,
-                      Code.block(resultName := defaultVL, Code.Break)
+                      defaultVL.map(v => Code.block(resultName := v, Code.Break))
                     )
 
                   Code.WithValue(

--- a/core/src/main/scala/dev/bosatsu/codegen/clang/Code.scala
+++ b/core/src/main/scala/dev/bosatsu/codegen/clang/Code.scala
@@ -478,7 +478,7 @@ object Code {
   case class Switch(
       on: Expression,
       cases: NonEmptyList[(IntLiteral, Block)],
-      default: Block
+      default: Option[Block]
   ) extends Statement
   case object Break extends Statement
   case class Effect(expr: Expression) extends Statement
@@ -790,10 +790,11 @@ object Code {
         val caseDocs = cases.toList.map { case (value, body) =>
           caseDoc + toDoc(value) + colon + Doc.space + toDoc(body)
         }
-        val defaultCaseDoc =
-          defaultDoc + colon + Doc.space + toDoc(defaultCase)
+        val defaultCaseDoc = defaultCase.map { block =>
+          defaultDoc + colon + Doc.space + toDoc(block)
+        }
         switchDoc + Doc.space + par(toDoc(on)) + Doc.space + curlyBlock(
-          caseDocs :+ defaultCaseDoc
+          defaultCaseDoc.fold(caseDocs)(caseDocs :+ _)
         )(identity)
       case _: Break.type =>
         breakSemi

--- a/core/src/main/scala/dev/bosatsu/codegen/python/PythonGen.scala
+++ b/core/src/main/scala/dev/bosatsu/codegen/python/PythonGen.scala
@@ -2912,7 +2912,7 @@ object PythonGen {
               cases.traverse { case (variant, branch) =>
                 loop(branch, slotName, inlineSlots).map((variant, _))
               },
-              loop(default, slotName, inlineSlots)
+              default.traverse(loop(_, slotName, inlineSlots))
             ).flatMapN { (onValue, caseValues, defaultValue) =>
               Env.onLastM(onValue) { onExpr =>
                 for {
@@ -2929,8 +2929,8 @@ object PythonGen {
                       resultName := branchValue
                     )
                   }
-                  val defaultAssign = resultName := defaultValue
-                  val dispatchStmt = Code.ifStatement(conds, Some(defaultAssign))
+                  val defaultAssign = defaultValue.map(resultName := _)
+                  val dispatchStmt = Code.ifStatement(conds, defaultAssign)
 
                   // Keep this assignment as a real statement so branch conditions
                   // reuse one cached tag instead of re-reading the scrutinee.

--- a/core/src/test/scala/dev/bosatsu/Issue1633Test.scala
+++ b/core/src/test/scala/dev/bosatsu/Issue1633Test.scala
@@ -132,7 +132,7 @@ main = parse_value(" null")
         case Matchless.SwitchVariant(on, _, cases, default) =>
           loopExpr(on) || cases.exists { case (_, branch) =>
             loopExpr(branch)
-          } || loopExpr(default)
+          } || default.exists(loopExpr)
         case Matchless.Always(cond, thenExpr) =>
           loopBool(cond) || loopExpr(thenExpr)
         case Matchless.PrevNat(of) =>

--- a/core/src/test/scala/dev/bosatsu/MatchlessRegressionTest.scala
+++ b/core/src/test/scala/dev/bosatsu/MatchlessRegressionTest.scala
@@ -164,7 +164,7 @@ class MatchlessRegressionTest extends munit.FunSuite {
           loopExpr(on, activeRecNames) + cases.iterator.map {
             case (_, branch) =>
               loopExpr(branch, activeRecNames)
-          }.sum + loopExpr(default, activeRecNames)
+          }.sum + default.fold(0)(loopExpr(_, activeRecNames))
         case Matchless.Always(cond, thenExpr) =>
           loopBool(cond, activeRecNames) + loopExpr(thenExpr, activeRecNames)
         case Matchless.PrevNat(of) =>
@@ -352,7 +352,7 @@ def branch_blowup(args: L) -> Nat:
             3 -> Matchless.Literal(Lit(30)),
             4 -> Matchless.Literal(Lit(40))
           ),
-          Matchless.Literal(Lit(99))
+          Some(Matchless.Literal(Lit(99)))
         )
       )
 

--- a/core/src/test/scala/dev/bosatsu/MatchlessTests.scala
+++ b/core/src/test/scala/dev/bosatsu/MatchlessTests.scala
@@ -115,7 +115,7 @@ class MatchlessTest extends munit.ScalaCheckSuite {
       case Matchless.SwitchVariant(on, _, cases, default) =>
         exprBoolSubexpressions(on) ++ cases.toList.flatMap { case (_, branch) =>
           exprBoolSubexpressions(branch)
-        } ++ exprBoolSubexpressions(default)
+        } ++ default.toList.flatMap(exprBoolSubexpressions)
       case Matchless.Always(cond, thenExpr) =>
         boolSubexpressions(cond) ++ exprBoolSubexpressions(thenExpr)
       case Matchless.PrevNat(of) =>
@@ -144,7 +144,7 @@ class MatchlessTest extends munit.ScalaCheckSuite {
         case switch @ Matchless.SwitchVariant(on, _, cases, default) =>
           switch :: (loopExpr(on) ++ cases.toList.flatMap { case (_, branch) =>
             loopExpr(branch)
-          } ++ loopExpr(default))
+          } ++ default.toList.flatMap(loopExpr))
         case Matchless.Always(cond, thenExpr) =>
           loopBool(cond) ++ loopExpr(thenExpr)
         case Matchless.PrevNat(of) =>
@@ -365,7 +365,7 @@ class MatchlessTest extends munit.ScalaCheckSuite {
           cases.toList.foreach { case (_, branch) =>
             loopExpr(branch)
           }
-          loopExpr(default)
+          default.foreach(loopExpr)
         case Matchless.Always(cond, thenExpr) =>
           loopBool(cond)
           loopExpr(thenExpr)
@@ -460,7 +460,7 @@ class MatchlessTest extends munit.ScalaCheckSuite {
         case Matchless.SwitchVariant(on, _, cases, default) =>
           loopCheap(on) + cases.iterator.map { case (_, branch) =>
             loopExpr(branch)
-          }.sum + loopExpr(default)
+          }.sum + default.fold(0)(loopExpr)
         case Matchless.Always(cond, thenExpr) =>
           loopBool(cond) + loopExpr(thenExpr)
         case Matchless.PrevNat(of) =>
@@ -557,7 +557,7 @@ class MatchlessTest extends munit.ScalaCheckSuite {
           loopCheap(on, inConditionalBranch) || cases.exists {
             case (_, branch) =>
               loopExpr(branch, inConditionalBranch = true)
-          } || loopExpr(default, inConditionalBranch = true)
+          } || default.exists(loopExpr(_, inConditionalBranch = true))
         case Matchless.Always(cond, thenExpr) =>
           loopBool(cond, inConditionalBranch) || loopExpr(
             thenExpr,
@@ -634,7 +634,7 @@ class MatchlessTest extends munit.ScalaCheckSuite {
         case Matchless.SwitchVariant(on, _, cases, default) =>
           loopCheap(on) + cases.iterator.map { case (_, branch) =>
             loopExpr(branch)
-          }.sum + loopExpr(default)
+          }.sum + default.fold(0)(loopExpr)
         case Matchless.Always(cond, thenExpr) =>
           loopBool(cond) + loopExpr(thenExpr)
         case Matchless.PrevNat(of) =>
@@ -719,7 +719,7 @@ class MatchlessTest extends munit.ScalaCheckSuite {
             }.collectFirst {
               case Some(found) => found
             }
-          }.orElse(loop(default))
+          }.orElse(default.flatMap(loop))
         case Matchless.Always(_, thenExpr) =>
           loop(thenExpr)
         case Matchless.PrevNat(of) =>
@@ -1025,7 +1025,7 @@ main = select
           case Matchless.SwitchVariant(on, _, cases, default) =>
             loopCheap(on) + cases.iterator.map { case (_, branch) =>
               loopExpr(branch)
-            }.sum + loopExpr(default)
+            }.sum + default.fold(0)(loopExpr)
           case Matchless.Always(cond, thenExpr) =>
             loopBool(cond) + loopExpr(thenExpr)
           case Matchless.PrevNat(of) =>
@@ -1268,41 +1268,6 @@ main = (cmp_guard, enum_guard)
               }
             }
 
-          def boolLiteralValue(expr: Matchless.Expr[Unit]): Option[Boolean] =
-            expr match {
-              case Matchless.MakeEnum(variant, 0, fam) if fam == (0 :: 0 :: Nil) =>
-                variant match {
-                  case 0 => Some(false)
-                  case 1 => Some(true)
-                  case _ => None
-                }
-              case Matchless.Literal(Lit.Integer(value)) =>
-                if (value == java.math.BigInteger.ONE) Some(true)
-                else if (value == java.math.BigInteger.ZERO) Some(false)
-                else None
-              case _ =>
-                None
-            }
-
-          def hasSwitchSelector(
-              switches: List[Matchless.SwitchVariant[Unit]],
-              trueVariants: Set[Int],
-              famArities: List[Int]
-          ): Boolean =
-            switches.exists { sw =>
-              val defaultBool = boolLiteralValue(sw.default)
-              (sw.famArities == famArities) &&
-              trueVariants.forall { variant =>
-                sw.cases.toList
-                  .collectFirst { case (`variant`, branch) =>
-                    boolLiteralValue(branch)
-                  }
-                  .flatten
-                  .orElse(defaultBool)
-                  .contains(true)
-              }
-            }
-
           val allExprs = byName.values.toList
           val allBools = allExprs.flatMap(exprBoolSubexpressions)
           val allSwitches = allExprs.flatMap(exprSwitchSubexpressions)
@@ -1316,11 +1281,10 @@ main = (cmp_guard, enum_guard)
               allBools,
               0 :: 2 :: 4 :: Nil,
               0 :: 0 :: 0 :: 0 :: 0 :: Nil
-            ) || hasSwitchSelector(
-              allSwitches,
-              Set(0, 2, 4),
-              0 :: 0 :: 0 :: 0 :: 0 :: Nil
-            ),
+            ) || allSwitches.exists { sw =>
+              (sw.famArities == (0 :: 0 :: 0 :: 0 :: 0 :: Nil)) &&
+              (sw.cases.map(_._1).toList.toSet == Set(0, 1, 2, 3, 4))
+            },
             s"expected A|C|E selector checks in lowered guards, got bools=$allBools switches=$allSwitches"
           )
         }
@@ -1365,7 +1329,7 @@ main = (cmp_guard, enum_guard)
           0 -> Matchless.Local(Identifier.Name("f0")),
           1 -> Matchless.Local(Identifier.Name("f1"))
         ),
-        Matchless.Local(Identifier.Name("fdef"))
+        Some(Matchless.Local(Identifier.Name("fdef")))
       )
 
     val pushed =
@@ -1381,7 +1345,7 @@ main = (cmp_guard, enum_guard)
           }
         }
         default match {
-          case Matchless.App(_, args) =>
+          case Some(Matchless.App(_, args)) =>
             assertEquals(args.length, 1)
           case other =>
             fail(s"expected pushed SwitchVariant default App, found: $other")
@@ -1403,7 +1367,7 @@ main = (cmp_guard, enum_guard)
             0 -> Matchless.ClosureSlot(0),
             1 -> Matchless.Local(argName)
           ),
-          Matchless.ClosureSlot(0)
+          Some(Matchless.ClosureSlot(0))
         )
       )
     val betaReduced =
@@ -1421,7 +1385,7 @@ main = (cmp_guard, enum_guard)
           0 -> Matchless.Literal(Lit.fromInt(0)),
           1 -> Matchless.Literal(Lit.fromInt(1))
         ),
-        Matchless.Literal(Lit.fromInt(2))
+        Some(Matchless.Literal(Lit.fromInt(2)))
       )
     val switchB: Matchless.Expr[Unit] =
       Matchless.SwitchVariant(
@@ -1431,7 +1395,7 @@ main = (cmp_guard, enum_guard)
           0 -> Matchless.Literal(Lit.fromInt(0)),
           1 -> Matchless.Literal(Lit.fromInt(1))
         ),
-        Matchless.Literal(Lit.fromInt(3))
+        Some(Matchless.Literal(Lit.fromInt(3)))
       )
 
     assertNotEquals(Matchless.Expr.exprOrder[Unit].compare(switchA, switchB), 0)
@@ -1747,7 +1711,7 @@ main = (cmp_guard, enum_guard)
           cases.toList.foreach { case (_, branch) =>
             requireSubset(branch)
           }
-          requireSubset(default)
+          default.foreach(requireSubset)
         case Matchless.Always(cond, thenExpr) =>
           checkBool(cond)
           requireSubset(thenExpr)
@@ -2044,7 +2008,7 @@ main = (cmp_guard, enum_guard)
           ),
           3 -> Matchless.LocalAnon(42L)
         ),
-        Matchless.Local(target)
+        Some(Matchless.Local(target))
       )
 
     assertEquals(Matchless.Expr.containsWhileExpr(switchExpr), true)
@@ -2063,11 +2027,11 @@ main = (cmp_guard, enum_guard)
           0 -> Matchless.UnitExpr,
           1 -> Matchless.UnitExpr
         ),
-        Matchless.WhileExpr(
+        Some(Matchless.WhileExpr(
           Matchless.TrueConst,
           Matchless.GetStructElement(Matchless.LocalAnonMut(701L), 0, 1),
           Matchless.LocalAnonMut(702L)
-        )
+        ))
       )
     assertEquals(Matchless.Expr.containsWhileExpr(defaultOnlySwitch), true)
     assertEquals(Matchless.Expr.readsMutable(defaultOnlySwitch), true)
@@ -2080,7 +2044,7 @@ main = (cmp_guard, enum_guard)
             0 -> Matchless.UnitExpr,
             1 -> Matchless.UnitExpr
           ),
-          Matchless.Local(target)
+          Some(Matchless.Local(target))
         ),
         target
       ),
@@ -2095,7 +2059,7 @@ main = (cmp_guard, enum_guard)
             0 -> Matchless.UnitExpr,
             1 -> Matchless.UnitExpr
           ),
-          Matchless.LocalAnon(42L)
+          Some(Matchless.LocalAnon(42L))
         ),
         42L
       ),
@@ -2110,11 +2074,11 @@ main = (cmp_guard, enum_guard)
             0 -> Matchless.UnitExpr,
             1 -> Matchless.UnitExpr
           ),
-          Matchless.WhileExpr(
+          Some(Matchless.WhileExpr(
             Matchless.TrueConst,
             Matchless.UnitExpr,
             Matchless.LocalAnonMut(703L)
-          )
+          ))
         )
       ),
       true
@@ -2134,7 +2098,7 @@ main = (cmp_guard, enum_guard)
         Matchless.Local(on),
         famArities,
         NonEmptyList.of(0 -> lamA, 1 -> lamB),
-        lamA
+        Some(lamA)
       )
 
     Matchless.recoverTopLevelLambda(switchFns) match {
@@ -2588,7 +2552,7 @@ main = (cmp_guard, enum_guard)
         case Matchless.SwitchVariant(on, _, cases, default) =>
           hasNestedProjectionCheap(on) || cases.exists { case (_, branch) =>
             hasNestedProjectionExpr(branch)
-          } || hasNestedProjectionExpr(default)
+          } || default.exists(hasNestedProjectionExpr)
         case Matchless.Always(cond, thenExpr) =>
           hasNestedProjectionBool(cond) || hasNestedProjectionExpr(thenExpr)
         case Matchless.PrevNat(of) =>
@@ -2809,7 +2773,7 @@ def pick(v):
         Matchless.Local(Identifier.Name("x")),
         0 :: 0 :: Nil,
         NonEmptyList.one(0 -> Matchless.Literal(Lit.fromInt(1))),
-        Matchless.Literal(Lit.fromInt(0))
+        Some(Matchless.Literal(Lit.fromInt(0)))
       )
     }
   }

--- a/core/src/test/scala/dev/bosatsu/codegen/clang/ClangGenTest.scala
+++ b/core/src/test/scala/dev/bosatsu/codegen/clang/ClangGenTest.scala
@@ -480,7 +480,7 @@ def pick(v):
     case F: 5
     case G: 6
     case H: 7
-    case _: 8
+    case I: 8
 
 main = pick
 """) { pm =>
@@ -500,7 +500,7 @@ main = pick
           assert(rendered.contains("switch ("), rendered)
           assert(rendered.contains("case 0:"), rendered)
           assert(rendered.contains("case 7:"), rendered)
-          assert(rendered.contains("default:"), rendered)
+          assertEquals(rendered.contains("default:"), false, rendered)
           assert(rendered.contains("break;"), rendered)
       }
     }
@@ -521,7 +521,7 @@ def pick(v):
     case B: 1
     case C: 2
     case D: 3
-    case _: 4
+    case E: 4
 
 main = pick
 """) { pm =>

--- a/core/src/test/scala/dev/bosatsu/codegen/clang/CodeTest.scala
+++ b/core/src/test/scala/dev/bosatsu/codegen/clang/CodeTest.scala
@@ -118,7 +118,7 @@ class CodeTest extends munit.FunSuite {
           IntLiteral(0) -> block(Ident("x") := IntLiteral(1), Break),
           IntLiteral(2) -> block(Ident("x") := IntLiteral(3), Break)
         ),
-        block(Ident("x") := IntLiteral(4), Break)
+        Some(block(Ident("x") := IntLiteral(4), Break))
       ),
       "switch (tag) {\n" +
         "    case 0: {\n" +
@@ -131,6 +131,20 @@ class CodeTest extends munit.FunSuite {
         "    }\n" +
         "    default: {\n" +
         "        x = 4;\n" +
+        "        break;\n" +
+        "    }\n" +
+        "}"
+    )
+    checkCode(
+      Switch(
+        Ident("tag"),
+        NonEmptyList.of(
+          IntLiteral(0) -> block(Break)
+        ),
+        None
+      ),
+      "switch (tag) {\n" +
+        "    case 0: {\n" +
         "        break;\n" +
         "    }\n" +
         "}"

--- a/core/src/test/scala/dev/bosatsu/codegen/python/PythonGenTest.scala
+++ b/core/src/test/scala/dev/bosatsu/codegen/python/PythonGenTest.scala
@@ -229,7 +229,7 @@ class PythonGenTest extends munit.ScalaCheckSuite {
           3 -> Matchless.Literal(Lit(3)),
           4 -> Matchless.Literal(Lit(4))
         ),
-        Matchless.Literal(Lit(0))
+        Some(Matchless.Literal(Lit(0)))
       )
     val mainExpr: Matchless.Expr[Unit] =
       Matchless.Lambda(Nil, None, NonEmptyList.one(arg), body)


### PR DESCRIPTION
Implemented issue #2059 per the design doc.

What changed:
- Added `Matchless.SwitchVariant(on, famArities, cases, default)` with constructor invariants (distinct/in-range variants, >=2 cases) in `core/src/main/scala/dev/bosatsu/Matchless.scala`.
- Updated exhaustive Matchless traversals/utilities to handle `SwitchVariant` (ordering/tags, side-effect checks, name/reference analysis, `applyArgs`, lambda arity recovery, substitution, optimization traversals, loop-tail rewriting helpers).
- Added matrix-time switch emission in `matchExprMatrixCheap` with `SwitchVariantMinCases = 4` and eligibility checks:
  - selected column signatures are enum-only,
  - shared `famArities`,
  - fanout >= 4.
- Kept non-eligible paths on existing ordered/if lowering.
- Extended selector guard recovery to understand `SwitchVariant` shape for boolified selector guards.
- Added evaluator support in `core/src/main/scala/dev/bosatsu/MatchlessToValue.scala` (evaluate scrutinee once, dispatch by variant, fallback to default).
- Added C AST support in `core/src/main/scala/dev/bosatsu/codegen/clang/Code.scala`:
  - new `Code.Switch` statement,
  - new `Code.Break` statement,
  - renderer support.
- Added Clang lowering in `core/src/main/scala/dev/bosatsu/codegen/clang/ClangGen.scala`:
  - compute variant tag once (`get_variant_value` for all-zero fams, else `get_variant`),
  - emit switch cases/default assigning one result temp.
- Added Python lowering in `core/src/main/scala/dev/bosatsu/codegen/python/PythonGen.scala`:
  - compute/caches variant tag once,
  - emit if/elif dispatch assigning one result temp,
  - return that result.

Tests updated:
- `MatchlessTests.scala`: recursion helpers updated for new node; added switch formation tests (>=4 emits switch, union-case behavior preserved, below-threshold stays non-switch), and guard-coverage compatibility for switch-shaped selectors.
- `MatchlessRegressionTest.scala`: added evaluator test for `SwitchVariant` case/default behavior.
- `Issue1633Test.scala`: traversal helper updated for `SwitchVariant`.
- `codegen/clang/CodeTest.scala`: switch/break rendering test.
- `codegen/clang/ClangGenTest.scala`: wide-enum match emits C `switch`/`case`/`default`.
- `codegen/python/PythonGenTest.scala`: switch lowering caches tag once and reuses in comparisons.

Validation run:
- `sbt "coreJVM/test:compile"`
- `sbt "coreJVM/testOnly dev.bosatsu.MatchlessTest"`
- `sbt "coreJVM/testOnly dev.bosatsu.MatchlessRegressionTest dev.bosatsu.Issue1633Test dev.bosatsu.MatchlessApplyArgsTest dev.bosatsu.codegen.clang.CodeTest dev.bosatsu.codegen.clang.ClangGenTest dev.bosatsu.codegen.python.PythonGenTest"`
- Required pre-push: `scripts/test_basic.sh` (passed)

Fixes #2059

Implements design doc: [docs/design/2059-add-a-switchvariant-expression-to-matchless.md](https://github.com/johnynek/bosatsu/blob/main/docs/design/2059-add-a-switchvariant-expression-to-matchless.md)

Design source PR: https://github.com/johnynek/bosatsu/pull/2061