### PR TITLE
Add `toIfElse` on `Matchless.SwitchVariant` and use it in Python codegen

### DIFF
--- a/core/src/main/scala/dev/bosatsu/Matchless.scala
+++ b/core/src/main/scala/dev/bosatsu/Matchless.scala
@@ -1975,6 +1975,49 @@ object Matchless {
       caseVariants.forall(v => (0 <= v) && (v < familySize)),
       s"SwitchVariant variants must be in [0, $familySize), found: $caseVariants"
     )
+
+    def toIfElse: Expr[A] = {
+      val caseMap = cases.toList.toMap
+      // A missing case without default is unreachable in well-typed lowered matches.
+      // Keep this total by reusing one branch if such a gap remains.
+      val fallbackExpr = default.getOrElse(cases.head._2)
+      val variantBranches = Vector.tabulate(familySize) { variant =>
+        caseMap.getOrElse(variant, fallbackExpr)
+      }
+
+      def sameExpr(from: Int, until: Int): Option[Expr[A]] = {
+        val first = variantBranches(from)
+        var idx = from + 1
+        var isSame = true
+        while (isSame && (idx < until)) {
+          isSame = first.equals(variantBranches(idx))
+          idx = idx + 1
+        }
+        if (isSame) Some(first) else None
+      }
+
+      def build(from: Int, until: Int): Expr[A] =
+        sameExpr(from, until) match {
+          case Some(single) =>
+            single
+          case None         =>
+            val split = from + ((until - from) / 2)
+            val left = build(from, split)
+            val right = build(split, until)
+            if (left.equals(right)) left
+            else {
+              val leftVariants =
+                NonEmptyList.fromListUnsafe((from until split).toList)
+              If(
+                CheckVariantSet(on, leftVariants, 0, famArities),
+                left,
+                right
+              )
+            }
+        }
+
+      build(0, familySize)
+    }
   }
   case class Always[A](cond: BoolExpr[A], thenExpr: Expr[A]) extends Expr[A]
   object Always {

--- a/core/src/main/scala/dev/bosatsu/codegen/python/PythonGen.scala
+++ b/core/src/main/scala/dev/bosatsu/codegen/python/PythonGen.scala
@@ -2906,43 +2906,8 @@ object PythonGen {
             (ifsV, loop(last, slotName, inlineSlots)).mapN { (ifs, elseV) =>
               Env.ifElse(ifs, elseV)
             }.flatten
-          case SwitchVariant(on, famArities, cases, default) =>
-            (
-              loop(on, slotName, inlineSlots),
-              cases.traverse { case (variant, branch) =>
-                loop(branch, slotName, inlineSlots).map((variant, _))
-              },
-              default.traverse(loop(_, slotName, inlineSlots))
-            ).flatMapN { (onValue, caseValues, defaultValue) =>
-              Env.onLastM(onValue) { onExpr =>
-                for {
-                  variantName <- Env.newAssignableVar
-                  resultName <- Env.newAssignableVar
-                } yield {
-                  val variantExpr =
-                    if (famArities.forall(_ == 0)) onExpr
-                    else onExpr.get(0)
-
-                  val conds = caseValues.map { case (variant, branchValue) =>
-                    (
-                      (variantName =:= Code.fromInt(variant)).simplify,
-                      resultName := branchValue
-                    )
-                  }
-                  val defaultAssign = defaultValue.map(resultName := _)
-                  val dispatchStmt = Code.ifStatement(conds, defaultAssign)
-
-                  // Keep this assignment as a real statement so branch conditions
-                  // reuse one cached tag instead of re-reading the scrutinee.
-                  Code
-                    .block(
-                      variantName := Code.Parens(variantExpr),
-                      dispatchStmt
-                    )
-                    .withValue(resultName)
-                }
-              }
-            }
+          case switch @ SwitchVariant(_, _, _, _) =>
+            loop(switch.toIfElse, slotName, inlineSlots)
 
           case Always.SetChain(setmuts, result) =>
             (

--- a/core/src/test/scala/dev/bosatsu/MatchlessRegressionTest.scala
+++ b/core/src/test/scala/dev/bosatsu/MatchlessRegressionTest.scala
@@ -335,25 +335,34 @@ def branch_blowup(args: L) -> Nat:
     assertEquals(evaluated, Vector(Value.VInt(1), Value.VInt(0)))
   }
 
-  test("MatchlessToValue evaluates SwitchVariant cases and default") {
+  test("SwitchVariant.toIfElse preserves MatchlessToValue semantics") {
     val famArities = 0 :: 0 :: 0 :: 0 :: 0 :: Nil
     val arg = Identifier.Name("v")
+    val switchBody: Matchless.SwitchVariant[Unit] =
+      Matchless.SwitchVariant(
+        Matchless.Local(arg),
+        famArities,
+        NonEmptyList.of(
+          0 -> Matchless.Literal(Lit(10)),
+          2 -> Matchless.Literal(Lit(20)),
+          3 -> Matchless.Literal(Lit(30)),
+          4 -> Matchless.Literal(Lit(40))
+        ),
+        Some(Matchless.Literal(Lit(99)))
+      )
     val switchExpr: Matchless.Expr[Unit] =
       Matchless.Lambda(
         Nil,
         None,
         NonEmptyList.one(arg),
-        Matchless.SwitchVariant(
-          Matchless.Local(arg),
-          famArities,
-          NonEmptyList.of(
-            0 -> Matchless.Literal(Lit(10)),
-            2 -> Matchless.Literal(Lit(20)),
-            3 -> Matchless.Literal(Lit(30)),
-            4 -> Matchless.Literal(Lit(40))
-          ),
-          Some(Matchless.Literal(Lit(99)))
-        )
+        switchBody
+      )
+    val ifElseExpr: Matchless.Expr[Unit] =
+      Matchless.Lambda(
+        Nil,
+        None,
+        NonEmptyList.one(arg),
+        switchBody.toIfElse
       )
 
     val evalExprs = Vector(
@@ -362,8 +371,24 @@ def branch_blowup(args: L) -> Nat:
         NonEmptyList.one(Matchless.MakeEnum(2, 0, famArities))
       ),
       Matchless.App(
+        ifElseExpr,
+        NonEmptyList.one(Matchless.MakeEnum(2, 0, famArities))
+      ),
+      Matchless.App(
         switchExpr,
         NonEmptyList.one(Matchless.MakeEnum(1, 0, famArities))
+      ),
+      Matchless.App(
+        ifElseExpr,
+        NonEmptyList.one(Matchless.MakeEnum(1, 0, famArities))
+      ),
+      Matchless.App(
+        switchExpr,
+        NonEmptyList.one(Matchless.MakeEnum(4, 0, famArities))
+      ),
+      Matchless.App(
+        ifElseExpr,
+        NonEmptyList.one(Matchless.MakeEnum(4, 0, famArities))
       )
     )
 
@@ -371,6 +396,16 @@ def branch_blowup(args: L) -> Nat:
       MatchlessToValue
         .traverse(evalExprs)((_, _, _) => Eval.now(Value.UnitValue))
         .map(_.value)
-    assertEquals(evaluated, Vector(Value.VInt(20), Value.VInt(99)))
+    assertEquals(
+      evaluated,
+      Vector(
+        Value.VInt(20),
+        Value.VInt(20),
+        Value.VInt(99),
+        Value.VInt(99),
+        Value.VInt(40),
+        Value.VInt(40)
+      )
+    )
   }
 }

--- a/core/src/test/scala/dev/bosatsu/codegen/python/PythonGenTest.scala
+++ b/core/src/test/scala/dev/bosatsu/codegen/python/PythonGenTest.scala
@@ -216,7 +216,7 @@ class PythonGenTest extends munit.ScalaCheckSuite {
     }
   }
 
-  test("SwitchVariant compiles to cached-tag if/elif chain in Python") {
+  test("SwitchVariant compiles through toIfElse in Python") {
     val famArities = 0 :: 0 :: 1 :: 0 :: 0 :: Nil
     val arg = Identifier.Name("v")
     val body: Matchless.Expr[Unit] =
@@ -268,18 +268,11 @@ class PythonGenTest extends munit.ScalaCheckSuite {
       val doc = rendered(())(pn)._2
       val code = doc.render(120)
 
-      val tagAssign = "^\\s*([_A-Za-z][_A-Za-z0-9]*)\\s*=\\s*.*\\[0\\].*$".r
-      val tagAssigns = code.linesIterator.collect {
-        case tagAssign(name) => name
-      }.toList
-      assertEquals(tagAssigns.length, 1, code)
-
-      val tag = tagAssigns.head
-      assert(code.contains(s"if $tag == 0"), code)
-      assert(code.contains(s"elif $tag == 1"), code)
-      assert(code.contains(s"elif $tag == 3"), code)
-      assert(code.contains(s"elif $tag == 4"), code)
-      assert(code.contains("elif"), code)
+      assert(code.contains("[0] < 2"), code)
+      assert(code.contains("[0] < 1"), code)
+      assert(code.contains("[0] == 2"), code)
+      assert(code.contains("[0] == 3"), code)
+      assert(!code.contains("elif"), code)
     }
   }
 


### PR DESCRIPTION
Implemented `SwitchVariant.toIfElse` in `Matchless` to lower variant dispatch into a balanced `If` tree using `CheckVariantSet` splits over sorted variant ranges, with branch collapsing when all variants in a range share the same expression. Updated Python codegen to compile `SwitchVariant` via this generic lowering (`switch.toIfElse`) instead of Python-specific switch dispatch construction. Updated tests: adjusted `PythonGenTest` to assert the new comparison-based output shape, and added a regression assertion in `MatchlessRegressionTest` that `SwitchVariant.toIfElse` preserves evaluation semantics against the original `SwitchVariant`. Ran required pre-push command `scripts/test_basic.sh` successfully (all tests passed).

Fixes #2072