### PR TITLE
Add effectful Bosatsu/Prog observe blackhole across runtimes

### DIFF
--- a/c_runtime/bosatsu_ext_Bosatsu_l_Prog.c
+++ b/c_runtime/bosatsu_ext_Bosatsu_l_Prog.c
@@ -59,6 +59,22 @@ BValue ___bsts_g_Bosatsu_l_Prog_l_recover(BValue p, BValue f)
   return alloc_enum2(3, p, f);
 }
 
+static volatile BValue bsts_prog_observe_sink = (BValue)0;
+
+static BValue bsts_prog_observe_effect(BValue *slots, BValue arg)
+{
+  (void)slots;
+  bsts_prog_observe_sink = arg;
+  bsts_prog_observe_sink = bsts_unit_value();
+  return ___bsts_g_Bosatsu_l_Prog_l_pure(bsts_unit_value());
+}
+
+BValue ___bsts_g_Bosatsu_l_Prog_l_observe(BValue a)
+{
+  BValue effect_fn = alloc_closure1(0, 0, bsts_prog_observe_effect);
+  return alloc_enum2(5, a, effect_fn);
+}
+
 BValue bsts_prog_step_fix_closure(BValue *slots, BValue a)
 {
   return ___bsts_g_Bosatsu_l_Prog_l_apply__fix(a, slots[0]);

--- a/c_runtime/bosatsu_ext_Bosatsu_l_Prog.h
+++ b/c_runtime/bosatsu_ext_Bosatsu_l_Prog.h
@@ -4,6 +4,8 @@ BValue ___bsts_g_Bosatsu_l_Prog_l_apply__fix(BValue a, BValue b);
 
 BValue ___bsts_g_Bosatsu_l_Prog_l_flat__map(BValue a, BValue b);
 
+BValue ___bsts_g_Bosatsu_l_Prog_l_observe(BValue a);
+
 BValue ___bsts_g_Bosatsu_l_Prog_l_pure(BValue a);
 
 BValue ___bsts_g_Bosatsu_l_Prog_l_raise__error(BValue a);

--- a/core/src/main/scala/dev/bosatsu/Predef.scala
+++ b/core/src/main/scala/dev/bosatsu/Predef.scala
@@ -462,6 +462,11 @@ object Predef {
       )
       .add(
         progPackageName,
+        "observe",
+        FfiCall.Fn1(PredefImpl.prog_observe(_))
+      )
+      .add(
+        progPackageName,
         "apply_fix",
         FfiCall.Fn2(PredefImpl.prog_apply_fix(_, _))
       )
@@ -837,6 +842,9 @@ object PredefImpl {
   private val ProgTagRecover = 3
   private val ProgTagApplyFix = 4
   private val ProgTagEffect = 5
+  // Atomic writes provide a backend-side consume barrier for benchmark values.
+  private val observedProgValueSink: AtomicReference[Value] =
+    new AtomicReference(UnitValue)
 
   private val IOErrorTagInvalidArgument = 12
   private val IOErrorTagInvalidUtf8 = 13
@@ -925,6 +933,17 @@ object PredefImpl {
 
   def prog_apply_fix(a: Value, fn: Value): Value =
     SumValue(ProgTagApplyFix, ProductValue.fromList(a :: fn :: Nil))
+
+  def prog_observe(a: Value): Value =
+    prog_effect(
+      a,
+      observed => {
+        observedProgValueSink.set(observed)
+        // Clear quickly so long benchmark loops do not retain observed values.
+        observedProgValueSink.set(UnitValue)
+        prog_pure(UnitValue)
+      }
+    )
 
   private def decodeUtf8Slice(
       bytes: Array[Byte],

--- a/core/src/test/scala/dev/bosatsu/EvaluationTest.scala
+++ b/core/src/test/scala/dev/bosatsu/EvaluationTest.scala
@@ -3248,6 +3248,17 @@ tests = TestSuite("lazy eval", [
     assertEquals(recoverLeft.value.get(0), recoverArg)
   }
 
+  test("prog observe evaluates to unit and composes with flat_map") {
+    val observed = PredefImpl.prog_observe(VInt(123))
+    assertEquals(PredefImpl.runProg(observed).result, Right(UnitValue))
+
+    val continueWith = FnValue { case NonEmptyList(_, _) =>
+      PredefImpl.prog_pure(VInt(99))
+    }
+    val chained = PredefImpl.prog_flat_map(observed, continueWith)
+    assertEquals(PredefImpl.runProg(chained).result, Right(VInt(99)))
+  }
+
   if (Platform.isScalaJvm)
     test("prog and io/std externals evaluate and run recursively") {
       val progPack = Predef.loadFileInCompile("test_workspace/Prog.bosatsu")
@@ -3271,7 +3282,7 @@ external struct Bytes
       val progRunPack = """
 package ProgRun
 
-from Bosatsu/Prog import Prog, Main, pure, recover, await, recursive
+from Bosatsu/Prog import Prog, Main, pure, recover, await, recursive, observe
 from Bosatsu/IO/Std import println, print, print_err, print_errln, read_stdin_utf8_bytes
 from Bosatsu/IO/Error import IOError
 
@@ -3294,6 +3305,7 @@ main = Main(args -> (
     _ <- print_err("args=").await()
     _ <- print_errln(int_to_String(arg_count)).await()
     s <- sum_to((10000, 0)).await()
+    _ <- observe(s).await()
     _ <- println("sum=${int_to_String(s)}").await()
     pure(0)
   ).recover(_ -> pure(0))

--- a/core/src/test/scala/dev/bosatsu/ToolAndLibCommandTest.scala
+++ b/core/src/test/scala/dev/bosatsu/ToolAndLibCommandTest.scala
@@ -420,7 +420,7 @@ class ToolAndLibCommandTest extends FunSuite {
   private val minimalProgModuleSrc: String =
     """package Bosatsu/Prog
 |
-|export (unit, pure, raise_error, recover, ignore_err, await, recursive, map, map_err, Prog, Main(), ProgTest())
+|export (unit, pure, raise_error, recover, ignore_err, await, recursive, map, map_err, observe, Prog, Main(), ProgTest())
 |
 |external struct Prog[err: +*, res: +*]
 |
@@ -441,6 +441,7 @@ class ToolAndLibCommandTest extends FunSuite {
 |
 |external def apply_fix(a: a,
 |  fn: (a -> Prog[err, b]) -> (a -> Prog[err, b])) -> Prog[err, b]
+|external def observe[a](a: a) -> forall err. Prog[err, Unit]
 |
 |def await(p, fn): p.flat_map(fn)
 |
@@ -1832,6 +1833,54 @@ class ToolAndLibCommandTest extends FunSuite {
     }
   }
 
+  test("tool eval --run supports Bosatsu/Prog observe in Main") {
+    val appSrc =
+      """package Tool/ObserveMain
+|
+|from Bosatsu/Prog import Main, await, observe, pure
+|
+|main = Main(_ -> (
+|  _ <- observe((1, 2, 3)).await()
+|  pure(0)
+|))
+|""".stripMargin
+    val files = List(
+      Chain("src", "Bosatsu", "Prog.bosatsu") -> minimalProgModuleSrc,
+      Chain("src", "Tool", "ObserveMain.bosatsu") -> appSrc
+    )
+
+    val result = for {
+      s0 <- MemoryMain.State.from[ErrorOr](files)
+      s1 <- runWithStateAndExit(
+        List(
+          "tool",
+          "eval",
+          "--run",
+          "--main",
+          "Tool/ObserveMain",
+          "--package_root",
+          "src",
+          "--input",
+          "src/Bosatsu/Prog.bosatsu",
+          "--input",
+          "src/Tool/ObserveMain.bosatsu"
+        ),
+        s0
+      )
+    } yield s1
+
+    result match {
+      case Left(err) =>
+        fail(err.getMessage)
+      case Right((_, out, exitCode)) =>
+        assertEquals(exitCode, ExitCode.Success)
+        out match {
+          case Output.RunMainResult(_) => ()
+          case other                   => fail(s"unexpected output: $other")
+        }
+    }
+  }
+
   test("tool eval --run reads stdin for IO/Std read_line and read_all_stdin") {
     val ioCoreSrc =
       """package Bosatsu/IO/Core
@@ -2089,6 +2138,48 @@ class ToolAndLibCommandTest extends FunSuite {
         fail(err.getMessage)
       case Right((_, out, exitCode)) =>
         assertEquals(exitCode, ExitCode.fromInt(3))
+        out match {
+          case Output.RunMainResult(_) => ()
+          case other                   => fail(s"unexpected output: $other")
+        }
+    }
+  }
+
+  test("lib eval --run supports Bosatsu/Prog observe in Main") {
+    val appSrc =
+      """from Bosatsu/Prog import Main, await, observe, pure
+|
+|main = Main(_ -> (
+|  _ <- observe("payload").await()
+|  pure(0)
+|))
+|""".stripMargin
+    val files =
+      baseLibFiles(appSrc) :+ (
+        Chain("repo", "src", "Bosatsu", "Prog.bosatsu") -> minimalProgModuleSrc
+      )
+
+    val result = for {
+      s0 <- MemoryMain.State.from[ErrorOr](files)
+      s1 <- runWithStateAndExit(
+        List(
+          "lib",
+          "eval",
+          "--repo_root",
+          "repo",
+          "--main",
+          "MyLib/Foo",
+          "--run"
+        ),
+        s0
+      )
+    } yield s1
+
+    result match {
+      case Left(err) =>
+        fail(err.getMessage)
+      case Right((_, out, exitCode)) =>
+        assertEquals(exitCode, ExitCode.Success)
         out match {
           case Output.RunMainResult(_) => ()
           case other                   => fail(s"unexpected output: $other")

--- a/core/src/test/scala/dev/bosatsu/codegen/clang/ClangGenLibraryDepsTest.scala
+++ b/core/src/test/scala/dev/bosatsu/codegen/clang/ClangGenLibraryDepsTest.scala
@@ -199,4 +199,89 @@ class ClangGenLibraryDepsTest extends munit.FunSuite {
       }
     }
   }
+
+  test("clang gen includes Bosatsu/Prog observe external when referenced") {
+    val predefIface = Package.interfaceOf(PackageMap.predefCompiled)
+
+    val progSrc =
+      """package Bosatsu/Prog
+        |
+        |export Prog(), ProgTest(), pure, observe, await
+        |
+        |external struct Prog[e: +*, a: +*]
+        |
+        |external def pure[a](a: a) -> forall e. Prog[e, a]
+        |external def flat_map[e, a, b](prog: Prog[e, a], fn: a -> Prog[e, b]) -> Prog[e, b]
+        |external def observe[a](a: a) -> forall e. Prog[e, Unit]
+        |
+        |def await(p, fn): p.flat_map(fn)
+        |
+        |struct ProgTest(test_fn: List[String] -> Prog[String, Test])
+        |""".stripMargin
+
+    val progPm = typeCheck(progSrc, predefIface :: Nil)
+    val progPack = progPm.toMap(PackageName.parts("Bosatsu", "Prog"))
+    val progIface = Package.interfaceOf(progPack)
+
+    val rootSrc =
+      """package Root/Main
+        |
+        |from Bosatsu/Prog import ProgTest, pure, observe, await
+        |
+        |tests = ProgTest(_ ->
+        |  observe("probe").await(_ -> pure(Assertion(True, "ok")))
+        |)
+        |""".stripMargin
+
+    val rootPm = typeCheck(rootSrc, predefIface :: progIface :: Nil)
+
+    val progVersion = Version(1, 0, 0)
+    val rootVersion = Version(1, 0, 0)
+
+    val progLib = DecodedLibrary[Algo.Blake3](
+      name = Name("prog"),
+      version = progVersion,
+      hashValue = HashValue[Algo.Blake3]("00"),
+      protoLib = proto.Library(
+        name = "prog",
+        descriptor =
+          Some(proto.LibDescriptor(version = Some(progVersion.toProto)))
+      ),
+      interfaces = progIface :: Nil,
+      implementations = progPm
+    )
+
+    val rootLib = DecodedLibrary[Algo.Blake3](
+      name = Name("root"),
+      version = rootVersion,
+      hashValue = HashValue[Algo.Blake3]("00"),
+      protoLib = proto.Library(
+        name = "root",
+        descriptor =
+          Some(proto.LibDescriptor(version = Some(rootVersion.toProto)))
+      ),
+      interfaces = Nil,
+      implementations = rootPm
+    )
+
+    val progDl = DecodedLibraryWithDeps(progLib, SortedMap.empty)
+    val rootDl =
+      DecodedLibraryWithDeps(
+        rootLib,
+        SortedMap(progDl.nameVersion -> progDl)
+      )
+
+    Par.withEC {
+      val values = rootDl.lib.implementations.testEntries.toList.collect {
+        case (pn, Right(entry)) => (pn, entry)
+      }.sortBy(_._1)
+      ClangGen(rootDl).renderTests(values) match {
+        case Right(doc) =>
+          val rendered = doc.render(120)
+          assert(rendered.contains("___bsts_g_Bosatsu_l_Prog_l_observe"), rendered)
+        case Left(err) =>
+          fail(err.display.render(80))
+      }
+    }
+  }
 }

--- a/docs/src/main/paradox/language_guide.md
+++ b/docs/src/main/paradox/language_guide.md
@@ -1018,6 +1018,14 @@ You can think of Bosatsu as a pure language for constructing executable programs
 with effects at the boundary. The goal is practical usability with strong safety:
 if pieces typecheck, they can be composed with confidence.
 
+For benchmarks, `Bosatsu/Prog` also exposes:
+
+1. `observe[a](a: a) -> forall err. Prog[err, Unit]`
+
+`observe` is an effectful consume barrier. It only runs when sequenced into an
+executed `Prog` (for example inside `Main` or `ProgTest` via `await`/`flat_map`).
+If you call `observe` but never execute that `Prog`, it has no effect.
+
 ## External functions and values
 There is syntax for declaring external values and functions, but regular Bosatsu
 library code cannot define new externals today.

--- a/test_workspace/Prog.bosatsu
+++ b/test_workspace/Prog.bosatsu
@@ -1,6 +1,6 @@
 package Bosatsu/Prog
 
-export (unit, pure, raise_error, recover, ignore_err, await, recursive, map, map_err, Prog, Main(), ProgTest())
+export (unit, pure, raise_error, recover, ignore_err, await, recursive, map, map_err, observe, Prog, Main(), ProgTest())
 
 external struct Prog[err: +*, res: +*]
 
@@ -21,6 +21,7 @@ def ignore_err[err, res](prog: Prog[err, res], default: res) -> forall e. Prog[e
 
 external def apply_fix(a: a,
   fn: (a -> Prog[err, b]) -> (a -> Prog[err, b])) -> Prog[err, b]
+external def observe[a](a: a) -> forall err. Prog[err, Unit]
 
 def await(p, fn): p.flat_map(fn)
 

--- a/test_workspace/Prog.bosatsu_externals
+++ b/test_workspace/Prog.bosatsu_externals
@@ -4,6 +4,7 @@
     raise_error: ProgExt.raise_error,
     flat_map: ProgExt.flat_map,
     recover: ProgExt.recover,
+    observe: ProgExt.observe,
     apply_fix: ProgExt.apply_fix
   },
   Bosatsu/IO/Core: {

--- a/test_workspace/ProgExt.py
+++ b/test_workspace/ProgExt.py
@@ -36,6 +36,15 @@ def apply_fix(a, f): return (4, a, f)
 def effect(f): return (5, f)
 
 _pure_unit = pure(())
+_observe_sink = ()
+
+def observe(value):
+  def fn():
+    global _observe_sink
+    _observe_sink = value
+    _observe_sink = ()
+    return _pure_unit
+  return effect(fn)
 
 _IOERR_NOT_FOUND = 0
 _IOERR_ACCESS_DENIED = 1

--- a/test_workspace/core_alpha_conf.json
+++ b/test_workspace/core_alpha_conf.json
@@ -1,7 +1,7 @@
 {
   "name": "core_alpha",
   "repo_uri": "https://github.com/johnynek/bosatsu.git",
-  "next_version": "4.2.8",
+  "next_version": "4.3.0",
   "previous": {
       "version": "4.2.7",
       "hashes": [ "blake3:14bd2ea640dd07e26daf4250fdd744575be9594b526535296ec31794b315336f" ],


### PR DESCRIPTION
Implemented issue #2084 per the merged design doc.
- Added `observe` to `Bosatsu/Prog` (`test_workspace/Prog.bosatsu`) with signature `external def observe[a](a: a) -> forall err. Prog[err, Unit]`.
- JVM evaluator: wired `Bosatsu/Prog::observe` in `core/src/main/scala/dev/bosatsu/Predef.scala` and added `PredefImpl.prog_observe` as a `Prog` effect that writes to an atomic sink, clears it, then returns `Pure(())`.
- C runtime: added declaration/definition for `___bsts_g_Bosatsu_l_Prog_l_observe` in `c_runtime/bosatsu_ext_Bosatsu_l_Prog.h/.c`, implemented as effect tag 5 with volatile sink + `Pure(())` callback result.
- Python runtime: added `ProgExt.observe` in `test_workspace/ProgExt.py` and mapped it in `test_workspace/Prog.bosatsu_externals`.
- Tests/docs: updated `core/src/test/scala/dev/bosatsu/EvaluationTest.scala`, `core/src/test/scala/dev/bosatsu/ToolAndLibCommandTest.scala`, and `core/src/test/scala/dev/bosatsu/codegen/clang/ClangGenLibraryDepsTest.scala`; documented observe sequencing requirements in `docs/src/main/paradox/language_guide.md`.
- Versioning: bumped `test_workspace/core_alpha_conf.json` `next_version` to `4.3.0` to satisfy API-diff version gating for the new exported binding.

Validation:
- `sbt "coreJVM/testOnly dev.bosatsu.EvaluationTest dev.bosatsu.ToolAndLibCommandTest dev.bosatsu.codegen.clang.ClangGenLibraryDepsTest"` passed.
- Required pre-push command `scripts/test_basic.sh` passed.
- `make -C c_runtime PROFILE=debug` passed.

Fixes #2084

Implements design doc: [docs/design/2084-design-a-benchmarking-blackhole-function.md](https://github.com/johnynek/bosatsu/blob/main/docs/design/2084-design-a-benchmarking-blackhole-function.md)

Design source PR: https://github.com/johnynek/bosatsu/pull/2086