### PR TITLE
Fix #2087: preserve Unit-thunk laziness across normalization

### DIFF
--- a/core/src/main/scala/dev/bosatsu/TypedExprNormalization.scala
+++ b/core/src/main/scala/dev/bosatsu/TypedExprNormalization.scala
@@ -67,6 +67,16 @@ object TypedExprNormalization {
     if (r.isRecursive) (Some(b), scope - b)
     else (None, scope)
 
+  private def isSuspensionLambdaArgs(
+      args: NonEmptyList[(Bindable, Type)]
+  ): Boolean =
+    args match {
+      case NonEmptyList((_, argTpe), Nil) =>
+        Type.normalize(argTpe).sameAs(Type.UnitType)
+      case _ =>
+        false
+    }
+
   // Share repeated immutable values within a lexical scope by introducing
   // non-recursive lets. This is conservative:
   // - only immutable expression forms (no Let/Loop/Recur/Match)
@@ -132,49 +142,65 @@ object TypedExprNormalization {
     def collect(
         expr: TypedExpr[A],
         blocked: Set[Bindable],
-        blockedTy: Set[TyBound]
+        blockedTy: Set[TyBound],
+        inSuspension: Boolean
     ): Unit = {
-      if (isShareable(expr) && !readsBlocked(expr, blocked, blockedTy))
+      if (
+        !inSuspension && isShareable(expr) && !readsBlocked(
+          expr,
+          blocked,
+          blockedTy
+        )
+      )
         addCandidate(expr)
 
       expr match {
         case Generic(quant, in) =>
           val blockedTy1 = blockedTy ++ quant.vars.iterator.map(_._1)
-          collect(in, blocked, blockedTy1)
+          collect(in, blocked, blockedTy1, inSuspension)
         case Annotation(in, _, _) =>
-          collect(in, blocked, blockedTy)
+          collect(in, blocked, blockedTy, inSuspension)
         case AnnotatedLambda(args, body, _) =>
-          collect(body, blocked ++ args.iterator.map(_._1), blockedTy)
+          // Unit -> a lambdas are suspension boundaries: don't hoist work out.
+          val inSuspension1 = inSuspension || isSuspensionLambdaArgs(args)
+          collect(
+            body,
+            blocked ++ args.iterator.map(_._1),
+            blockedTy,
+            inSuspension1
+          )
         case App(fn, args, _, _) =>
-          collect(fn, blocked, blockedTy)
-          args.iterator.foreach(collect(_, blocked, blockedTy))
+          collect(fn, blocked, blockedTy, inSuspension)
+          args.iterator.foreach(collect(_, blocked, blockedTy, inSuspension))
         case Let(arg, expr1, in, rec, _) =>
           val blockedExpr =
             if (rec.isRecursive) blocked + arg
             else blocked
-          collect(expr1, blockedExpr, blockedTy)
-          collect(in, blocked + arg, blockedTy)
+          collect(expr1, blockedExpr, blockedTy, inSuspension)
+          collect(in, blocked + arg, blockedTy, inSuspension)
         case Loop(args, body, _) =>
           val blockedLoop = blocked ++ args.iterator.map(_._1)
           args.iterator.foreach { case (_, initExpr) =>
-            collect(initExpr, blockedLoop, blockedTy)
+            collect(initExpr, blockedLoop, blockedTy, inSuspension)
           }
-          collect(body, blockedLoop, blockedTy)
+          collect(body, blockedLoop, blockedTy, inSuspension)
         case Recur(args, _, _) =>
-          args.iterator.foreach(collect(_, blocked, blockedTy))
+          args.iterator.foreach(collect(_, blocked, blockedTy, inSuspension))
         case Match(arg, branches, _) =>
-          collect(arg, blocked, blockedTy)
+          collect(arg, blocked, blockedTy, inSuspension)
           branches.iterator.foreach { case Branch(pat, guard, branchExpr) =>
             val blockedBranch = blocked ++ pat.names
-            guard.iterator.foreach(collect(_, blockedBranch, blockedTy))
-            collect(branchExpr, blockedBranch, blockedTy)
+            guard.iterator.foreach(
+              collect(_, blockedBranch, blockedTy, inSuspension)
+            )
+            collect(branchExpr, blockedBranch, blockedTy, inSuspension)
           }
         case Local(_, _, _) | Global(_, _, _, _) | Literal(_, _, _) =>
           ()
       }
     }
 
-    collect(te, Set.empty, Set.empty)
+    collect(te, Set.empty, Set.empty, inSuspension = false)
 
     val dupes: List[(Key, TypedExpr[A])] =
       seen.iterator.collect {
@@ -208,10 +234,12 @@ object TypedExprNormalization {
       def replace(
           expr: TypedExpr[A],
           blocked: Set[Bindable],
-          blockedTy: Set[TyBound]
+          blockedTy: Set[TyBound],
+          inSuspension: Boolean
       ): TypedExpr[A] = {
         val byKey =
-          if (!readsBlocked(expr, blocked, blockedTy)) replaceMap.get(expr.void)
+          if (!inSuspension && !readsBlocked(expr, blocked, blockedTy))
+            replaceMap.get(expr.void)
           else None
 
         byKey match {
@@ -221,53 +249,68 @@ object TypedExprNormalization {
             expr match {
               case g @ Generic(q, in) =>
                 val blockedTy1 = blockedTy ++ q.vars.iterator.map(_._1)
-                val in1 = replace(in, blocked, blockedTy1)
+                val in1 = replace(in, blocked, blockedTy1, inSuspension)
                 if (in1 eq in) g else Generic(q, in1)
               case ann @ Annotation(in, tpe, qev) =>
-                val in1 = replace(in, blocked, blockedTy)
+                val in1 = replace(in, blocked, blockedTy, inSuspension)
                 if (in1 eq in) ann else Annotation(in1, tpe, qev)
               case lam @ AnnotatedLambda(args, body, tag) =>
+                val inSuspension1 = inSuspension || isSuspensionLambdaArgs(args)
                 val body1 =
-                  replace(body, blocked ++ args.iterator.map(_._1), blockedTy)
+                  replace(
+                    body,
+                    blocked ++ args.iterator.map(_._1),
+                    blockedTy,
+                    inSuspension1
+                  )
                 if (body1 eq body) lam
                 else AnnotatedLambda(args, body1, tag)
               case app0 @ App(fn, args, tpe, tag) =>
-                val fn1 = replace(fn, blocked, blockedTy)
+                val fn1 = replace(fn, blocked, blockedTy, inSuspension)
                 val args1 =
-                  ListUtil.mapConserveNel(args)(replace(_, blocked, blockedTy))
+                  ListUtil.mapConserveNel(args)(
+                    replace(_, blocked, blockedTy, inSuspension)
+                  )
                 if ((fn1 eq fn) && (args1 eq args)) app0
                 else App(fn1, args1, tpe, tag)
               case let0 @ Let(arg, expr1, in, rec, tag) =>
                 val blockedExpr =
                   if (rec.isRecursive) blocked + arg
                   else blocked
-                val expr2 = replace(expr1, blockedExpr, blockedTy)
-                val in1 = replace(in, blocked + arg, blockedTy)
+                val expr2 =
+                  replace(expr1, blockedExpr, blockedTy, inSuspension)
+                val in1 = replace(in, blocked + arg, blockedTy, inSuspension)
                 if ((expr2 eq expr1) && (in1 eq in)) let0
                 else Let(arg, expr2, in1, rec, tag)
               case loop0 @ Loop(args, body, tag) =>
                 val blockedLoop = blocked ++ args.iterator.map(_._1)
                 val args1 = ListUtil.mapConserveNel(args) {
                   case (n, initExpr) =>
-                    val init1 = replace(initExpr, blockedLoop, blockedTy)
+                    val init1 =
+                      replace(initExpr, blockedLoop, blockedTy, inSuspension)
                     if (init1 eq initExpr) (n, initExpr)
                     else (n, init1)
                 }
-                val body1 = replace(body, blockedLoop, blockedTy)
+                val body1 = replace(body, blockedLoop, blockedTy, inSuspension)
                 if ((args1 eq args) && (body1 eq body)) loop0
                 else Loop(args1, body1, tag)
               case recur0 @ Recur(args, tpe, tag) =>
                 val args1 =
-                  ListUtil.mapConserveNel(args)(replace(_, blocked, blockedTy))
+                  ListUtil.mapConserveNel(args)(
+                    replace(_, blocked, blockedTy, inSuspension)
+                  )
                 if (args1 eq args) recur0
                 else Recur(args1, tpe, tag)
               case m @ Match(arg, branches, tag) =>
-                val arg1 = replace(arg, blocked, blockedTy)
+                val arg1 = replace(arg, blocked, blockedTy, inSuspension)
                 val branches1 = ListUtil.mapConserveNel(branches) { branch =>
                   val blockedBranch = blocked ++ branch.pattern.names
                   val guard1 =
-                    branch.guard.map(replace(_, blockedBranch, blockedTy))
-                  val expr1 = replace(branch.expr, blockedBranch, blockedTy)
+                    branch.guard.map(
+                      replace(_, blockedBranch, blockedTy, inSuspension)
+                    )
+                  val expr1 =
+                    replace(branch.expr, blockedBranch, blockedTy, inSuspension)
                   if (guard1.eq(branch.guard) && (expr1 eq branch.expr)) branch
                   else branch.copy(guard = guard1, expr = expr1)
                 }
@@ -280,7 +323,7 @@ object TypedExprNormalization {
         }
       }
 
-      val replaced = replace(te, Set.empty, Set.empty)
+      val replaced = replace(te, Set.empty, Set.empty, inSuspension = false)
       val bindings = bindingsByKey.map { case (_, nm, rep) => (nm, rep) }
 
       NonEmptyList.fromList(bindings) match {
@@ -996,6 +1039,7 @@ object TypedExprNormalization {
         val lambda1 = AnnotatedLambda(lamArgs, e1, tag)
         if (changed) normalize1(namerec, lambda1, scope, typeEnv)
         else {
+          val isSuspensionLambda = isSuspensionLambdaArgs(lamArgs)
 
           def doesntUseArgs(te: TypedExpr[A]): Boolean =
             lamArgs.forall { case (n, _) => te.notFree(n) }
@@ -1019,9 +1063,10 @@ object TypedExprNormalization {
               // note, e1 is already normalized, so fn is normalized
               Some(setType(fn, te.getType))
             case Let(arg1, ex, in, rec, tag1)
-                if !Impl.isSimple(ex, lambdaSimple = true) && doesntUseArgs(
-                  ex
-                ) && doesntShadow(arg1) =>
+                if !isSuspensionLambda &&
+                  !Impl.isSimple(ex, lambdaSimple = true) &&
+                  doesntUseArgs(ex) &&
+                  doesntShadow(arg1) =>
               // x ->
               //   y = z
               //   f(y)
@@ -1040,7 +1085,7 @@ object TypedExprNormalization {
                 typeEnv
               )
             case m @ Match(arg1, branches, tag1)
-                if lamArgs.forall { case (arg, _) =>
+                if !isSuspensionLambda && lamArgs.forall { case (arg, _) =>
                   arg1.notFree(arg)
                 } && ((branches.length > 1) || !Impl.isSimple(
                   arg1,

--- a/core/src/test/scala/dev/bosatsu/Issue2087Test.scala
+++ b/core/src/test/scala/dev/bosatsu/Issue2087Test.scala
@@ -1,0 +1,150 @@
+package dev.bosatsu
+
+import cats.data.NonEmptyList
+import dev.bosatsu.rankn.Type
+import Identifier.Bindable
+
+class Issue2087Test extends munit.FunSuite with ParTest {
+  private val lazyPack = Predef.loadFileInCompile("test_workspace/Bosatsu/Lazy.bosatsu")
+
+  private val reproPackage = PackageName.parts("Repro", "Issue2087")
+  private val opaqueName = Identifier.Name("opaque_Int")
+  private val thunkLetName = Identifier.Name("thunk_let")
+  private val thunkShareName = Identifier.Name("thunk_share")
+
+  private val reproPack = """
+package Repro/Issue2087
+
+from Bosatsu/Lazy import (
+  Lazy,
+  lazy,
+)
+
+external def opaque_Int(x: Int) -> Int
+
+thunk_let: Lazy[Int] = lazy(() -> (
+  y = opaque_Int(1)
+  add(y, y)
+))
+
+thunk_share: Lazy[Int] = lazy(() -> add(opaque_Int(1), opaque_Int(1)))
+
+main = [thunk_let, thunk_share]
+"""
+
+  @annotation.tailrec
+  private def stripTypeWrappers[A](te: TypedExpr[A]): TypedExpr[A] =
+    te match {
+      case TypedExpr.Generic(_, in)       => stripTypeWrappers(in)
+      case TypedExpr.Annotation(in, _, _) => stripTypeWrappers(in)
+      case _                              => te
+    }
+
+  private def isSuspensionLambdaArgs(
+      args: NonEmptyList[(Bindable, Type)]
+  ): Boolean =
+    args match {
+      case NonEmptyList((_, argTpe), Nil) =>
+        Type.normalize(argTpe).sameAs(Type.UnitType)
+      case _ =>
+        false
+    }
+
+  private def isOpaqueCall[A](te: TypedExpr[A]): Boolean =
+    stripTypeWrappers(te) match {
+      case TypedExpr.App(fn, _, _, _) =>
+        stripTypeWrappers(fn) match {
+          case TypedExpr.Global(_, name: Bindable, _, _) =>
+            name == opaqueName
+          case _ =>
+            false
+        }
+      case _ =>
+        false
+    }
+
+  private def countOpaqueCalls[A](
+      te: TypedExpr[A],
+      inSuspension: Boolean
+  ): (Int, Int) = {
+    val self =
+      if (isOpaqueCall(te)) {
+        if (inSuspension) (1, 0) else (0, 1)
+      } else (0, 0)
+
+    def add(left: (Int, Int), right: (Int, Int)): (Int, Int) =
+      (left._1 + right._1, left._2 + right._2)
+
+    te match {
+      case TypedExpr.Generic(_, in) =>
+        add(self, countOpaqueCalls(in, inSuspension))
+      case TypedExpr.Annotation(in, _, _) =>
+        add(self, countOpaqueCalls(in, inSuspension))
+      case TypedExpr.AnnotatedLambda(args, in, _) =>
+        val inSuspension1 = inSuspension || isSuspensionLambdaArgs(args)
+        add(self, countOpaqueCalls(in, inSuspension1))
+      case TypedExpr.App(fn, args, _, _) =>
+        args.toList
+          .foldLeft(add(self, countOpaqueCalls(fn, inSuspension))) {
+            case (acc, arg) =>
+              add(acc, countOpaqueCalls(arg, inSuspension))
+          }
+      case TypedExpr.Let(_, ex, in, _, _) =>
+        add(
+          add(self, countOpaqueCalls(ex, inSuspension)),
+          countOpaqueCalls(in, inSuspension)
+        )
+      case TypedExpr.Loop(args, in, _) =>
+        val initCounts = args.toList.foldLeft(self) { case (acc, (_, init)) =>
+          add(acc, countOpaqueCalls(init, inSuspension))
+        }
+        add(initCounts, countOpaqueCalls(in, inSuspension))
+      case TypedExpr.Recur(args, _, _) =>
+        args.toList.foldLeft(self) { case (acc, arg) =>
+          add(acc, countOpaqueCalls(arg, inSuspension))
+        }
+      case TypedExpr.Match(arg, branches, _) =>
+        branches.toList
+          .foldLeft(add(self, countOpaqueCalls(arg, inSuspension))) {
+            case (acc, TypedExpr.Branch(_, guard, branchExpr)) =>
+              val guardCount =
+                guard.fold((0, 0))(countOpaqueCalls(_, inSuspension))
+              add(add(acc, guardCount), countOpaqueCalls(branchExpr, inSuspension))
+          }
+      case TypedExpr.Local(_, _, _) | TypedExpr.Global(_, _, _, _) |
+          TypedExpr.Literal(_, _, _) =>
+        self
+    }
+  }
+
+  private def assertOpaqueCallsRemainSuspended(expr: TypedExpr[Declaration]): Unit = {
+    val (insideSuspension, outsideSuspension) =
+      countOpaqueCalls(expr, inSuspension = false)
+    assert(insideSuspension > 0, expr.reprString)
+    assertEquals(outsideSuspension, 0, expr.reprString)
+  }
+
+  test("issue 2087: lazy thunks keep delayed opaque work inside Unit lambdas") {
+    var out: Option[Package.Inferred] = None
+    TestUtils.testInferred(
+      List(lazyPack, reproPack),
+      reproPackage.asString,
+      { (pm, _) =>
+        out = pm.toMap.get(reproPackage)
+      }
+    )
+
+    val pack = out.getOrElse(
+      fail(s"missing inferred package: ${reproPackage.asString}")
+    )
+    def getLet(name: Bindable): TypedExpr[Declaration] =
+      pack.lets.find(_._1 == name) match {
+        case Some((_, _, te)) => te
+        case None             =>
+          fail(s"missing let ${name.sourceCodeRepr} in ${pack.lets.map(_._1)}")
+      }
+
+    assertOpaqueCallsRemainSuspended(getLet(thunkLetName))
+    assertOpaqueCallsRemainSuspended(getLet(thunkShareName))
+  }
+}

--- a/core/src/test/scala/dev/bosatsu/TypedExprTest.scala
+++ b/core/src/test/scala/dev/bosatsu/TypedExprTest.scala
@@ -1291,6 +1291,85 @@ foo = _ -> 1
     }
   }
 
+  test("normalization keeps non-simple lets inside Unit suspension lambdas") {
+    val unitName = Identifier.Name("unit")
+    val yName = Identifier.Name("y")
+    val unaryInt = Type.Fun(NonEmptyList.one(intTpe), intTpe)
+
+    val boundExpr = app(varTE("opaque", unaryInt), int(1), intTpe)
+    val yVar = TypedExpr.Local(yName, intTpe, ())
+    val body = TypedExpr.Let(
+      yName,
+      boundExpr,
+      TypedExpr.App(PredefAdd, NonEmptyList.of(yVar, yVar), intTpe, ()),
+      RecursionKind.NonRecursive,
+      ()
+    )
+    val lamExpr =
+      TypedExpr.AnnotatedLambda(NonEmptyList.one((unitName, Type.UnitType)), body, ())
+
+    val normalized = TypedExprNormalization.normalize(lamExpr).getOrElse(lamExpr)
+    normalized match {
+      case TypedExpr.AnnotatedLambda(args, lamBody, _) =>
+        assertEquals(args.length, 1)
+        assert(Type.normalize(args.head._2).sameAs(Type.UnitType))
+        assert(countLet(lamBody) > 0, normalized.reprString)
+      case other =>
+        fail(s"expected Unit lambda to remain outermost, got: ${other.reprString}")
+    }
+  }
+
+  test("normalization keeps matches inside Unit suspension lambdas") {
+    val unitName = Identifier.Name("unit")
+    val body = TypedExpr.Match(
+      varTE("z", intTpe),
+      NonEmptyList.of(
+        branch(Pattern.Literal(Lit.fromInt(0)), int(1)),
+        branch(Pattern.WildCard, int(2))
+      ),
+      ()
+    )
+    val lamExpr =
+      TypedExpr.AnnotatedLambda(NonEmptyList.one((unitName, Type.UnitType)), body, ())
+
+    val normalized = TypedExprNormalization.normalize(lamExpr).getOrElse(lamExpr)
+    normalized match {
+      case TypedExpr.AnnotatedLambda(args, TypedExpr.Match(_, _, _), _) =>
+        assert(Type.normalize(args.head._2).sameAs(Type.UnitType))
+      case other =>
+        fail(s"expected Unit lambda with inner match, got: ${other.reprString}")
+    }
+  }
+
+  test(
+    "normalization does not share immutable values outside Unit suspension lambdas"
+  ) {
+    val unitName = Identifier.Name("unit")
+    val fnType = Type.Fun(NonEmptyList.one(intTpe), intTpe)
+    val opaque = app(varTE("f", fnType), int(1), intTpe)
+    val body = TypedExpr.App(PredefAdd, NonEmptyList.of(opaque, opaque), intTpe, ())
+    val lamExpr =
+      TypedExpr.AnnotatedLambda(NonEmptyList.one((unitName, Type.UnitType)), body, ())
+
+    val normalized = TypedExprNormalization.normalize(lamExpr).getOrElse(lamExpr)
+    normalized match {
+      case TypedExpr.Let(
+            _,
+            bound,
+            TypedExpr.AnnotatedLambda(args, _, _),
+            RecursionKind.NonRecursive,
+            _
+          ) if bound.void === opaque.void &&
+            Type.normalize(args.head._2).sameAs(Type.UnitType) =>
+        fail(s"unexpected shared let hoisted above Unit thunk: ${normalized.reprString}")
+      case TypedExpr.AnnotatedLambda(args, lamBody, _) =>
+        assert(Type.normalize(args.head._2).sameAs(Type.UnitType))
+        assert(countExpr(lamBody, opaque) > 0, normalized.reprString)
+      case other =>
+        fail(s"expected Unit lambda result, got: ${other.reprString}")
+    }
+  }
+
   test(
     "normalization keeps lambda-match shape when branch guards depend on lambda args"
   ) {


### PR DESCRIPTION
Implemented the merged design doc by treating `Unit -> a` lambdas as suspension boundaries in `TypedExprNormalization`.

What changed:
- Added `isSuspensionLambdaArgs` in `core/src/main/scala/dev/bosatsu/TypedExprNormalization.scala`.
- In `normalizeLetOpt` lambda rewrites, blocked outward `let` floating and outward `match` floating when the lambda is a suspension boundary, while keeping eta/in-lambda simplifications.
- In `shareImmutableValues`, threaded an `inSuspension` flag through collect/replace traversals so expressions inside suspension lambdas are neither added to outer sharing candidates nor replaced by outer shared bindings.

Tests added/updated:
- `core/src/test/scala/dev/bosatsu/TypedExprTest.scala`
  - Unit-suspension lambda keeps non-simple inner `let`.
  - Unit-suspension lambda keeps inner `match` (no outward match float).
  - Repeated immutable values inside Unit-suspension lambda are not shared via an outer `let`.
- Added `core/src/test/scala/dev/bosatsu/Issue2087Test.scala`
  - `Bosatsu/Lazy` regression that compiles/normalizes lazy thunks and asserts delayed `opaque_Int(...)` calls remain inside Unit suspension lambdas (for both let-style and repeated-expression cases).

Validation run:
- `sbt "coreJVM/testOnly dev.bosatsu.TypedExprTest dev.bosatsu.Issue2087Test"` passed.
- Required command `scripts/test_basic.sh` passed (62/62 tests).

Fixes #2087

Implements design doc: [docs/design/2087-optimization-rules-may-prevent-lazy-from-being-lazy.md](https://github.com/johnynek/bosatsu/blob/main/docs/design/2087-optimization-rules-may-prevent-lazy-from-being-lazy.md)

Design source PR: https://github.com/johnynek/bosatsu/pull/2088