### PR TITLE
Audit TypedExprRecursionCheck stack safety with deferred traversal

### DIFF
--- a/core/src/main/scala/dev/bosatsu/TypedExprRecursionCheck.scala
+++ b/core/src/main/scala/dev/bosatsu/TypedExprRecursionCheck.scala
@@ -2444,6 +2444,12 @@ object TypedExprRecursionCheck {
           }
         }
 
+      def defer[A](st: => St[A]): St[A] =
+        new St[A] {
+          def run(state: State): Eval[ErrorOr[(State, A)]] =
+            Eval.defer(st.run(state))
+        }
+
       implicit val monadForSt: StackSafeMonad[St] =
         new StackSafeMonad[St] {
           def pure[A](a: A): St[A] = St.pure(a)
@@ -2508,6 +2514,7 @@ object TypedExprRecursionCheck {
     private def toSt[A](v: Res[A]): St[A] =
       St.liftEither(v.toEither)
     private def pureSt[A](a: A): St[A] = St.pure(a)
+    private def deferSt[A](st: => St[A]): St[A] = St.defer(st)
     private val unitSt: St[Unit] = pureSt(())
 
     private def checkForIllegalBindsSt(
@@ -2668,7 +2675,8 @@ object TypedExprRecursionCheck {
         wrappers: WrapperScope,
         lambdaTag: Declaration
     ): St[Unit] =
-      body match {
+      deferSt {
+        body match {
         case TypedExpr.Match(arg, branches, tag)
             if (tag == lambdaTag) &&
               (branches.length == 1) &&
@@ -2688,6 +2696,7 @@ object TypedExprRecursionCheck {
         case _ =>
           checkExpr(currentPackage, body, wrappers)
       }
+      }
 
     private def checkApply(
         currentPackage: PackageName,
@@ -2696,7 +2705,8 @@ object TypedExprRecursionCheck {
         region: Region,
         wrappers: WrapperScope
     ): St[Unit] =
-      getSt.flatMap {
+      deferSt {
+        getSt.flatMap {
         case TopLevel(_) =>
           // without any recursion, normal typechecking will detect bad states:
           checkExpr(currentPackage, fn, wrappers) *> args.parTraverse_(
@@ -2787,13 +2797,15 @@ object TypedExprRecursionCheck {
               )
           }
       }
+      }
 
     private def checkExpr(
         currentPackage: PackageName,
         expr: TypedExpr[Declaration],
         wrappers: WrapperScope
     ): St[Unit] =
-      expr match {
+      deferSt {
+        expr match {
         case TypedExpr.Generic(q, in) =>
           checkExpr(currentPackage, in, wrappers.pushQuant(q))
         case TypedExpr.Annotation(term, _, _) =>
@@ -3091,6 +3103,7 @@ object TypedExprRecursionCheck {
                   }
               }
           }
+        }
       }
 
     private def checkExprV(

--- a/core/src/test/scala/dev/bosatsu/TypedExprRecursionCheckTest.scala
+++ b/core/src/test/scala/dev/bosatsu/TypedExprRecursionCheckTest.scala
@@ -1147,8 +1147,8 @@ main = loop(1)
   }
 
   Platform.onJvm(
-    test("moderately large list literals do not overflow recursion checker stack") {
-      val n = 211
+    test("large list literals do not overflow recursion checker stack") {
+      val n = 1024
       val items = List.fill(n)("\"x\"").mkString(", ")
       val source = s"""#
 vals: List[String] = [$items]
@@ -1187,7 +1187,7 @@ main = vals
 
       failure match {
         case Some(_: StackOverflowError) =>
-          fail("recursion checker overflowed on a moderately large list literal")
+          fail("recursion checker overflowed on a large list literal")
         case Some(other) =>
           throw other
         case None =>


### PR DESCRIPTION
Implemented a focused stack-safety improvement in `TypedExprRecursionCheck` without API changes:
- Added `St.defer` plus a local `deferSt` helper.
- Wrapped the main recursive traversal entry points (`checkExpr`, `checkApply`, `checkReachableLambdaBody`) in deferred execution so deep expression trees no longer build/execute recursion eagerly on the JVM call stack.
- Kept existing recursion-check semantics intact.

Also tightened stack regression coverage in `TypedExprRecursionCheckTest`:
- Renamed the JVM stack test to reflect larger coverage.
- Increased list literal size from `211` to `1024` in the small-stack thread test.
- Updated the corresponding failure message text.

Validation:
- `sbt "coreJVM/testOnly dev.bosatsu.TypedExprRecursionCheckTest"` passed.
- Required command `scripts/test_basic.sh` passed.

Fixes #2098