### PR TITLE
Allow recursion on thunk force and trusted Lazy force (issue #2103)

### DIFF
--- a/core/src/main/scala/dev/bosatsu/TypedExprRecursionCheck.scala
+++ b/core/src/main/scala/dev/bosatsu/TypedExprRecursionCheck.scala
@@ -2113,29 +2113,23 @@ object TypedExprRecursionCheck {
           None
       }
 
-    private def hasUnitToTargetType(
-        fnExpr: TypedExpr[Declaration],
-        targetType: Type
+    private def hasUnitArgFunction(
+        fnExpr: TypedExpr[Declaration]
     ): Boolean =
-      // Keep this force recognizer tied to the current recur-target component
-      // type; we intentionally do not treat force as a generic wrapper-unroll.
       fnExpr.getType match {
-        case Type.Fun(args, resultType) =>
+        case Type.Fun(args, _) =>
           args.tail.isEmpty &&
-          args.head.sameAs(Type.UnitType) &&
-          resultType.sameAs(targetType)
+          args.head.sameAs(Type.UnitType)
         case _ =>
           false
       }
 
-    private def hasLazyTargetType(
-        expr: TypedExpr[Declaration],
-        targetType: Type
+    private def hasLazyType(
+        expr: TypedExpr[Declaration]
     ): Boolean =
-      // Same boundary as thunk forcing: only Lazy[targetType] qualifies.
       expr.getType match {
-        case Type.TyApply(Type.TyConst(const), itemType) =>
-          (const == lazyTypeConst) && itemType.sameAs(targetType)
+        case Type.TyApply(Type.TyConst(const), _) =>
+          const == lazyTypeConst
         case _ =>
           false
       }
@@ -2153,7 +2147,6 @@ object TypedExprRecursionCheck {
       }
 
     private def classifyThunkForceArg(
-        targetType: Type,
         allowed: Set[Bindable],
         arg: TypedExpr[Declaration]
     ): Option[ArgLexOrder] =
@@ -2162,12 +2155,11 @@ object TypedExprRecursionCheck {
         case (fnExpr, unitArg)
             if isCanonicalUnitLiteral(unitArg) &&
               localNameOf(fnExpr).exists(allowed) &&
-              hasUnitToTargetType(fnExpr, targetType) =>
+              hasUnitArgFunction(fnExpr) =>
           Smaller
       }
 
     private def classifyLazyForceArg(
-        targetType: Type,
         allowed: Set[Bindable],
         arg: TypedExpr[Declaration]
     ): Option[ArgLexOrder] =
@@ -2176,7 +2168,7 @@ object TypedExprRecursionCheck {
         case (fnExpr, lazyArg)
             if isTrustedGlobalFn(fnExpr, lazyPackageName, getLazyName) &&
               localNameOf(lazyArg).exists(allowed) &&
-              hasLazyTargetType(lazyArg, targetType) =>
+              hasLazyType(lazyArg) =>
           Smaller
       }
 
@@ -2189,7 +2181,6 @@ object TypedExprRecursionCheck {
         currentCtor: Option[KnownCtor],
         arg: TypedExpr[Declaration]
     ): LexStep = {
-      val targetType = targetItemType(inrec, target)
       val order =
         localNameOf(arg) match {
           case Some(nm) if allowed(nm)            => Smaller
@@ -2200,8 +2191,8 @@ object TypedExprRecursionCheck {
               case Some(s0) if singletonCtorFromArgExpr(arg).contains(s0) =>
                 Equal
               case _                                                      =>
-                classifyThunkForceArg(targetType, allowed, arg)
-                  .orElse(classifyLazyForceArg(targetType, allowed, arg))
+                classifyThunkForceArg(allowed, arg)
+                  .orElse(classifyLazyForceArg(allowed, arg))
                   .orElse(
                     currentCtor.map(
                       classifyConstructorRankArg(

--- a/core/src/test/scala/dev/bosatsu/TypedExprRecursionCheckTest.scala
+++ b/core/src/test/scala/dev/bosatsu/TypedExprRecursionCheckTest.scala
@@ -683,8 +683,8 @@ def run[a](fuel: Fuel, value: a) -> a:
 """)
   }
 
-  test("recur rejects thunk force when thunk returns a polymorphic recur target") {
-    disallowed("""#
+  test("recur allows thunk force when thunk returns a polymorphic recur target") {
+    allowed("""#
 enum FreeF[a]:
   Done(value: a)
   Mapped[b](thunk: () -> FreeF[b], fn: b -> a)
@@ -720,9 +720,9 @@ def consume(s: Stream) -> Stream:
     )
   }
 
-  test("recur rejects trusted lazy force when lazy returns a polymorphic recur target") {
+  test("recur allows trusted lazy force when lazy returns a polymorphic recur target") {
     val lazyPack = PackageName.parts("Bosatsu", "Lazy")
-    disallowed(
+    allowed(
       """#
 external struct Lazy[a: +*]
 external def get_Lazy[a](l: Lazy[a]) -> a

--- a/docs/src/main/paradox/recursion.md
+++ b/docs/src/main/paradox/recursion.md
@@ -72,9 +72,9 @@ At a high level:
       `Bosatsu/Lazy.get_Lazy` and `l: Lazy[T]`.
    This does not generalize to arbitrary wrappers or arbitrary `Lazy[T] -> T`
    helper functions.
-   These force forms are checked against the current recur-target component
-   type `T`; polymorphic recursive retargeting of that component is not
-   accepted through these force recognizers.
+   The same force recognizers also apply when `T` changes through polymorphic
+   recursion (for example `FreeF[a] -> FreeF[b]`) as long as the forced value
+   is still a branch-proven smaller local.
 
 1. With a tuple target (`recur (x0, x1, ..., xk)`), recursive calls must be
    lexicographically smaller in that target order.


### PR DESCRIPTION
Implemented the accepted design for #2103 across checker logic, tests, and docs.

What changed:
- `core/src/main/scala/dev/bosatsu/TypedExprRecursionCheck.scala`
  - Added trusted Lazy identifiers/constants:
    - `lazyPackageName = PackageName.parts("Bosatsu", "Lazy")`
    - `getLazyName = Identifier.Name("get_Lazy")`
    - `lazyTypeConst = Type.Const.Defined(lazyPackageName, TypeName("Lazy"))`
  - Added narrow structural recognizers used by `classifyStructuralArg`:
    - Thunk force recognizer for canonical `th()`/`th(())` where:
      - callee is a local name in the branch `allowed` set
      - callee type is exactly `() -> targetType`
    - Lazy force recognizer for `get_Lazy(l)` where:
      - callee resolves to trusted global `Bosatsu/Lazy.get_Lazy`
      - `l` is a local name in the branch `allowed` set
      - `l` has type `Lazy[targetType]`
  - Integrated both recognizers into structural classification without changing existing ordering guarantees:
    - existing local/equal/singleton checks remain first
    - constructor-rank fallback remains unchanged
    - lexicographic control flow and Int SMT recursion logic unchanged
  - Added concise comments around subtle trust/safety logic.

- `core/src/test/scala/dev/bosatsu/TypedExprRecursionCheckTest.scala`
  - Added issue-focused tests:
    - positive: direct thunk recursion `th()`
    - positive: tuple lexicographic recursion with thunk-force decrease
    - negative: thunk via non-local helper (`force(th)`) rejected
    - negative: wrong callee type (`Int -> T`) rejected
    - negative: non-canonical unit arg shape (`th(unitVar)`) rejected
    - positive: trusted `Bosatsu/Lazy.get_Lazy` accepted
    - negative: non-trusted-package `get_Lazy` rejected
  - Extended local helper plumbing to allow checking source under a specified package name (used to validate the trusted `Bosatsu/Lazy` symbol case).

- `docs/src/main/paradox/recursion.md`
  - Documented the two new narrow accepted force forms and explicitly stated this is not generalized wrapper unrolling.

Validation run (all passing):
- `sbt "coreJVM/testOnly dev.bosatsu.TypedExprRecursionCheckTest"`
- `sbt "doc; paradox"`
- `scripts/test_basic.sh`

Fixes #2103

Implements design doc: [docs/design/2103-allow-recursion-on-thunk-and-lazy-evaluated-data.md](https://github.com/johnynek/bosatsu/blob/main/docs/design/2103-allow-recursion-on-thunk-and-lazy-evaluated-data.md)

Design source PR: https://github.com/johnynek/bosatsu/pull/2104