### PR TITLE
Fix ClangGen int64 min literal emission to avoid C warning

### DIFF
--- a/core/src/main/scala/dev/bosatsu/codegen/clang/ClangGen.scala
+++ b/core/src/main/scala/dev/bosatsu/codegen/clang/ClangGen.scala
@@ -606,9 +606,12 @@ class ClangGen[K](ns: CompilationNamespace[K]) {
               case _: ArithmeticException =>
                 try {
                   val lv = toBigInteger.longValueExact()
+                  val int64Const =
+                    if (lv == Long.MinValue) Code.Ident("INT64_MIN")
+                    else Code.IntLiteral(BigInt(lv))
                   pv(
                     Code.Ident("bsts_integer_from_int64")(
-                      Code.IntLiteral(BigInt(lv))
+                      int64Const
                     )
                   )
                 } catch {

--- a/core/src/test/scala/dev/bosatsu/codegen/clang/ClangGenTest.scala
+++ b/core/src/test/scala/dev/bosatsu/codegen/clang/ClangGenTest.scala
@@ -725,6 +725,46 @@ main = 4294967296
     }
   }
 
+  test("int64 literal arguments are C11-safe constants") {
+    TestUtils.checkPackageMap("""
+a = -9223372036854775808
+b = -9223372036854775807
+c = 4294967296
+main = a
+""") { pm =>
+      val renderedE = Par.withEC {
+        ClangGen(pm).renderMain(
+          TestUtils.testPackage,
+          Identifier.Name("main"),
+          Code.Ident("run_main")
+        )
+      }
+      renderedE match {
+        case Left(err) =>
+          fail(err.toString)
+        case Right(doc) =>
+          val rendered = doc.render(80)
+          val int64Args =
+            "bsts_integer_from_int64\\(([^)]*)\\)".r
+              .findAllMatchIn(rendered)
+              .map(_.group(1).nn.trim)
+              .toList
+
+          assert(int64Args.nonEmpty)
+          assert(!int64Args.contains("-9223372036854775808"))
+          assert(
+            int64Args.forall { arg =>
+              (arg == "INT64_MIN") || {
+                val parsed = BigInt(arg)
+                (parsed > BigInt(Long.MinValue)) &&
+                (parsed <= BigInt(Long.MaxValue))
+              }
+            }
+          )
+        }
+      }
+    }
+
   test("float literals with sign bit use unsigned bit literals") {
     TestUtils.checkPackageMap("""
 main = -0.0


### PR DESCRIPTION
Reproduced issue #2112 by running the CI-style transpile path and confirming generated `output.c` contained `bsts_integer_from_int64(-9223372036854775808)` at the same locations reported in the issue.

Implemented the fix in `core/src/main/scala/dev/bosatsu/codegen/clang/ClangGen.scala`: when a Bosatsu integer literal fits `Long` and equals `Long.MinValue`, codegen now emits `bsts_integer_from_int64(INT64_MIN)` instead of a raw `-9223372036854775808` constant token.

Added regression coverage in `core/src/test/scala/dev/bosatsu/codegen/clang/ClangGenTest.scala` with `int64 literal arguments are C11-safe constants`. The test renders C output, extracts all `bsts_integer_from_int64(...)` arguments, and asserts:
- the warning-triggering raw literal `-9223372036854775808` is never emitted;
- emitted arguments are either `INT64_MIN` or valid numeric constants in signed int64 range (excluding raw `Long.MinValue`).

Validation completed:
- Re-ran transpile repro and verified old form no longer appears; `INT64_MIN` appears in those callsites.
- Ran required pre-push command successfully: `scripts/test_basic.sh`.

Fixes #2112