### PR TITLE
Canonicalize circular dependency errors into minimal actionable cycles

### DIFF
--- a/core/src/main/scala/dev/bosatsu/PackageMap.scala
+++ b/core/src/main/scala/dev/bosatsu/PackageMap.scala
@@ -105,6 +105,75 @@ case class PackageMap[A, B, C, +D](
 }
 
 object PackageMap {
+  private def circularDependencyCycle(
+      err: PackageError.CircularDependency[?, ?, ?]
+  ): List[PackageName] = {
+    val path = err.path.toList
+    val idx = path.indexOf(err.from)
+    val nonRepeating =
+      if (idx < 0) path.reverse
+      else path.take(idx).reverse
+
+    err.from :: nonRepeating ::: (err.from :: Nil)
+  }
+
+  private def canonicalCycle(cycle: List[PackageName]): List[PackageName] =
+    cycle match {
+      case first :: rest =>
+        val nodes = first :: rest.dropRight(1)
+        val min = nodes.min
+        val idx = nodes.indexOf(min)
+        val rotated = nodes.drop(idx) ::: nodes.take(idx)
+        rotated ::: (rotated.head :: Nil)
+      case Nil => Nil
+    }
+
+  private def normalizeCircularDependencyErrors(
+      errs: NonEmptyList[PackageError]
+  ): NonEmptyList[PackageError] = {
+    val circularAndOther =
+      errs.toList.foldLeft(
+        (List.empty[List[PackageName]], List.empty[PackageError])
+      ) { case ((cycles, others), err) =>
+        err match {
+          case circular: PackageError.CircularDependency[?, ?, ?] =>
+            (circularDependencyCycle(circular) :: cycles, others)
+          case other =>
+            (cycles, other :: others)
+        }
+      }
+
+    val (rawCyclesRev, otherErrsRev) = circularAndOther
+
+    if (rawCyclesRev.isEmpty) errs
+    else {
+      val canonicalCycles = rawCyclesRev.reverse.map(canonicalCycle)
+      val byStart = canonicalCycles.groupBy(_.head)
+
+      val minimalCycles: List[List[PackageName]] = byStart.iterator
+        .flatMap { case (_, cycles) =>
+          val minSize = cycles.iterator.map(_.size).min
+          cycles.filter(_.size == minSize)
+        }
+        .toList
+
+      implicit val cycleOrdering: Ordering[List[PackageName]] =
+        ListOrdering.onType(PackageName.packageNameOrdering)
+
+      val normalizedCircularErrs: List[PackageError] =
+        minimalCycles
+          .distinct
+          .sorted
+          .map { cycle =>
+            val from = cycle.head
+            val path = NonEmptyList.fromListUnsafe(cycle.tail)
+            PackageError.CircularDependency(from, path)
+          }
+
+      NonEmptyList.fromListUnsafe(normalizedCircularErrs ::: otherErrsRev.reverse)
+    }
+  }
+
   def empty[A, B, C, D]: PackageMap[A, B, C, D] =
     PackageMap(SortedMap.empty)
 
@@ -284,7 +353,7 @@ object PackageMap {
     // we start with no imports on
     val m: ErrorOr[M] = r.run(Nil)
 
-    m.map(PackageMap(_)).toValidated
+    m.leftMap(normalizeCircularDependencyErrors).map(PackageMap(_)).toValidated
   }
 
   /** Convenience method to create a PackageMap then resolve it

--- a/core/src/test/scala/dev/bosatsu/ErrorMessageTest.scala
+++ b/core/src/test/scala/dev/bosatsu/ErrorMessageTest.scala
@@ -70,6 +70,98 @@ class ErrorMessageTest extends munit.FunSuite with ParTest {
     (errs, PackageMap.buildSourceMap(withPre))
   }
 
+  private def circularCycles(errs: NonEmptyList[PackageError]): List[List[String]] =
+    errs.toList.collect { case circular: PackageError.CircularDependency[?, ?, ?] =>
+      (circular.from :: circular.path.toList).map(_.asString)
+    }
+
+  test("circular dependency errors report canonical minimal loops") {
+    val a =
+      """package A
+        |from B import main as bMain
+        |from C import main as cMain
+        |from D import main as dMain
+        |
+        |main = 1
+        |""".stripMargin
+
+    val b =
+      """package B
+        |from A import main as aMain
+        |from C import main as cMain
+        |from D import main as dMain
+        |
+        |main = 2
+        |""".stripMargin
+
+    val c =
+      """package C
+        |from A import main as aMain
+        |from B import main as bMain
+        |from D import main as dMain
+        |
+        |main = 3
+        |""".stripMargin
+
+    val d =
+      """package D
+        |from A import main as aMain
+        |from B import main as bMain
+        |from C import main as cMain
+        |
+        |main = 4
+        |""".stripMargin
+
+    val (errs, _) = compileErrors(List(a, b, c, d))
+    val cycles = circularCycles(errs)
+
+    assertEquals(
+      cycles,
+      List(
+        List("A", "B", "A"),
+        List("A", "C", "A"),
+        List("A", "D", "A"),
+        List("B", "C", "B"),
+        List("B", "D", "B"),
+        List("C", "D", "C")
+      )
+    )
+  }
+
+  test("circular dependency loop path is trimmed to the cycle itself") {
+    val root =
+      """package Root
+        |from A import main as aMain
+        |
+        |main = 0
+        |""".stripMargin
+
+    val a =
+      """package A
+        |from B import main as bMain
+        |
+        |main = 1
+        |""".stripMargin
+
+    val b =
+      """package B
+        |from C import main as cMain
+        |
+        |main = 2
+        |""".stripMargin
+
+    val c =
+      """package C
+        |from A import main as aMain
+        |
+        |main = 3
+        |""".stripMargin
+
+    val (errs, _) = compileErrors(List(root, a, b, c))
+    val cycles = circularCycles(errs)
+    assertEquals(cycles, List(List("A", "B", "C", "A")))
+  }
+
   test("unused top-level let points to the whole binding") {
     val source =
       """package A


### PR DESCRIPTION
Implemented issue #2116 by normalizing circular package dependency diagnostics in `PackageMap.resolvePackages`.

What changed:
- Added cycle normalization logic in `core/src/main/scala/dev/bosatsu/PackageMap.scala` that:
  - Reconstructs the actual loop from raw recursion paths.
  - Trims non-cycle prefixes/suffixes.
  - Canonicalizes each cycle by rotating it to start at the lexicographically smallest package.
  - Keeps only shortest cycles per canonical start.
  - De-duplicates and lexicographically sorts cycles.
- Preserved non-circular errors while replacing circular error spam with the normalized set.

Regression tests added:
- `core/src/test/scala/dev/bosatsu/ErrorMessageTest.scala`
  - `circular dependency errors report canonical minimal loops`
  - `circular dependency loop path is trimmed to the cycle itself`

Validation run:
- `sbt "coreJVM/testOnly dev.bosatsu.ErrorMessageTest"` passed.
- Required pre-push command `scripts/test_basic.sh` passed.

Fixes #2116