### PR TITLE
Add `lib test --value` selector with export-gated validation

### DIFF
--- a/core/src/main/scala/dev/bosatsu/Package.scala
+++ b/core/src/main/scala/dev/bosatsu/Package.scala
@@ -186,6 +186,17 @@ object Package {
     ) extends TestDiscoveryError
   }
 
+  private def testEntryForLet[A](
+      bindable: Identifier.Bindable,
+      recursionKind: RecursionKind,
+      expr: TypedExpr[A]
+  ): Option[TestEntry[A]] =
+    if (expr.getType.sameAs(Type.TestType)) {
+      Some(TestEntry.PlainTest(bindable, recursionKind, expr))
+    } else if (expr.getType.sameAs(Type.ProgTestType)) {
+      Some(TestEntry.ProgTest(bindable, recursionKind, expr))
+    } else None
+
   /** Return the selected test entry for a package.
     *
     * Discovery rules:
@@ -199,13 +210,19 @@ object Package {
   ): Either[TestDiscoveryError, Option[TestEntry[A]]] = {
     val indexedLets = tp.lets.zipWithIndex
     val plainTests = indexedLets.collect {
-      case ((name, rec, te), idx) if te.getType.sameAs(Type.TestType) =>
-        (idx, TestEntry.PlainTest(name, rec, te))
+      case ((name, rec, te), idx) =>
+        testEntryForLet(name, rec, te).collect {
+          case plainTest @ TestEntry.PlainTest(_, _, _) => (idx, plainTest)
+        }
     }
+      .flatten
     val progTests = indexedLets.collect {
-      case ((name, rec, te), idx) if te.getType.sameAs(Type.ProgTestType) =>
-        (idx, TestEntry.ProgTest(name, rec, te))
+      case ((name, rec, te), idx) =>
+        testEntryForLet(name, rec, te).collect {
+          case progTest @ TestEntry.ProgTest(_, _, _) => (idx, progTest)
+        }
     }
+      .flatten
 
     progTests.lastOption match {
       case None =>
@@ -237,6 +254,17 @@ object Package {
     testEntry(tp).toOption.flatten.collect {
       case TestEntry.PlainTest(bindable, recursionKind, expr) =>
         (bindable, recursionKind, expr)
+    }
+
+  /** Return the selected top-level test value if this bindable has test type.
+    */
+  def testEntryForBindable[A](
+      tp: Typed[A],
+      bindable: Identifier.Bindable
+  ): Option[TestEntry[A]] =
+    tp.lets.collectFirstSome { case (name, recursionKind, expr) =>
+      if (name == bindable) testEntryForLet(name, recursionKind, expr)
+      else None
     }
 
   def testRootBindables[A](tp: Typed[A]): Set[Identifier.Bindable] =

--- a/core/src/main/scala/dev/bosatsu/codegen/CompilationNamespace.scala
+++ b/core/src/main/scala/dev/bosatsu/codegen/CompilationNamespace.scala
@@ -22,6 +22,18 @@ trait CompilationNamespace[K] {
 
   def topoSort: Toposort.Result[(K, PackageName)]
   def compiled: SortedMap[K, MatchlessFromTypedExpr.Compiled[K]]
+  def exportedValues(
+      packageName: PackageName
+  ): Option[Map[Identifier.Bindable, Type]]
+  def exportedValueType(
+      packageName: PackageName,
+      bindable: Identifier.Bindable
+  ): Option[Type] =
+    exportedValues(packageName).flatMap(_.get(bindable))
+  def exportedTestEntry(
+      packageName: PackageName,
+      bindable: Identifier.Bindable
+  ): Option[Package.TestEntry[Any]]
   def testEntries
       : Map[PackageName, Either[Package.TestDiscoveryError, Package.TestEntry[
         Any

--- a/core/src/main/scala/dev/bosatsu/codegen/CompilationSource.scala
+++ b/core/src/main/scala/dev/bosatsu/codegen/CompilationSource.scala
@@ -3,11 +3,14 @@ package dev.bosatsu.codegen
 import cats.{Order, Show}
 import cats.data.NonEmptyList
 import dev.bosatsu.{
+  ExportedName,
   Identifier,
   MatchlessFromTypedExpr,
+  Package,
   PackageName,
   PackageMap,
-  Par
+  Par,
+  Referant
 }
 import dev.bosatsu.rankn.Type
 import scala.collection.immutable.{SortedMap, SortedSet}
@@ -53,6 +56,24 @@ object CompilationSource {
           )
 
           lazy val topoSort = pm.topoSort.map(p => ((), p))
+
+          def exportedValues(
+              packageName: PackageName
+          ): Option[Map[Identifier.Bindable, Type]] =
+            pm.toMap.get(packageName).map { pack =>
+              pack.exports.iterator.collect {
+                case ExportedName.Binding(name, Referant.Value(tpe)) =>
+                  (name, tpe)
+              }.toMap
+            }
+
+          def exportedTestEntry(
+              packageName: PackageName,
+              bindable: Identifier.Bindable
+          ): Option[Package.TestEntry[Any]] =
+            pm.toMap
+              .get(packageName)
+              .flatMap(Package.testEntryForBindable(_, bindable))
 
           lazy val testEntries = pm.testEntries
 

--- a/core/src/main/scala/dev/bosatsu/codegen/clang/ClangTranspiler.scala
+++ b/core/src/main/scala/dev/bosatsu/codegen/clang/ClangTranspiler.scala
@@ -1,6 +1,7 @@
 package dev.bosatsu.codegen.clang
 
-import cats.data.{NonEmptyList, Validated}
+import cats.data.{NonEmptyList, Validated, ValidatedNel}
+import cats.parse.{Parser => CP}
 import com.monovore.decline.{Argument, Opts}
 import java.util.regex.{Pattern => RegexPat}
 import dev.bosatsu.codegen.{Transpiler, CompilationNamespace}
@@ -67,40 +68,198 @@ case object ClangTranspiler extends Transpiler {
   sealed abstract class Mode[F[_]](val name: String)
   object Mode {
     case class Main[F[_]](pack: F[PackageName]) extends Mode[F]("main")
-    case class Test[F[_]](
-        filter: Option[PackageName => Boolean],
-        filterRegexes: NonEmptyList[String],
-        execute: Boolean,
-        quiet: Boolean
-    ) extends Mode[F]("test") {
-      def values[K](
-          ns: CompilationNamespace[K]
-      ): Either[List[(PackageName, Package.TestDiscoveryError)], List[(
-        PackageName,
-        Package.TestEntry[Any]
-      )]] = {
-        val filtered = (filter match {
-          case None =>
-            ns.testEntries.toList
-          case Some(k) =>
-            ns.testEntries.iterator.filter { case (p, _) => k(p) }.toList
-        }).sortBy(_._1)
+    object Test {
+      type ValueSelector = (PackageName, Identifier.Bindable)
 
-        val errors =
-          filtered.collect { case (pn, Left(err)) => (pn, err) }
-        if (errors.nonEmpty) Left(errors)
-        else Right(filtered.collect { case (pn, Right(entry)) => (pn, entry) })
+      sealed trait SelectionMode {
+        def sourceFilter: Option[PackageName => Boolean]
+        def filterRegexes: NonEmptyList[String]
+      }
+      object SelectionMode {
+        final case class ByFilter(
+            filterRegexes: NonEmptyList[String],
+            filter: Option[PackageName => Boolean]
+        ) extends SelectionMode {
+          def sourceFilter: Option[PackageName => Boolean] = filter
+        }
+
+        final case class ByValue(
+            packageName: PackageName,
+            bindable: Identifier.Bindable
+        ) extends SelectionMode {
+          def sourceFilter: Option[PackageName => Boolean] = Some(_ == packageName)
+          def filterRegexes: NonEmptyList[String] =
+            NonEmptyList.one(show"${packageName.asString}::${bindable.sourceCodeRepr}")
+        }
       }
     }
 
+    case class Test[F[_]](
+        selection: Test.SelectionMode,
+        execute: Boolean,
+        quiet: Boolean
+    ) extends Mode[F]("test") {
+      def sourceFilter: Option[PackageName => Boolean] = selection.sourceFilter
+      def filterRegexes: NonEmptyList[String] = selection.filterRegexes
+
+      def values[K](
+          ns: CompilationNamespace[K]
+      ): Either[Exception & CliException, List[(
+        PackageName,
+        Package.TestEntry[Any]
+      )]] =
+        selection match {
+          case Test.SelectionMode.ByFilter(_, filter) =>
+            val filtered = (filter match {
+              case None =>
+                ns.testEntries.toList
+              case Some(k) =>
+                ns.testEntries.iterator.filter { case (p, _) => k(p) }.toList
+            }).sortBy(_._1)
+
+            val errors =
+              filtered.collect { case (pn, Left(err)) => (pn, err) }
+            NonEmptyList.fromList(errors) match {
+              case Some(errs) =>
+                Left(InvalidTestDiscovery(errs))
+              case None       =>
+                Right(filtered.collect { case (pn, Right(entry)) => (pn, entry) })
+            }
+          case Test.SelectionMode.ByValue(packageName, bindable) =>
+            val knownPacks = ns.rootPackages.toList.sorted
+            if (!ns.rootPackages.contains(packageName)) {
+              Left(
+                InvalidTestValueSelection(
+                  packageName,
+                  bindable,
+                  unknownTestPackMsg(packageName, bindable, knownPacks)
+                )
+              )
+            } else {
+              val exported = ns.exportedValues(packageName).getOrElse(Map.empty)
+              val exportedTestValues = exported.iterator.collect {
+                case (name, tpe) if isTestValueType(tpe) => name
+              }.toList
+              exported.get(bindable) match {
+                case None =>
+                  if (exportedTestValues.isEmpty) {
+                    Left(
+                      InvalidTestValueSelection(
+                        packageName,
+                        bindable,
+                        noExportedTestValuesMsg(packageName, bindable)
+                      )
+                    )
+                  } else {
+                    val exportedTests = exportedTestValues.map(_.sourceCodeRepr).sorted
+                    Left(
+                      InvalidTestValueSelection(
+                        packageName,
+                        bindable,
+                        testValueNotExportedMsg(
+                          packageName,
+                          bindable,
+                          exportedTests
+                        )
+                      )
+                    )
+                  }
+                case Some(tpe) if !isTestValueType(tpe) =>
+                  Left(
+                    InvalidTestValueSelection(
+                      packageName,
+                      bindable,
+                      exportedValueNotTestMsg(packageName, bindable, tpe)
+                    )
+                  )
+                case Some(_) =>
+                  ns.exportedTestEntry(packageName, bindable) match {
+                    case Some(entry) =>
+                      Right((packageName, entry) :: Nil)
+                    case None        =>
+                      Left(
+                        InvalidTestValueSelection(
+                          packageName,
+                          bindable,
+                          exportedValueNotTopLevelTestMsg(packageName, bindable)
+                        )
+                      )
+                  }
+              }
+            }
+        }
+    }
+
+    private implicit val testValueArgument: Argument[Test.ValueSelector] =
+      new Argument[Test.ValueSelector] {
+        def defaultMetavar: String = "valueIdent"
+
+        def read(
+            string: String
+        ): ValidatedNel[String, Test.ValueSelector] =
+          (PackageName.parser ~ (CP.string("::") *> Identifier.parser))
+            .parseAll(string) match {
+            case Right((pack, bindable: Identifier.Bindable)) =>
+              Validated.valid((pack, bindable))
+            case Right((pack, cons: Identifier.Constructor))  =>
+              Validated.invalidNel(
+                show"${pack.asString}::${cons.asString} is a constructor or type name, not a value. A top-level value is required."
+              )
+            case _ =>
+              Validated.invalidNel(
+                s"could not parse $string as package::value. Must be package::value, e.g. Foo/Bar::bippy."
+              )
+          }
+      }
+
+    private def testFilterSelectionOpts: Opts[Test.SelectionMode.ByFilter] =
+      Opts
+        .options[String](
+          "filter",
+          help = "regular expression to filter package names"
+        )
+        .orNone
+        .mapValidated {
+          case None      =>
+            Validated.valid(
+              Test.SelectionMode.ByFilter(
+                NonEmptyList.one(".*"),
+                None
+              )
+            )
+          case Some(res) =>
+            Try(res.map(RegexPat.compile(_))) match {
+              case Success(pats) =>
+                Validated.valid(
+                  Test.SelectionMode.ByFilter(
+                    res,
+                    Some(pn => pats.exists(_.matcher(pn.asString).matches()))
+                  )
+                )
+              case Failure(e)    =>
+                Validated.invalidNel(
+                  s"could not parse pattern: $res\n\n${e.getMessage}"
+                )
+            }
+        }
+
+    private def testSelectionOpts: Opts[Test.SelectionMode] =
+      Opts
+        .option[Test.ValueSelector](
+          "value",
+          help = "single exported test value to run (package::value)"
+        )
+        .map { case (packageName, bindable) =>
+          Test.SelectionMode.ByValue(packageName, bindable)
+        }
+        .orElse(testFilterSelectionOpts)
+
+    def testFilterOpts: Opts[Option[PackageName => Boolean]] =
+      testFilterSelectionOpts.map(_.sourceFilter)
+
     def testOpts[F[_]](executeOpts: Opts[Boolean]): Opts[Mode.Test[F]] =
       (
-        Opts
-          .options[String](
-            "filter",
-            help = "regular expression to filter package names"
-          )
-          .orNone,
+        testSelectionOpts,
         executeOpts,
         Opts
           .flag(
@@ -108,27 +267,7 @@ case object ClangTranspiler extends Transpiler {
             help = "only print failure details and final test summary"
           )
           .orFalse
-      ).tupled
-        .mapValidated {
-          case (None, execute, quiet) =>
-            Validated.valid(Test(None, NonEmptyList.one(".*"), execute, quiet))
-          case (Some(res), execute, quiet) =>
-            Try(res.map(RegexPat.compile(_))) match {
-              case Success(pats) =>
-                Validated.valid(
-                  Test(
-                    Some(pn => pats.exists(_.matcher(pn.asString).matches())),
-                    res,
-                    execute,
-                    quiet
-                  )
-                )
-              case Failure(e) =>
-                Validated.invalidNel(
-                  s"could not parse pattern: $res\n\n${e.getMessage}"
-                )
-            }
-        }
+      ).mapN(Test(_, _, _))
 
     def opts[F[_]: Applicative]: Opts[Mode[F]] =
       Opts
@@ -390,6 +529,17 @@ case object ClangTranspiler extends Transpiler {
     def exitCode: ExitCode = ExitCode.Error
   }
 
+  case class InvalidTestValueSelection(
+      packageName: PackageName,
+      valueName: Identifier.Bindable,
+      message: String
+  ) extends Exception(message)
+      with CliException {
+    def errDoc = Doc.text(getMessage())
+    def stdOutDoc: Doc = Doc.empty
+    def exitCode: ExitCode = ExitCode.Error
+  }
+
   private def packageIdent(pack: PackageName): Identifier =
     Identifier.Synthetic(pack.asString)
 
@@ -423,6 +573,79 @@ case object ClangTranspiler extends Transpiler {
 
   private def invalidMainPackMsg(mainPack: PackageName, detail: String): String =
     s"invalid main package `${mainPack.asString}`: $detail"
+
+  private def invalidTestValueMsg(
+      packageName: PackageName,
+      bindable: Identifier.Bindable,
+      detail: String
+  ): String =
+    s"invalid test value `${packageName.asString}::${bindable.sourceCodeRepr}`: $detail"
+
+  private def unknownTestPackMsg(
+      packageName: PackageName,
+      bindable: Identifier.Bindable,
+      knownPacks: List[PackageName]
+  ): String = {
+    val suggestion =
+      nearestPackage(packageName, knownPacks)
+        .fold("")(pack => s"\nDid you mean: ${pack.asString} ?")
+    invalidTestValueMsg(
+      packageName,
+      bindable,
+      s"unknown package.$suggestion\n${packageCountMsg(knownPacks.size)}"
+    )
+  }
+
+  private def noExportedTestValuesMsg(
+      packageName: PackageName,
+      bindable: Identifier.Bindable
+  ): String =
+    invalidTestValueMsg(
+      packageName,
+      bindable,
+      s"${packageName.asString} has no exported test values. Export a value with type Bosatsu/Predef::Test or Bosatsu/Prog::ProgTest."
+    )
+
+  private def testValueNotExportedMsg(
+      packageName: PackageName,
+      bindable: Identifier.Bindable,
+      exportedTestValues: List[String]
+  ): String = {
+    val detail =
+      if (exportedTestValues.isEmpty) {
+        s"value is not exported by ${packageName.asString}."
+      } else {
+        val rendered = exportedTestValues.mkString(", ")
+        s"value is not exported by ${packageName.asString}. exported test values: [$rendered]"
+      }
+    invalidTestValueMsg(packageName, bindable, detail)
+  }
+
+  private def exportedValueNotTestMsg(
+      packageName: PackageName,
+      bindable: Identifier.Bindable,
+      tpe: Type
+  ): String = {
+    val actualType = Type.fullyResolvedDocument.document(tpe).render(80)
+    invalidTestValueMsg(
+      packageName,
+      bindable,
+      s"exported value is not a test value. Expected Bosatsu/Predef::Test or Bosatsu/Prog::ProgTest, found: $actualType"
+    )
+  }
+
+  private def exportedValueNotTopLevelTestMsg(
+      packageName: PackageName,
+      bindable: Identifier.Bindable
+  ): String =
+    invalidTestValueMsg(
+      packageName,
+      bindable,
+      "exported value is not a top-level test value in this package."
+    )
+
+  private def isTestValueType(tpe: Type): Boolean =
+    tpe.sameAs(Type.TestType) || tpe.sameAs(Type.ProgTestType)
 
   private def testDiscoveryErrMsg(
       err: Package.TestDiscoveryError
@@ -550,18 +773,14 @@ case object ClangTranspiler extends Transpiler {
                       )
                 })
               }
-            case test @ Mode.Test(_, re, execute, quiet) =>
+            case test @ Mode.Test(_, execute, quiet) =>
               test.values(ns) match {
-                case Left(errors) =>
-                  moduleIOMonad.raiseError(
-                    InvalidTestDiscovery(
-                      NonEmptyList.fromListUnsafe(errors)
-                    )
-                  )
+                case Left(err) =>
+                  moduleIOMonad.raiseError(err)
                 case Right(tvs)   =>
                   if (tvs.isEmpty) {
                     moduleIOMonad.raiseError(
-                      NoTestsFound(ns.rootPackages.toList, re)
+                      NoTestsFound(ns.rootPackages.toList, test.filterRegexes)
                     )
                   } else {
                     val roots = tvs.iterator.map { case (p, entry) =>

--- a/core/src/main/scala/dev/bosatsu/library/Command.scala
+++ b/core/src/main/scala/dev/bosatsu/library/Command.scala
@@ -1522,7 +1522,7 @@ object Command {
         "check all the code, but do not build the final output library (faster than build)."
       ) {
         val sourceFilterOpt: Opts[Option[PackageName => Boolean]] =
-          ClangTranspiler.Mode.testOpts[F](Opts(false)).map(_.filter)
+          ClangTranspiler.Mode.testFilterOpts
 
         (
           ConfigConf.opts,
@@ -2454,7 +2454,7 @@ object Command {
                 msg <- cc.build(
                   colorize,
                   trans,
-                  test.filter,
+                  test.sourceFilter,
                   cacheDirFn(cc.gitRoot)
                 )
               } yield (Output.Basic(msg, None): Output[P])

--- a/core/src/main/scala/dev/bosatsu/library/DecodedLibraryWithDeps.scala
+++ b/core/src/main/scala/dev/bosatsu/library/DecodedLibraryWithDeps.scala
@@ -5,11 +5,14 @@ import cats.{MonadError, Order, Show}
 import cats.data.{NonEmptyList, StateT}
 import cats.syntax.all._
 import dev.bosatsu.{
+  ExportedName,
   Identifier,
   MatchlessFromTypedExpr,
+  Package,
   PackageName,
   PackageMap,
-  Par
+  Par,
+  Referant
 }
 import dev.bosatsu.codegen.{CompilationNamespace, CompilationSource}
 import dev.bosatsu.hashing.{Algo, Hashed}
@@ -224,6 +227,24 @@ object DecodedLibraryWithDeps {
               }
               .to(SortedMap)
               .transform((_, p) => Par.await(p))
+
+          def exportedValues(
+              packageName: PackageName
+          ): Option[Map[Identifier.Bindable, Type]] =
+            a.lib.implementations.toMap.get(packageName).map { pack =>
+              pack.exports.iterator.collect {
+                case ExportedName.Binding(name, Referant.Value(tpe)) =>
+                  (name, tpe)
+              }.toMap
+            }
+
+          def exportedTestEntry(
+              packageName: PackageName,
+              bindable: Identifier.Bindable
+          ): Option[Package.TestEntry[Any]] =
+            a.lib.implementations.toMap
+              .get(packageName)
+              .flatMap(Package.testEntryForBindable(_, bindable))
 
           lazy val testEntries = a.lib.implementations.testEntries
 

--- a/core/src/test/scala/dev/bosatsu/ToolAndLibCommandTest.scala
+++ b/core/src/test/scala/dev/bosatsu/ToolAndLibCommandTest.scala
@@ -6826,6 +6826,289 @@ main = 0
     }
   }
 
+  test("lib test rejects --value with --filter") {
+    module.run(
+      List(
+        "lib",
+        "test",
+        "--repo_root",
+        "repo",
+        "--value",
+        "MyLib/Euler/One::test_one",
+        "--filter",
+        "MyLib/Euler/.*"
+      )
+    ) match {
+      case Left(_)  => ()
+      case Right(_) =>
+        fail("expected parser error when both --value and --filter are supplied")
+    }
+  }
+
+  test("lib test --value accepts exported plain Test values") {
+    val targetSrc =
+      """export test_one
+|
+|test_one = Assertion(True, "ok")
+|""".stripMargin
+    val unrelatedBrokenSrc =
+      """bad = does_not_exist
+|""".stripMargin
+    val ccConfJson =
+      """{
+        |  "cc_path": "cc",
+        |  "flags": [],
+        |  "iflags": [],
+        |  "libs": [],
+        |  "os": "test"
+        |}
+|""".stripMargin
+    val libs = Libraries(SortedMap(Name("mylib") -> "src"))
+    val conf =
+      LibConfig.init(Name("mylib"), "https://example.com", Version(0, 0, 1))
+    val files = List(
+      Chain("repo", "bosatsu_libs.json") -> renderJson(libs),
+      Chain("repo", "src", "mylib_conf.json") -> renderJson(conf),
+      Chain("repo", "src", "MyLib", "Euler", "One.bosatsu") -> targetSrc,
+      Chain("repo", "src", "MyLib", "ReproMin8.bosatsu") -> unrelatedBrokenSrc,
+      Chain("repo", "cc_conf.json") -> ccConfJson
+    )
+
+    module.runWith(files)(
+      List(
+        "lib",
+        "test",
+        "--repo_root",
+        "repo",
+        "--value",
+        "MyLib/Euler/One::test_one",
+        "--cc_conf",
+        "repo/cc_conf.json"
+      )
+    ) match {
+      case Right(out) =>
+        fail(s"expected failure in memory mode, got: $out")
+      case Left(err) =>
+        val msg = Option(err.getMessage).getOrElse(err.toString)
+        assert(msg.contains("system not supported in memory mode"), msg)
+        assert(!msg.contains("ReproMin8"), msg)
+        assert(!msg.contains("invalid test value"), msg)
+    }
+  }
+
+  test("lib test --value accepts exported ProgTest values") {
+    val targetSrc =
+      """from Bosatsu/Prog import ProgTest, pure
+|
+|export prog_tests
+|
+|prog_tests = ProgTest(_ -> pure(Assertion(True, "ok")))
+|""".stripMargin
+    val unrelatedBrokenSrc =
+      """bad = does_not_exist
+|""".stripMargin
+    val ccConfJson =
+      """{
+        |  "cc_path": "cc",
+        |  "flags": [],
+        |  "iflags": [],
+        |  "libs": [],
+        |  "os": "test"
+        |}
+|""".stripMargin
+    val libs = Libraries(SortedMap(Name("mylib") -> "src"))
+    val conf =
+      LibConfig.init(Name("mylib"), "https://example.com", Version(0, 0, 1))
+    val files = List(
+      Chain("repo", "bosatsu_libs.json") -> renderJson(libs),
+      Chain("repo", "src", "mylib_conf.json") -> renderJson(conf),
+      Chain("repo", "src", "Bosatsu", "Prog.bosatsu") -> minimalProgModuleSrc,
+      Chain("repo", "src", "MyLib", "Euler", "ProgSel.bosatsu") -> targetSrc,
+      Chain("repo", "src", "MyLib", "ReproMin8.bosatsu") -> unrelatedBrokenSrc,
+      Chain("repo", "cc_conf.json") -> ccConfJson
+    )
+
+    module.runWith(files)(
+      List(
+        "lib",
+        "test",
+        "--repo_root",
+        "repo",
+        "--value",
+        "MyLib/Euler/ProgSel::prog_tests",
+        "--cc_conf",
+        "repo/cc_conf.json"
+      )
+    ) match {
+      case Right(out) =>
+        fail(s"expected failure in memory mode, got: $out")
+      case Left(err) =>
+        val msg = Option(err.getMessage).getOrElse(err.toString)
+        assert(msg.contains("system not supported in memory mode"), msg)
+        assert(!msg.contains("ReproMin8"), msg)
+        assert(!msg.contains("invalid test value"), msg)
+    }
+  }
+
+  test("lib test --value rejects non-exported test values") {
+    val targetSrc =
+      """export visible
+|
+|visible = Assertion(True, "ok")
+|hidden = Assertion(True, "hidden")
+|""".stripMargin
+    val ccConfJson =
+      """{
+        |  "cc_path": "cc",
+        |  "flags": [],
+        |  "iflags": [],
+        |  "libs": [],
+        |  "os": "test"
+        |}
+|""".stripMargin
+    val files =
+      baseLibFiles(targetSrc) :+ (Chain("repo", "cc_conf.json") -> ccConfJson)
+
+    module.runWith(files)(
+      List(
+        "lib",
+        "test",
+        "--repo_root",
+        "repo",
+        "--value",
+        "MyLib/Foo::hidden",
+        "--cc_conf",
+        "repo/cc_conf.json"
+      )
+    ) match {
+      case Right(out) =>
+        fail(s"expected invalid value selection, got: $out")
+      case Left(err) =>
+        val msg = Option(err.getMessage).getOrElse(err.toString)
+        assert(msg.contains("invalid test value `MyLib/Foo::hidden`"), msg)
+        assert(msg.contains("value is not exported"), msg)
+        assert(msg.contains("exported test values: [visible]"), msg)
+    }
+  }
+
+  test("lib test --value rejects exported values that are not test values") {
+    val targetSrc =
+      """export not_test
+|
+|not_test = 1
+|""".stripMargin
+    val ccConfJson =
+      """{
+        |  "cc_path": "cc",
+        |  "flags": [],
+        |  "iflags": [],
+        |  "libs": [],
+        |  "os": "test"
+        |}
+|""".stripMargin
+    val files =
+      baseLibFiles(targetSrc) :+ (Chain("repo", "cc_conf.json") -> ccConfJson)
+
+    module.runWith(files)(
+      List(
+        "lib",
+        "test",
+        "--repo_root",
+        "repo",
+        "--value",
+        "MyLib/Foo::not_test",
+        "--cc_conf",
+        "repo/cc_conf.json"
+      )
+    ) match {
+      case Right(out) =>
+        fail(s"expected invalid value selection, got: $out")
+      case Left(err) =>
+        val msg = Option(err.getMessage).getOrElse(err.toString)
+        assert(msg.contains("invalid test value `MyLib/Foo::not_test`"), msg)
+        assert(msg.contains("exported value is not a test value"), msg)
+        assert(msg.contains("Bosatsu/Predef::Test"), msg)
+    }
+  }
+
+  test("lib test --value reports unknown package with a clear error") {
+    val targetSrc =
+      """export test_one
+|
+|test_one = Assertion(True, "ok")
+|""".stripMargin
+    val ccConfJson =
+      """{
+        |  "cc_path": "cc",
+        |  "flags": [],
+        |  "iflags": [],
+        |  "libs": [],
+        |  "os": "test"
+        |}
+|""".stripMargin
+    val files =
+      baseLibFiles(targetSrc) :+ (Chain("repo", "cc_conf.json") -> ccConfJson)
+
+    module.runWith(files)(
+      List(
+        "lib",
+        "test",
+        "--repo_root",
+        "repo",
+        "--value",
+        "Nope/Missing::test_one",
+        "--cc_conf",
+        "repo/cc_conf.json"
+      )
+    ) match {
+      case Right(out) =>
+        fail(s"expected invalid value selection, got: $out")
+      case Left(err) =>
+        val msg = Option(err.getMessage).getOrElse(err.toString)
+        assert(msg.contains("invalid test value `Nope/Missing::test_one`"), msg)
+        assert(msg.contains("unknown package"), msg)
+    }
+  }
+
+  test("lib test --value reports packages with no exported test values") {
+    val targetSrc =
+      """export main
+|
+|main = 42
+|""".stripMargin
+    val ccConfJson =
+      """{
+        |  "cc_path": "cc",
+        |  "flags": [],
+        |  "iflags": [],
+        |  "libs": [],
+        |  "os": "test"
+        |}
+|""".stripMargin
+    val files =
+      baseLibFiles(targetSrc) :+ (Chain("repo", "cc_conf.json") -> ccConfJson)
+
+    module.runWith(files)(
+      List(
+        "lib",
+        "test",
+        "--repo_root",
+        "repo",
+        "--value",
+        "MyLib/Foo::missing",
+        "--cc_conf",
+        "repo/cc_conf.json"
+      )
+    ) match {
+      case Right(out) =>
+        fail(s"expected invalid value selection, got: $out")
+      case Left(err) =>
+        val msg = Option(err.getMessage).getOrElse(err.toString)
+        assert(msg.contains("invalid test value `MyLib/Foo::missing`"), msg)
+        assert(msg.contains("has no exported test values"), msg)
+    }
+  }
+
   test(
     "lib test --filter scopes local typechecking to matching package roots"
   ) {
@@ -6919,6 +7202,23 @@ main = 0
       case Right(other)              => fail(s"unexpected output: $other")
       case Left(err)                 =>
         fail(Option(err.getMessage).getOrElse(err.toString))
+    }
+  }
+
+  test("lib check rejects --value") {
+    module.run(
+      List(
+        "lib",
+        "check",
+        "--repo_root",
+        "repo",
+        "--value",
+        "MyLib/Euler/One::test_one"
+      )
+    ) match {
+      case Left(_)  => ()
+      case Right(_) =>
+        fail("expected parser error for unsupported --value on lib check")
     }
   }
 

--- a/core/src/test/scala/dev/bosatsu/codegen/clang/ClangGenTest.scala
+++ b/core/src/test/scala/dev/bosatsu/codegen/clang/ClangGenTest.scala
@@ -414,6 +414,15 @@ main = pick
       val compiled = scala.collection.immutable.SortedMap(
         () -> Map(pn -> List((Identifier.Name("main"), mainExpr)))
       )
+      def exportedValues(
+          packageName: PackageName
+      ): Option[Map[Identifier.Bindable, dev.bosatsu.rankn.Type]] =
+        None
+      def exportedTestEntry(
+          packageName: PackageName,
+          bindable: Identifier.Bindable
+      ): Option[dev.bosatsu.Package.TestEntry[Any]] =
+        None
       val testEntries = Map.empty
       def mainValues(
           mainTypeFn: dev.bosatsu.rankn.Type => Boolean

--- a/core/src/test/scala/dev/bosatsu/codegen/clang/ExternalNamespaceTest.scala
+++ b/core/src/test/scala/dev/bosatsu/codegen/clang/ExternalNamespaceTest.scala
@@ -35,6 +35,15 @@ class ExternalNamespaceTest extends munit.FunSuite {
         Toposort.Success(Vector.empty)
       def compiled: SortedMap[K, MatchlessFromTypedExpr.Compiled[K]] =
         SortedMap.empty
+      def exportedValues(
+          packageName: PackageName
+      ): Option[Map[Identifier.Bindable, Type]] =
+        None
+      def exportedTestEntry(
+          packageName: PackageName,
+          bindable: Identifier.Bindable
+      ): Option[Package.TestEntry[Any]] =
+        None
       def testEntries
           : Map[PackageName, Either[Package.TestDiscoveryError, Package.TestEntry[
             Any

--- a/core/src/test/scala/dev/bosatsu/codegen/python/PythonGenTest.scala
+++ b/core/src/test/scala/dev/bosatsu/codegen/python/PythonGenTest.scala
@@ -183,6 +183,15 @@ class PythonGenTest extends munit.ScalaCheckSuite {
       val compiled = scala.collection.immutable.SortedMap(
         () -> Map(pn -> List((Identifier.Name("main"), mainExpr)))
       )
+      def exportedValues(
+          packageName: PackageName
+      ): Option[Map[Identifier.Bindable, dev.bosatsu.rankn.Type]] =
+        None
+      def exportedTestEntry(
+          packageName: PackageName,
+          bindable: Identifier.Bindable
+      ): Option[dev.bosatsu.Package.TestEntry[Any]] =
+        None
       val testEntries = Map.empty
       def mainValues(
           mainTypeFn: dev.bosatsu.rankn.Type => Boolean
@@ -295,6 +304,15 @@ main = classify_char
       val compiled = scala.collection.immutable.SortedMap(
         () -> Map(pn -> List((Identifier.Name("main"), mainExpr)))
       )
+      def exportedValues(
+          packageName: PackageName
+      ): Option[Map[Identifier.Bindable, dev.bosatsu.rankn.Type]] =
+        None
+      def exportedTestEntry(
+          packageName: PackageName,
+          bindable: Identifier.Bindable
+      ): Option[dev.bosatsu.Package.TestEntry[Any]] =
+        None
       val testEntries = Map.empty
       def mainValues(
           mainTypeFn: dev.bosatsu.rankn.Type => Boolean


### PR DESCRIPTION
Implemented issue #2119 per the merged design doc.

What changed:
- Refactored `ClangTranspiler.Mode.Test` to use explicit selection modes:
  - `ByFilter(regexes, predicate)` for existing behavior
  - `ByValue(package::value)` for single-value selection
- Added `--value <package::value>` parsing (bindable-only) and composed parsing as `valueBranch.orElse(filterBranch)` to enforce `--value`/`--filter` exclusivity at parse time.
- Split parser helpers so `lib check` remains filter-only (`Mode.testFilterOpts`) and does not accept `--value`.
- Added `InvalidTestValueSelection` CLI error with clear messages for:
  - unknown package
  - value not exported
  - exported value not a test type
  - package with no exported test values
- Updated `Mode.Test.values`:
  - filter mode preserves existing discovery behavior and errors
  - value mode resolves exactly one exported top-level test value or fails with `InvalidTestValueSelection`
- Added namespace lookup support needed for value selection:
  - `CompilationNamespace.exportedValues`
  - `CompilationNamespace.exportedTestEntry`
  - implemented in both `CompilationSource` and `DecodedLibraryWithDeps`.
- Added `Package.testEntryForBindable` helper to resolve a named top-level test entry (`Test`/`ProgTest`).
- Updated `Command.testCommand` to use the selector-derived source filter (`test.sourceFilter`).
- Updated `Command.checkCommand` to use filter-only parsing.

Tests added/updated:
- `ToolAndLibCommandTest` now covers:
  - `lib test --value` and `--filter` exclusivity
  - exported plain `Test` value selection
  - exported `ProgTest` value selection
  - non-exported value rejection
  - exported non-test value rejection
  - unknown package/value rejection
  - package with no exported test values rejection
  - `lib check` rejecting `--value`
- Updated `CompilationNamespace` test stubs in:
  - `ClangGenTest`
  - `ExternalNamespaceTest`
  - `PythonGenTest`

Validation run:
- `sbt "coreJVM/test:compile"`
- `sbt "coreJVM/testOnly dev.bosatsu.ToolAndLibCommandTest"`
- `scripts/test_basic.sh`

Fixes #2119

Implements design doc: [docs/design/2119-add-an-option-to-lib-test-to-select-particular-test-values.md](https://github.com/johnynek/bosatsu/blob/main/docs/design/2119-add-an-option-to-lib-test-to-select-particular-test-values.md)

Design source PR: https://github.com/johnynek/bosatsu/pull/2121