### PR TITLE
Follow-up: remove Bosatsu/Predef from core_alpha exported packages

### DIFF
--- a/test_workspace/core_alpha_conf.json
+++ b/test_workspace/core_alpha_conf.json
@@ -29,7 +29,6 @@
     "Bosatsu/Num/BinNat",
     "Bosatsu/Nothing",
     "Bosatsu/Option",
-    "Bosatsu/Predef",
     "Bosatsu/Json",
     "Bosatsu/Prog",
     "Bosatsu/Rand",


### PR DESCRIPTION
## Summary
Follow-up fix for the recently merged docs-linking PR: remove `Bosatsu/Predef` from `core_alpha` exported package metadata.

`Bosatsu/Predef` is compiler-injected and not part of any library API surface, so it should not be listed as an exported package in `core_alpha_conf.json`.

## Change
- Remove `"Bosatsu/Predef"` from `test_workspace/core_alpha_conf.json` `exported_packages`.

## Validation
- JSON parse check: `python3 -m json.tool test_workspace/core_alpha_conf.json`
