### PR TITLE
Increase flattenLets usage for non-recursive TypedExpr let traversals

### DIFF
--- a/core/src/main/scala/dev/bosatsu/TypedExpr.scala
+++ b/core/src/main/scala/dev/bosatsu/TypedExpr.scala
@@ -35,7 +35,10 @@ sealed abstract class TypedExpr[+T] { self: Product =>
       case Local(_, tpe, _)     => tpe
       case Global(_, _, tpe, _) => tpe
       case App(_, _, tpe, _)    => tpe
-      case Let(_, _, in, _, _)  =>
+      case let @ Let(_, _, _, RecursionKind.NonRecursive, _) =>
+        val (_, tail) = TypedExpr.flattenLets(let)
+        tail.getType
+      case Let(_, _, in, _, _) =>
         in.getType
       case Loop(_, body, _) =>
         body.getType
@@ -56,7 +59,13 @@ sealed abstract class TypedExpr[+T] { self: Product =>
         res.size
       case Local(_, _, _) | Literal(_, _, _) | Global(_, _, _, _) => 1
       case App(fn, args, _, _) => fn.size + args.foldMap(_.size)
-      case Let(_, e, in, _, _) => e.size + in.size
+      case let @ Let(_, _, _, RecursionKind.NonRecursive, _) =>
+        val (lets, tail) = TypedExpr.flattenLets(let)
+        lets.foldLeft(tail.size) { case (acc, (_, rhs, _)) =>
+          rhs.size + acc
+        }
+      case Let(_, e, in, _, _) =>
+        e.size + in.size
       case Loop(args, body, _) =>
         args.foldMap(_._2.size) + body.size
       case Recur(args, _, _) =>
@@ -212,14 +221,19 @@ sealed abstract class TypedExpr[+T] { self: Product =>
         ListUtil.filterNot(res.freeVarsDup)(nameSet)
       case App(fn, args, _, _) =>
         fn.freeVarsDup ::: args.reduceMap(_.freeVarsDup)
-      case Let(arg, argE, in, rec, _) =>
+      case Let(arg, argE, in, RecursionKind.Recursive, _) =>
         val argFree0 = argE.freeVarsDup
-        val argFree =
-          if (rec.isRecursive) {
-            ListUtil.filterNot(argFree0)(_ == arg)
-          } else argFree0
-
+        val argFree = ListUtil.filterNot(argFree0)(_ == arg)
         argFree ::: (ListUtil.filterNot(in.freeVarsDup)(_ == arg))
+      case let @ Let(_, _, _, RecursionKind.NonRecursive, _) =>
+        val (lets, tail) = TypedExpr.flattenLets(let)
+        val rev = lets.reverseIterator
+        var acc = tail.freeVarsDup
+        while (rev.hasNext) {
+          val (arg, rhs, _) = rev.next()
+          acc = rhs.freeVarsDup ::: ListUtil.filterNot(acc)(_ == arg)
+        }
+        acc
       case Loop(args, body, _) =>
         val argsSet = args.iterator.map(_._1).toSet
         val argsFree = args.foldMap(_._2.freeVarsDup)
@@ -278,8 +292,17 @@ sealed abstract class TypedExpr[+T] { self: Product =>
         args.toList.map(_._1) ::: res.allVarsDup
       case App(fn, args, _, _) =>
         fn.allVarsDup ::: args.reduceMap(_.allVarsDup)
-      case Let(arg, argE, in, _, _) =>
+      case Let(arg, argE, in, RecursionKind.Recursive, _) =>
         arg :: (argE.allVarsDup ::: in.allVarsDup)
+      case let @ Let(_, _, _, RecursionKind.NonRecursive, _) =>
+        val (lets, tail) = TypedExpr.flattenLets(let)
+        val rev = lets.reverseIterator
+        var acc = tail.allVarsDup
+        while (rev.hasNext) {
+          val (arg, rhs, _) = rev.next()
+          acc = arg :: (rhs.allVarsDup ::: acc)
+        }
+        acc
       case Loop(args, body, _) =>
         args.toList
           .map(_._1) ::: (args.foldMap(_._2.allVarsDup) ::: body.allVarsDup)
@@ -1102,6 +1125,20 @@ object TypedExpr {
         } else {
           None
         }
+      case let @ Let(_, _, _, RecursionKind.NonRecursive, _) =>
+        val (lets, tail) = flattenLets(let)
+        toArgsBody(arity, tail).flatMap { case (args, body0) =>
+          val rev = lets.reverseIterator
+          var ok = true
+          var body = body0
+          while (ok && rev.hasNext) {
+            val (arg, rhs, letTag) = rev.next()
+            if (args.exists(_._1 == arg)) ok = false
+            else body = Let(arg, rhs, body, RecursionKind.NonRecursive, letTag)
+          }
+          if (ok) Some((args, body))
+          else None
+        }
       case Let(arg, e, in, r, t) =>
         toArgsBody(arity, in).flatMap { case (args, body) =>
           // if args0 don't shadow arg, we can push
@@ -1271,6 +1308,14 @@ object TypedExpr {
             visitExpr(f, shadowed)
             foreach(args.iterator)(visitExpr(_, shadowed))
             visitType(tpe, shadowed)
+          case let @ Let(_, _, _, RecursionKind.NonRecursive, _) =>
+            val (lets, tail) = flattenLets(let)
+            val it = lets.iterator
+            while (it.hasNext) {
+              val (_, rhs, _) = it.next()
+              visitExpr(rhs, shadowed)
+            }
+            visitExpr(tail, shadowed)
           case Let(_, exp, in, _, _) =>
             visitExpr(exp, shadowed)
             visitExpr(in, shadowed)
@@ -1418,6 +1463,14 @@ object TypedExpr {
             loopExpr(f)
             foreach(args.iterator)(loopExpr(_))
             addType(tpe)
+          case let @ Let(_, _, _, RecursionKind.NonRecursive, _) =>
+            val (lets, tail) = flattenLets(let)
+            val it = lets.iterator
+            while (it.hasNext) {
+              val (_, rhs, _) = it.next()
+              loopExpr(rhs)
+            }
+            loopExpr(tail)
           case Let(_, exp, in, _, _) =>
             loopExpr(exp)
             loopExpr(in)
@@ -2249,6 +2302,18 @@ object TypedExpr {
           }
           Some(Match(arg, b1, tag))
         }
+      case let @ Let(_, _, _, RecursionKind.NonRecursive, _) =>
+        val (lets, tail) = flattenLets(let)
+        val blocked = lets.exists { case (_, rhs, _) =>
+          val argFree = Type.freeBoundTyVars(rhs.getType :: Nil).toSet
+          Type.quantVars(g.quantType).exists { case (b, _) => argFree(b) }
+        }
+        if (blocked) None
+        else {
+          val gin = Generic(g.quant, tail)
+          val gin1 = pushGeneric(gin).getOrElse(gin)
+          Some(letAllNonRecWithTags(lets, gin1))
+        }
       case Let(b, v, in, rec, tag) =>
         val argFree = Type.freeBoundTyVars(v.getType :: Nil).toSet
         if (Type.quantVars(g.quantType).exists { case (b, _) => argFree(b) }) {
@@ -2334,6 +2399,9 @@ object TypedExpr {
                         ann(expr, tpe, None)
                     }
                 }
+              case let @ Let(_, _, _, RecursionKind.NonRecursive, _) =>
+                val (lets, tail) = flattenLets(let)
+                letAllNonRecWithTags(lets, self(tail))
               case Let(arg, argE, in, rec, tag) =>
                 Let(arg, argE, self(in), rec, tag)
               case Loop(args, body, tag) =>
@@ -2669,6 +2737,21 @@ object TypedExpr {
             Type.substituteVar(tpe, env),
             tag
           )
+        case let @ Let(_, _, _, RecursionKind.NonRecursive, _) =>
+          val (lets, tail) = flattenLets(let)
+          var changed = false
+          val rebuilt = List.newBuilder[(Bindable, TypedExpr[A], A)]
+          val it = lets.iterator
+          while (it.hasNext) {
+            val (n, rhs, letTag) = it.next()
+            val rhs1 = substituteTypeVar(rhs, env)
+            if (!(rhs1 eq rhs)) changed = true
+            rebuilt += ((n, rhs1, letTag))
+          }
+          val tail1 = substituteTypeVar(tail, env)
+          if (!(tail1 eq tail)) changed = true
+          if (!changed) let
+          else letAllNonRecWithTags(rebuilt.result(), tail1)
         case Let(v, exp, in, rec, tag) =>
           Let(
             v,
@@ -2727,18 +2810,31 @@ object TypedExpr {
       case n: Name[A]                      => n
       case App(fnT, args, tpe, tag)        =>
         App(recur(fnT), args.map(recur), tpe, tag)
-      case Let(b, e, in, r, t) =>
+      case Let(b, e, in, RecursionKind.Recursive, t) =>
         if (b == name) {
-          if (r.isRecursive) {
-            // in this case, b is in scope for e
-            // so it shadows a the previous definition
-            te // shadow
-          } else {
-            // then b is not in scope for e
-            // but b does shadow inside `in`
-            Let(b, recur(e), in, r, t)
-          }
-        } else Let(b, recur(e), recur(in), r, t)
+          // in this case, b is in scope for e
+          // so it shadows the previous definition
+          te
+        } else Let(b, recur(e), recur(in), RecursionKind.Recursive, t)
+      case let @ Let(_, _, _, RecursionKind.NonRecursive, _) =>
+        val (lets, tail) = flattenLets(let)
+        var visible = true
+        var changed = false
+        val rebuilt = List.newBuilder[(Bindable, TypedExpr[A], A)]
+        val it = lets.iterator
+        while (it.hasNext) {
+          val (arg, rhs, letTag) = it.next()
+          val rhs1 =
+            if (visible) recur(rhs)
+            else rhs
+          if (!(rhs1 eq rhs)) changed = true
+          rebuilt += ((arg, rhs1, letTag))
+          if (visible && (arg == name)) visible = false
+        }
+        val tail1 = if (visible) recur(tail) else tail
+        if (!(tail1 eq tail)) changed = true
+        if (!changed) let
+        else letAllNonRecWithTags(rebuilt.result(), tail1)
       case Loop(args, body, tag) =>
         val args1 = args.map { case (b, expr) =>
           (b, recur(expr))
@@ -2829,6 +2925,9 @@ object TypedExpr {
             }
           case Local(_, _, _) | Global(_, _, _, _) | Literal(_, _, _) =>
             ann(expr, fntpe, None)
+          case let @ Let(_, _, _, RecursionKind.NonRecursive, _) =>
+            val (lets, tail) = flattenLets(let)
+            letAllNonRecWithTags(lets, self(tail))
           case Let(arg, argE, in, rec, tag) =>
             Let(arg, argE, self(in), rec, tag)
           case Loop(args, body, tag) =>

--- a/core/src/main/scala/dev/bosatsu/TypedExprNormalization.scala
+++ b/core/src/main/scala/dev/bosatsu/TypedExprNormalization.scala
@@ -172,12 +172,20 @@ object TypedExprNormalization {
         case App(fn, args, _, _) =>
           collect(fn, blocked, blockedTy, inSuspension)
           args.iterator.foreach(collect(_, blocked, blockedTy, inSuspension))
-        case Let(arg, expr1, in, rec, _) =>
-          val blockedExpr =
-            if (rec.isRecursive) blocked + arg
-            else blocked
+        case Let(arg, expr1, in, RecursionKind.Recursive, _) =>
+          val blockedExpr = blocked + arg
           collect(expr1, blockedExpr, blockedTy, inSuspension)
           collect(in, blocked + arg, blockedTy, inSuspension)
+        case let @ Let(_, _, _, RecursionKind.NonRecursive, _) =>
+          val (lets, tail) = TypedExpr.flattenLets(let)
+          var blockedIn = blocked
+          val it = lets.iterator
+          while (it.hasNext) {
+            val (arg, rhs, _) = it.next()
+            collect(rhs, blockedIn, blockedTy, inSuspension)
+            blockedIn = blockedIn + arg
+          }
+          collect(tail, blockedIn, blockedTy, inSuspension)
         case Loop(args, body, _) =>
           val blockedLoop = blocked ++ args.iterator.map(_._1)
           args.iterator.foreach { case (_, initExpr) =>
@@ -273,15 +281,30 @@ object TypedExprNormalization {
                   )
                 if ((fn1 eq fn) && (args1 eq args)) app0
                 else App(fn1, args1, tpe, tag)
-              case let0 @ Let(arg, expr1, in, rec, tag) =>
-                val blockedExpr =
-                  if (rec.isRecursive) blocked + arg
-                  else blocked
+              case let0 @ Let(arg, expr1, in, RecursionKind.Recursive, tag) =>
+                val blockedExpr = blocked + arg
                 val expr2 =
                   replace(expr1, blockedExpr, blockedTy, inSuspension)
                 val in1 = replace(in, blocked + arg, blockedTy, inSuspension)
                 if ((expr2 eq expr1) && (in1 eq in)) let0
-                else Let(arg, expr2, in1, rec, tag)
+                else Let(arg, expr2, in1, RecursionKind.Recursive, tag)
+              case let0 @ Let(_, _, _, RecursionKind.NonRecursive, _) =>
+                val (lets, tail) = TypedExpr.flattenLets(let0)
+                var blockedIn = blocked
+                var changed = false
+                val rebuilt = List.newBuilder[(Bindable, TypedExpr[A], A)]
+                val it = lets.iterator
+                while (it.hasNext) {
+                  val (arg, rhs, letTag) = it.next()
+                  val rhs1 = replace(rhs, blockedIn, blockedTy, inSuspension)
+                  if (!(rhs1 eq rhs)) changed = true
+                  rebuilt += ((arg, rhs1, letTag))
+                  blockedIn = blockedIn + arg
+                }
+                val tail1 = replace(tail, blockedIn, blockedTy, inSuspension)
+                if (!(tail1 eq tail)) changed = true
+                if (!changed) let0
+                else TypedExpr.letAllNonRecWithTags(rebuilt.result(), tail1)
               case loop0 @ Loop(args, body, tag) =>
                 val blockedLoop = blocked ++ args.iterator.map(_._1)
                 val args1 = ListUtil.mapConserveNel(args) {
@@ -1921,6 +1944,11 @@ object TypedExprNormalization {
           // maybe inline lambdas so we can possibly
           // apply (x -> f)(g) => let x = g in f
           lambdaSimple
+        case let @ Let(_, _, _, RecursionKind.NonRecursive, _) =>
+          val (lets, tail) = TypedExpr.flattenLets(let)
+          lets.forall { case (_, rhs, _) =>
+            isSimpleNotTail(rhs, lambdaSimple)
+          } && isSimple(tail, lambdaSimple)
         case Let(_, ex, in, _, _) =>
           isSimpleNotTail(ex, lambdaSimple) && isSimple(in, lambdaSimple)
         case Loop(_, _, _) | Recur(_, _, _) =>
@@ -1972,12 +2000,12 @@ object TypedExprNormalization {
               else None
             case _ => None
           }
-        case Let(arg, expr, in, RecursionKind.NonRecursive, _) =>
-          evaluate(
-            in,
-            scope.updated(arg, (RecursionKind.NonRecursive, expr, scope)),
-            totalityCheck
-          )
+        case let @ Let(_, _, _, RecursionKind.NonRecursive, _) =>
+          val (lets, tail) = TypedExpr.flattenLets(let)
+          val scope1 = lets.foldLeft(scope) { case (accScope, (arg, expr, _)) =>
+            accScope.updated(arg, (RecursionKind.NonRecursive, expr, accScope))
+          }
+          evaluate(tail, scope1, totalityCheck)
         case FnArgs(fn, args) =>
           evaluate(fn, scope, totalityCheck).map {
             case EvalResult.Cons(p, c, ahead) =>


### PR DESCRIPTION
Implemented issue #2133 with focused changes in `TypedExpr.scala` and `TypedExprNormalization.scala` to reduce traversal depth on non-recursive let chains by using `flattenLets` in additional recursive hotspots. Updated `TypedExpr` paths include type/size/free-var/all-var computation and several let-recursing rewrite/coercion/substitution helpers, while leaving `Traverse[TypedExpr]` untouched. Updated `TypedExprNormalization` paths include share-collection/replace traversal, `isSimple`, and non-recursive `evaluate` scope threading. Ran `sbt "coreJVM/test:compile"` and the required `scripts/test_basic.sh`; both passed (tests: Total 64, Failed 0, Errors 0).

Fixes #2133