### PR TITLE
Optimize exact trailing list pattern lowering

### DIFF
--- a/core/src/main/scala/dev/bosatsu/Matchless.scala
+++ b/core/src/main/scala/dev/bosatsu/Matchless.scala
@@ -3362,6 +3362,16 @@ object Matchless {
         case _: Pattern.ListPart.Glob => None
       }
 
+    def prepareLeftGlob(
+        glob: Pattern.ListPart.Glob
+    ): F[Option[(LocalAnonMut, Bindable)]] =
+      glob match {
+        case Pattern.ListPart.WildList =>
+          Monad[F].pure(None)
+        case Pattern.ListPart.NamedList(ln) =>
+          makeAnon.map(nm => Some((LocalAnonMut(nm), ln)))
+      }
+
     def advanceListBy(
         lead: LocalAnonMut,
         ok: LocalAnonMut,
@@ -3426,13 +3436,7 @@ object Matchless {
         exactItems: NonEmptyList[Pattern[(PackageName, Constructor), Type]]
     ): F[UnionMatch] = {
       val exactPat = Pattern.ListPat(exactItems.toList.map(Pattern.ListPart.Item(_)))
-      val leftF: F[Option[(LocalAnonMut, Bindable)]] =
-        glob match {
-          case Pattern.ListPart.WildList =>
-            Monad[F].pure(None)
-          case Pattern.ListPart.NamedList(ln) =>
-            makeAnon.map(nm => Some((LocalAnonMut(nm), ln)))
-        }
+      val leftF = prepareLeftGlob(glob)
       val anon = makeAnon.map(LocalAnonMut(_))
 
       for {
@@ -3636,13 +3640,7 @@ object Matchless {
                   // we know all the bindings we will make, allocate
                   // anons for them, do the loop, and then return
                   // the boolean of did we match
-                  val leftF: F[Option[(LocalAnonMut, Bindable)]] =
-                    glob match {
-                      case Pattern.ListPart.WildList =>
-                        Monad[F].pure(None)
-                      case Pattern.ListPart.NamedList(ln) =>
-                        makeAnon.map(nm => Some((LocalAnonMut(nm), ln)))
-                    }
+                  val leftF = prepareLeftGlob(glob)
 
                   (leftF, makeAnon).tupled
                     .flatMap { case (optAnonLeft, tmpList) =>

--- a/core/src/test/scala/dev/bosatsu/MatchlessTests.scala
+++ b/core/src/test/scala/dev/bosatsu/MatchlessTests.scala
@@ -443,53 +443,40 @@ class MatchlessTest extends munit.ScalaCheckSuite {
           false
       }
 
-    def loopBool(b: Matchless.BoolExpr[Unit]): Boolean =
+    def walkBool(
+        b: Matchless.BoolExpr[Unit]
+    )(
+        exprFn: Matchless.Expr[Unit] => Boolean,
+        boolFn: Matchless.BoolExpr[Unit] => Boolean
+    ): Boolean =
       b match {
         case Matchless.EqualsLit(e, _) =>
-          loopExpr(e)
+          exprFn(e)
         case Matchless.LtEqLit(e, _) =>
-          loopExpr(e)
+          exprFn(e)
         case Matchless.EqualsNat(e, _) =>
-          loopExpr(e)
+          exprFn(e)
         case Matchless.And(l, r) =>
-          loopBool(l) || loopBool(r)
+          boolFn(l) || boolFn(r)
         case Matchless.CheckVariant(e, _, _, _) =>
-          loopExpr(e)
+          exprFn(e)
         case Matchless.CheckVariantSet(e, _, _, _) =>
-          loopExpr(e)
+          exprFn(e)
         case Matchless.SetMut(_, e) =>
-          loopExpr(e)
+          exprFn(e)
         case Matchless.TrueConst =>
           false
         case Matchless.LetBool(_, value, in) =>
-          loopExpr(value) || loopBool(in)
+          exprFn(value) || boolFn(in)
         case Matchless.LetMutBool(_, in) =>
-          loopBool(in)
+          boolFn(in)
       }
 
+    def loopBool(b: Matchless.BoolExpr[Unit]): Boolean =
+      walkBool(b)(loopExpr, loopBool)
+
     def boolHasIf(b: Matchless.BoolExpr[Unit]): Boolean =
-      b match {
-        case Matchless.EqualsLit(e, _) =>
-          exprHasIf(e)
-        case Matchless.LtEqLit(e, _) =>
-          exprHasIf(e)
-        case Matchless.EqualsNat(e, _) =>
-          exprHasIf(e)
-        case Matchless.And(l, r) =>
-          boolHasIf(l) || boolHasIf(r)
-        case Matchless.CheckVariant(e, _, _, _) =>
-          exprHasIf(e)
-        case Matchless.CheckVariantSet(e, _, _, _) =>
-          exprHasIf(e)
-        case Matchless.SetMut(_, e) =>
-          exprHasIf(e)
-        case Matchless.TrueConst =>
-          false
-        case Matchless.LetBool(_, value, in) =>
-          exprHasIf(value) || boolHasIf(in)
-        case Matchless.LetMutBool(_, in) =>
-          boolHasIf(in)
-      }
+      walkBool(b)(exprHasIf, boolHasIf)
 
     def loopExpr(e: Matchless.Expr[Unit]): Boolean =
       e match {


### PR DESCRIPTION
## Summary
- add a fast path for list patterns with a leading glob and exact trailing items
- keep later-glob list searches on the existing retry-based lowering
- add Matchless tests for the new loop shape and named-prefix binding semantics

## Testing
- sbt "coreJVM/testOnly dev.bosatsu.MatchlessTest" "coreJVM/testOnly dev.bosatsu.MatchlessRegressionTest"
- sbt "cli/test" "coreJVM/testOnly dev.bosatsu.EvaluationTest"