### PR TITLE
Document explicit-interface design philosophy

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,18 @@ Bosatsu is a simple, non-turing complete language designed for configuration, qu
 borrows from [Python](https://www.python.org/), [Haskell](https://www.haskell.org/),
 [Dhall](https://hackage.haskell.org/package/dhall) and [Rust](https://www.rust-lang.org/en-US/).
 
+Bosatsu aims to keep logic flow literal in the source even when the compiler is
+doing sophisticated checking. A reader should be able to see the package
+interface at the top of the file, where each non-predef name comes from, and
+how control flows through the program directly from the syntax. Bosatsu is
+stricter about names than about type annotations: dependencies stay explicit,
+while most types can be inferred unless the source literally names a foreign
+type.
+
+Correctness comes from a sound total language with explicit effects and
+private-by-default package boundaries. Simplicity comes from local reasoning,
+not from minimizing keystrokes at all costs.
+
 Please see the [documentation site](https://johnynek.github.io/bosatsu/)
 and the [Getting started guide](docs/src/main/paradox/getting_started.md)
 or try basic expressions using this [in-browser Bosatsu compiler](https://johnynek.github.io/bosatsu/compiler/).

--- a/docs/src/main/paradox/design.md
+++ b/docs/src/main/paradox/design.md
@@ -8,11 +8,70 @@ Bosatsu has three main themes:
 These are in priority order: we won’t trade correctness for usability, and we’re
 skeptical of features that add complexity just for convenience.
 
+Bosatsu aims to let the compiler do difficult proof work without hiding program
+behavior from readers. A human reading typechecked source should be able to
+recover a package's interface, the origin of each non-predef name, and the
+control flow of each function directly from the file.
+
 ## Relationship to Python
 The user experience is inspired by Python, but Bosatsu is a minimal, statically
 typed, total language. All external names must be explicitly imported, and all
 values are private unless exported. This keeps package dependencies explicit
-without type inference.
+even with type inference.
+
+The goal is not "Python with more types." It is a language with Python-like
+syntax and much stricter rules about what may be implicit.
+
+## Literal Source Over Hidden Flow
+Bosatsu prefers source that is easy for humans to reason about locally:
+
+1. the interface of a package is at the top of the file: package name, imports,
+   and exports
+2. every non-predef name used in a file should have an obvious source: defined
+   locally or imported explicitly
+3. control flow should be visible in the syntax rather than hidden in mutation,
+   exceptions, implicit effects, or implicit currying
+4. surface sugar should desugar locally and mechanically: operators are
+   functions, method syntax is function application, and `<-` is explicit
+   continuation-style binding
+
+The compiler may infer, normalize, and prove, but it should not invent hidden
+dependencies or hidden program behavior.
+
+## Names Are Stricter Than Types
+Bosatsu is intentionally stricter about names than about type annotations.
+
+Names create dependencies and carry most of the burden of human readability, so
+they stay explicit. Types also help humans, but once types can be inferred and
+checked, we do not require them just for ceremony.
+
+The practical rule is:
+
+1. if source literally names a type from another package, import that type so
+   the dependency remains explicit
+2. if a foreign type appears only through inference from values already
+   imported from a direct dependency, no extra type import is required
+
+This keeps logic flow readable without forcing type noise into every
+definition, while still making package dependencies visible.
+
+## Explicit Boundaries
+Bosatsu uses explicit boundaries to preserve modularity and safety:
+
+1. values are private unless exported
+2. types and constructors can be exported separately (`Type` vs `Type()`)
+3. effects are explicit `Prog[...]` values rather than implicit execution
+4. external power lives behind narrow trusted boundaries
+5. unused imports and unused top-level values are errors; discard should be
+   written intentionally as `_ = expr`
+
+These boundaries are part of both simplicity and correctness: they reduce
+surprising behavior and make composition safer.
+
+## Source Locality And Determinism
+Bosatsu prefers rules that preserve source order, stable diagnostics, and
+deterministic interfaces. Compiler checks may be sophisticated, but they should
+stay anchored to the user's source rather than to rewritten intermediate forms.
 
 ## Problem domain for Bosatsu
 Bosatsu targets the space between general-purpose languages and data formats

--- a/docs/src/main/paradox/language_guide.md
+++ b/docs/src/main/paradox/language_guide.md
@@ -27,6 +27,16 @@ the constraints too far, we risk losing non-negotiable properties: a sound type
 system we can trust, and recursion/loop forms with proven termination (so we do
 not admit nonsense inhabitants of types such as `forall a, b. a -> b`).
 
+Bosatsu also aims for source that is easy for humans to reason about locally.
+The compiler may do sophisticated work such as type inference, totality
+checking, and recursion checking, but the logic flow should remain literal in
+the code. A reader should be able to see:
+
+1. the package interface at the top of the file
+1. where each non-predef name comes from
+1. control flow directly from syntax rather than hidden mutation, implicit
+   effects, or implicit currying
+
 ## Quick start (5 minutes)
 A tiny, complete file:
 
@@ -69,6 +79,23 @@ most_fav = match mammals:
   case [head, *tail]: head
   case []: "who knows?"
 ```
+
+This is a design philosophy, not just a parser rule. A human reading a file
+should be able to answer:
+
+1. which packages this file depends on
+1. what values and types this package exposes
+1. where each external name used below came from
+
+Bosatsu is stricter about names than about type annotations. If source
+literally mentions a type from another package, import that type so the
+dependency stays explicit. If a foreign type appears only through inference
+from values you already import from a direct dependency, no extra type import
+is required.
+
+`Bosatsu/Predef` is the standard exception: its names are available by default,
+though you can still import or rename predef names explicitly when that is
+clearer.
 
 ## Literals
 


### PR DESCRIPTION
## Summary
- expand the design philosophy docs to state that Bosatsu keeps interfaces, name provenance, and control flow literal in source
- document that Bosatsu is stricter about names than type annotations, including the rule for importing foreign types only when they are named in source
- add a compact version of the same philosophy to the language guide and README

## Testing
- git diff --check
- did not run a full docs/site build