### PR TITLE
Move lib check CPU-heavy work onto compute

### DIFF
--- a/core/src/main/scala/dev/bosatsu/PackageMap.scala
+++ b/core/src/main/scala/dev/bosatsu/PackageMap.scala
@@ -782,8 +782,11 @@ object PackageMap {
       cache: InferCache[F],
       phases: InferPhases
   ): F[Ior[NonEmptyList[PackageError], Inferred]] =
-    IorT
-      .fromIor[F](resolveAll(ps, ifs))
+    IorT(
+      summon[CanPromise[F]].compute {
+        resolveAll(ps, ifs)
+      }
+    )
       .flatMap(resolved => IorT(inferAll(resolved, compileOptions, cache, phases)))
       .value
 

--- a/core/src/main/scala/dev/bosatsu/cache/CompileCache.scala
+++ b/core/src/main/scala/dev/bosatsu/cache/CompileCache.scala
@@ -179,10 +179,15 @@ object CompileCache {
 
     override def dependencyHash(interface: Package.Interface): F[DepHash] = {
       statsUpdate { dependencyHashCalls.incrementAndGet(); () }
-      moduleIOMonad.fromTry(memoizedInterfaceHash(interface)).map { hash =>
-        interfaceByHashHex.putIfAbsent(hash.hex, interface)
-        hash
-      }
+      platformIO.canPromiseF
+        .compute {
+          memoizedInterfaceHash(interface)
+        }
+        .flatMap(moduleIOMonad.fromTry(_))
+        .map { hash =>
+          interfaceByHashHex.putIfAbsent(hash.hex, interface)
+          hash
+        }
     }
 
     private def keyPath(hash: HashValue[Algo.Blake3]): P =
@@ -219,7 +224,7 @@ object CompileCache {
         phaseIdentity: String
     ): F[Key] = {
       statsUpdate { keyGenCalls.incrementAndGet(); () }
-      moduleIOMonad.fromTry {
+      platformIO.canPromiseF.compute {
         val depInterfacesBuilder =
           SortedMap.newBuilder[PackageName, Package.Interface]
         val depHashIter = depInterfaceHashes.iterator
@@ -258,6 +263,7 @@ object CompileCache {
             Failure(err)
         }
       }
+      .flatMap(moduleIOMonad.fromTry(_))
     }
 
     def get(key: Key): F[Option[Package.Inferred]] = {

--- a/core/src/main/scala/dev/bosatsu/tool/PackageResolver.scala
+++ b/core/src/main/scala/dev/bosatsu/tool/PackageResolver.scala
@@ -36,17 +36,19 @@ sealed abstract class PackageResolver[IO[_], Path] {
   )(
       platformIO: PlatformIO[IO, Path]
   ): IO[ValidatedNel[PathParseError[Path], List[(Path, Package.Header)]]] = {
-    import platformIO.moduleIOMonad
+    import platformIO.{canPromiseF, moduleIOMonad}
     // we use IO(traverse) so we can accumulate all the errors in parallel easily
     // if do this with parseFile returning an IO, we need to do IO.Par[Validated[...]]
     // and use the composed applicative... too much work for the same result
     val headerParser = Package.headerParser <* P.anyChar.rep0
     paths
       .traverse { path =>
-        platformIO.readUtf8(path).map { str =>
-          PathParseError
-            .parseString(headerParser, path, str)
-            .map { case (_, pp) => (path, pp) }
+        platformIO.readUtf8(path).flatMap { str =>
+          canPromiseF.compute {
+            PathParseError
+              .parseString(headerParser, path, str)
+              .map { case (_, pp) => (path, pp) }
+          }
         }
       }
       .map(_.sequence)

--- a/core/src/main/scala/dev/bosatsu/tool/PathParseError.scala
+++ b/core/src/main/scala/dev/bosatsu/tool/PathParseError.scala
@@ -28,15 +28,20 @@ object PathParseError {
       path: Path,
       platformIO: PlatformIO[IO, Path]
   ): IO[ValidatedNel[PathParseError[Path], (LocationMap, A)]] = {
-    import platformIO.moduleIOMonad
+    import platformIO.{canPromiseF, moduleIOMonad}
 
     platformIO
       .readUtf8(path)
       .attempt
-      .map {
-        case Right(str) => PathParseError.parseString(p, path, str)
+      .flatMap {
+        case Right(str) =>
+          canPromiseF.compute {
+            PathParseError.parseString(p, path, str)
+          }
         case Left(err)  =>
-          Validated.invalidNel(PathParseError.FileError(path, err))
+          moduleIOMonad.pure(
+            Validated.invalidNel(PathParseError.FileError(path, err))
+          )
       }
   }
 }


### PR DESCRIPTION
## Summary
- move source and header parsing onto `CanPromise.compute`
- run `resolveAll` inside `CanPromise.compute` before inference
- move compile-cache interface hashing and key generation onto `CanPromise.compute` while preserving explicit `Try` and `fromTry` error handling

## Context
Issue #2166 reported cats-effect starvation warnings in CI when running the native image. The typed recursion checker and Z3 calls were already inside the existing `CanPromise.compute` block in `PackageMap.inferAll`, so this change targets the remaining CPU-heavy pure work in the `lib check` path that was still running on the compute pool.

## Testing
- `sbt compile`

Fixes #2166