### PR TITLE
Increase ExprTest timeout to 2 minutes

### DIFF
--- a/core/src/test/scala/dev/bosatsu/ExprTest.scala
+++ b/core/src/test/scala/dev/bosatsu/ExprTest.scala
@@ -6,8 +6,11 @@ import cats.syntax.all._
 import dev.bosatsu.rankn.Type
 import org.scalacheck.{Arbitrary, Gen}
 import org.scalacheck.Prop.forAll
+import scala.concurrent.duration.DurationInt
 
 class ExprTest extends munit.ScalaCheckSuite {
+  override val munitTimeout = 2.minutes
+
   override def scalaCheckTestParameters =
     super.scalaCheckTestParameters.withMinSuccessfulTests(
       if (Platform.isScalaJvm) 5000 else 500


### PR DESCRIPTION
Implemented issue #2172 with a focused one-file change in `core/src/test/scala/dev/bosatsu/ExprTest.scala`: added `scala.concurrent.duration.DurationInt` import and set `override val munitTimeout = 2.minutes` on `ExprTest`. This raises the per-test timeout from the default 30s to 2 minutes, which covers the intermittently slow test `Expr recursive app utilities are stack safe on right-deep binary app chains` without changing test logic. Verification: `scripts/test_basic.sh` passed (`Passed: Total 60, Failed 0, Errors 0`).

Fixes #2172