### PR TITLE
Rename Float64 predef `timesf` to `mulf`

### DIFF
--- a/c_runtime/bosatsu_ext_Bosatsu_l_Predef.c
+++ b/c_runtime/bosatsu_ext_Bosatsu_l_Predef.c
@@ -278,8 +278,13 @@ BValue ___bsts_g_Bosatsu_l_Predef_l_times(BValue a, BValue b) {
   return ___bsts_g_Bosatsu_l_Predef_l_mul(a, b);
 }
 
-BValue ___bsts_g_Bosatsu_l_Predef_l_timesf(BValue a, BValue b) {
+BValue ___bsts_g_Bosatsu_l_Predef_l_mulf(BValue a, BValue b) {
   return bsts_float64_from_double(bsts_float64_to_double(a) * bsts_float64_to_double(b));
+}
+
+BValue ___bsts_g_Bosatsu_l_Predef_l_timesf(BValue a, BValue b) {
+  // compatibility alias for previously exported predef name
+  return ___bsts_g_Bosatsu_l_Predef_l_mulf(a, b);
 }
 
 BValue ___bsts_g_Bosatsu_l_Predef_l_trace(BValue a, BValue b) {

--- a/c_runtime/bosatsu_ext_Bosatsu_l_Predef.h
+++ b/c_runtime/bosatsu_ext_Bosatsu_l_Predef.h
@@ -62,6 +62,8 @@ BValue ___bsts_g_Bosatsu_l_Predef_l_mul(BValue a, BValue b);
 
 BValue ___bsts_g_Bosatsu_l_Predef_l_times(BValue a, BValue b);
 
+BValue ___bsts_g_Bosatsu_l_Predef_l_mulf(BValue a, BValue b);
+
 BValue ___bsts_g_Bosatsu_l_Predef_l_timesf(BValue a, BValue b);
 
 BValue ___bsts_g_Bosatsu_l_Predef_l_trace(BValue a, BValue b);

--- a/core/src/main/resources/bosatsu/predef.bosatsu
+++ b/core/src/main/resources/bosatsu/predef.bosatsu
@@ -96,7 +96,7 @@ export (
   cmp_String,
   string_Order,
   mul,
-  timesf,
+  mulf,
   trace,
   uncurry2,
   uncurry3,
@@ -255,7 +255,7 @@ external def addf(a: Float64, b: Float64) -> Float64
 # Floating-point subtraction.
 external def subf(a: Float64, b: Float64) -> Float64
 # Floating-point multiplication.
-external def timesf(a: Float64, b: Float64) -> Float64
+external def mulf(a: Float64, b: Float64) -> Float64
 # IEEE754 floating-point division; unlike `div`, dividing by `0.0` yields `∞`, `-∞`, or `.NaN`.
 external def divf(a: Float64, b: Float64) -> Float64
 # Total Float64 comparison where all `.NaN` values are equal and ordered before non-`.NaN` values.

--- a/core/src/main/scala/dev/bosatsu/OperatorHints.scala
+++ b/core/src/main/scala/dev/bosatsu/OperatorHints.scala
@@ -174,7 +174,7 @@ object OperatorHints {
       case "-" =>
         numericFns(site, "sub", "subf")
       case "*" =>
-        numericFns(site, "mul", "timesf")
+        numericFns(site, "mul", "mulf")
       case "/" =>
         numericFns(site, "div", "divf")
       case "%" =>

--- a/core/src/main/scala/dev/bosatsu/Predef.scala
+++ b/core/src/main/scala/dev/bosatsu/Predef.scala
@@ -173,7 +173,7 @@ object Predef {
       .add(predefPackageName, "sub", FfiCall.Fn2(PredefImpl.sub(_, _)))
       .add(predefPackageName, "subf", FfiCall.Fn2(PredefImpl.subf(_, _)))
       .add(predefPackageName, "mul", FfiCall.Fn2(PredefImpl.mul(_, _)))
-      .add(predefPackageName, "timesf", FfiCall.Fn2(PredefImpl.timesf(_, _)))
+      .add(predefPackageName, "mulf", FfiCall.Fn2(PredefImpl.mulf(_, _)))
       .add(predefPackageName, "eq_Int", FfiCall.Fn2(PredefImpl.eq_Int(_, _)))
       .add(
         predefPackageName,
@@ -836,7 +836,7 @@ object PredefImpl {
   def mul(a: Value, b: Value): Value =
     ExternalValue(mulInt(intRaw(a), intRaw(b)))
 
-  def timesf(a: Value, b: Value): Value =
+  def mulf(a: Value, b: Value): Value =
     vf(d(a) * d(b))
 
   def eq_Int(a: Value, b: Value): Value =

--- a/core/src/main/scala/dev/bosatsu/codegen/python/PythonGen.scala
+++ b/core/src/main/scala/dev/bosatsu/codegen/python/PythonGen.scala
@@ -1175,7 +1175,7 @@ object PythonGen {
             )
           ),
           (
-            Identifier.Name("timesf"),
+            Identifier.Name("mulf"),
             (
               { input =>
                 Env.onLast2(input.head, input.tail.head)(_.evalTimes(_))

--- a/core/src/test/scala/dev/bosatsu/EvaluationTest.scala
+++ b/core/src/test/scala/dev/bosatsu/EvaluationTest.scala
@@ -416,7 +416,7 @@ def classify(x):
 test = TestSuite("float", [
   Assertion(eqf(addf(1.25, 2.5), 3.75), "addf"),
   Assertion(eqf(subf(5.5, 2.25), 3.25), "subf"),
-  Assertion(eqf(timesf(1.5, 2.0), 3.0), "timesf"),
+  Assertion(eqf(mulf(1.5, 2.0), 3.0), "mulf"),
   Assertion(eqf(divf(7.5, 2.5), 3.0), "divf"),
   Assertion(eqf(.NaN, nan0), "nan equality"),
   Assertion(eqf(∞, inf0), "literal infinity"),

--- a/test_workspace/Float64.bosatsu
+++ b/test_workspace/Float64.bosatsu
@@ -4,7 +4,7 @@ from Bosatsu/Predef import (
   Float64,
   addf as addf_predef,
   subf as subf_predef,
-  timesf as timesf_predef,
+  mulf as mulf_predef,
   divf as divf_predef,
   cmp_Float64 as cmp_Float64_predef
 )
@@ -12,7 +12,7 @@ from Bosatsu/Predef import (
 export (
   addf,
   subf,
-  timesf,
+  mulf,
   divf,
   cmp_Float64,
   eq_Float64,
@@ -88,8 +88,8 @@ def addf(a: Float64, b: Float64) -> Float64:
 def subf(a: Float64, b: Float64) -> Float64:
   subf_predef(a, b)
 
-def timesf(a: Float64, b: Float64) -> Float64:
-  timesf_predef(a, b)
+def mulf(a: Float64, b: Float64) -> Float64:
+  mulf_predef(a, b)
 
 def divf(a: Float64, b: Float64) -> Float64:
   divf_predef(a, b)
@@ -102,7 +102,7 @@ neg_inf: Float64 = -∞
 
 def operator +(a, b): addf(a, b)
 def operator -(a, b): subf(a, b)
-def operator *(a, b): timesf(a, b)
+def operator *(a, b): mulf(a, b)
 def operator /(a, b): divf(a, b)
 
 def eq_Float64(a: Float64, b: Float64) -> Bool:

--- a/test_workspace/PredefTests.bosatsu
+++ b/test_workspace/PredefTests.bosatsu
@@ -451,7 +451,7 @@ test_list_patterns = TestSuite("List pattern tests", [
 test_float = TestSuite("Float tests", [
   Assertion(eqf(addf(1.25, 2.5), 3.75), "addf"),
   Assertion(eqf(subf(5.5, 2.25), 3.25), "subf"),
-  Assertion(eqf(timesf(1.5, 2.0), 3.0), "timesf"),
+  Assertion(eqf(mulf(1.5, 2.0), 3.0), "mulf"),
   Assertion(eqf(divf(7.5, 2.5), 3.0), "divf"),
   Assertion(eqf(.NaN, nan0), "nan equality"),
   Assertion(eqf(1_234.5_6, 1234.56), "underscore parsing"),

--- a/test_workspace/core_alpha_conf.json
+++ b/test_workspace/core_alpha_conf.json
@@ -1,7 +1,7 @@
 {
   "name": "core_alpha",
   "repo_uri": "https://github.com/johnynek/bosatsu.git",
-  "next_version": "4.4.2",
+  "next_version": "5.0.0",
   "previous": {
     "version": "4.4.1",
     "hashes": [


### PR DESCRIPTION
Implemented issue #2171 by renaming floating-point predef multiplication from `timesf` to `mulf` in the predef surface and runtime integration points: `core/src/main/resources/bosatsu/predef.bosatsu`, `core/src/main/scala/dev/bosatsu/Predef.scala`, `core/src/main/scala/dev/bosatsu/OperatorHints.scala`, and `core/src/main/scala/dev/bosatsu/codegen/python/PythonGen.scala`. Updated Float64-facing usage/tests in `test_workspace/Float64.bosatsu`, `test_workspace/PredefTests.bosatsu`, and `core/src/test/scala/dev/bosatsu/EvaluationTest.scala`. Added C runtime symbol `___bsts_g_Bosatsu_l_Predef_l_mulf` and kept `timesf` as a compatibility alias in `c_runtime/bosatsu_ext_Bosatsu_l_Predef.{c,h}`. Since this removes/renames a public binding in `Bosatsu/Num/Float64`, bumped `test_workspace/core_alpha_conf.json` `next_version` to `5.0.0` to satisfy semver checks. Required test command passed: `scripts/test_basic.sh` (Total 60, Failed 0).

Fixes #2171