### PR TITLE
Add launcher regression test for eval passthrough

### DIFF
--- a/scripts/test_launcher_passthrough.sh
+++ b/scripts/test_launcher_passthrough.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+
+TMPDIR_ROOT="${TMPDIR:-/tmp}"
+WORKDIR="$(mktemp -d "${TMPDIR_ROOT%/}/bosatsu-launcher-test.XXXXXX")"
+cleanup() {
+  rm -rf "$WORKDIR"
+}
+trap cleanup EXIT
+
+TEST_REPO="$WORKDIR/repo"
+mkdir -p "$TEST_REPO"
+git -C "$TEST_REPO" init -q
+
+cp "$REPO_ROOT/bosatsu" "$TEST_REPO/bosatsu"
+chmod +x "$TEST_REPO/bosatsu"
+printf 'test-version\n' > "$TEST_REPO/.bosatsu_version"
+printf 'native\n' > "$TEST_REPO/.bosatsu_platform"
+
+FAKE_ARTIFACT="$WORKDIR/fake-bosatsu"
+cat > "$FAKE_ARTIFACT" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "$@" > "$PWD/argv.txt"
+EOF
+chmod +x "$FAKE_ARTIFACT"
+
+(
+  cd "$TEST_REPO"
+  ./bosatsu \
+    --artifact "$FAKE_ARTIFACT" \
+    lib eval --main Zafu/Tool/JsonFormat::main --run -- --compact
+)
+
+EXPECTED="$WORKDIR/expected.txt"
+cat > "$EXPECTED" <<'EOF'
+lib
+eval
+--main
+Zafu/Tool/JsonFormat::main
+--run
+--
+--compact
+EOF
+
+if ! cmp -s "$EXPECTED" "$TEST_REPO/argv.txt"; then
+  echo "launcher did not preserve the eval passthrough delimiter" >&2
+  diff -u "$EXPECTED" "$TEST_REPO/argv.txt" >&2 || true
+  exit 1
+fi

--- a/test_cli.sh
+++ b/test_cli.sh
@@ -6,6 +6,8 @@ check_lib_eval_output() {
   printf '%s\n' "$output" | grep -Eq '^Main \{ run: <fn arity=1> \}: Bosatsu/Prog::Main$'
 }
 
+./scripts/test_launcher_passthrough.sh
+
 sbt cli/assembly
 time ./bosatsuj tool test \
   --input_dir test_workspace \


### PR DESCRIPTION
## Summary
- add a shell regression test for the published `./bosatsu` launcher script
- run that test from `test_cli.sh`, which is already exercised in CI
- lock in the existing fix for `lib/tool eval --run -- ...` passthrough args

## Context
The launcher fix itself is already on `main` in commit `41dc6e086` (`Allow `lib/tool eval --run` to accept `--` passthrough args`). This PR adds upstream coverage for that behavior so downstream copies of the published script do not drift silently.

The regression is specifically that the launcher must preserve the explicit `--` delimiter when forwarding args to the CLI artifact. If it drops that delimiter, a command like:

```sh
./bosatsu lib eval --main Zafu/Tool/JsonFormat::main --run -- --compact
```

arrives at the real CLI as:

```sh
lib eval --main Zafu/Tool/JsonFormat::main --run --compact
```

which causes `Unexpected option: --compact`.

## Testing
- `./scripts/test_launcher_passthrough.sh`
- `./test_cli.sh`
- manual verification that the new test passes against current `main` and that a pre-fix wrapper (`fa7f65f5a:bosatsu`) drops the delimiter
