### PR TITLE
Improve constructor arity mismatch diagnostics

### DIFF
--- a/core/src/main/scala/dev/bosatsu/PackageError.scala
+++ b/core/src/main/scala/dev/bosatsu/PackageError.scala
@@ -1351,6 +1351,32 @@ object PackageError {
               Some(region)
             )
 
+          case Infer.Error.ConstructorArityMismatch(
+                (optPack, cons),
+                expectedArity,
+                foundArity,
+                region
+              ) =>
+            def args(n: Int) =
+              if (n == 0) "no arguments"
+              else if (n == 1) "one argument"
+              else s"$n arguments"
+
+            val constructorName =
+              optPack match {
+                case Some(pn) if pn =!= pack =>
+                  s"${pn.asString}::${cons.sourceCodeRepr}"
+                case _ =>
+                  cons.sourceCodeRepr
+              }
+
+            (
+              Doc.text(
+                s"$constructorName is a constructor that takes ${args(expectedArity)}, but this call passes ${args(foundArity)}."
+              ) + Doc.hardLine + contextDoc(region),
+              Some(region)
+            )
+
           case Infer.Error.ArityMismatch(leftA, leftR, rightA, rightR) =>
             val context0 = contextDoc(leftR)
             val context1 =

--- a/core/src/main/scala/dev/bosatsu/rankn/Infer.scala
+++ b/core/src/main/scala/dev/bosatsu/rankn/Infer.scala
@@ -321,6 +321,12 @@ object Infer {
         rightArity: Int,
         rightRegion: Region
     ) extends TypeError
+    case class ConstructorArityMismatch(
+        constructorName: (Option[PackageName], Constructor),
+        expectedArity: Int,
+        foundArity: Int,
+        region: Region
+    ) extends TypeError
     case class ArityTooLarge(arity: Int, maxArity: Int, region: Region)
         extends TypeError
 
@@ -1772,6 +1778,16 @@ object Infer {
           None
       }
 
+    private def constructorNameHint[A](
+        fn: Expr[A]
+    ): Option[(Option[PackageName], Constructor)] =
+      fn match {
+        case Expr.Global(pack, cons: Constructor, _) =>
+          Some((Some(pack), cons))
+        case _ =>
+          None
+      }
+
     private def contextualTypeError(
         site: Error.MismatchSite
     ): Error => Error = {
@@ -2096,7 +2112,22 @@ object Infer {
           region(fn),
           argsRegion,
           Error.Direction.ExpectRight
-        )
+        ).mapError {
+          case ar @ Error.ArityMismatch(expectedArity, _, foundArity, _) =>
+            constructorNameHint(fn) match {
+              case Some(name) =>
+                Error.ConstructorArityMismatch(
+                  name,
+                  expectedArity,
+                  foundArity,
+                  region(tag)
+                )
+              case None =>
+                ar
+            }
+          case other =>
+            other
+        }
         fnName = functionNameHint(fn)
         typedArg <- args.zip(argT).zipWithIndex.parTraverse {
           case ((arg, argT), idx) =>

--- a/core/src/test/scala/dev/bosatsu/ErrorMessageTest.scala
+++ b/core/src/test/scala/dev/bosatsu/ErrorMessageTest.scala
@@ -3066,6 +3066,33 @@ x = 1.0 + 2.0
     assert(pointers.distinct.length >= 2, message)
   }
 
+  test("constructor arity mismatch reports constructor-specific message") {
+    val source =
+      """package Repro
+        |
+        |struct Foo(a: Int, b: Int)
+        |
+        |x = Foo(1)
+        |""".stripMargin
+
+    val (errs, sourceMap) = compileErrors(List(source))
+    val message =
+      errs.toList.collectFirst {
+        case te: PackageError.TypeErrorIn =>
+          te.message(sourceMap, Colorize.None)
+      }.getOrElse(fail(s"expected TypeErrorIn, found: ${errs.toList}"))
+
+    assert(
+      message.contains("Foo is a constructor that takes 2 arguments"),
+      message
+    )
+    assert(message.contains("this call passes one argument"), message)
+    assert(message.contains("x = Foo(1)"), message)
+    assert(!message.contains("does not match function with"), message)
+    val pointers = message.linesIterator.filter(_.contains("^")).toList
+    assertEquals(pointers.length, 1, message)
+  }
+
   test(
     "inferred imported types from direct dependencies do not require type imports"
   ) {


### PR DESCRIPTION
Added a constructor-specific arity mismatch path in type inference so calls like Foo(1) now report a single call-site error that names the constructor and expected vs. provided argument counts, while leaving generic function arity mismatches unchanged. Added a regression test in ErrorMessageTest for the reported struct-constructor case. Verification: sbt -batch "coreJVM/testOnly dev.bosatsu.ErrorMessageTest -- --log=failure" and scripts/test_basic.sh both pass.

Fixes #2190