### PR TITLE
Add and/or/not to Bosatsu/Predef

### DIFF
--- a/cli/src/test/scala/dev/bosatsu/codegen/clang/ClangGenTest.scala
+++ b/cli/src/test/scala/dev/bosatsu/codegen/clang/ClangGenTest.scala
@@ -42,7 +42,7 @@ class ClangGenTest extends munit.FunSuite {
       To inspect the code, change the hash, and it will print the code out
      */
     testFilesCompilesToHash("test_workspace/Ackermann.bosatsu")(
-      "bcd830f1232c65dc3f0c721989a12a94"
+      "9492efd0bbabd2b0e0fea2e85210cd6f"
     )
   }
 }

--- a/core/src/main/resources/bosatsu/predef.bosatsu
+++ b/core/src/main/resources/bosatsu/predef.bosatsu
@@ -47,6 +47,7 @@ export (
   Dict,
   add,
   addf,
+  and,
   add_key,
   build_List,
   char_to_Int,
@@ -70,6 +71,8 @@ export (
   int_to_Char,
   int_to_String,
   length_String,
+  not,
+  or,
   string_to_Int,
   tail_or_empty_String,
   uncons_String,
@@ -138,6 +141,18 @@ struct Tuple32[a: +*, b: +*, c: +*, d: +*, e: +*, f: +*, g: +*, h: +*, i: +*, j:
 
 enum Bool:
   False, True
+
+# Boolean conjunction.
+def and(x: Bool, y: Bool) -> Bool:
+  y if x else False
+
+# Boolean disjunction.
+def or(x: Bool, y: Bool) -> Bool:
+  True if x else y
+
+# Boolean negation.
+def not(x: Bool) -> Bool:
+  False if x else True
 
 #############
 # Support for built-in lists

--- a/test_workspace/AvlTree.bosatsu
+++ b/test_workspace/AvlTree.bosatsu
@@ -190,8 +190,6 @@ Module { add: add_i, contains: contains_i_opt, single: single_i, remove: rem_i .
 
 contains_i = (tree, i) -> (contains_i_opt(tree, i) matches Some(_))
 
-def not(x): False if x else True
-
 contains_test = (
     def add_law(t, i, msg):
         Assertion(t.add_i(i).contains_i(i), msg)

--- a/test_workspace/Bool.bosatsu
+++ b/test_workspace/Bool.bosatsu
@@ -1,9 +1,10 @@
 package Bosatsu/Bool
 
+from Bosatsu/Predef import not as not_predef
+
 export not
 
-def not(b: Bool) -> Bool:
-  False if b else True
+not = not_predef
 
 test = TestSuite("not tests", [
   Assertion(not(True) matches False, "not(True)"),

--- a/test_workspace/Bosatsu/IO/Core.bosatsu
+++ b/test_workspace/Bosatsu/IO/Core.bosatsu
@@ -131,17 +131,9 @@ def duration_to_nanos(d: Duration) -> Int:
   Duration { to_nanos } = d
   to_nanos
 
-def andb(left: Bool, right: Bool) -> Bool:
-  if left:
-    right
-  else:
-    False
+andb = and
 
-def orb(left: Bool, right: Bool) -> Bool:
-  if left:
-    True
-  else:
-    right
+orb = or
 
 def starts_with_slash(s: String) -> Bool:
   s matches "/${_}" | "/"

--- a/test_workspace/Bosatsu/IO/CreateModeMain.bosatsu
+++ b/test_workspace/Bosatsu/IO/CreateModeMain.bosatsu
@@ -17,11 +17,7 @@ from Bosatsu/IO/Core import (
 )
 from Bosatsu/IO/Std import println, show_error
 
-def andb(left: Bool, right: Bool) -> Bool:
-  if left:
-    right
-  else:
-    False
+andb = and
 
 def create_new_success(path: Path) -> Prog[IOError, Bool]:
   recover(

--- a/test_workspace/Bosatsu/Json.bosatsu
+++ b/test_workspace/Bosatsu/Json.bosatsu
@@ -41,11 +41,7 @@ enum Nullable[a]:
   Null
   NonNull(value: a)
 
-def andb(left: Bool, right: Bool) -> Bool:
-  if left:
-    right
-  else:
-    False
+andb = and
 
 def operator &(left: Bool, right: Bool) -> Bool:
   andb(left, right)

--- a/test_workspace/Char.bosatsu
+++ b/test_workspace/Char.bosatsu
@@ -48,17 +48,9 @@ def int_to_Char(code_point: Int) -> Option[Char]:
 def cmp_Char(a: Char, b: Char) -> Comparison:
   cmp_Int(char_to_Int(a), char_to_Int(b))
 
-def andb(left: Bool, right: Bool) -> Bool:
-  if left:
-    right
-  else:
-    False
+andb = and
 
-def orb(left: Bool, right: Bool) -> Bool:
-  if left:
-    True
-  else:
-    right
+orb = or
 
 def lte_Int(left: Int, right: Int) -> Bool:
   cmp_Int(left, right) matches (LT | EQ)

--- a/test_workspace/List.bosatsu
+++ b/test_workspace/List.bosatsu
@@ -1,6 +1,5 @@
 package Bosatsu/List
 
-from Bosatsu/Bool import not
 from Bosatsu/Num/Nat import Nat, Zero, Succ
 export any, eq_List, exists, get_List, head, for_all, set_List, size, sum, sort, uncons, zip
 

--- a/test_workspace/PatternExamples.bosatsu
+++ b/test_workspace/PatternExamples.bosatsu
@@ -8,9 +8,7 @@ combine = "foo: ${foo} bar: ${bar}"
 def operator ==(a, b):
   cmp_String(a, b) matches EQ
 
-def operator &&(a, b):
-    if a: b
-    else: False
+operator && = and
 
 fb = match combine:
     case "foo: ${f} bar: ${b}" if (f == foo) && (b == bar):

--- a/test_workspace/PredefTests.bosatsu
+++ b/test_workspace/PredefTests.bosatsu
@@ -22,14 +22,19 @@ def oi(opt):
     case None: "None"
     case Some(v): "Some(${i(v)})"
 
-def notb(a):
-  match a:
-    case True: False
-    case False: True
-def andb(a, b):
-  match a:
-    case True: b
-    case False: False
+notb = not
+andb = and
+
+test_bool = TestSuite("Bool tests", [
+  Assertion(and(True, True), "and(True, True)"),
+  Assertion(and(True, False) matches False, "and(True, False)"),
+  Assertion(and(False, True) matches False, "and(False, True)"),
+  Assertion(or(False, False) matches False, "or(False, False)"),
+  Assertion(or(False, True), "or(False, True)"),
+  Assertion(or(True, False), "or(True, False)"),
+  Assertion(not(True) matches False, "not(True)"),
+  Assertion(not(False), "not(False)"),
+])
 
 test_int = TestSuite("Int tests", [
       Assertion((4 % -3) matches -2, "(4 % -3) == -2 got: ${i(4 % -3)}"),
@@ -519,6 +524,7 @@ test_float = TestSuite("Float tests", [
 ])
 
 test = TestSuite("Predef tests", [
+    test_bool,
     test_int,
     test_string,
     test_list_patterns,

--- a/test_workspace/Properties.bosatsu
+++ b/test_workspace/Properties.bosatsu
@@ -54,7 +54,7 @@ shift_unshift_law = forall_Prop(
   ))
 
 def gtez(x): x.cmp_Int(0) matches (GT | EQ)
-def operator ||(a, b): True if a else b
+operator || = or
 def implies(a, b): b if a else True
 
 positive_and_law = forall_Prop(

--- a/test_workspace/StringPatternBranchTests.bosatsu
+++ b/test_workspace/StringPatternBranchTests.bosatsu
@@ -2,17 +2,8 @@ package StringPatternBranchTests
 
 export tests
 
-def andb(a: Bool, b: Bool) -> Bool:
-  if a:
-    b
-  else:
-    False
-
-def notb(a: Bool) -> Bool:
-  if a:
-    False
-  else:
-    True
+andb = and
+notb = not
 
 tests = TestSuite("String pattern branch tests", [
   Assertion(uncons_String("") matches None, "uncons empty"),

--- a/test_workspace/euler1.bosatsu
+++ b/test_workspace/euler1.bosatsu
@@ -7,8 +7,7 @@ package Euler/One
 operator == = eq_Int
 operator % = mod_Int
 
-def operator ||(x, y):
-  True if x else y
+operator || = or
 
 def keep(i):
   (i % 3 == 0) || (i % 5 == 0)

--- a/test_workspace/euler7.bosatsu
+++ b/test_workspace/euler7.bosatsu
@@ -1,6 +1,5 @@
 package Euler/P7
 
-from Bosatsu/Bool import not
 from Bosatsu/List import for_all
 
 # By listing the first six prime numbers: 2, 3, 5, 7, 11, and 13, we can see that the 6th prime is 13.

--- a/test_workspace/recordset.bosatsu
+++ b/test_workspace/recordset.bosatsu
@@ -88,9 +88,6 @@ def bool_field[shape: (* -> *) -> *](name, fn: shape[RecordValue] -> Bool): Reco
 
 ##################################################
 
-def and(x, y):
-  y if x else False
-
 operator && = and
 
 def equals(compare, x, y):


### PR DESCRIPTION
Added `and`, `or`, and `not` to `Bosatsu/Predef` and exported them, added focused Predef boolean coverage in `test_workspace/PredefTests.bosatsu`, replaced redundant boolean helper redefinitions across `test_workspace` with direct Predef aliases/use, and updated the `ClangGenTest` hash for `Ackermann.bosatsu` because the generated C changed when Predef grew new functions. Verified with `scripts/test_basic.sh`.

Fixes #2191