### PR TITLE
Add xor/implies support to predef recursion checks

### DIFF
--- a/cli/src/test/scala/dev/bosatsu/codegen/clang/ClangGenTest.scala
+++ b/cli/src/test/scala/dev/bosatsu/codegen/clang/ClangGenTest.scala
@@ -42,7 +42,7 @@ class ClangGenTest extends munit.FunSuite {
       To inspect the code, change the hash, and it will print the code out
      */
     testFilesCompilesToHash("test_workspace/Ackermann.bosatsu")(
-      "4f7e9c1785d8f28f6a529151749da7e7"
+      "8423c08f796f8d06e4839aebc70326ae"
     )
   }
 }

--- a/core/src/main/resources/bosatsu/predef.bosatsu
+++ b/core/src/main/resources/bosatsu/predef.bosatsu
@@ -71,6 +71,7 @@ export (
   foldl_List,
   foldr_List,
   gcd_Int,
+  implies,
   get_key,
   int_loop,
   int_to_Char,
@@ -110,6 +111,7 @@ export (
   trace,
   uncurry2,
   uncurry3,
+  xor,
 )
 
 struct Unit
@@ -169,6 +171,14 @@ def or(x: Bool, y: Bool) -> Bool:
 # Boolean negation.
 def not(x: Bool) -> Bool:
   False if x else True
+
+# Boolean exclusive or.
+def xor(x: Bool, y: Bool) -> Bool:
+  (x, y) matches (True, False) | (False, True)
+
+# Boolean implication.
+def implies(x: Bool, y: Bool) -> Bool:
+  y if x else True
 
 #############
 # Support for built-in lists

--- a/core/src/main/scala/dev/bosatsu/TypedExprRecursionCheck.scala
+++ b/core/src/main/scala/dev/bosatsu/TypedExprRecursionCheck.scala
@@ -1048,7 +1048,9 @@ object TypedExprRecursionCheck {
       Identifier.Name("eq_Int"),
       Identifier.Name("and"),
       Identifier.Name("or"),
-      Identifier.Name("not")
+      Identifier.Name("not"),
+      Identifier.Name("xor"),
+      Identifier.Name("implies")
     )
 
     private def resolvedPredefFnName(
@@ -1617,6 +1619,21 @@ object TypedExprRecursionCheck {
             case Some(Identifier.Name("not")) =>
               lowerUnaryBool(args, state)(arg =>
                 simplifyBoolExpr(SmtExpr.Not(arg))
+              )
+            case Some(Identifier.Name("xor")) =>
+              lowerBinaryBool(args, state)((left, right) =>
+                simplifyBoolExpr(
+                  mkOr(
+                    Vector(
+                      mkAnd(Vector(left, SmtExpr.Not(right))),
+                      mkAnd(Vector(SmtExpr.Not(left), right))
+                    )
+                  )
+                )
+              )
+            case Some(Identifier.Name("implies")) =>
+              lowerBinaryBool(args, state)((left, right) =>
+                simplifyBoolExpr(mkOr(Vector(SmtExpr.Not(left), right)))
               )
             case _ =>
               inlinedTopLevelAliasApp(fn, args, state) match {

--- a/core/src/test/scala/dev/bosatsu/TypedExprRecursionCheckTest.scala
+++ b/core/src/test/scala/dev/bosatsu/TypedExprRecursionCheckTest.scala
@@ -558,6 +558,30 @@ def ok(i: Int) -> Int:
 """)
   }
 
+  test("Int recursion lowers predef xor/implies aliases into SMT guard facts") {
+    allowed("""#
+both = and
+exclusive = xor
+follows = implies
+
+def ok(i: Int) -> Int:
+  recur i:
+    case _ if both(
+      follows(cmp_Int(i, 0) matches LT, False),
+      follows(
+        exclusive(
+          cmp_Int(i, 0) matches LT,
+          cmp_Int(i, 0) matches LT | EQ
+        ),
+        False
+      )
+    ):
+      ok(i.sub(1))
+    case _:
+      i
+""")
+  }
+
   test("Int recursion lowers total string-pattern guard matches via final fallback") {
     allowed("""#
 def walk(idx: Int, txt: String) -> Int:


### PR DESCRIPTION
Added `xor` and `implies` to `Bosatsu/Predef` exports and definitions, taught `TypedExprRecursionCheck` to lower both boolean ops for SMT-based recursion proofs, and added a recursion test that forces solver reasoning through the new operations. Updated the affected Clang codegen hash snapshot because the expanded predef now emits two extra functions. Verification: `sbt "coreJVM/testOnly dev.bosatsu.TypedExprRecursionCheckTest"` and `scripts/test_basic.sh` both passed.

Fixes #2210