### PR TITLE
Remove deprecated helper functions from Predef

### DIFF
--- a/bench/src/main/scala/dev/bosatsu/TestBench.scala
+++ b/bench/src/main/scala/dev/bosatsu/TestBench.scala
@@ -95,6 +95,20 @@ def operator >(a, b):
 
 operator - = sub
 
+def int_loop(i: Int, state: a, fn: (Int, a) -> (Int, a)) -> a:
+  loop i:
+    case _ if cmp_Int(i, 0) matches GT:
+      (next_i, next_state) = fn(i, state)
+      if cmp_Int(next_i, 0) matches GT:
+        if cmp_Int(next_i, i) matches LT:
+          int_loop(next_i, next_state, fn)
+        else:
+          next_state
+      else:
+        next_state
+    case _:
+      state
+
 # given a maximum value, and a function to Option[Int], return
 # the maximum value of the function for inputs greater than 0
 # if the starting number is <= 0, we return None

--- a/cli/src/test/scala/dev/bosatsu/codegen/clang/ClangGenTest.scala
+++ b/cli/src/test/scala/dev/bosatsu/codegen/clang/ClangGenTest.scala
@@ -42,7 +42,7 @@ class ClangGenTest extends munit.FunSuite {
       To inspect the code, change the hash, and it will print the code out
      */
     testFilesCompilesToHash("test_workspace/Ackermann.bosatsu")(
-      "8423c08f796f8d06e4839aebc70326ae"
+      "4813579e235673a7f589a5e37807c4b1"
     )
   }
 }

--- a/core/src/main/resources/bosatsu/predef.bosatsu
+++ b/core/src/main/resources/bosatsu/predef.bosatsu
@@ -73,7 +73,6 @@ export (
   gcd_Int,
   implies,
   get_key,
-  int_loop,
   int_to_Char,
   int_to_String,
   length_List,
@@ -96,7 +95,6 @@ export (
   partition_String,
   rpartition_String,
   range,
-  range_fold,
   remove_key,
   replicate_List,
   reverse,
@@ -109,8 +107,6 @@ export (
   mul,
   mulf,
   trace,
-  uncurry2,
-  uncurry3,
   xor,
 )
 
@@ -243,17 +239,6 @@ def length_List(lst: List[a]) -> Int:
   loop(lst, 0)
 
 #############
-# Some utilities for dealing with functions
-#############
-
-def uncurry2(f: t1 -> t2 -> r) -> (t1, t2) -> r:
-  (x1, x2) -> f(x1)(x2)
-
-# Convert a curried 3-argument function into one that takes a tuple of 3 arguments.
-def uncurry3(f: t1 -> t2 -> t3 -> r) -> (t1, t2, t3) -> r:
-  (x1, x2, x3) -> f(x1)(x2)(x3)
-
-#############
 # Standardize notion of ordering
 #############
 enum Comparison:
@@ -325,21 +310,6 @@ external def cmp_Float64(a: Float64, b: Float64) -> Comparison
 def eq_Float64(a: Float64, b: Float64) -> Bool:
   cmp_Float64(a, b) matches EQ
 
-# Loop until the returned Int is <= 0 or >= intValue.
-def int_loop(intValue: Int, state: a, fn: (Int, a) -> (Int, a)) -> a:
-  loop intValue:
-    case _ if cmp_Int(intValue, 0) matches GT:
-      (next_i, next_state) = fn(intValue, state)
-      if cmp_Int(next_i, 0) matches GT:
-        if cmp_Int(next_i, intValue) matches LT:
-          int_loop(next_i, next_state, fn)
-        else:
-          next_state
-      else:
-        next_state
-    case _:
-      state
-
 # Repeat `item` `cnt` times.
 def replicate_List[a](item: a, cnt: Int) -> List[a]:
   def go(i: Int, acc: List[a]) -> List[a]:
@@ -362,18 +332,6 @@ def range(exclusiveUpper: Int) -> List[Int]:
         tail
 
   go(exclusiveUpper, [])
-
-# Fold over `[inclusiveLower, ..., exclusiveUpper - 1]`.
-def range_fold(inclusiveLower: Int, exclusiveUpper: Int, init: a, fn: (a, Int) -> a) -> a:
-  def go(diff0: Int, acc: a) -> a:
-    loop diff0:
-      case _ if cmp_Int(diff0, 0) matches GT:
-        idx = exclusiveUpper.sub(diff0)
-        go(diff0.sub(1), fn(acc, idx))
-      case _:
-        acc
-
-  go(exclusiveUpper.sub(inclusiveLower), init)
 
 #############
 # String functions

--- a/core/src/test/scala/dev/bosatsu/EvaluationTest.scala
+++ b/core/src/test/scala/dev/bosatsu/EvaluationTest.scala
@@ -577,6 +577,17 @@ main = 1
       List("""
 package Foo
 
+def range_fold(inclusiveLower: Int, exclusiveUpper: Int, init: a, fn: (a, Int) -> a) -> a:
+  def go(diff0: Int, acc: a) -> a:
+    loop diff0:
+      case _ if cmp_Int(diff0, 0) matches GT:
+        idx = exclusiveUpper.sub(diff0)
+        go(diff0.sub(1), fn(acc, idx))
+      case _:
+        acc
+
+  go(exclusiveUpper.sub(inclusiveLower), init)
+
 main = range_fold(0, 10, 0, add)
 """),
       "Foo",
@@ -587,6 +598,17 @@ main = range_fold(0, 10, 0, add)
       List("""
 package Foo
 
+def range_fold(inclusiveLower: Int, exclusiveUpper: Int, init: a, fn: (a, Int) -> a) -> a:
+  def go(diff0: Int, acc: a) -> a:
+    loop diff0:
+      case _ if cmp_Int(diff0, 0) matches GT:
+        idx = exclusiveUpper.sub(diff0)
+        go(diff0.sub(1), fn(acc, idx))
+      case _:
+        acc
+
+  go(exclusiveUpper.sub(inclusiveLower), init)
+
 main = range_fold(0, 10, 0, (_, y) -> y)
 """),
       "Foo",
@@ -596,6 +618,17 @@ main = range_fold(0, 10, 0, (_, y) -> y)
     evalTest(
       List("""
 package Foo
+
+def range_fold(inclusiveLower: Int, exclusiveUpper: Int, init: a, fn: (a, Int) -> a) -> a:
+  def go(diff0: Int, acc: a) -> a:
+    loop diff0:
+      case _ if cmp_Int(diff0, 0) matches GT:
+        idx = exclusiveUpper.sub(diff0)
+        go(diff0.sub(1), fn(acc, idx))
+      case _:
+        acc
+
+  go(exclusiveUpper.sub(inclusiveLower), init)
 
 main = range_fold(0, 10, 100, (x, _) -> x)
 """),
@@ -1466,6 +1499,9 @@ package A
 
 struct TwoVar(one, two)
 
+def uncurry2(f: t1 -> t2 -> r) -> (t1, t2) -> r:
+  (x1, x2) -> f(x1)(x2)
+
 constructed = uncurry2(x -> y -> TwoVar(x, y))(1, "two")
 
 main = match constructed:
@@ -1482,6 +1518,9 @@ main = match constructed:
 package A
 
 struct ThreeVar(one, two, three)
+
+def uncurry3(f: t1 -> t2 -> t3 -> r) -> (t1, t2, t3) -> r:
+  (x1, x2, x3) -> f(x1)(x2)(x3)
 
 constructed = uncurry3(x -> y -> z -> ThreeVar(x, y, z))(1, "two", 3)
 

--- a/core/src/test/scala/dev/bosatsu/ToolAndLibCommandTest.scala
+++ b/core/src/test/scala/dev/bosatsu/ToolAndLibCommandTest.scala
@@ -1907,14 +1907,20 @@ class ToolAndLibCommandTest extends FunSuite {
 |  "\"${pad3(i)}\""
 |
 |def make_csv(n: Int) -> String:
-|  int_loop(n, "", (i, acc) ->
-|    part = quoted(i)
-|    next =
-|      if acc matches "":
-|        part
-|      else:
-|        "${part},${acc}"
-|    (i.sub(1), next))
+|  def go(i: Int, acc: String) -> String:
+|    loop i:
+|      case _ if cmp_Int(i, 0) matches GT:
+|        part = quoted(i)
+|        next =
+|          if acc matches "":
+|            part
+|          else:
+|            "${part},${acc}"
+|        go(i.sub(1), next)
+|      case _:
+|        acc
+|
+|  go(n, "")
 |
 |names_csv = make_csv(178)
 |computed = list_len(sort_names(parse_names(names_csv)), 0)
@@ -3885,9 +3891,7 @@ main = 1
           !indexSection.contains("[`Fn2[i0, i1, z]`](#type-fn2)"),
           predefDoc
         )
-        assert(predefDoc.contains("[`int_loop`](#value-int-loop)"), predefDoc)
         assert(predefDoc.contains("<a id=\"type-bool\"></a>"), predefDoc)
-        assert(predefDoc.contains("<a id=\"value-int-loop\"></a>"), predefDoc)
         assert(predefDoc.contains("type Dict[k: *, v: +*]"), predefDoc)
         assert(predefDoc.contains("type Int"), predefDoc)
         assert(!predefDoc.contains("type Int: *"), predefDoc)
@@ -3926,18 +3930,19 @@ main = 1
           ),
           predefDoc
         )
-        assert(
-          predefDoc.contains("returned Int is <= 0"),
-          predefDoc
-        )
-        assert(
-          predefDoc.contains("intValue"),
-          predefDoc
-        )
-        assert(predefDoc.contains("def int_loop[a]("), predefDoc)
-        assert(predefDoc.contains("intValue: Int"), predefDoc)
-        assert(predefDoc.contains("state: a"), predefDoc)
-        assert(predefDoc.contains("fn: (Int, a) -> (Int, a)"), predefDoc)
+        List(
+          "[`int_loop`](#value-int-loop)",
+          "[`range_fold`](#value-range-fold)",
+          "[`uncurry2`](#value-uncurry2)",
+          "[`uncurry3`](#value-uncurry3)",
+          "<a id=\"value-int-loop\"></a>",
+          "def int_loop",
+          "def range_fold",
+          "def uncurry2",
+          "def uncurry3"
+        ).foreach { removed =>
+          assert(!predefDoc.contains(removed), predefDoc)
+        }
         def containsAny(strs: List[String]): Boolean =
           strs.exists(predefDoc.contains)
         assert(

--- a/core/src/test/scala/dev/bosatsu/codegen/clang/ClangGenTest.scala
+++ b/core/src/test/scala/dev/bosatsu/codegen/clang/ClangGenTest.scala
@@ -568,6 +568,20 @@ main = pick
         |operator - = sub
         |operator * = mul
         |
+        |def int_loop(i: Int, state: a, fn: (Int, a) -> (Int, a)) -> a:
+        |  loop i:
+        |    case _ if cmp_Int(i, 0) matches GT:
+        |      (next_i, next_state) = fn(i, state)
+        |      if cmp_Int(next_i, 0) matches GT:
+        |        if cmp_Int(next_i, i) matches LT:
+        |          int_loop(next_i, next_state, fn)
+        |        else:
+        |          next_state
+        |      else:
+        |        next_state
+        |    case _:
+        |      state
+        |
         |def sum(fn, n):
         |  int_loop(n, 0, (i, r) ->
         |    i = i - 1
@@ -599,13 +613,13 @@ main = pick
         )
         assert(
           rendered.contains(
-            "___bsts_g_Bosatsu_l_Predef_l_int__loop(__bsts_b_n0,"
+            "___bsts_g_Euler_l_P6_l_int__loop(__bsts_b_n0,"
           )
         )
         val boxedLambda = "alloc_boxed_pure_fn2\\(__bsts_t_lambda\\d+\\)".r
         assert(boxedLambda.findFirstIn(rendered).nonEmpty)
         assert(
-          !rendered.contains("call_fn2(___bsts_g_Bosatsu_l_Predef_l_int__loop")
+          !rendered.contains("call_fn2(___bsts_g_Euler_l_P6_l_int__loop")
         )
     }
   }

--- a/docs/src/main/paradox/recursion.md
+++ b/docs/src/main/paradox/recursion.md
@@ -378,7 +378,7 @@ proof idea as sorting: derive a bound, decrease it, recurse.
 ## Int Loops
 Bosatsu supports direct recursion on `Int` when the checker can prove the next
 recursive argument is non-negative and strictly smaller on the recursive path.
-The standard library `int_loop` is implemented in Bosatsu using these checks.
+A helper like `int_loop` can be implemented in Bosatsu using these checks.
 
 ## Relation To Fuel And Bove-Capretta
 The design request for this page is tracked at

--- a/docs/src/main/paradox/writing_bosatsu_5_minutes.md
+++ b/docs/src/main/paradox/writing_bosatsu_5_minutes.md
@@ -38,7 +38,7 @@ Top-order bits:
 
 1. Everything is immutable. You can shadow names, but not mutate values.
 2. Blocks are expressions: the last line is the return value.
-3. No `while`/mutation loops; use `recur`, `int_loop`, folds, or comprehensions.
+3. No `while`/mutation loops; use `recur`, direct recursion on `Int`, folds, or comprehensions.
 4. No exceptions as control flow in normal code. Model errors in types.
 5. Side effects are explicit `Prog[...]` values, not implicit execution.
 


### PR DESCRIPTION
Removed `int_loop`, `range_fold`, `uncurry2`, and `uncurry3` from `Bosatsu/Predef`, updated in-repo Bosatsu snippets that still relied on them to define local equivalents or recurse directly on `Int`, refreshed Predef doc expectations and the affected clang snapshot hash, and adjusted docs to stop describing `int_loop` as a standard Predef helper. Verified with `scripts/test_basic.sh`.

Fixes #2212