### PR TITLE
Implement strict/warn/lax `todo` behavior for check commands

### DIFF
--- a/core/src/main/scala/dev/bosatsu/PackageCustoms.scala
+++ b/core/src/main/scala/dev/bosatsu/PackageCustoms.scala
@@ -23,6 +23,8 @@ import dev.bosatsu.graph.Dag
   * are valid
   */
 object PackageCustoms {
+  private val todoGlobalName: Identifier = Identifier.Name("todo")
+
   def apply[A: HasRegion](
       pack: Package.Typed[A]
   ): ValidatedNec[PackageError, Package.Typed[A]] =
@@ -72,6 +74,26 @@ object PackageCustoms {
             }
         )
       )
+
+  private[bosatsu] def todoUsageLintFromSource(
+      packName: PackageName,
+      sourceProgram: Program[?, Expr[Declaration], List[Statement]]
+  ): List[PackageError] =
+    NonEmptyList
+      .fromList(
+        sourceProgram.lets.iterator
+          .flatMap { case (_, _, expr) =>
+            expr.globals.iterator.collect {
+              case Expr.Global(PackageName.PredefName, `todoGlobalName`, tag) =>
+                HasRegion.region(tag)
+            }
+          }
+          .toSet
+          .toList
+          .sorted
+      )
+      .map(PackageError.TodoUsage(packName, _): PackageError)
+      .toList
 
   /** Build the exports and check the customs, and then return the Typed package
     */

--- a/core/src/main/scala/dev/bosatsu/PackageError.scala
+++ b/core/src/main/scala/dev/bosatsu/PackageError.scala
@@ -176,9 +176,17 @@ object PackageError {
   private def checkModeTodoHint(name: Identifier): Doc =
     name match {
       case b: Identifier.Bindable if b.sourceCodeRepr == "todo" =>
-        Doc.hardLine + Doc.text(
-          "hint: `todo` is only available in type-check mode (`tool check`/`lib check`) and is not available in emit commands (`show`/`build`/`transpile`/`test`)."
-        )
+        Doc.hardLine + (
+          Doc.text(
+            "hint: built-in `todo` is only available in relaxed `lib check` modes."
+          ) + Doc.lineOrSpace +
+            Doc.text(
+              "`lib check --warn` warns and `lib check --lax` allows it silently."
+            ) + Doc.lineOrSpace +
+            Doc.text(
+              "Strict `tool check`, strict `lib check`, and emit/run commands do not include `todo`."
+            )
+        ).grouped
       case _ =>
         Doc.empty
     }
@@ -244,6 +252,7 @@ object PackageError {
       case _: PackageError.UnusedImport           => true
       case _: PackageError.UnusedLetError         => true
       case _: PackageError.UnusedLets             => true
+      case _: PackageError.TodoUsage              => true
       case _: PackageError.ShadowedBindingTypeError =>
         true
       case PackageError.TotalityCheckError(
@@ -1772,6 +1781,56 @@ object PackageError {
       .render(80)
   }
 
+  private def todoUsageMessage(
+      pack: PackageName,
+      regions: NonEmptyList[Region],
+      sourceMap: Map[PackageName, (LocationMap, String)],
+      errColor: Colorize
+  ): String = {
+    val (lm, _) = sourceMap.getMapSrc(pack)
+    val sorted = regions.toList.distinct.sorted
+    val occurrenceDocs = sorted.map { region =>
+      val context = lm
+        .showRegion(region, 2, errColor)
+        .getOrElse(Doc.str(region.show))
+      Doc.text("temporary `todo` placeholder used here") +
+        Doc.hardLine +
+        context
+    }
+
+    val countDoc =
+      if (sorted.tail.isEmpty) None
+      else Some(Doc.text(s"found ${sorted.length} `todo` placeholders."))
+
+    val hintDoc =
+      Doc.text("How to resolve:") +
+        Doc.hardLine +
+        Doc.intercalate(
+          Doc.hardLine,
+          List(
+            Doc.text("- replace each `todo` with the real implementation"),
+            Doc.text(
+              "- keep using `lib check --warn` or `lib check --lax` only while iterating"
+            ),
+            Doc.text(
+              "- remove all `todo` calls before strict `tool check` / `lib check` or any emit/run command"
+            )
+          )
+        )
+
+    val line2 = Doc.hardLine + Doc.hardLine
+    val packDoc = sourceMap.headLine(pack, Some(sorted.head))
+    val intro =
+      Doc.text(
+        "`todo` is a temporary placeholder. It is only accepted during relaxed `lib check` runs."
+      )
+
+    (packDoc + (line2 + Doc.intercalate(
+      line2,
+      intro :: occurrenceDocs ::: List(countDoc, Some(hintDoc)).flatten
+    )).nested(2)).render(80)
+  }
+
   case class UnusedLetError(
       pack: PackageName,
       errs: NonEmptyList[(Identifier.Bindable, Region)]
@@ -1790,6 +1849,17 @@ object PackageError {
           "if intentional, ignore it with `_` (for example: `_ = <expr>`)"
         )
       )
+  }
+
+  case class TodoUsage(
+      pack: PackageName,
+      regions: NonEmptyList[Region]
+  ) extends PackageError {
+    def message(
+        sourceMap: Map[PackageName, (LocationMap, String)],
+        errColor: Colorize
+    ) =
+      todoUsageMessage(pack, regions, sourceMap, errColor)
   }
 
   case class RecursionError(

--- a/core/src/main/scala/dev/bosatsu/PackageMap.scala
+++ b/core/src/main/scala/dev/bosatsu/PackageMap.scala
@@ -881,12 +881,19 @@ object PackageMap {
   ): List[SourceUnit[F, A]] =
     sources.map(_.withImport(predefImports))
 
-  private def withEffectivePredefSources[F[_]: Monad, A](
+  private[bosatsu] final case class EffectiveSourceUnits[F[_], A](
+      sourceUnits: List[SourceUnit[F, A]],
+      usesInternalPredefSource: Boolean
+  )
+
+  // A user-supplied `Bosatsu/Predef` interface suppresses the internal predef
+  // source, but we still inject the same implicit import surface either way.
+  private[bosatsu] def effectivePredefSources[F[_]: Applicative, A](
       sources: NonEmptyList[SourceUnit[F, A]],
       ifs: List[Package.Interface],
       predefKey: A,
       mode: CompileOptions.Mode
-  ): List[SourceUnit[F, A]] = {
+  ): EffectiveSourceUnits[F, A] = {
     val predefIface = ifs.find(_.name == PackageName.PredefName)
     val withPredefImports =
       withPredefImportsSourceUnits(
@@ -897,8 +904,16 @@ object PackageMap {
       )
 
     predefIface match {
-      case None       => SourceUnit.predef(predefKey, mode) :: withPredefImports
-      case Some(_)    => withPredefImports
+      case None       =>
+        EffectiveSourceUnits(
+          SourceUnit.predef(predefKey, mode) :: withPredefImports,
+          usesInternalPredefSource = true
+        )
+      case Some(_)    =>
+        EffectiveSourceUnits(
+          withPredefImports,
+          usesInternalPredefSource = false
+        )
     }
   }
 
@@ -911,12 +926,12 @@ object PackageMap {
       phases: InferPhases
   ): F[Ior[NonEmptyList[PackageError], PackageMap.Compiled]] =
     PackageMap.resolveThenInferSourceUnits[F, A](
-      withEffectivePredefSources(
+      effectivePredefSources(
         sources,
         ifs,
         predefKey,
         compileOptions.mode
-      ),
+      ).sourceUnits,
       ifs,
       compileOptions,
       cache,

--- a/core/src/main/scala/dev/bosatsu/library/Command.scala
+++ b/core/src/main/scala/dev/bosatsu/library/Command.scala
@@ -1635,10 +1635,16 @@ object Command {
             for {
               cc <- fcc
               cacheDir = cacheDirFn(cc.gitRoot)
+              compileOptions =
+                lintMode match {
+                  case LintMode.Strict          => CompileOptions.NoOptimize
+                  case LintMode.Warn | LintMode.Lax =>
+                    CompileOptions.TypeCheckOnly
+                }
               _ <- cc.check(
                 colorize,
                 sourceFilter,
-                CompileOptions.TypeCheckOnly,
+                compileOptions,
                 lintMode,
                 cacheDir
               )

--- a/core/src/main/scala/dev/bosatsu/tool/CompilerApi.scala
+++ b/core/src/main/scala/dev/bosatsu/tool/CompilerApi.scala
@@ -75,7 +75,8 @@ object CompilerApi {
         extends LintCategory("shadowed binding", "shadowed bindings", 1)
     case UnreachableBranch
         extends LintCategory("unreachable branch", "unreachable branches", 2)
-    case UnusedImport extends LintCategory("unused import", "unused imports", 3)
+    case TodoUsage extends LintCategory("todo usage", "todo usages", 3)
+    case UnusedImport extends LintCategory("unused import", "unused imports", 4)
   }
 
   private sealed trait RenderedDiagnostic {
@@ -194,6 +195,8 @@ object CompilerApi {
       case e: PackageError.DuplicatedPackageError =>
         val count = e.dups.length
         renderedError(ErrorCategory.PackageError, count, body)
+      case e: PackageError.TodoUsage =>
+        renderedError(ErrorCategory.PackageError, e.regions.length, body)
     }
 
   // This classifier assumes `err` is already known to be postponable. Passing
@@ -231,6 +234,8 @@ object CompilerApi {
           ) =>
         val count = branches.length
         renderedLint(LintCategory.UnreachableBranch, count, body)
+      case e: PackageError.TodoUsage =>
+        renderedLint(LintCategory.TodoUsage, e.regions.length, body)
       case _ =>
         sys.error(s"unexpected non-lint warning: $err")
     }
@@ -382,7 +387,8 @@ object CompilerApi {
 
   private def replaySourceLintDiagnostics(
       pack: Package.Compiled,
-      parsed: Package.Parsed
+      parsed: Package.Parsed,
+      includeTodoUsageWarnings: Boolean
   ): List[PackageError] = {
     // Cached compiled packages can drop the source-level statement/region
     // detail needed for unused-let replay, so reusing the parsed source here
@@ -413,6 +419,9 @@ object CompilerApi {
             parsed.exports,
             program0
           ) :::
+            (if (includeTodoUsageWarnings)
+               PackageCustoms.todoUsageLintFromSource(pack.name, program0)
+             else Nil) :::
             replayUnusedLets(parsed.name, program0.lets)
         ).filter(PackageError.isPostponable)
       case Ior.Both(_, program0) =>
@@ -424,6 +433,9 @@ object CompilerApi {
             parsed.exports,
             program0
           ) :::
+            (if (includeTodoUsageWarnings)
+               PackageCustoms.todoUsageLintFromSource(pack.name, program0)
+             else Nil) :::
             replayUnusedLets(parsed.name, program0.lets)
         ).filter(PackageError.isPostponable)
     }
@@ -434,6 +446,7 @@ object CompilerApi {
       sourceFiles: NonEmptyList[PackageResolver.SourceFile[IO, Path]],
       packs: PackageMap.Compiled,
       allowedPackages: Set[PackageName],
+      includeTodoUsageWarnings: Boolean,
       errColor: Colorize
   ): IO[List[PackageError]] = {
     import platformIO.moduleIOMonad
@@ -450,7 +463,11 @@ object CompilerApi {
             sourceFile.loadParsed
               .flatMap(parsed0 => fromParse(platformIO, parsed0, errColor))
               .map(parsed =>
-                replaySourceLintDiagnostics(pack, parsed) :::
+                replaySourceLintDiagnostics(
+                  pack,
+                  parsed,
+                  includeTodoUsageWarnings
+                ) :::
                   replayTypedLintDiagnostics(pack)
               )
         }
@@ -560,6 +577,13 @@ object CompilerApi {
           source.loadParsed.flatMap(parsed => fromParse(platformIO, parsed, errColor))
         )
       }
+      effectiveSources =
+        PackageMap.effectivePredefSources(
+          sources,
+          ifs,
+          "predef",
+          compileOptions.mode
+        )
       cache: InferCache[IO] = compileCacheDirOpt match {
         case Some(cacheDir) => CompileCache.filesystem(cacheDir, platformIO)
         case None           => InferCache.noop[IO]
@@ -576,6 +600,12 @@ object CompilerApi {
       sourceMap = PackageMap.buildSourceMapFromSources(sources)
       pathToName = sourceFiles.map(source => (source.path, source.packageName))
       sourcePackageNames = pathToName.iterator.map(_._2).toSet
+      // Only the built-in type-check predef should trigger the warn-only todo
+      // lint. An explicit `Bosatsu/Predef` interface can define its own `todo`.
+      includeTodoUsageWarnings =
+        lintMode == LintMode.Warn &&
+          compileOptions.mode == CompileOptions.Mode.TypeCheckOnly &&
+          effectiveSources.usesInternalPredefSource
       (compileDiagnostics, compiled) = checked match {
         case Ior.Left(errs)      => (errs.toList, None)
         case Ior.Right(packs)    => (Nil, Some(packs))
@@ -594,6 +624,7 @@ object CompilerApi {
               sourceFiles,
               packs,
               sourcePackageNames,
+              includeTodoUsageWarnings,
               errColor
             )
           case _ =>

--- a/core/src/main/scala/dev/bosatsu/tool_command/CheckCommand.scala
+++ b/core/src/main/scala/dev/bosatsu/tool_command/CheckCommand.scala
@@ -53,7 +53,7 @@ object CheckCommand {
         interfaces ::: CommandSupport.dependencyInterfaces(dependencies),
         errColor,
         packageResolver,
-        CompileOptions.TypeCheckOnly,
+        CompileOptions.NoOptimize,
         compileCacheDirOpt
       )
     } yield packPath._1

--- a/core/src/test/scala/dev/bosatsu/PackageTest.scala
+++ b/core/src/test/scala/dev/bosatsu/PackageTest.scala
@@ -1,6 +1,6 @@
 package dev.bosatsu
 
-import cats.Show
+import cats.{Id, Show}
 import cats.data.{NonEmptyList, Validated, ValidatedNel}
 
 import IorMethods.IorExtension
@@ -393,5 +393,43 @@ main = todo(42)
 
     assert(!emitExports.contains("todo"), emitExports.toString)
     assert(typeCheckExports.contains("todo"), typeCheckExports.toString)
+  }
+
+  test("effective predef sources respect explicit Predef interfaces") {
+    val pack = parse("""
+package Foo
+
+main = 1
+""")
+    val predefIface =
+      Package.interfaceOf(PackageMap.predefCompiledForMode(CompileOptions.Mode.Emit))
+
+    val source =
+      PackageMap.SourceUnit.fromParsedWithoutLocation[Id, Int]((0, pack))
+    val withoutIface =
+      PackageMap.effectivePredefSources(
+        NonEmptyList.one(source),
+        Nil,
+        -1,
+        CompileOptions.Mode.TypeCheckOnly
+      )
+    val withIface =
+      PackageMap.effectivePredefSources(
+        NonEmptyList.one(source),
+        predefIface :: Nil,
+        -1,
+        CompileOptions.Mode.TypeCheckOnly
+      )
+
+    assert(withoutIface.usesInternalPredefSource)
+    assertEquals(
+      withoutIface.sourceUnits.count(_.packageName == PackageName.PredefName),
+      1
+    )
+    assert(!withIface.usesInternalPredefSource)
+    assertEquals(
+      withIface.sourceUnits.count(_.packageName == PackageName.PredefName),
+      0
+    )
   }
 }

--- a/core/src/test/scala/dev/bosatsu/ToolAndLibCommandTest.scala
+++ b/core/src/test/scala/dev/bosatsu/ToolAndLibCommandTest.scala
@@ -5273,7 +5273,7 @@ main = depBox
     }
   }
 
-  test("tool check accepts todo but tool show rejects it") {
+  test("tool check rejects todo and tool show still rejects it") {
     val src =
       """package Todo/Foo
 |
@@ -5291,9 +5291,13 @@ main = depBox
         "src/Todo/Foo.bosatsu"
       )
     ) match {
-      case Right(Output.CompileOut(_, _, _)) => ()
-      case Right(other)                      => fail(s"unexpected output: $other")
-      case Left(err)                         => fail(err.getMessage)
+      case Right(out) =>
+        fail(s"expected strict todo rejection, got: $out")
+      case Left(err) =>
+        val msg = Option(err.getMessage).getOrElse(err.toString)
+        assert(msg.contains("Unknown name"), msg)
+        assert(msg.contains("todo"), msg)
+        assert(msg.contains("lib check --warn"), msg)
     }
 
     runWithFiles(files)(
@@ -5311,7 +5315,7 @@ main = depBox
       case Left(err) =>
         val msg = Option(err.getMessage).getOrElse(err.toString)
         assert(msg.contains("todo"), msg)
-        assert(msg.contains("only available in type-check mode"), msg)
+        assert(msg.contains("lib check --warn"), msg)
     }
   }
 
@@ -5729,6 +5733,70 @@ main = depBox
     }
   }
 
+  test("lib check --warn keeps todo warnings stable on cache hits") {
+    val cmd = List(
+      "lib",
+      "check",
+      "--repo_root",
+      "repo",
+      "--cache_dir",
+      "cache",
+      "--warn"
+    )
+
+    val result = for {
+      s0 <- stateFromFiles(baseLibFiles("main = todo(1)\n"))
+      s1 <- runWithState(cmd, s0)
+      (state1, out1) = s1
+      s2 <- runWithState(cmd, resetLogs(state1))
+      (state2, out2) = s2
+    } yield (state1, state2, out1, out2)
+
+    result match {
+      case Left(err) =>
+        fail(err.getMessage)
+      case Right((state1, state2, out1, out2)) =>
+        val err1 = state1.stdErr.render(400)
+        val err2 = state2.stdErr.render(400)
+        assertEquals(out1, Output.Basic(Doc.text(""), None))
+        assertEquals(out2, Output.Basic(Doc.text(""), None))
+        assert(err1.contains("temporary `todo` placeholder used here"), err1)
+        assert(err1.contains("1 warning: 1 todo usage"), err1)
+        assert(err1.contains("lib check --warn"), err1)
+        assertEquals(err2, err1)
+    }
+  }
+
+  test("lib check --lax allows todo without warnings") {
+    val cmd = List(
+      "lib",
+      "check",
+      "--repo_root",
+      "repo",
+      "--cache_dir",
+      "cache",
+      "--lax"
+    )
+
+    val result = for {
+      s0 <- stateFromFiles(baseLibFiles("main = todo(1)\n"))
+      s1 <- runWithState(cmd, s0)
+      (state1, out1) = s1
+      s2 <- runWithState(cmd, resetLogs(state1))
+      (state2, out2) = s2
+    } yield (state1, state2, out1, out2)
+
+    result match {
+      case Left(err) =>
+        fail(err.getMessage)
+      case Right((state1, state2, out1, out2)) =>
+        assertEquals(out1, Output.Basic(Doc.text(""), None))
+        assertEquals(out2, Output.Basic(Doc.text(""), None))
+        assertEquals(state1.stdErr.render(200), "")
+        assertEquals(state2.stdErr.render(200), "")
+    }
+  }
+
   test("lib check strict mode still fails on lint after a prior --lax cache hit") {
     val laxCmd = List(
       "lib",
@@ -5763,6 +5831,44 @@ main = depBox
         assert(rendered.contains("unused value 'unused'"), rendered)
       case Left(err) =>
         fail(err.getMessage)
+    }
+  }
+
+  test("lib check strict mode still rejects todo after a prior --warn cache hit") {
+    val warnCmd = List(
+      "lib",
+      "check",
+      "--repo_root",
+      "repo",
+      "--cache_dir",
+      "cache",
+      "--warn"
+    )
+    val strictCmd = List(
+      "lib",
+      "check",
+      "--repo_root",
+      "repo",
+      "--cache_dir",
+      "cache"
+    )
+
+    val result = for {
+      s0 <- stateFromFiles(baseLibFiles("main = todo(1)\n"))
+      s1 <- runWithState(warnCmd, s0)
+      (state1, _) = s1
+      s2 <- runAndReportWithState(strictCmd, resetLogs(state1))
+    } yield s2
+
+    result match {
+      case Left(err) =>
+        fail(err.getMessage)
+      case Right((state, exitCode)) =>
+        val errOutput = state.stdErr.render(400)
+        assertEquals(exitCode, ExitCode.Error)
+        assert(errOutput.contains("Unknown name"), errOutput)
+        assert(errOutput.contains("todo"), errOutput)
+        assert(errOutput.contains("lib check --warn"), errOutput)
     }
   }
 
@@ -6027,7 +6133,7 @@ main = depBox
     }
   }
 
-  test("lib test --warn still rejects todo") {
+  test("lib test strict, warn, and lax modes still reject todo") {
     val ccConfJson =
       """{
         |  "cc_path": "cc",
@@ -6043,25 +6149,32 @@ main = depBox
         |test_one = todo(Assertion(True, "later"))
         |""".stripMargin
 
-    runWithFiles(
+    val files =
       baseLibFiles(todoTestSrc) :+ (Chain("repo", "cc_conf.json") -> ccConfJson)
-    )(
-      List(
-        "lib",
-        "test",
-        "--repo_root",
-        "repo",
-        "--cc_conf",
-        "repo/cc_conf.json",
-        "--warn"
-      )
-    ) match {
-      case Right(out) =>
-        fail(s"expected todo failure, got: $out")
-      case Left(err) =>
-        val msg = Option(err.getMessage).getOrElse(err.toString)
-        assert(msg.contains("`todo` is only available"), msg)
+
+    List(
+      "strict" -> Nil,
+      "warn" -> List("--warn"),
+      "lax" -> List("--lax")
+    ).foreach { case (modeLabel, modeFlags) =>
+      runWithFiles(files)(
+        List(
+          "lib",
+          "test",
+          "--repo_root",
+          "repo",
+          "--cc_conf",
+          "repo/cc_conf.json"
+        ) ::: modeFlags
+      ) match {
+        case Right(out) =>
+          fail(s"expected todo failure in $modeLabel mode, got: $out")
+        case Left(err) =>
+          val msg = Option(err.getMessage).getOrElse(err.toString)
+          assert(msg.contains("todo"), msg)
+          assert(msg.contains("lib check --warn"), msg)
       }
+    }
   }
 
   test("lib deps list text output includes public and private sections") {
@@ -7087,10 +7200,10 @@ main = 0
     }
   }
 
-  test("lib check accepts todo but lib show rejects it") {
+  test("lib check --warn accepts todo but lib show rejects it") {
     val files = baseLibFiles("main = todo(1)\n")
 
-    runWithFiles(files)(List("lib", "check", "--repo_root", "repo")) match {
+    runWithFiles(files)(List("lib", "check", "--repo_root", "repo", "--warn")) match {
       case Right(Output.Basic(_, _)) => ()
       case Right(other)              => fail(s"unexpected output: $other")
       case Left(err)                 => fail(err.getMessage)
@@ -7104,7 +7217,40 @@ main = 0
       case Left(err) =>
         val msg = Option(err.getMessage).getOrElse(err.toString)
         assert(msg.contains("todo"), msg)
-        assert(msg.contains("only available in type-check mode"), msg)
+        assert(msg.contains("lib check --warn"), msg)
+    }
+  }
+
+  test("lib check --warn only warns on built-in todo") {
+    val src =
+      """from MyLib/Helper import todo as imported_todo
+        |
+        |todo = (x) -> x.add(1)
+        |main = todo(1).add(imported_todo(2))
+        |""".stripMargin
+    val helperSrc =
+      """export todo
+        |
+        |todo = (x) -> x.add(2)
+        |""".stripMargin
+    val files =
+      baseLibFiles(src) :+
+        (Chain("repo", "src", "MyLib", "Helper.bosatsu") -> helperSrc)
+
+    val result = for {
+      s0 <- stateFromFiles(files)
+      s1 <- runWithState(
+        List("lib", "check", "--repo_root", "repo", "--warn"),
+        s0
+      )
+    } yield s1
+
+    result match {
+      case Left(err) =>
+        fail(err.getMessage)
+      case Right((state, out)) =>
+        assertEquals(out, Output.Basic(Doc.text(""), None))
+        assertEquals(state.stdErr.render(200), "")
     }
   }
 

--- a/docs/src/main/paradox/language_guide.md
+++ b/docs/src/main/paradox/language_guide.md
@@ -990,10 +990,12 @@ def big_hard_function(a: Arg1, b: Arg2) -> Result:
 This is useful for an "always-be-compiling" workflow: keep moving from one
 typechecking state to the next, then remove placeholders incrementally.
 
-`todo` is intentionally unsound, so it is only available in check-only commands
-(`tool check` and `lib check`). Commands that emit or execute outputs
-(`show`/`json`/`eval`/`build`/`transpile`/`test`) do not include `todo`, so
-those commands fail until all `todo` calls are removed.
+`todo` is intentionally unsound, so strict `tool check` and strict `lib check`
+reject it. For a relaxed edit loop, `lib check --warn` accepts built-in `todo`
+and reports each use as a warning, while `lib check --lax` accepts it without
+running that warning pass. Commands that emit or execute outputs
+(`show`/`json`/`eval`/`build`/`transpile`/`test`) still do not include `todo`,
+so those commands fail until all `todo` calls are removed.
 
 ## Testing
 Bosatsu supports two test entrypoint styles:

--- a/docs/src/main/paradox/writing_bosatsu_5_minutes.md
+++ b/docs/src/main/paradox/writing_bosatsu_5_minutes.md
@@ -90,10 +90,12 @@ def hard_part(a: String, b: Int) -> Bool:
 
 Rules:
 
-1. `todo` is only available in check-only commands (`tool check` / `lib check`).
-2. Commands that emit or run code (`lib test`, `lib build`, `tool eval`, etc.)
+1. Strict `tool check` and strict `lib check` reject built-in `todo`.
+2. `lib check --warn` accepts built-in `todo` and prints a warning for each use.
+3. `lib check --lax` accepts built-in `todo` without that warning pass.
+4. Commands that emit or run code (`lib test`, `lib build`, `tool eval`, etc.)
    fail until `todo` is removed.
-3. Keep `todo` arguments meaningful (usually tuple all planned inputs) so you do
+5. Keep `todo` arguments meaningful (usually tuple all planned inputs) so you do
    not lose type information during refactors.
 
 Once placeholders are removed, run:


### PR DESCRIPTION
This implements issue #2219 from the merged design doc. `tool check` and strict `lib check` now use `CompileOptions.NoOptimize`, so built-in `todo` is rejected in strict mode, while `lib check --warn` and `lib check --lax` continue to use type-check-only mode.

A new postponable `PackageError.TodoUsage` warning is emitted only for resolved built-in `Bosatsu/Predef::todo` usages during `lib check --warn`, including warm-cache runs. The warning scan reuses the effective predef selection logic, skips explicit `Bosatsu/Predef` overrides, and stays disabled for `--lax` and all emit/run paths.

I updated CLI hint text and the two user docs to describe the new behavior, and added regression coverage for strict rejection, warn/lax behavior, cache-hit stability, false-positive avoidance, emit/test rejection, and explicit predef handling.

Checks run and passing:
- `sbt "coreJVM/testOnly dev.bosatsu.PackageTest" "coreJVM/testOnly dev.bosatsu.ToolAndLibCommandTest"`
- `sbt "coreJVM/test; cli/test"`
- `sbt "doc; paradox"`
- `scripts/test_basic.sh`

Fixes #2219

Implements design doc: [docs/design/2219-change-todo-behavior-in-type-check-mode.md](https://github.com/johnynek/bosatsu/blob/main/docs/design/2219-change-todo-behavior-in-type-check-mode.md)

Design source PR: https://github.com/johnynek/bosatsu/pull/2220