### PR TITLE
Support git worktrees when finding repo root

### DIFF
--- a/bosatsu
+++ b/bosatsu
@@ -19,7 +19,7 @@ find_repo_root() {
 
   local dir="$PWD"
   while [ "$dir" != "/" ]; do
-    if [ -d "$dir/.git" ]; then
+    if [ -e "$dir/.git" ]; then
       printf '%s\n' "$dir"
       return 0
     fi
@@ -29,7 +29,7 @@ find_repo_root() {
   return 1
 }
 
-repo_root="$(find_repo_root)" || fail "could not find repo root (.git not found)"
+repo_root="$(find_repo_root)" || fail "could not find repo root (.git entry not found)"
 
 version_file="${repo_root}/.bosatsu_version"
 platform_file="${repo_root}/.bosatsu_platform"

--- a/c_runtime/install.py
+++ b/c_runtime/install.py
@@ -10,10 +10,10 @@ from argparse import ArgumentParser
 def find_git_directory(start_path):
     current_path = start_path
     while current_path != os.path.dirname(current_path):
-        if os.path.isdir(os.path.join(current_path, ".git")):
+        if os.path.exists(os.path.join(current_path, ".git")):
             return current_path
         current_path = os.path.dirname(current_path)
-    raise FileNotFoundError("No .git directory found in current or parent directories.")
+    raise FileNotFoundError("No .git entry found in current or parent directories.")
 
 
 def detect_os_type():
@@ -177,7 +177,7 @@ def main():
     parser.add_argument("--version", required=True, help="Version directory name.")
     parser.add_argument(
         "--root",
-        help="Path to the repo root where .bosatsuc should be installed; defaults to locating .git.",
+        help="Path to the repo root where .bosatsuc should be installed; defaults to locating a .git entry.",
     )
     parser.add_argument(
         "--cc",

--- a/cli/src/main/scala/dev/bosatsu/IOPlatformIO.scala
+++ b/cli/src/main/scala/dev/bosatsu/IOPlatformIO.scala
@@ -100,19 +100,8 @@ object IOPlatformIO extends PlatformIO[IO, JPath] {
     cats.effect.IO.asyncForIO
 
   override def gitTopLevel: IO[Option[Path]] = {
-    def searchStep(current: Path): IO[Either[Path, Option[Path]]] =
-      fsDataType(current).flatMap {
-        case Some(PlatformIO.FSDataType.Dir) =>
-          fsDataType(resolve(current, ".git"))
-            .map {
-              case Some(PlatformIO.FSDataType.Dir) => Right(Some(current))
-              case _ => Left(resolve(current, ".."))
-            }
-        case _ => moduleIOMonad.pure(Right(None))
-      }
-
     val start = Paths.get(".").toAbsolutePath.normalize
-    moduleIOMonad.tailRecM(start)(searchStep)
+    gitTopLevelFrom(start)
   }
 
   private def deleteRecursively(path: Path): IO[Unit] =
@@ -211,6 +200,8 @@ object IOPlatformIO extends PlatformIO[IO, JPath] {
       root.relativize(pf)
     }
     else None
+  def parent(p: Path): Option[Path] =
+    Option(p.getParent)
 
   def read[A <: GeneratedMessage](
       path: Path

--- a/cli/src/test/scala/dev/bosatsu/IOPlatformIOTest.scala
+++ b/cli/src/test/scala/dev/bosatsu/IOPlatformIOTest.scala
@@ -1,10 +1,12 @@
 package dev.bosatsu
 
 import cats.Eq
-import cats.implicits._
 import cats.effect.{IO, Resource}
+import cats.implicits._
+import cats.effect.unsafe.implicits.global
 import java.io.File
 import java.nio.file.{Files, Path, Paths}
+import java.util.Comparator
 import org.scalacheck.Gen
 import org.scalacheck.Prop.forAll
 
@@ -26,6 +28,22 @@ class IOPlatformIOTest extends munit.ScalaCheckSuite {
         l.sortBy(_.name.asString) === r
     }
 
+  private def deleteRecursively(path: Path): Unit = {
+    val walk = Files.walk(path)
+    try {
+      walk.sorted(Comparator.reverseOrder()).forEach { p =>
+        Files.deleteIfExists(p)
+        ()
+      }
+    } finally walk.close()
+  }
+
+  private def withTempDir[A](fn: Path => A): A = {
+    val dir = Files.createTempDirectory("bosatsu-io-platform-")
+    try fn(dir)
+    finally deleteRecursively(dir)
+  }
+
   def testWithTempFile(fn: Path => IO[Unit]): Unit = {
     val tempRes = Resource.make(IO.blocking {
       val f = File.createTempFile("proto_test", ".proto")
@@ -37,8 +55,6 @@ class IOPlatformIOTest extends munit.ScalaCheckSuite {
       }
     }
 
-    // allow us to unsafeRunSync
-    import cats.effect.unsafe.implicits.global
     tempRes.use(fn).unsafeRunSync()
   }
 
@@ -89,4 +105,38 @@ class IOPlatformIOTest extends munit.ScalaCheckSuite {
     )
   }
 
+  test("gitTopLevelFrom finds a checkout root with a .git directory") {
+    withTempDir { root =>
+      Files.createDirectories(root.resolve(".git"))
+      val nested = Files.createDirectories(root.resolve("a/b"))
+
+      assertEquals(
+        IOPlatformIO.gitTopLevelFrom(nested).unsafeRunSync(),
+        Some(root)
+      )
+    }
+  }
+
+  test("gitTopLevelFrom finds a checkout root with a .git worktree file") {
+    withTempDir { root =>
+      Files.writeString(root.resolve(".git"), "gitdir: /tmp/worktree\n")
+      val nested = Files.createDirectories(root.resolve("a/b"))
+
+      assertEquals(
+        IOPlatformIO.gitTopLevelFrom(nested).unsafeRunSync(),
+        Some(root)
+      )
+    }
+  }
+
+  test("gitTopLevelFrom stops at filesystem root when no .git entry exists") {
+    withTempDir { root =>
+      val nested = Files.createDirectories(root.resolve("a/b"))
+
+      assertEquals(
+        IOPlatformIO.gitTopLevelFrom(nested).unsafeRunSync(),
+        None
+      )
+    }
+  }
 }

--- a/cliJS/src/main/scala/dev/bosatsu/Fs2PlatformIO.scala
+++ b/cliJS/src/main/scala/dev/bosatsu/Fs2PlatformIO.scala
@@ -59,19 +59,8 @@ object Fs2PlatformIO extends PlatformIO[IO, Path] {
   def pathToString(p: Path): String = p.toString
 
   override def gitTopLevel: IO[Option[Path]] = {
-    def searchStep(current: Path): IO[Either[Path, Option[Path]]] =
-      fsDataType(current).flatMap {
-        case Some(PlatformIO.FSDataType.Dir) =>
-          fsDataType(resolve(current, ".git"))
-            .map {
-              case Some(PlatformIO.FSDataType.Dir) => Right(Some(current))
-              case _ => Left(resolve(current, ".."))
-            }
-        case _ => moduleIOMonad.pure(Right(None))
-      }
-
     val start = Path(js.Dynamic.global.process.cwd().asInstanceOf[String])
-    moduleIOMonad.tailRecM(start)(searchStep)
+    gitTopLevelFrom(start)
   }
 
   def withTempPrefix[A](name: String)(fn: Path => IO[A]): IO[A] = {
@@ -202,6 +191,9 @@ object Fs2PlatformIO extends PlatformIO[IO, Path] {
               case false => Some(PlatformIO.FSDataType.File)
             }
       }
+
+  def parent(p: Path): Option[Path] =
+    p.parent
 
   private def read[A <: GeneratedMessage](
       path: Path

--- a/core/src/main/scala/dev/bosatsu/MemoryMain.scala
+++ b/core/src/main/scala/dev/bosatsu/MemoryMain.scala
@@ -251,6 +251,12 @@ object MemoryMain {
               Validated.valid(Chain.fromSeq(string.split("/", -1).toIndexedSeq))
         }
       def pathToString(path: Chain[String]): String = path.mkString_("/")
+      def parent(p: Path): Option[Path] =
+        p.toList match {
+          case Nil      => None
+          case _ :: Nil => None
+          case items    => Some(Chain.fromSeq(items.init))
+        }
       def system(command: String, args: List[String]) =
         moduleIOMonad.raiseError(
           new Exception(

--- a/core/src/main/scala/dev/bosatsu/PlatformIO.scala
+++ b/core/src/main/scala/dev/bosatsu/PlatformIO.scala
@@ -85,6 +85,13 @@ trait PlatformIO[F[_], Path] {
   def resolve(p: Path, child: String): Path
   def resolve(p: Path, child: Path): Path
   def relativize(prefix: Path, deeper: Path): Option[Path]
+  def parent(p: Path): Option[Path]
+
+  final def hasGitMetadataEntry(dir: Path): F[Boolean] =
+    fsDataType(resolve(dir, ".git")).map {
+      case Some(_) => true
+      case None    => false
+    }
 
   def resolveFile(root: Path, pack: PackageName): F[Option[Path]] = {
     val dir = resolve(root, pack.parts.init)
@@ -111,20 +118,29 @@ trait PlatformIO[F[_], Path] {
 
   def gitShaHead: F[String]
 
-  def gitTopLevel: F[Option[Path]] = {
+  final def gitTopLevelFrom(start: Path): F[Option[Path]] = {
     def searchStep(current: Path): F[Either[Path, Option[Path]]] =
       fsDataType(current).flatMap {
         case Some(PlatformIO.FSDataType.Dir) =>
-          fsDataType(resolve(current, ".git"))
-            .map {
-              case Some(PlatformIO.FSDataType.Dir) => Right(Some(current))
-              case _ => Left(resolve(current, ".."))
-            }
+          hasGitMetadataEntry(current).map {
+            case true => Right(Some(current))
+            case false =>
+              parent(current) match {
+                case Some(next) if !pathOrdering.equiv(next, current) =>
+                  Left(next)
+                case _ =>
+                  Right(None)
+              }
+          }
         case _ => moduleIOMonad.pure(Right(None))
       }
 
+    moduleIOMonad.tailRecM(start)(searchStep)
+  }
+
+  def gitTopLevel: F[Option[Path]] = {
     path(".") match {
-      case Valid(a)   => moduleIOMonad.tailRecM(a)(searchStep)
+      case Valid(a)   => gitTopLevelFrom(a)
       case Invalid(e) =>
         moduleIOMonad.raiseError(
           new Exception(s"could not find current directory: $e")

--- a/core/src/main/scala/dev/bosatsu/codegen/clang/ClangTranspiler.scala
+++ b/core/src/main/scala/dev/bosatsu/codegen/clang/ClangTranspiler.scala
@@ -344,7 +344,7 @@ case object ClangTranspiler extends Transpiler {
         root <- platformIO.getOrError(
           rootOpt,
           CliException.Basic(
-            "could not find .git directory to locate default cc_conf.\n" +
+            "could not find a .git entry to locate default cc_conf.\n" +
               "Pass --cc_conf <path/to/cc_conf.json>, or run from a git checkout with .git available."
           )
         )

--- a/core/src/main/scala/dev/bosatsu/cruntime/Command.scala
+++ b/core/src/main/scala/dev/bosatsu/cruntime/Command.scala
@@ -25,7 +25,7 @@ object Command {
       Opts
         .option[P](
           "repo_root",
-          "the path to the root of the repo, if not set, search for .git directory"
+          "the path to the root of the repo, if not set, search for a .git entry"
         )
         .orNone
         .map {
@@ -37,7 +37,7 @@ object Command {
                 case None        =>
                   moduleIOMonad.raiseError(
                     CliException
-                      .Basic("could not find .git directory in parents.")
+                      .Basic("could not find a .git entry in parents.")
                   )
               }
         }

--- a/core/src/main/scala/dev/bosatsu/library/Command.scala
+++ b/core/src/main/scala/dev/bosatsu/library/Command.scala
@@ -155,7 +155,7 @@ object Command {
       Opts
         .option[P](
           "repo_root",
-          "the path to the root of the repo, if not set, search for .git directory"
+          "the path to the root of the repo, if not set, search for a .git entry"
         )
         .orNone
         .map {
@@ -167,7 +167,7 @@ object Command {
                 case None        =>
                   moduleIOMonad.raiseError(
                     CliException
-                      .Basic("could not find .git directory in parents.")
+                      .Basic("could not find a .git entry in parents.")
                   )
               }
         }

--- a/docs/src/main/paradox/getting_started.md
+++ b/docs/src/main/paradox/getting_started.md
@@ -128,8 +128,9 @@ mkdir -p src
 
 Notes:
 
-- `init` searches for `.git` to find the repo root. If you need to override
-  that, add `--repo_root <path>`.
+- `init` searches for a `.git` entry to find the repo root. This works for
+  standard checkouts and git worktrees. If you need to override that, add
+  `--repo_root <path>`.
 - It writes `bosatsu_libs.json` in the repo root and `src/mylib_conf.json` in the
   source root you selected.
 


### PR DESCRIPTION
## Summary
- treat `.git` as a repo marker whether it is a directory or a worktree file
- stop repo-root traversal cleanly at the filesystem root and reuse the shared lookup in JVM and JS platforms
- align wrapper/runtime helper messaging and add regression coverage for checkout, worktree, and no-git cases

## Testing
- sbt "cli/testOnly dev.bosatsu.IOPlatformIOTest"
- sbt "cliJSJS/testOnly dev.bosatsu.Fs2PlatformIOTest"
- scripts/test_basic.sh