### PR TITLE
Use xlarge macOS runner for native-image release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -210,8 +210,9 @@ jobs:
           path: bosatsu-linux
 
   native_macos:
-    runs-on: macos-14
+    runs-on: macos-14-xlarge
     needs: prepare
+    timeout-minutes: 45
     steps:
       - name: Check out code
         uses: actions/checkout@v4
@@ -244,6 +245,8 @@ jobs:
       - name: Build native image (macos)
         env:
           BOSATSU_C_RUNTIME_HASH: ${{ needs.prepare.outputs.c_runtime_hash }}
+          BOSATSU_NATIVE_IMAGE_BUILD_JAVA_XMX: 12g
+          BOSATSU_NATIVE_IMAGE_DEADLOCK_WATCHDOG_INTERVAL_MINUTES: "30"
         run: |
           sbt "cli/nativeImage"
           cp cli/target/native-image/bosatsu-cli bosatsu-macos

--- a/build.sbt
+++ b/build.sbt
@@ -308,14 +308,27 @@ lazy val cli = (project in file("cli"))
         munitScalaCheck.value % Test
       ),
     // static linking doesn't work with macos or with linux http4s on the path
-    nativeImageOptions ++= List(
-      "--no-fallback",
-      "--verbose",
-      "-O2",
-      "-J-Xmx12g",
-      "-H:IncludeResources=dev/bosatsu/scalawasiz3/aot/.*\\.meta",
-      "-H:+RemoveUnusedSymbols"
-    ) ++ {
+    nativeImageOptions ++= {
+      val nativeImageBuilderXmx =
+        sys.env
+          .get("BOSATSU_NATIVE_IMAGE_BUILD_JAVA_XMX")
+          .filter(_.nonEmpty)
+          .getOrElse("12g")
+      val watchdogOpts =
+        sys.env
+          .get("BOSATSU_NATIVE_IMAGE_DEADLOCK_WATCHDOG_INTERVAL_MINUTES")
+          .filter(_.nonEmpty)
+          .toList
+          .map(minutes => s"-H:DeadlockWatchdogInterval=$minutes") ++
+          sys.env
+            .get("BOSATSU_NATIVE_IMAGE_DEADLOCK_WATCHDOG_EXIT_ON_TIMEOUT")
+            .collect {
+              case value if value.equalsIgnoreCase("true") =>
+                "-H:+DeadlockWatchdogExitOnTimeout"
+              case value if value.equalsIgnoreCase("false") =>
+                "-H:-DeadlockWatchdogExitOnTimeout"
+            }
+            .toList
       val staticOpt =
         if (sys.env.get("BOSATSU_STATIC_NATIVE_IMAGE").exists(_.nonEmpty))
           List("--static")
@@ -337,7 +350,14 @@ lazy val cli = (project in file("cli"))
           .map(_.trim)
           .filter(_.nonEmpty)
           .map(p => s"-H:CLibraryPath=$p")
-      staticOpt ++ muslOpt ++ clibPaths
+      List(
+        "--no-fallback",
+        "--verbose",
+        "-O2",
+        s"-J-Xmx$nativeImageBuilderXmx",
+        "-H:IncludeResources=dev/bosatsu/scalawasiz3/aot/.*\\.meta",
+        "-H:+RemoveUnusedSymbols"
+      ) ++ watchdogOpts ++ staticOpt ++ muslOpt ++ clibPaths
     },
     nativeImageJvm := "graalvm-java23",
     nativeImageVersion := "23.0.2"

--- a/test_workspace/Bosatsu/Example/Json/Github/Workflows/Release.bosatsu
+++ b/test_workspace/Bosatsu/Example/Json/Github/Workflows/Release.bosatsu
@@ -19,7 +19,7 @@ from Bosatsu/Example/Json/Github/Workflows/Util import (
   needs_prepare,
   Step,
   permission_write,
-  runner_macos_14,
+  runner_macos_14_xlarge,
   runner_ubuntu_latest,
   sbt_cache_fetch_step,
   setup_sbt_title_step,
@@ -79,6 +79,7 @@ struct WorkflowJobsNativeMacosStepsItemWith(
 struct WorkflowJobsNativeMacos(
   `runs-on`: String,
   needs: String,
+  `timeout-minutes`: Int,
   steps: List[Step[WorkflowJobsNativeMacosStepsItemWith]],
 )
 
@@ -160,6 +161,13 @@ def release_env_lib_publish(
     `OUTDIR`: Set(out_dir),
     `GIT_SHA`: Set(git_sha),
     `URI_BASE`: Set(uri_base),
+  }
+
+def native_macos_env(hash: String, xmx: String, watchdog_minutes: String) -> StepEnv:
+  StepEnv {
+    `BOSATSU_C_RUNTIME_HASH`: Set(hash),
+    `BOSATSU_NATIVE_IMAGE_BUILD_JAVA_XMX`: Set(xmx),
+    `BOSATSU_NATIVE_IMAGE_DEADLOCK_WATCHDOG_INTERVAL_MINUTES`: Set(watchdog_minutes),
   }
 
 release_java17_bootstrap_steps = [
@@ -467,8 +475,9 @@ workflow =
         ],
       ),
       WorkflowJobsNativeMacos(
-        runner_macos_14,
+        runner_macos_14_xlarge,
         needs_prepare,
+        45,
         [
           *native_macos_bootstrap_steps,
           Step {
@@ -485,7 +494,11 @@ workflow =
               "file bosatsu-macos | grep -q \"arm64\" || { echo \"Expected arm64 binary\"; exit 1; }",
               "",
             ])),
-            env: Set(runtime_hash_env("\${{ needs.prepare.outputs.c_runtime_hash }}")),
+            env: Set(native_macos_env(
+              "\${{ needs.prepare.outputs.c_runtime_hash }}",
+              "12g",
+              "30",
+            )),
           },
           Step {
             uses: Set(action_upload_artifact),

--- a/test_workspace/Bosatsu/Example/Json/Github/Workflows/Util.bosatsu
+++ b/test_workspace/Bosatsu/Example/Json/Github/Workflows/Util.bosatsu
@@ -36,6 +36,7 @@ export (
   python_version_matrix,
   python_version_3_9,
   runner_macos_14,
+  runner_macos_14_xlarge,
   runner_macos_latest,
   runner_ubuntu_latest,
   Step(),
@@ -95,6 +96,8 @@ struct StepEnv(
   `URI_BASE`: Optional[String] = Missing,
   `PUBLISH_DRY_RUN`: Optional[String] = Missing,
   `C_RUNTIME_ARCHIVE`: Optional[String] = Missing,
+  `BOSATSU_NATIVE_IMAGE_BUILD_JAVA_XMX`: Optional[String] = Missing,
+  `BOSATSU_NATIVE_IMAGE_DEADLOCK_WATCHDOG_INTERVAL_MINUTES`: Optional[String] = Missing,
   `GITHUB_TOKEN`: Optional[String] = Missing,
   `GITHUB_REF_NAME`: Optional[String] = Missing,
   `GH_TOKEN`: Optional[String] = Missing,
@@ -131,6 +134,7 @@ struct JavaStrategy(matrix: JavaStrategyMatrix)
 runner_ubuntu_latest = "ubuntu-latest"
 runner_macos_latest = "macos-latest"
 runner_macos_14 = "macos-14"
+runner_macos_14_xlarge = "macos-14-xlarge"
 
 action_checkout_v2 = "actions/checkout@v2.1.0"
 action_checkout_v4 = "actions/checkout@v4"


### PR DESCRIPTION
## Summary
- switch the release macOS native-image job to `macos-14-xlarge`
- keep the macOS native-image heap at `12g` and relax the watchdog interval to `"30"`
- update the Bosatsu workflow model so workflow parity tests match the checked-in YAML

## Testing
- `./scripts/test_basic.sh`
