### PR TITLE
Disable native-image compilation timeouts

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -356,7 +356,9 @@ lazy val cli = (project in file("cli"))
         "-O2",
         s"-J-Xmx$nativeImageBuilderXmx",
         "-H:IncludeResources=dev/bosatsu/scalawasiz3/aot/.*\\.meta",
-        "-H:+RemoveUnusedSymbols"
+        "-H:+RemoveUnusedSymbols",
+        "-H:CompilationExpirationPeriod=0",
+        "-H:CompilationNoProgressPeriod=0"
       ) ++ watchdogOpts ++ staticOpt ++ muslOpt ++ clibPaths
     },
     nativeImageJvm := "graalvm-java23",


### PR DESCRIPTION
Adds the Graal native-image compiler timeout overrides:
- -H:CompilationExpirationPeriod=0
- -H:CompilationNoProgressPeriod=0

Rationale: release native-image builds are only exercised during release, so we want them to avoid failing on long method compilation.