### PR TITLE
Revert premium macOS release runner changes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -210,9 +210,8 @@ jobs:
           path: bosatsu-linux
 
   native_macos:
-    runs-on: macos-14-xlarge
+    runs-on: macos-14
     needs: prepare
-    timeout-minutes: 45
     steps:
       - name: Check out code
         uses: actions/checkout@v4
@@ -245,8 +244,6 @@ jobs:
       - name: Build native image (macos)
         env:
           BOSATSU_C_RUNTIME_HASH: ${{ needs.prepare.outputs.c_runtime_hash }}
-          BOSATSU_NATIVE_IMAGE_BUILD_JAVA_XMX: 12g
-          BOSATSU_NATIVE_IMAGE_DEADLOCK_WATCHDOG_INTERVAL_MINUTES: "30"
         run: |
           sbt "cli/nativeImage"
           cp cli/target/native-image/bosatsu-cli bosatsu-macos

--- a/test_workspace/Bosatsu/Example/Json/Github/Workflows/Release.bosatsu
+++ b/test_workspace/Bosatsu/Example/Json/Github/Workflows/Release.bosatsu
@@ -19,7 +19,7 @@ from Bosatsu/Example/Json/Github/Workflows/Util import (
   needs_prepare,
   Step,
   permission_write,
-  runner_macos_14_xlarge,
+  runner_macos_14,
   runner_ubuntu_latest,
   sbt_cache_fetch_step,
   setup_sbt_title_step,
@@ -79,7 +79,6 @@ struct WorkflowJobsNativeMacosStepsItemWith(
 struct WorkflowJobsNativeMacos(
   `runs-on`: String,
   needs: String,
-  `timeout-minutes`: Int,
   steps: List[Step[WorkflowJobsNativeMacosStepsItemWith]],
 )
 
@@ -161,13 +160,6 @@ def release_env_lib_publish(
     `OUTDIR`: Set(out_dir),
     `GIT_SHA`: Set(git_sha),
     `URI_BASE`: Set(uri_base),
-  }
-
-def native_macos_env(hash: String, xmx: String, watchdog_minutes: String) -> StepEnv:
-  StepEnv {
-    `BOSATSU_C_RUNTIME_HASH`: Set(hash),
-    `BOSATSU_NATIVE_IMAGE_BUILD_JAVA_XMX`: Set(xmx),
-    `BOSATSU_NATIVE_IMAGE_DEADLOCK_WATCHDOG_INTERVAL_MINUTES`: Set(watchdog_minutes),
   }
 
 release_java17_bootstrap_steps = [
@@ -475,9 +467,8 @@ workflow =
         ],
       ),
       WorkflowJobsNativeMacos(
-        runner_macos_14_xlarge,
+        runner_macos_14,
         needs_prepare,
-        45,
         [
           *native_macos_bootstrap_steps,
           Step {
@@ -494,11 +485,7 @@ workflow =
               "file bosatsu-macos | grep -q \"arm64\" || { echo \"Expected arm64 binary\"; exit 1; }",
               "",
             ])),
-            env: Set(native_macos_env(
-              "\${{ needs.prepare.outputs.c_runtime_hash }}",
-              "12g",
-              "30",
-            )),
+            env: Set(runtime_hash_env("\${{ needs.prepare.outputs.c_runtime_hash }}")),
           },
           Step {
             uses: Set(action_upload_artifact),

--- a/test_workspace/Bosatsu/Example/Json/Github/Workflows/Util.bosatsu
+++ b/test_workspace/Bosatsu/Example/Json/Github/Workflows/Util.bosatsu
@@ -36,7 +36,6 @@ export (
   python_version_matrix,
   python_version_3_9,
   runner_macos_14,
-  runner_macos_14_xlarge,
   runner_macos_latest,
   runner_ubuntu_latest,
   Step(),
@@ -97,8 +96,6 @@ struct StepEnv(
   `URI_BASE`: Optional[String] = Missing,
   `PUBLISH_DRY_RUN`: Optional[String] = Missing,
   `C_RUNTIME_ARCHIVE`: Optional[String] = Missing,
-  `BOSATSU_NATIVE_IMAGE_BUILD_JAVA_XMX`: Optional[String] = Missing,
-  `BOSATSU_NATIVE_IMAGE_DEADLOCK_WATCHDOG_INTERVAL_MINUTES`: Optional[String] = Missing,
   `GITHUB_TOKEN`: Optional[String] = Missing,
   `GITHUB_REF_NAME`: Optional[String] = Missing,
   `GH_TOKEN`: Optional[String] = Missing,
@@ -135,7 +132,6 @@ struct JavaStrategy(matrix: JavaStrategyMatrix)
 runner_ubuntu_latest = "ubuntu-latest"
 runner_macos_latest = "macos-latest"
 runner_macos_14 = "macos-14"
-runner_macos_14_xlarge = "macos-14-xlarge"
 
 action_checkout_v2 = "actions/checkout@v2.1.0"
 action_checkout_v4 = "actions/checkout@v4"


### PR DESCRIPTION
## Summary
- switch the release workflow macOS native-image job back to `macos-14`
- remove the workflow-level 45 minute timeout and 30 minute watchdog env wiring added in #2245
- keep the later native-image compilation timeout disabling in `build.sbt`

## Testing
- not run (workflow-only change)

This reverts the paid-runner/workflow changes from #2245 without undoing #2252.