### PR TITLE
Disable macOS native-image deadlock watchdog

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -244,6 +244,7 @@ jobs:
       - name: Build native image (macos)
         env:
           BOSATSU_C_RUNTIME_HASH: ${{ needs.prepare.outputs.c_runtime_hash }}
+          BOSATSU_NATIVE_IMAGE_DEADLOCK_WATCHDOG_INTERVAL_MINUTES: "0"
         run: |
           sbt "cli/nativeImage"
           cp cli/target/native-image/bosatsu-cli bosatsu-macos

--- a/test_workspace/Bosatsu/Example/Json/Github/Workflows/Release.bosatsu
+++ b/test_workspace/Bosatsu/Example/Json/Github/Workflows/Release.bosatsu
@@ -119,6 +119,12 @@ def tag_env(tag_name: String) -> StepEnv:
 def runtime_hash_env(hash: String) -> StepEnv:
   StepEnv { `BOSATSU_C_RUNTIME_HASH`: Set(hash) }
 
+def native_macos_env(hash: String) -> StepEnv:
+  StepEnv {
+    `BOSATSU_C_RUNTIME_HASH`: Set(hash),
+    `BOSATSU_NATIVE_IMAGE_DEADLOCK_WATCHDOG_INTERVAL_MINUTES`: Set("0"),
+  }
+
 def native_linux_env(
   hash: String,
   static_native: String,
@@ -485,7 +491,7 @@ workflow =
               "file bosatsu-macos | grep -q \"arm64\" || { echo \"Expected arm64 binary\"; exit 1; }",
               "",
             ])),
-            env: Set(runtime_hash_env("\${{ needs.prepare.outputs.c_runtime_hash }}")),
+            env: Set(native_macos_env("\${{ needs.prepare.outputs.c_runtime_hash }}")),
           },
           Step {
             uses: Set(action_upload_artifact),

--- a/test_workspace/Bosatsu/Example/Json/Github/Workflows/Util.bosatsu
+++ b/test_workspace/Bosatsu/Example/Json/Github/Workflows/Util.bosatsu
@@ -96,6 +96,7 @@ struct StepEnv(
   `URI_BASE`: Optional[String] = Missing,
   `PUBLISH_DRY_RUN`: Optional[String] = Missing,
   `C_RUNTIME_ARCHIVE`: Optional[String] = Missing,
+  `BOSATSU_NATIVE_IMAGE_DEADLOCK_WATCHDOG_INTERVAL_MINUTES`: Optional[String] = Missing,
   `GITHUB_TOKEN`: Optional[String] = Missing,
   `GITHUB_REF_NAME`: Optional[String] = Missing,
   `GH_TOKEN`: Optional[String] = Missing,


### PR DESCRIPTION
## Summary
- disable GraalVM's deadlock watchdog for the macOS release native-image build by setting `BOSATSU_NATIVE_IMAGE_DEADLOCK_WATCHDOG_INTERVAL_MINUTES=0`
- keep the existing `macos-14` runner and `-J-Xmx12g` setting path unchanged
- keep the checked-in workflow source and generated workflow in sync

## Why
- the failing release run hit GraalVM's deadlock watchdog, not an OOM: https://github.com/johnynek/bosatsu/actions/runs/23661814876
- the last successful release on `macos-14` also used `-J-Xmx12g`, so lowering heap size is not the first lever to pull: https://github.com/johnynek/bosatsu/actions/runs/23472933816
- GraalVM 23.0.2 `native-image --expert-options-all` reports `-H:DeadlockWatchdogInterval=10` by default and says `0 disables the watchdog`

## Testing
- not run (workflow-only change)