### PR TITLE
Wrap library decode work on the blocking pool

### DIFF
--- a/core/src/main/scala/dev/bosatsu/cache/CompileCache.scala
+++ b/core/src/main/scala/dev/bosatsu/cache/CompileCache.scala
@@ -214,12 +214,15 @@ object CompileCache {
         case Some(outputHash) =>
           val packagePath = casPath(outputHash)
           val read = platformIO.readBytes(packagePath).flatMap { bytes =>
-            moduleIOMonad.fromTry(decodeValue(key, bytes)).map {
-              case some @ Some(_) => some
-              case None           =>
-                statsUpdate { getCasDecodeMisses.incrementAndGet(); () }
-                None
-            }
+            platformIO.canPromiseF
+              .compute(decodeValue(key, bytes))
+              .flatMap(moduleIOMonad.fromTry)
+              .map {
+                case some @ Some(_) => some
+                case None           =>
+                  statsUpdate { getCasDecodeMisses.incrementAndGet(); () }
+                  None
+              }
           }
           onError(
             read,

--- a/core/src/main/scala/dev/bosatsu/library/Command.scala
+++ b/core/src/main/scala/dev/bosatsu/library/Command.scala
@@ -141,7 +141,7 @@ object Command {
       platformIO: PlatformIO[F, P],
       evalPassthroughArgs: List[String] = Nil
   ): Opts[F[Output[P]]] = {
-    import platformIO.{pathArg, moduleIOMonad, showPath, parallelF}
+    import platformIO.{canPromiseF, pathArg, moduleIOMonad, showPath, parallelF}
 
     implicit val hashArg: Argument[Algo.WithAlgo[HashValue]] =
       Parser.argFromParser(

--- a/core/src/main/scala/dev/bosatsu/library/DecodedLibrary.scala
+++ b/core/src/main/scala/dev/bosatsu/library/DecodedLibrary.scala
@@ -5,6 +5,7 @@ import cats.MonadError
 import cats.data.{NonEmptyChain, StateT, Validated, ValidatedNec}
 import cats.syntax.all._
 import dev.bosatsu.hashing.{Algo, Hashed, HashValue}
+import dev.bosatsu.graph.CanPromise
 import dev.bosatsu.tool.CliException
 import dev.bosatsu.{
   Kind,
@@ -216,35 +217,41 @@ object DecodedLibrary {
   def decode[F[_], A: Algo](
       protoLib: Hashed[A, proto.Library],
       dependencyIfaces: Iterable[Package.Interface] = Nil
-  )(implicit F: MonadError[F, Throwable]): F[DecodedLibrary[A]] =
+  )(implicit
+      F: MonadError[F, Throwable],
+      C: CanPromise[F]
+  ): F[DecodedLibrary[A]] =
     for {
-      ifsImpls <- F.fromTry(
-        ProtoConverter
-          .packagesFromProto(
-            protoLib.arg.exportedIfaces,
-            protoLib.arg.internalPackages,
-            dependencyIfaces
-          )
-      )
-      (ifs, impls) = ifsImpls
-      // TODO: should verify somewhere that all the package names are distinct, but since this is presumed to be
-      // a good library maybe that's a waste
       version <- F.fromEither(versionOf(protoLib))
-    } yield DecodedLibrary[A](
-      Name(protoLib.arg.name),
-      version,
-      protoLib.hash,
-      protoLib.arg,
-      ifs,
-      PackageMap(
-        impls.iterator.map(pack => (pack.name, pack)).to(SortedMap)
-      )
-    )
+      decoded <- C
+        .compute {
+          ProtoConverter
+            .packagesFromProto(
+              protoLib.arg.exportedIfaces,
+              protoLib.arg.internalPackages,
+              dependencyIfaces
+            )
+            .map { case (ifs, impls) =>
+              DecodedLibrary[A](
+                Name(protoLib.arg.name),
+                version,
+                protoLib.hash,
+                protoLib.arg,
+                ifs,
+                PackageMap(
+                  impls.iterator.map(pack => (pack.name, pack)).to(SortedMap)
+                )
+              )
+            }
+        }
+        .flatMap(F.fromTry)
+    } yield decoded
 
   def decodeWithDeps[F[_], A: Algo](
       protoLib: Hashed[A, proto.Library]
   )(getDep: proto.LibDependency => F[Hashed[A, proto.Library]])(implicit
-      F: MonadError[F, Throwable]
+      F: MonadError[F, Throwable],
+      C: CanPromise[F]
   ): F[DecodedLibrary[A]] = {
     type Key = (Name, Version)
     type Cache = Map[Key, DecodedLibrary[A]]

--- a/core/src/main/scala/dev/bosatsu/library/DecodedLibraryWithDeps.scala
+++ b/core/src/main/scala/dev/bosatsu/library/DecodedLibraryWithDeps.scala
@@ -17,7 +17,7 @@ import dev.bosatsu.{
 }
 import dev.bosatsu.codegen.{CompilationNamespace, CompilationSource}
 import dev.bosatsu.hashing.{Algo, Hashed}
-import dev.bosatsu.graph.{Dag, Memoize, Toposort}
+import dev.bosatsu.graph.{CanPromise, Dag, Memoize, Toposort}
 import dev.bosatsu.rankn.Type
 import dev.bosatsu.tool.CliException
 import org.typelevel.paiges.Doc
@@ -72,14 +72,16 @@ object DecodedLibraryWithDeps {
   def decodeAll[F[_]](
       protoLib: Hashed[Algo.Blake3, proto.Library]
   )(load: proto.LibDependency => F[Hashed[Algo.Blake3, proto.Library]])(implicit
-      F: MonadError[F, Throwable]
+      F: MonadError[F, Throwable],
+      C: CanPromise[F]
   ): F[DecodedLibraryWithDeps[Algo.Blake3]] =
     DecodedLibrary.decodeWithDeps(protoLib)(load).flatMap(decodeAll(_)(load))
 
   def decodeAll[F[_]](
       dec: DecodedLibrary[Algo.Blake3]
   )(load: proto.LibDependency => F[Hashed[Algo.Blake3, proto.Library]])(implicit
-      F: MonadError[F, Throwable]
+      F: MonadError[F, Throwable],
+      C: CanPromise[F]
   ): F[DecodedLibraryWithDeps[Algo.Blake3]] = {
     type Key = (Name, Version)
     type Value = DecodedLibraryWithDeps[Algo.Blake3]

--- a/core/src/main/scala/dev/bosatsu/tool/CommandSupport.scala
+++ b/core/src/main/scala/dev/bosatsu/tool/CommandSupport.scala
@@ -77,7 +77,7 @@ object CommandSupport {
       platformIO: PlatformIO[F, Path],
       path: Path
   ): F[DecodedLibrary[Algo.Blake3]] = {
-    import platformIO.moduleIOMonad
+    import platformIO.{canPromiseF, moduleIOMonad}
 
     for {
       lib <- platformIO.readLibrary(path)


### PR DESCRIPTION
## Summary
- wrap library decode work in `CanPromise.compute` so JVM runs `ProtoConverter.packagesFromProto` on the blocking pool
- thread that requirement through dependency decode entry points and command support
- wrap compile-cache hit decoding in the same compute path so cached package deserialization is covered too

## Reproduction
- build a fresh local jar from current main with `sbt 'cli/assembly'`
- run it against `/Users/oscar/code/zafu` with a cold infer cache:
  `rm -rf /Users/oscar/code/zafu/.bosatsuc/infer-cache && java -Dcats.effect.detectBlockedThreads=true -jar /Users/oscar/code/bosatsu/cli/target/scala-3.8.2/bosatsu-cli-assembly-0.0.60+0-8e95b9db+20260329-1313-SNAPSHOT.jar check --warn`
- send `INFO` after ~2s to capture the active fiber dump
- before this change, the stable hot stack was `DecodedLibrary.decodeWithDeps -> DecodedLibrary.decode -> ProtoConverter.packagesFromProto` on the compute pool
- after this change, the same stack is consistently under `blocking @ dev.bosatsu.IOPlatformIO$.fsDataType`, indicating the decode work is running through the blocking wrapper

## Verification
- `sbt 'coreJVM/compile' 'cli/compile'`
- `sbt 'cli/assembly'`
- 20 cold-cache runs from `/Users/oscar/code/zafu` with the rebuilt jar and `check --warn`, deleting `/Users/oscar/code/zafu/.bosatsuc/infer-cache` before each run
- all 20 runs completed without the user-visible Cats Effect responsiveness warning