### PR TITLE
Teach ClangGen to direct-call top-level function aliases

### DIFF
--- a/core/src/main/scala/dev/bosatsu/MatchlessGlobalInlining.scala
+++ b/core/src/main/scala/dev/bosatsu/MatchlessGlobalInlining.scala
@@ -385,6 +385,24 @@ object MatchlessGlobalInlining {
           None
       }
 
+    def resolvedCalleeGlobal(
+        from: K,
+        pack: PackageName,
+        name: Bindable,
+        seen: Set[SummaryKey[K]]
+    ): Option[Global[K]] = {
+      val key = summaryKey(from, pack, name)
+      if (seen(key)) None
+      else
+        summaries.get(key) match {
+          case Some(ValueSummary(Global(nextFrom, nextPack, nextName), _, _, _)) =>
+            resolvedCalleeGlobal(nextFrom, nextPack, nextName, seen + key)
+              .orElse(Some(Global(nextFrom, nextPack, nextName)))
+          case _ =>
+            None
+        }
+    }
+
     def loop(ex: Expr[K]): Expr[K] =
       ex match {
         case Matchless.Lambda(captures, recursiveName, args, body) =>
@@ -501,20 +519,27 @@ object MatchlessGlobalInlining {
         args: NonEmptyList[Expr[K]]
     ): Option[Expr[K]] =
       fn match {
-        case Global(from, pack, name) =>
-          val key = summaryKey(from, pack, name)
-          summaries
-            .get(key)
-            .collect { case summary: LambdaSummary[K] => summary }
-            .flatMap { summary =>
-              shouldInline(summary, args, remainingInlineBudget).map { inlineCost =>
-                (summary, inlineCost)
-              }
+        case global @ Global(from, pack, name) =>
+          val resolvedOpt = resolvedCalleeGlobal(from, pack, name, Set.empty)
+          val resolved = resolvedOpt.getOrElse(global)
+          val maybeInlined =
+            resolved match {
+              case Global(resolvedFrom, resolvedPack, resolvedName) =>
+                summaries
+                  .get(summaryKey(resolvedFrom, resolvedPack, resolvedName))
+                  .collect { case summary: LambdaSummary[K] => summary }
+                  .flatMap { summary =>
+                    shouldInline(summary, args, remainingInlineBudget).map {
+                      inlineCost =>
+                        (summary, inlineCost)
+                    }
+                  }
+                  .map { case (summary, inlineCost) =>
+                    remainingInlineBudget = (remainingInlineBudget - inlineCost).max(0)
+                    loop(Matchless.inlineApplyArgs(summary.lambda, args))
+                  }
             }
-            .map { case (summary, inlineCost) =>
-              remainingInlineBudget = (remainingInlineBudget - inlineCost).max(0)
-              loop(Matchless.inlineApplyArgs(summary.lambda, args))
-            }
+          maybeInlined.orElse(resolvedOpt.map(_ => Matchless.App(resolved, args)))
         case _ =>
           None
       }
@@ -732,10 +757,12 @@ object MatchlessGlobalInlining {
   private def summarizeValue[K](
       expr: Expr[K]
   ): Option[InlineSummary[K]] = {
-    def knownValueNoGlobals(ex: Expr[K]): Option[Expr[K]] =
+    def knownValue(ex: Expr[K]): Option[Expr[K]] =
       ex match {
         case lit @ Matchless.Literal(_) =>
           Some(lit)
+        case global @ Matchless.Global(_, _, _) =>
+          Some(global)
         case enumExpr @ Matchless.MakeEnum(_, 0, _) =>
           Some(enumExpr)
         case structExpr @ Matchless.MakeStruct(0) =>
@@ -745,22 +772,22 @@ object MatchlessGlobalInlining {
         case Matchless.App(cons @ Matchless.MakeEnum(_, arity, _), args)
             if args.length == arity =>
           args.toList
-            .traverse(knownValueNoGlobals)
+            .traverse(knownValue)
             .map(args1 => Matchless.App(cons, NonEmptyList.fromListUnsafe(args1)))
         case Matchless.App(cons @ Matchless.MakeStruct(arity), args)
             if args.length == arity =>
           args.toList
-            .traverse(knownValueNoGlobals)
+            .traverse(knownValue)
             .map(args1 => Matchless.App(cons, NonEmptyList.fromListUnsafe(args1)))
         case Matchless.App(Matchless.SuccNat, NonEmptyList(arg, Nil)) =>
-          knownValueNoGlobals(arg)
+          knownValue(arg)
             .map(arg1 => Matchless.App(Matchless.SuccNat, NonEmptyList.one(arg1)))
         case Matchless.PrevNat(of) =>
-          knownValueNoGlobals(of).collect {
+          knownValue(of).collect {
             case Matchless.App(Matchless.SuccNat, NonEmptyList(prev, Nil)) => prev
           }
         case Matchless.GetEnumElement(arg, variant, index, size) =>
-          knownValueNoGlobals(arg).flatMap {
+          knownValue(arg).flatMap {
             case Matchless.App(Matchless.MakeEnum(v, arity, _), args)
                 if (v == variant) && (arity == size) =>
               args.toList.lift(index)
@@ -768,7 +795,7 @@ object MatchlessGlobalInlining {
               None
           }
         case Matchless.GetStructElement(arg, index, size) =>
-          knownValueNoGlobals(arg).flatMap {
+          knownValue(arg).flatMap {
             case Matchless.App(Matchless.MakeStruct(arity), args) if arity == size =>
               args.toList.lift(index)
             case value if (size == 1) && (index == 0) =>
@@ -790,7 +817,7 @@ object MatchlessGlobalInlining {
       Matchless.Expr.readsMutable(expr)
     ) None
     else
-      knownValueNoGlobals(expr).flatMap { value =>
+      knownValue(expr).flatMap { value =>
         val bodyWeight = Matchless.exprWeight(value)
         if (bodyWeight <= TinyBodyWeightBudget)
           Some(

--- a/core/src/main/scala/dev/bosatsu/codegen/clang/ClangGen.scala
+++ b/core/src/main/scala/dev/bosatsu/codegen/clang/ClangGen.scala
@@ -1449,21 +1449,35 @@ class ClangGen[K](ns: CompilationNamespace[K]) {
               b: Bindable
           ): T[Option[(Code.Ident, Int)]] =
             StateT { s =>
-              val depKey = ns.depFor(k, pack)
-              val key = (depKey, pack, b)
-              s.allValues.get(key) match {
-                case Some((fn: Matchless.Lambda[K], ident)) if fn.captures.isEmpty =>
-                  result(s, Some((ident, fn.arity)))
-                case None =>
-                  // this is external
-                  s.externals(depKey, pack, b) match {
-                    case Some((incl, ident, arity)) if arity > 0 =>
-                      val withIncl = s.include(incl)
-                      result(withIncl, Some((ident, arity)))
-                    case _ => result(s, None)
+              def loop(
+                  state: State,
+                  key: (K, PackageName, Bindable),
+                  seen: Set[(K, PackageName, Bindable)]
+              ): EitherT[Eval, Error, (State, Option[(Code.Ident, Int)])] = {
+                val (depKey, pn, bn) = key
+                if (seen(key)) result(state, None)
+                else
+                  state.allValues.get(key) match {
+                    case Some((fn: Matchless.Lambda[K], ident))
+                        if fn.captures.isEmpty =>
+                      result(state, Some((ident, fn.arity)))
+                    case Some((Matchless.Global(nextK, nextPack, nextB), _)) =>
+                      val nextKey = (ns.depFor(nextK, nextPack), nextPack, nextB)
+                      loop(state, nextKey, seen + key)
+                    case None =>
+                      // this is external
+                      state.externals(depKey, pn, bn) match {
+                        case Some((incl, ident, arity)) if arity > 0 =>
+                          val withIncl = state.include(incl)
+                          result(withIncl, Some((ident, arity)))
+                        case _ => result(state, None)
+                      }
+                    case _ =>
+                      result(state, None)
                   }
-                case _ => result(s, None)
               }
+
+              loop(s, (ns.depFor(k, pack), pack, b), Set.empty)
             }
 
           def directFn(b: Bindable): T[Option[DirectFnRef]] =

--- a/core/src/main/scala/dev/bosatsu/codegen/clang/ClangGen.scala
+++ b/core/src/main/scala/dev/bosatsu/codegen/clang/ClangGen.scala
@@ -1454,7 +1454,6 @@ class ClangGen[K](ns: CompilationNamespace[K]) {
                   key: (K, PackageName, Bindable),
                   seen: Set[(K, PackageName, Bindable)]
               ): EitherT[Eval, Error, (State, Option[(Code.Ident, Int)])] = {
-                val (depKey, pn, bn) = key
                 if (seen(key)) result(state, None)
                 else
                   state.allValues.get(key) match {
@@ -1466,6 +1465,7 @@ class ClangGen[K](ns: CompilationNamespace[K]) {
                       loop(state, nextKey, seen + key)
                     case None =>
                       // this is external
+                      val (depKey, pn, bn) = key
                       state.externals(depKey, pn, bn) match {
                         case Some((incl, ident, arity)) if arity > 0 =>
                           val withIncl = state.include(incl)

--- a/core/src/test/scala/dev/bosatsu/MatchlessTests.scala
+++ b/core/src/test/scala/dev/bosatsu/MatchlessTests.scala
@@ -5356,6 +5356,109 @@ ${tmpLines}
     }
   }
 
+  test("optimized Matchless rewrites same-package callee alias chains") {
+    val pack = PackageName.parts("Alias", "Same")
+    val targetPack = PackageName.parts("Target", "Fn")
+    val targetName = Identifier.Name("target")
+    val aliasName = Identifier.Name("alias")
+    val alias2Name = Identifier.Name("alias2")
+    val useName = Identifier.Name("use")
+    val arg = Matchless.Literal(Lit.fromInt(1))
+
+    val rawCompiled =
+      SortedMap(
+        () -> Map(
+          pack -> List(
+            (aliasName, Matchless.Global((), targetPack, targetName)),
+            (alias2Name, Matchless.Global((), pack, aliasName)),
+            (
+              useName,
+              Matchless.App(
+                Matchless.Global((), pack, alias2Name),
+                NonEmptyList.one(arg)
+              )
+            )
+          )
+        )
+      )
+    val topoSort =
+      dev.bosatsu.graph.Toposort.sort(List(((), pack)))(_ => Nil)
+
+    val optimized =
+      Par.withEC {
+        MatchlessGlobalInlining.optimize(
+          rawCompiled,
+          topoSort,
+          (_, _) => (),
+          Matchless.LocalPassOptions.Default
+        )
+      }
+    val useExpr = optimized(())(pack).toMap.apply(useName)
+
+    assertEquals(
+      useExpr,
+      Matchless.App(
+        Matchless.Global((), targetPack, targetName),
+        NonEmptyList.one(arg)
+      )
+    )
+  }
+
+  test("optimized Matchless rewrites cross-package callee alias chains") {
+    val helperPack = PackageName.parts("Alias", "Cross", "Helper")
+    val callerPack = PackageName.parts("Alias", "Cross", "Caller")
+    val targetPack = PackageName.parts("Target", "Fn")
+    val targetName = Identifier.Name("target")
+    val aliasName = Identifier.Name("alias")
+    val alias2Name = Identifier.Name("alias2")
+    val useName = Identifier.Name("use")
+    val arg = Matchless.Literal(Lit.fromInt(1))
+
+    val rawCompiled =
+      SortedMap(
+        () -> Map(
+          helperPack -> List(
+            (aliasName, Matchless.Global((), targetPack, targetName)),
+            (alias2Name, Matchless.Global((), helperPack, aliasName))
+          ),
+          callerPack -> List(
+            (
+              useName,
+              Matchless.App(
+                Matchless.Global((), helperPack, alias2Name),
+                NonEmptyList.one(arg)
+              )
+            )
+          )
+        )
+      )
+    val topoSort =
+      dev.bosatsu.graph.Toposort.sort(
+        List(((), helperPack), ((), callerPack))
+      ) { case (_, pack) =>
+        if (pack == callerPack) List(((), helperPack)) else Nil
+      }
+
+    val optimized =
+      Par.withEC {
+        MatchlessGlobalInlining.optimize(
+          rawCompiled,
+          topoSort,
+          (_, _) => (),
+          Matchless.LocalPassOptions.Default
+        )
+      }
+    val useExpr = optimized(())(callerPack).toMap.apply(useName)
+
+    assertEquals(
+      useExpr,
+      Matchless.App(
+        Matchless.Global((), targetPack, targetName),
+        NonEmptyList.one(arg)
+      )
+    )
+  }
+
   test("optimized Matchless inlines tiny pure struct values through local aliases") {
     val helperPack = PackageName.parts("Helper", "Value")
     val callerPack = PackageName.parts("Caller", "Value")

--- a/core/src/test/scala/dev/bosatsu/MatchlessTests.scala
+++ b/core/src/test/scala/dev/bosatsu/MatchlessTests.scala
@@ -5253,6 +5253,42 @@ def seg_final_literal_char(s):
     }
   }
 
+  test("optimized Matchless inlines cross-package foldl_List step aliases") {
+    val helperPack = PackageName.parts("Matchless", "Global", "FoldlHelper")
+    val callerPack = PackageName.parts("Matchless", "Global", "FoldlCaller")
+    val useAlias = Identifier.Name("use_alias")
+    val foo = Identifier.Name("foo")
+    val foldlName = Identifier.Name("foldl_List")
+    val plus = Identifier.Operator("+")
+
+    checkOptimizedMatchlessPackages(
+      NonEmptyList.of(
+        """package Matchless/Global/FoldlHelper
+          |
+          |export operator +
+          |
+          |operator + = add
+          |""".stripMargin,
+        """package Matchless/Global/FoldlCaller
+          |
+          |from Matchless/Global/FoldlHelper import operator +
+          |
+          |foo = operator +
+          |
+          |def use_alias(items: List[Int]) -> Int:
+          |  items.foldl_List(0, foo)
+          |""".stripMargin
+      )
+    ) { compiled =>
+      val useExpr = compiled(callerPack).toMap.apply(useAlias)
+
+      assertEquals(containsGlobal(useExpr, helperPack, plus), false)
+      assertEquals(containsGlobal(useExpr, callerPack, foo), false)
+      assertEquals(containsGlobal(useExpr, PackageName.PredefName, foldlName), false)
+      assertEquals(Matchless.Expr.containsWhileExpr(useExpr), true)
+    }
+  }
+
   test("optimized Matchless applies a per-definition budget to repeated loop helper inlining") {
     val pack = PackageName.parts("Matchless", "Global", "Budget")
     val smallName = Identifier.Name("small")

--- a/core/src/test/scala/dev/bosatsu/codegen/clang/ClangGenTest.scala
+++ b/core/src/test/scala/dev/bosatsu/codegen/clang/ClangGenTest.scala
@@ -537,8 +537,8 @@ main = use
         )
         assert(!add1Fn.contains("call_fn2("), add1Fn)
         assert(!add1Fn.contains("___bsts_g_Test_l_add__alias2"), add1Fn)
+      }
     }
-  }
 
   test(
     "top-level unit-arg function remains direct when nested matches share False branches"

--- a/core/src/test/scala/dev/bosatsu/codegen/clang/ClangGenTest.scala
+++ b/core/src/test/scala/dev/bosatsu/codegen/clang/ClangGenTest.scala
@@ -494,6 +494,52 @@ main = use
     }
   }
 
+  test("top-level function alias chains stay direct calls in C") {
+    val pm = typeCheckPackages(
+      List(
+        int64Pack,
+        """package Test
+          |
+          |from Bosatsu/Num/Int64 import (
+          |  Int64,
+          |  add_Int64,
+          |  int_low_bits_to_Int64 as i64,
+          |)
+          |
+          |add_alias = add_Int64
+          |add_alias2 = add_alias
+          |
+          |def add1(x: Int64) -> Int64:
+          |  add_alias2(x, i64(1))
+          |
+          |main = add1
+          |""".stripMargin
+      )
+    )
+
+    val renderedE = Par.withEC {
+      ClangGen(pm).renderMain(
+        PackageName.parse("Test").get,
+        Identifier.Name("add1"),
+        Code.Ident("run_main")
+      )
+    }
+
+    renderedE match {
+      case Left(err) =>
+        fail(err.toString)
+      case Right(doc) =>
+        val rendered = doc.render(120)
+        val add1Fn = extractCFunction(rendered, "_l_add1(BValue")
+        assert(
+          add1Fn.contains("___bsts_g_Bosatsu_l_Num_l_Int64_l_add__Int64"),
+          add1Fn
+        )
+        assert(!add1Fn.contains("call_fn2("), add1Fn)
+        assert(!add1Fn.contains("___bsts_g_Test_l_add__alias2"), add1Fn)
+    }
+  }
+
   test(
     "top-level unit-arg function remains direct when nested matches share False branches"
   ) {


### PR DESCRIPTION
Updated `ClangGen.directFn` to follow top-level global alias chains until they resolve to an external or a null-capture lambda, so C codegen no longer routes those calls through cached function values and `call_fn$arity`. Added a focused `ClangGenTest` regression covering an `Int64` alias chain and verified the generated helper calls `add_Int64` directly. Validation: `sbt "coreJVM/testOnly dev.bosatsu.codegen.clang.ClangGenTest"` and `scripts/test_basic.sh` both passed.

Fixes #2318