### PR TITLE
Lower common numeric comparison observations in Matchless

### DIFF
--- a/cli/src/test/scala/dev/bosatsu/codegen/clang/ClangGenTest.scala
+++ b/cli/src/test/scala/dev/bosatsu/codegen/clang/ClangGenTest.scala
@@ -42,7 +42,7 @@ class ClangGenTest extends munit.FunSuite {
       To inspect the code, change the hash, and it will print the code out
      */
     testFilesCompilesToHash("test_workspace/Ackermann.bosatsu")(
-      "65648bd5f28859776f62693da75740aa"
+      "0ff1f7f19496c5e37508c58e3581a78f"
     )
   }
 }

--- a/core/src/main/scala/dev/bosatsu/Matchless.scala
+++ b/core/src/main/scala/dev/bosatsu/Matchless.scala
@@ -3575,6 +3575,22 @@ object Matchless {
       case DataRepr.ZeroNat => 0
       case DataRepr.SuccNat => 1
     }
+    private def compareExprRelExpr[A: Order](
+        leftL: Expr[A],
+        relL: CompareRel,
+        rightL: Expr[A],
+        leftR: Expr[A],
+        relR: CompareRel,
+        rightR: Expr[A]
+    ): Int = {
+      val c1 = Order[Expr[A]].compare(leftL, leftR)
+      if (c1 != 0) c1
+      else {
+        val c2 = Order[CompareRel].compare(relL, relR)
+        if (c2 != 0) c2
+        else Order[Expr[A]].compare(rightL, rightR)
+      }
+    }
 
     given [A: Order]: Order[BoolExpr[A]] with {
       def compare(left: BoolExpr[A], right: BoolExpr[A]): Int =
@@ -3589,37 +3605,19 @@ object Matchless {
             }
 
           case (CompareInt(leftL, relL, rightL), CompareInt(leftR, relR, rightR)) =>
-            val c1 = Order[Expr[A]].compare(leftL, leftR)
-            if (c1 != 0) c1
-            else {
-              val c2 = Order[CompareRel].compare(relL, relR)
-              if (c2 != 0) c2
-              else Order[Expr[A]].compare(rightL, rightR)
-            }
+            compareExprRelExpr(leftL, relL, rightL, leftR, relR, rightR)
 
           case (
                 CompareInt64(leftL, relL, rightL),
                 CompareInt64(leftR, relR, rightR)
               ) =>
-            val c1 = Order[Expr[A]].compare(leftL, leftR)
-            if (c1 != 0) c1
-            else {
-              val c2 = Order[CompareRel].compare(relL, relR)
-              if (c2 != 0) c2
-              else Order[Expr[A]].compare(rightL, rightR)
-            }
+            compareExprRelExpr(leftL, relL, rightL, leftR, relR, rightR)
 
           case (
                 CompareFloat64(leftL, relL, rightL),
                 CompareFloat64(leftR, relR, rightR)
               ) =>
-            val c1 = Order[Expr[A]].compare(leftL, leftR)
-            if (c1 != 0) c1
-            else {
-              val c2 = Order[CompareRel].compare(relL, relR)
-              if (c2 != 0) c2
-              else Order[Expr[A]].compare(rightL, rightR)
-            }
+            compareExprRelExpr(leftL, relL, rightL, leftR, relR, rightR)
 
           case (EqualsNat(exprL, natL), EqualsNat(exprR, natR)) =>
             val c1 = Order[Expr[A]].compare(exprL, exprR)

--- a/core/src/main/scala/dev/bosatsu/Matchless.scala
+++ b/core/src/main/scala/dev/bosatsu/Matchless.scala
@@ -3534,7 +3534,7 @@ object Matchless {
       case (lhs: Lit.Chr, rhs: Lit.Chr) =>
         Some(compareRelHolds(rel, Integer.compare(lhs.toCodePoint, rhs.toCodePoint)))
       case (lhs: Lit.StringMatchResult, rhs: Lit.StringMatchResult) =>
-        Some(compareRelHolds(rel, lhs.asStr.compareTo(rhs.asStr)))
+        Some(compareRelHolds(rel, StringUtil.codePointCompare(lhs.asStr, rhs.asStr)))
       case (lhs: Lit.Float64, rhs: Lit.Float64) =>
         Some(compareFloat64Values(lhs.toDouble, rel, rhs.toDouble))
       case _ =>

--- a/core/src/main/scala/dev/bosatsu/Matchless.scala
+++ b/core/src/main/scala/dev/bosatsu/Matchless.scala
@@ -3810,27 +3810,11 @@ object Matchless {
   object EqualsLit {
     def apply[A](expr: CheapExpr[A], lit: Lit): BoolExpr[A] =
       CompareLit(expr, CompareRel.Eq, lit)
-
-    def unapply[A](boolExpr: BoolExpr[A]): Option[(CheapExpr[A], Lit)] =
-      boolExpr match {
-        case CompareLit(expr, CompareRel.Eq, lit) =>
-          Some((expr, lit))
-        case _ =>
-          None
-      }
   }
 
   object LtEqLit {
     def apply[A](expr: CheapExpr[A], lit: Lit): BoolExpr[A] =
       CompareLit(expr, CompareRel.Lte, lit)
-
-    def unapply[A](boolExpr: BoolExpr[A]): Option[(CheapExpr[A], Lit)] =
-      boolExpr match {
-        case CompareLit(expr, CompareRel.Lte, lit) =>
-          Some((expr, lit))
-        case _ =>
-          None
-      }
   }
   case class EqualsNat[A](expr: CheapExpr[A], nat: DataRepr.Nat)
       extends BoolExpr[A]
@@ -5599,6 +5583,9 @@ object Matchless {
         right: Expr[B],
         value: Boolean
     ): F[Expr[B]] =
+      // A total Comparison observation can be constant, but evaluating the
+      // original cmp_* application still has to force both operands exactly
+      // once in source order because those expressions can contain effects.
       memoizeBinaryExpr(left, right) { (_, _) =>
         if (value) TrueExpr else FalseExpr
       }

--- a/core/src/main/scala/dev/bosatsu/Matchless.scala
+++ b/core/src/main/scala/dev/bosatsu/Matchless.scala
@@ -5578,17 +5578,8 @@ object Matchless {
         If(comparePredicate(domain, leftCheap, rel, rightCheap), TrueExpr, FalseExpr)
       }
 
-    def lowerConstantBoolWithOperands(
-        left: Expr[B],
-        right: Expr[B],
-        value: Boolean
-    ): F[Expr[B]] =
-      // A total Comparison observation can be constant, but evaluating the
-      // original cmp_* application still has to force both operands exactly
-      // once in source order because those expressions can contain effects.
-      memoizeBinaryExpr(left, right) { (_, _) =>
-        if (value) TrueExpr else FalseExpr
-      }
+    def lowerConstantBool(value: Boolean): F[Expr[B]] =
+      Monad[F].pure(if (value) TrueExpr else FalseExpr)
 
     val comparisonFamArities = 0 :: 0 :: 0 :: Nil
 
@@ -5629,7 +5620,7 @@ object Matchless {
       } yield {
         observation match {
           case Left(boolValue) =>
-            lowerConstantBoolWithOperands(left, right, boolValue)
+            lowerConstantBool(boolValue)
           case Right(rel)      =>
             lowerBooleanCompare(domain, left, rel, right)
         }
@@ -8955,7 +8946,7 @@ object Matchless {
         } yield {
           comparisonObservation(trueVariants) match {
             case Left(value) =>
-              lowerConstantBoolWithOperands(left, right, value)
+              lowerConstantBool(value)
             case Right(rel)  =>
               lowerBooleanCompare(domain, left, rel, right)
           }

--- a/core/src/main/scala/dev/bosatsu/Matchless.scala
+++ b/core/src/main/scala/dev/bosatsu/Matchless.scala
@@ -3497,6 +3497,32 @@ object Matchless {
   ): Boolean =
     compareRelHolds(rel, PredefImpl.compareFloat64Total(left, right))
 
+  private[bosatsu] val comparisonTrueVariants: Set[Int] =
+    Set(0, 1, 2)
+
+  // Match lowering observes Comparison values only through the LT/EQ/GT
+  // constructors, so every total boolean observation must collapse to one
+  // relation or a constant.
+  private[bosatsu] def comparisonObservation(
+      trueVariants: Set[Int]
+  ): Either[Boolean, CompareRel] =
+    if (trueVariants.isEmpty) Left(false)
+    else if (trueVariants == Set(0)) Right(CompareRel.Lt)
+    else if (trueVariants == Set(0, 1)) Right(CompareRel.Lte)
+    else if (trueVariants == Set(1)) Right(CompareRel.Eq)
+    else if (trueVariants == Set(1, 2)) Right(CompareRel.Gte)
+    else if (trueVariants == Set(2)) Right(CompareRel.Gt)
+    else if (trueVariants == Set(0, 2)) Right(CompareRel.Ne)
+    else if (trueVariants == comparisonTrueVariants) Left(true)
+    else {
+      // total boolean matches over Comparison only have these subsets
+      // $COVERAGE-OFF$
+      throw new IllegalStateException(
+        s"unexpected Comparison observation: $trueVariants"
+      )
+      // $COVERAGE-ON$
+    }
+
   private[bosatsu] def compareLiteralValues(
       left: Lit,
       rel: CompareRel,
@@ -3505,6 +3531,8 @@ object Matchless {
     (left, right) match {
       case (Lit.Integer(lhs), Lit.Integer(rhs)) =>
         Some(compareRelHolds(rel, lhs.compareTo(rhs)))
+      case (lhs: Lit.Chr, rhs: Lit.Chr) =>
+        Some(compareRelHolds(rel, Integer.compare(lhs.toCodePoint, rhs.toCodePoint)))
       case (lhs: Lit.StringMatchResult, rhs: Lit.StringMatchResult) =>
         Some(compareRelHolds(rel, lhs.asStr.compareTo(rhs.asStr)))
       case (lhs: Lit.Float64, rhs: Lit.Float64) =>
@@ -5578,27 +5606,6 @@ object Matchless {
       }
 
     val comparisonFamArities = 0 :: 0 :: 0 :: Nil
-    val comparisonTrueVariants = Set(0, 1, 2)
-
-    def comparisonObservation(
-        trueVariants: Set[Int]
-    ): Either[Boolean, CompareRel] =
-      if (trueVariants.isEmpty) Left(false)
-      else if (trueVariants == Set(0)) Right(CompareRel.Lt)
-      else if (trueVariants == Set(0, 1)) Right(CompareRel.Lte)
-      else if (trueVariants == Set(1)) Right(CompareRel.Eq)
-      else if (trueVariants == Set(1, 2)) Right(CompareRel.Gte)
-      else if (trueVariants == Set(2)) Right(CompareRel.Gt)
-      else if (trueVariants == Set(0, 2)) Right(CompareRel.Ne)
-      else if (trueVariants == comparisonTrueVariants) Left(true)
-      else {
-        // total boolean matches over Comparison only have these subsets
-        // $COVERAGE-OFF$
-        throw new IllegalStateException(
-          s"unexpected Comparison observation: $trueVariants"
-        )
-        // $COVERAGE-ON$
-      }
 
     def comparisonObservationFor(
         selector: CheapExpr[B],

--- a/core/src/main/scala/dev/bosatsu/Matchless.scala
+++ b/core/src/main/scala/dev/bosatsu/Matchless.scala
@@ -96,11 +96,12 @@ object Matchless {
         case _: GetEnumElement[?]   => 13
         case _: GetStructElement[?] => 14
         case Literal(_)             => 15
-        case _: MakeEnum            => 16
-        case _: MakeStruct          => 17
-        case ZeroNat                => 18
-        case SuccNat                => 19
-        case _: PrevNat[?]          => 20
+        case LitInt64(_)            => 16
+        case _: MakeEnum            => 17
+        case _: MakeStruct          => 18
+        case ZeroNat                => 19
+        case SuccNat                => 20
+        case _: PrevNat[?]          => 21
       }
 
     private given Order[LocalAnon] = Order.by(_.ident)
@@ -246,6 +247,9 @@ object Matchless {
           case (Literal(left), Literal(right)) =>
             Order[Lit].compare(left, right)
 
+          case (LitInt64(left), LitInt64(right)) =>
+            java.lang.Long.compare(left, right)
+
           case (
                 MakeEnum(variantL, arityL, famAritiesL),
                 MakeEnum(variantR, arityR, famAritiesR)
@@ -306,17 +310,21 @@ object Matchless {
           case gs: GetStructElement[?] =>
             loopExpr(gs.arg)
           case Local(_) | Global(_, _, _) | ClosureSlot(_) | LocalAnon(_) |
-              LocalAnonMut(_) | Literal(_) | MakeEnum(_, _, _) | MakeStruct(_) |
+              LocalAnonMut(_) | Literal(_) | LitInt64(_) | MakeEnum(_, _, _) | MakeStruct(_) |
               SuccNat | ZeroNat =>
             false
         }
 
       def loopBool(b: BoolExpr[A]): Boolean =
         b match {
-          case EqualsLit(expr, _) =>
+          case CompareLit(expr, _, _) =>
             loopExpr(expr)
-          case LtEqLit(expr, _) =>
-            loopExpr(expr)
+          case CompareInt(left, _, right) =>
+            loopExpr(left) || loopExpr(right)
+          case CompareInt64(left, _, right) =>
+            loopExpr(left) || loopExpr(right)
+          case CompareFloat64(left, _, right) =>
+            loopExpr(left) || loopExpr(right)
           case EqualsNat(expr, _) =>
             loopExpr(expr)
           case And(left, right) =>
@@ -368,17 +376,21 @@ object Matchless {
           case gs: GetStructElement[?] =>
             loopExpr(gs.arg)
           case Local(_) | Global(_, _, _) | ClosureSlot(_) | LocalAnon(_) |
-              Literal(_) | MakeEnum(_, _, _) | MakeStruct(_) | SuccNat |
+              Literal(_) | LitInt64(_) | MakeEnum(_, _, _) | MakeStruct(_) | SuccNat |
               ZeroNat =>
             false
         }
 
       def loopBool(b: BoolExpr[A]): Boolean =
         b match {
-          case EqualsLit(expr, _) =>
+          case CompareLit(expr, _, _) =>
             loopExpr(expr)
-          case LtEqLit(expr, _) =>
-            loopExpr(expr)
+          case CompareInt(left, _, right) =>
+            loopExpr(left) || loopExpr(right)
+          case CompareInt64(left, _, right) =>
+            loopExpr(left) || loopExpr(right)
+          case CompareFloat64(left, _, right) =>
+            loopExpr(left) || loopExpr(right)
           case EqualsNat(expr, _) =>
             loopExpr(expr)
           case And(left, right) =>
@@ -470,7 +482,7 @@ object Matchless {
           case gs: GetStructElement[?] =>
             loopExpr(gs.arg)
           case ClosureSlot(_) | LocalAnon(_) | LocalAnonMut(_) |
-              Global(_, _, _) | Literal(_) | MakeEnum(_, _, _) |
+              Global(_, _, _) | Literal(_) | LitInt64(_) | MakeEnum(_, _, _) |
               MakeStruct(_) | SuccNat | ZeroNat =>
             false
         }
@@ -547,7 +559,7 @@ object Matchless {
           case gs: GetStructElement[?] =>
             loopExpr(gs.arg)
           case Local(_) | ClosureSlot(_) | LocalAnonMut(_) | Global(_, _, _) |
-              Literal(_) | MakeEnum(_, _, _) | MakeStruct(_) | SuccNat |
+              Literal(_) | LitInt64(_) | MakeEnum(_, _, _) | MakeStruct(_) | SuccNat |
               ZeroNat =>
             false
         }
@@ -702,10 +714,14 @@ object Matchless {
               loop(ge.arg :: tail, acc)
             case gs: GetStructElement[?] =>
               loop(gs.arg :: tail, acc)
-            case EqualsLit(arg, _) =>
+            case CompareLit(arg, _, _) =>
               loop(arg :: tail, acc)
-            case LtEqLit(arg, _) =>
-              loop(arg :: tail, acc)
+            case CompareInt(left, _, right) =>
+              loop(left :: right :: tail, acc)
+            case CompareInt64(left, _, right) =>
+              loop(left :: right :: tail, acc)
+            case CompareFloat64(left, _, right) =>
+              loop(left :: right :: tail, acc)
             case EqualsNat(arg, _) =>
               loop(arg :: tail, acc)
             case And(left, right) =>
@@ -725,7 +741,7 @@ object Matchless {
             case LetMutBool(_, in) =>
               loop(in :: tail, acc)
             case Local(_) | Global(_, _, _) | ClosureSlot(_) | LocalAnonMut(_) |
-                Literal(_) | MakeEnum(_, _, _) | MakeStruct(_) | _: SuccNat.type |
+                Literal(_) | LitInt64(_) | MakeEnum(_, _, _) | MakeStruct(_) | _: SuccNat.type |
                 _: ZeroNat.type | _: TrueConst.type =>
               loop(tail, acc)
           }
@@ -766,10 +782,14 @@ object Matchless {
               loop(ge.arg :: tail, acc)
             case gs: GetStructElement[?] =>
               loop(gs.arg :: tail, acc)
-            case EqualsLit(arg, _) =>
+            case CompareLit(arg, _, _) =>
               loop(arg :: tail, acc)
-            case LtEqLit(arg, _) =>
-              loop(arg :: tail, acc)
+            case CompareInt(left, _, right) =>
+              loop(left :: right :: tail, acc)
+            case CompareInt64(left, _, right) =>
+              loop(left :: right :: tail, acc)
+            case CompareFloat64(left, _, right) =>
+              loop(left :: right :: tail, acc)
             case EqualsNat(arg, _) =>
               loop(arg :: tail, acc)
             case And(left, right) =>
@@ -785,7 +805,7 @@ object Matchless {
             case LetMutBool(name, in) =>
               loop(in :: tail, acc + name.ident)
             case Local(_) | Global(_, _, _) | ClosureSlot(_) | LocalAnon(_) |
-                Literal(_) | MakeEnum(_, _, _) | MakeStruct(_) | _: SuccNat.type |
+                Literal(_) | LitInt64(_) | MakeEnum(_, _, _) | MakeStruct(_) | _: SuccNat.type |
                 _: ZeroNat.type | _: TrueConst.type =>
               loop(tail, acc)
           }
@@ -910,7 +930,7 @@ object Matchless {
           val (arg1, st1) = loopCheap(gs.arg, env, st)
           (gs.copy(arg = arg1), st1)
         case Global(_, _, _) | Local(_) | ClosureSlot(_) | Literal(_) |
-            MakeEnum(_, _, _) | MakeStruct(_) | SuccNat | ZeroNat =>
+            LitInt64(_) | MakeEnum(_, _, _) | MakeStruct(_) | SuccNat | ZeroNat =>
           (ex, st)
       }
 
@@ -935,12 +955,21 @@ object Matchless {
         st: RenameState
     ): (BoolExpr[A], RenameState) =
       ex match {
-        case EqualsLit(arg, lit) =>
+        case CompareLit(arg, rel, lit) =>
           val (arg1, st1) = loopCheap(arg, env, st)
-          (EqualsLit(arg1, lit), st1)
-        case LtEqLit(arg, lit) =>
-          val (arg1, st1) = loopCheap(arg, env, st)
-          (LtEqLit(arg1, lit), st1)
+          (CompareLit(arg1, rel, lit), st1)
+        case CompareInt(left, rel, right) =>
+          val (left1, st1) = loopCheap(left, env, st)
+          val (right1, st2) = loopCheap(right, env, st1)
+          (CompareInt(left1, rel, right1), st2)
+        case CompareInt64(left, rel, right) =>
+          val (left1, st1) = loopCheap(left, env, st)
+          val (right1, st2) = loopCheap(right, env, st1)
+          (CompareInt64(left1, rel, right1), st2)
+        case CompareFloat64(left, rel, right) =>
+          val (left1, st1) = loopCheap(left, env, st)
+          val (right1, st2) = loopCheap(right, env, st1)
+          (CompareFloat64(left1, rel, right1), st2)
         case EqualsNat(arg, nat) =>
           val (arg1, st1) = loopCheap(arg, env, st)
           (EqualsNat(arg1, nat), st1)
@@ -1036,7 +1065,7 @@ object Matchless {
         case gs: GetStructElement[?] =>
           gs.copy(arg = loopCheap(gs.arg))
         case Local(_) | Global(_, _, _) | LocalAnon(_) | LocalAnonMut(_) |
-            Literal(_) | MakeEnum(_, _, _) | MakeStruct(_) | SuccNat |
+            Literal(_) | LitInt64(_) | MakeEnum(_, _, _) | MakeStruct(_) | SuccNat |
             ZeroNat =>
           ex
       }
@@ -1054,10 +1083,14 @@ object Matchless {
 
     def loopBool(ex: BoolExpr[A]): BoolExpr[A] =
       ex match {
-        case EqualsLit(arg, lit) =>
-          EqualsLit(loopCheap(arg), lit)
-        case LtEqLit(arg, lit) =>
-          LtEqLit(loopCheap(arg), lit)
+        case CompareLit(arg, rel, lit) =>
+          CompareLit(loopCheap(arg), rel, lit)
+        case CompareInt(left, rel, right) =>
+          CompareInt(loopCheap(left), rel, loopCheap(right))
+        case CompareInt64(left, rel, right) =>
+          CompareInt64(loopCheap(left), rel, loopCheap(right))
+        case CompareFloat64(left, rel, right) =>
+          CompareFloat64(loopCheap(left), rel, loopCheap(right))
         case EqualsNat(arg, nat) =>
           EqualsNat(loopCheap(arg), nat)
         case And(left, right) =>
@@ -1155,7 +1188,7 @@ object Matchless {
           case gs: GetStructElement[?] =>
             gs.copy(arg = loopCheap(gs.arg, env))
           case Global(_, _, _) | ClosureSlot(_) | LocalAnon(_) | LocalAnonMut(_) |
-              Literal(_) | MakeEnum(_, _, _) | MakeStruct(_) | SuccNat |
+              Literal(_) | LitInt64(_) | MakeEnum(_, _, _) | MakeStruct(_) | SuccNat |
               ZeroNat =>
             ex
         }
@@ -1174,10 +1207,14 @@ object Matchless {
 
       def loopBool(ex: BoolExpr[A], env: Map[Bindable, Expr[A]]): BoolExpr[A] = {
         ex match {
-          case EqualsLit(arg, lit) =>
-            EqualsLit(loopCheap(arg, env), lit)
-          case LtEqLit(arg, lit) =>
-            LtEqLit(loopCheap(arg, env), lit)
+          case CompareLit(arg, rel, lit) =>
+            CompareLit(loopCheap(arg, env), rel, lit)
+          case CompareInt(left, rel, right) =>
+            CompareInt(loopCheap(left, env), rel, loopCheap(right, env))
+          case CompareInt64(left, rel, right) =>
+            CompareInt64(loopCheap(left, env), rel, loopCheap(right, env))
+          case CompareFloat64(left, rel, right) =>
+            CompareFloat64(loopCheap(left, env), rel, loopCheap(right, env))
           case EqualsNat(arg, nat) =>
             EqualsNat(loopCheap(arg, env), nat)
           case And(left, right) =>
@@ -1241,10 +1278,14 @@ object Matchless {
 
     def loopBool(b: BoolExpr[A]): Int =
       b match {
-        case EqualsLit(expr, _) =>
+        case CompareLit(expr, _, _) =>
           1 + loopExpr(expr)
-        case LtEqLit(expr, _) =>
-          1 + loopExpr(expr)
+        case CompareInt(left, _, right) =>
+          1 + loopExpr(left) + loopExpr(right)
+        case CompareInt64(left, _, right) =>
+          1 + loopExpr(left) + loopExpr(right)
+        case CompareFloat64(left, _, right) =>
+          1 + loopExpr(left) + loopExpr(right)
         case EqualsNat(expr, _) =>
           1 + loopExpr(expr)
         case And(left, right) =>
@@ -1547,7 +1588,7 @@ object Matchless {
           case gs: GetStructElement[?] =>
             val (arg1, st1) = loopCheap(gs.arg, env, st)
             (gs.copy(arg = arg1), st1)
-          case Global(_, _, _) | ClosureSlot(_) | Literal(_) | MakeEnum(_, _, _) |
+          case Global(_, _, _) | ClosureSlot(_) | Literal(_) | LitInt64(_) | MakeEnum(_, _, _) |
               MakeStruct(_) | SuccNat | ZeroNat =>
             (ex, st)
         }
@@ -1573,12 +1614,21 @@ object Matchless {
           st: RenameState
       ): (BoolExpr[A], RenameState) =
         ex match {
-          case EqualsLit(arg, lit) =>
+          case CompareLit(arg, rel, lit) =>
             val (arg1, st1) = loopCheap(arg, env, st)
-            (EqualsLit(arg1, lit), st1)
-          case LtEqLit(arg, lit) =>
-            val (arg1, st1) = loopCheap(arg, env, st)
-            (LtEqLit(arg1, lit), st1)
+            (CompareLit(arg1, rel, lit), st1)
+          case CompareInt(left, rel, right) =>
+            val (left1, st1) = loopCheap(left, env, st)
+            val (right1, st2) = loopCheap(right, env, st1)
+            (CompareInt(left1, rel, right1), st2)
+          case CompareInt64(left, rel, right) =>
+            val (left1, st1) = loopCheap(left, env, st)
+            val (right1, st2) = loopCheap(right, env, st1)
+            (CompareInt64(left1, rel, right1), st2)
+          case CompareFloat64(left, rel, right) =>
+            val (left1, st1) = loopCheap(left, env, st)
+            val (right1, st2) = loopCheap(right, env, st1)
+            (CompareFloat64(left1, rel, right1), st2)
           case EqualsNat(arg, nat) =>
             val (arg1, st1) = loopCheap(arg, env, st)
             (EqualsNat(arg1, nat), st1)
@@ -1924,10 +1974,26 @@ object Matchless {
               loop(
                 LoopState(gs.arg, branchOnly, false, insideLambda, true, shadowed) :: tail
               )
-            case EqualsLit(arg, _) =>
+            case CompareLit(arg, _, _) =>
               loop(LoopState(arg, branchOnly, false, insideLambda, true, shadowed) :: tail)
-            case LtEqLit(arg, _) =>
-              loop(LoopState(arg, branchOnly, false, insideLambda, true, shadowed) :: tail)
+            case CompareInt(left, _, right) =>
+              loop(
+                LoopState(left, branchOnly, false, insideLambda, true, shadowed) ::
+                  LoopState(right, branchOnly, false, insideLambda, true, shadowed) ::
+                  tail
+              )
+            case CompareInt64(left, _, right) =>
+              loop(
+                LoopState(left, branchOnly, false, insideLambda, true, shadowed) ::
+                  LoopState(right, branchOnly, false, insideLambda, true, shadowed) ::
+                  tail
+              )
+            case CompareFloat64(left, _, right) =>
+              loop(
+                LoopState(left, branchOnly, false, insideLambda, true, shadowed) ::
+                  LoopState(right, branchOnly, false, insideLambda, true, shadowed) ::
+                  tail
+              )
             case EqualsNat(arg, _) =>
               loop(LoopState(arg, branchOnly, false, insideLambda, true, shadowed) :: tail)
             case And(left, right) =>
@@ -1960,7 +2026,7 @@ object Matchless {
                 LoopState(in, branchOnly, false, insideLambda, cheapContext, shadowed) :: tail
               )
             case Global(_, _, _) | ClosureSlot(_) | LocalAnon(_) | LocalAnonMut(_) |
-                Literal(_) | MakeEnum(_, _, _) | MakeStruct(_) | _: SuccNat.type |
+                Literal(_) | LitInt64(_) | MakeEnum(_, _, _) | MakeStruct(_) | _: SuccNat.type |
                 _: ZeroNat.type | _: TrueConst.type =>
               loop(tail)
           }
@@ -2039,6 +2105,7 @@ object Matchless {
         case gs: GetStructElement[?] =>
           loopCheap(gs.arg, acc)
         case ClosureSlot(_) | LocalAnon(_) | LocalAnonMut(_) | Literal(_) |
+            LitInt64(_) |
             MakeEnum(_, _, _) | MakeStruct(_) | SuccNat | ZeroNat =>
           acc
       }
@@ -2048,10 +2115,14 @@ object Matchless {
 
     def loopBool(ex: BoolExpr[A], acc: Set[Bindable]): Set[Bindable] =
       ex match {
-        case EqualsLit(expr, _) =>
+        case CompareLit(expr, _, _) =>
           loopCheap(expr, acc)
-        case LtEqLit(expr, _) =>
-          loopCheap(expr, acc)
+        case CompareInt(left, _, right) =>
+          loopCheap(right, loopCheap(left, acc))
+        case CompareInt64(left, _, right) =>
+          loopCheap(right, loopCheap(left, acc))
+        case CompareFloat64(left, _, right) =>
+          loopCheap(right, loopCheap(left, acc))
         case EqualsNat(expr, _) =>
           loopCheap(expr, acc)
         case And(left, right) =>
@@ -2232,16 +2303,20 @@ object Matchless {
           case gs: GetStructElement[?] =>
             loopExpr(gs.arg, curr)
           case Local(_) | ClosureSlot(_) | Global(_, _, _) | Literal(_) |
-              MakeEnum(_, _, _) | MakeStruct(_) | SuccNat | ZeroNat =>
+              LitInt64(_) | MakeEnum(_, _, _) | MakeStruct(_) | SuccNat | ZeroNat =>
             curr
         }
 
       def loopBool(b: BoolExpr[A], curr: Long): Long =
         b match {
-          case EqualsLit(expr, _) =>
+          case CompareLit(expr, _, _) =>
             loopExpr(expr, curr)
-          case LtEqLit(expr, _) =>
-            loopExpr(expr, curr)
+          case CompareInt(left, _, right) =>
+            loopExpr(right, loopExpr(left, curr))
+          case CompareInt64(left, _, right) =>
+            loopExpr(right, loopExpr(left, curr))
+          case CompareFloat64(left, _, right) =>
+            loopExpr(right, loopExpr(left, curr))
           case EqualsNat(expr, _) =>
             loopExpr(expr, curr)
           case And(left, right) =>
@@ -2275,7 +2350,7 @@ object Matchless {
     def isImmutableCheap(ex: Expr[A]): Boolean =
       ex match {
         case Local(_) | ClosureSlot(_) | LocalAnon(_) | Global(_, _, _) |
-            Literal(_) =>
+            Literal(_) | LitInt64(_) =>
           true
         case ge: GetEnumElement[?] =>
           isImmutableCheap(ge.arg)
@@ -2559,14 +2634,22 @@ object Matchless {
 
     def recurBool(b: BoolExpr[A], st: CseState): (BoolExpr[A], CseState) =
       b match {
-        case EqualsLit(expr, lit) =>
+        case CompareLit(expr, rel, lit) =>
           recurExprCheap(expr, st) match {
-            case (expr1, st1) => (EqualsLit(expr1, lit), st1)
+            case (expr1, st1) => (CompareLit(expr1, rel, lit), st1)
           }
-        case LtEqLit(expr, lit) =>
-          recurExprCheap(expr, st) match {
-            case (expr1, st1) => (LtEqLit(expr1, lit), st1)
-          }
+        case CompareInt(left, rel, right) =>
+          val (left1, st1) = recurExprCheap(left, st)
+          val (right1, st2) = recurExprCheap(right, st1)
+          (CompareInt(left1, rel, right1), st2)
+        case CompareInt64(left, rel, right) =>
+          val (left1, st1) = recurExprCheap(left, st)
+          val (right1, st2) = recurExprCheap(right, st1)
+          (CompareInt64(left1, rel, right1), st2)
+        case CompareFloat64(left, rel, right) =>
+          val (left1, st1) = recurExprCheap(left, st)
+          val (right1, st2) = recurExprCheap(right, st1)
+          (CompareFloat64(left1, rel, right1), st2)
         case EqualsNat(expr, nat) =>
           recurExprCheap(expr, st) match {
             case (expr1, st1) => (EqualsNat(expr1, nat), st1)
@@ -2659,7 +2742,7 @@ object Matchless {
             val (of1, st1) = recurExpr(of, st)
             (PrevNat(of1), st1)
           case Local(_) | ClosureSlot(_) | LocalAnon(_) | LocalAnonMut(_) |
-              Global(_, _, _) | Literal(_) | MakeEnum(_, _, _) | MakeStruct(_) |
+              Global(_, _, _) | Literal(_) | LitInt64(_) | MakeEnum(_, _, _) | MakeStruct(_) |
               SuccNat | ZeroNat | GetEnumElement(_, _, _, _) |
               GetStructElement(_, _, _) =>
             (ex, st)
@@ -2739,10 +2822,14 @@ object Matchless {
 
     def recurBool(b: BoolExpr[A]): BoolExpr[A] =
       b match {
-        case EqualsLit(expr, lit) =>
-          EqualsLit(recurExprCheap(expr), lit)
-        case LtEqLit(expr, lit) =>
-          LtEqLit(recurExprCheap(expr), lit)
+        case CompareLit(expr, rel, lit) =>
+          CompareLit(recurExprCheap(expr), rel, lit)
+        case CompareInt(left, rel, right) =>
+          CompareInt(recurExprCheap(left), rel, recurExprCheap(right))
+        case CompareInt64(left, rel, right) =>
+          CompareInt64(recurExprCheap(left), rel, recurExprCheap(right))
+        case CompareFloat64(left, rel, right) =>
+          CompareFloat64(recurExprCheap(left), rel, recurExprCheap(right))
         case EqualsNat(expr, nat) =>
           EqualsNat(recurExprCheap(expr), nat)
         case And(left, right) =>
@@ -2800,7 +2887,7 @@ object Matchless {
         case PrevNat(of) =>
           PrevNat(recurExpr(of))
         case Local(_) | ClosureSlot(_) | LocalAnon(_) | LocalAnonMut(_) |
-            Global(_, _, _) | Literal(_) | MakeEnum(_, _, _) | MakeStruct(_) |
+            Global(_, _, _) | Literal(_) | LitInt64(_) | MakeEnum(_, _, _) | MakeStruct(_) |
             SuccNat | ZeroNat | GetEnumElement(_, _, _, _) |
             GetStructElement(_, _, _) =>
           ex
@@ -2885,10 +2972,14 @@ object Matchless {
 
     def loopBool(boolExpr: BoolExpr[A]): BoolExpr[A] =
       boolExpr match {
-        case EqualsLit(expr, lit) =>
-          EqualsLit(loopCheap(expr), lit)
-        case LtEqLit(expr, lit) =>
-          LtEqLit(loopCheap(expr), lit)
+        case CompareLit(expr, rel, lit) =>
+          CompareLit(loopCheap(expr), rel, lit)
+        case CompareInt(left, rel, right) =>
+          CompareInt(loopCheap(left), rel, loopCheap(right))
+        case CompareInt64(left, rel, right) =>
+          CompareInt64(loopCheap(left), rel, loopCheap(right))
+        case CompareFloat64(left, rel, right) =>
+          CompareFloat64(loopCheap(left), rel, loopCheap(right))
         case EqualsNat(expr, nat) =>
           EqualsNat(loopCheap(expr), nat)
         case And(left, right) =>
@@ -2948,7 +3039,7 @@ object Matchless {
         case PrevNat(of) =>
           PrevNat(loopExpr(of))
         case Local(_) | ClosureSlot(_) | LocalAnon(_) | LocalAnonMut(_) |
-            Global(_, _, _) | Literal(_) | MakeEnum(_, _, _) | MakeStruct(_) |
+            Global(_, _, _) | Literal(_) | LitInt64(_) | MakeEnum(_, _, _) | MakeStruct(_) |
             SuccNat | ZeroNat | GetEnumElement(_, _, _, _) |
             GetStructElement(_, _, _) =>
           ex
@@ -2997,7 +3088,7 @@ object Matchless {
           Some(lam)
         case global @ Global(_, _, _) =>
           Some(global)
-        case lit @ Literal(_) =>
+        case lit @ (Literal(_) | LitInt64(_)) =>
           Some(lit)
         case enumExpr @ MakeEnum(_, 0, _) =>
           Some(enumExpr)
@@ -3059,23 +3150,73 @@ object Matchless {
         case _                                  => None
       }
 
+    def compareLitBoolValue(
+        left: Expr[A],
+        rel: CompareRel,
+        right: Lit
+    ): Option[Boolean] =
+      left match {
+        case Literal(found) =>
+          compareLiteralValues(found, rel, right)
+        case _ =>
+          None
+      }
+
+    def compareIntBoolValue(
+        left: Expr[A],
+        rel: CompareRel,
+        right: Expr[A]
+    ): Option[Boolean] =
+      (left, right) match {
+        case (Literal(Lit.Integer(lhs)), Literal(Lit.Integer(rhs))) =>
+          Some(compareRelHolds(rel, lhs.compareTo(rhs)))
+        case _ =>
+          None
+      }
+
+    def compareInt64BoolValue(
+        left: Expr[A],
+        rel: CompareRel,
+        right: Expr[A]
+    ): Option[Boolean] =
+      (left, right) match {
+        case (LitInt64(lhs), LitInt64(rhs)) =>
+          Some(compareRelHolds(rel, java.lang.Long.compare(lhs, rhs)))
+        case _ =>
+          None
+      }
+
+    def compareFloat64BoolValue(
+        left: Expr[A],
+        rel: CompareRel,
+        right: Expr[A]
+    ): Option[Boolean] =
+      (left, right) match {
+        case (Literal(lhs: Lit.Float64), Literal(rhs: Lit.Float64)) =>
+          Some(compareFloat64Values(lhs.toDouble, rel, rhs.toDouble))
+        case _ =>
+          None
+      }
+
     def boolValue(ex: BoolExpr[A], env: KnownEnv): Option[Boolean] =
       ex match {
-        case EqualsLit(expr, lit) =>
-          knownValue(expr, env, Set.empty, Set.empty).collect {
-            case Literal(found) =>
-              Lit.litOrdering.compare(found, lit) == 0
-          }
-        case LtEqLit(expr, Lit.Integer(rhs)) =>
-          knownValue(expr, env, Set.empty, Set.empty).collect {
-            case Literal(Lit.Integer(lhs)) => lhs.compareTo(rhs) <= 0
-          }
-        case LtEqLit(expr, rhs: Lit.Chr) =>
-          knownValue(expr, env, Set.empty, Set.empty).collect {
-            case Literal(lit: Lit.Chr) => lit.toCodePoint <= rhs.toCodePoint
-          }
-        case LtEqLit(_, _) =>
-          None
+        case CompareLit(expr, rel, lit) =>
+          knownValue(expr, env, Set.empty, Set.empty).flatMap(compareLitBoolValue(_, rel, lit))
+        case CompareInt(left, rel, right) =>
+          (
+            knownValue(left, env, Set.empty, Set.empty),
+            knownValue(right, env, Set.empty, Set.empty)
+          ).flatMapN(compareIntBoolValue(_, rel, _))
+        case CompareInt64(left, rel, right) =>
+          (
+            knownValue(left, env, Set.empty, Set.empty),
+            knownValue(right, env, Set.empty, Set.empty)
+          ).flatMapN(compareInt64BoolValue(_, rel, _))
+        case CompareFloat64(left, rel, right) =>
+          (
+            knownValue(left, env, Set.empty, Set.empty),
+            knownValue(right, env, Set.empty, Set.empty)
+          ).flatMapN(compareFloat64BoolValue(_, rel, _))
         case EqualsNat(expr, nat) =>
           knownNatTag(expr, env).map(_ == nat)
         case And(left, right) =>
@@ -3129,7 +3270,7 @@ object Matchless {
     def canDiscardBinding(value: Expr[A], env: KnownEnv): Boolean =
       knownValue(value, env, Set.empty, Set.empty).isDefined || (value match {
         case Local(_) | ClosureSlot(_) | LocalAnon(_) | Global(_, _, _) |
-            Literal(_) | MakeEnum(_, _, _) | MakeStruct(_) | SuccNat |
+            Literal(_) | LitInt64(_) | MakeEnum(_, _, _) | MakeStruct(_) | SuccNat |
             ZeroNat | Lambda(_, _, _, _) =>
           true
         case _ =>
@@ -3149,10 +3290,14 @@ object Matchless {
 
     def recurBool(ex: BoolExpr[A], env: KnownEnv): BoolExpr[A] =
       ex match {
-        case EqualsLit(expr, lit) =>
-          EqualsLit(recurExprCheap(expr, env), lit)
-        case LtEqLit(expr, lit) =>
-          LtEqLit(recurExprCheap(expr, env), lit)
+        case CompareLit(expr, rel, lit) =>
+          CompareLit(recurExprCheap(expr, env), rel, lit)
+        case CompareInt(left, rel, right) =>
+          CompareInt(recurExprCheap(left, env), rel, recurExprCheap(right, env))
+        case CompareInt64(left, rel, right) =>
+          CompareInt64(recurExprCheap(left, env), rel, recurExprCheap(right, env))
+        case CompareFloat64(left, rel, right) =>
+          CompareFloat64(recurExprCheap(left, env), rel, recurExprCheap(right, env))
         case EqualsNat(expr, nat) =>
           EqualsNat(recurExprCheap(expr, env), nat)
         case And(left, right) =>
@@ -3283,7 +3428,7 @@ object Matchless {
           val rewritten = GetStructElement(recurExprCheap(arg, env), index, size)
           knownValue(rewritten, env, Set.empty, Set.empty).fold(rewritten: Expr[A])(recurExpr(_, env))
         case Local(_) | ClosureSlot(_) | LocalAnon(_) | LocalAnonMut(_) |
-            Global(_, _, _) | Literal(_) | MakeEnum(_, _, _) | MakeStruct(_) |
+            Global(_, _, _) | Literal(_) | LitInt64(_) | MakeEnum(_, _, _) | MakeStruct(_) |
             SuccNat | ZeroNat =>
           ex
       }
@@ -3317,6 +3462,7 @@ object Matchless {
     }
   }
   case class Literal(lit: Lit) extends CheapExpr[Nothing]
+  case class LitInt64(value: Long) extends CheapExpr[Nothing]
 
   // these result in Int values which are also used as booleans
   // evaluating these CAN have side effects of mutating LocalAnon
@@ -3329,19 +3475,58 @@ object Matchless {
         case _              => And(this, that)
       }
   }
+
+  enum CompareRel derives CanEqual {
+    case Eq, Ne, Lt, Lte, Gt, Gte
+  }
+
+  private[bosatsu] def compareRelHolds(rel: CompareRel, cmp: Int): Boolean =
+    rel match {
+      case CompareRel.Eq  => cmp == 0
+      case CompareRel.Ne  => cmp != 0
+      case CompareRel.Lt  => cmp < 0
+      case CompareRel.Lte => cmp <= 0
+      case CompareRel.Gt  => cmp > 0
+      case CompareRel.Gte => cmp >= 0
+    }
+
+  private[bosatsu] def compareFloat64Values(
+      left: Double,
+      rel: CompareRel,
+      right: Double
+  ): Boolean =
+    compareRelHolds(rel, PredefImpl.compareFloat64Total(left, right))
+
+  private[bosatsu] def compareLiteralValues(
+      left: Lit,
+      rel: CompareRel,
+      right: Lit
+  ): Option[Boolean] =
+    (left, right) match {
+      case (Lit.Integer(lhs), Lit.Integer(rhs)) =>
+        Some(compareRelHolds(rel, lhs.compareTo(rhs)))
+      case (lhs: Lit.StringMatchResult, rhs: Lit.StringMatchResult) =>
+        Some(compareRelHolds(rel, lhs.asStr.compareTo(rhs.asStr)))
+      case (lhs: Lit.Float64, rhs: Lit.Float64) =>
+        Some(compareFloat64Values(lhs.toDouble, rel, rhs.toDouble))
+      case _ =>
+        None
+    }
   object BoolExpr {
     private def boolTag[A](boolExpr: BoolExpr[A]): Int =
       boolExpr match {
-        case _: EqualsLit[?]    => 0
-        case _: LtEqLit[?]      => 1
-        case _: EqualsNat[?]    => 2
-        case _: And[?]          => 3
-        case _: CheckVariant[?] => 4
-        case _: CheckVariantSet[?] => 5
-        case _: SetMut[?]          => 6
-        case TrueConst             => 7
-        case _: LetBool[?]         => 8
-        case _: LetMutBool[?]      => 9
+        case _: CompareLit[?]     => 0
+        case _: CompareInt[?]     => 1
+        case _: CompareInt64[?]   => 2
+        case _: CompareFloat64[?] => 3
+        case _: EqualsNat[?]      => 4
+        case _: And[?]            => 5
+        case _: CheckVariant[?]   => 6
+        case _: CheckVariantSet[?] => 7
+        case _: SetMut[?]          => 8
+        case TrueConst             => 9
+        case _: LetBool[?]         => 10
+        case _: LetMutBool[?]      => 11
       }
 
     private given Order[LocalAnon] = Order.by(_.ident)
@@ -3350,6 +3535,14 @@ object Matchless {
     private given Order[Either[LocalAnon, Bindable]] =
       Order[Either[LocalAnon, Bindable]]
     private given Order[Lit] = Order.fromOrdering(using Lit.litOrdering)
+    private given Order[CompareRel] = Order.by {
+      case CompareRel.Eq  => 0
+      case CompareRel.Ne  => 1
+      case CompareRel.Lt  => 2
+      case CompareRel.Lte => 3
+      case CompareRel.Gt  => 4
+      case CompareRel.Gte => 5
+    }
     private given Order[DataRepr.Nat] = Order.by {
       case DataRepr.ZeroNat => 0
       case DataRepr.SuccNat => 1
@@ -3358,15 +3551,47 @@ object Matchless {
     given [A: Order]: Order[BoolExpr[A]] with {
       def compare(left: BoolExpr[A], right: BoolExpr[A]): Int =
         (left, right) match {
-          case (EqualsLit(exprL, litL), EqualsLit(exprR, litR)) =>
+          case (CompareLit(exprL, relL, litL), CompareLit(exprR, relR, litR)) =>
             val c1 = Order[Expr[A]].compare(exprL, exprR)
             if (c1 != 0) c1
-            else Order[Lit].compare(litL, litR)
+            else {
+              val c2 = Order[CompareRel].compare(relL, relR)
+              if (c2 != 0) c2
+              else Order[Lit].compare(litL, litR)
+            }
 
-          case (LtEqLit(exprL, litL), LtEqLit(exprR, litR)) =>
-            val c1 = Order[Expr[A]].compare(exprL, exprR)
+          case (CompareInt(leftL, relL, rightL), CompareInt(leftR, relR, rightR)) =>
+            val c1 = Order[Expr[A]].compare(leftL, leftR)
             if (c1 != 0) c1
-            else Order[Lit].compare(litL, litR)
+            else {
+              val c2 = Order[CompareRel].compare(relL, relR)
+              if (c2 != 0) c2
+              else Order[Expr[A]].compare(rightL, rightR)
+            }
+
+          case (
+                CompareInt64(leftL, relL, rightL),
+                CompareInt64(leftR, relR, rightR)
+              ) =>
+            val c1 = Order[Expr[A]].compare(leftL, leftR)
+            if (c1 != 0) c1
+            else {
+              val c2 = Order[CompareRel].compare(relL, relR)
+              if (c2 != 0) c2
+              else Order[Expr[A]].compare(rightL, rightR)
+            }
+
+          case (
+                CompareFloat64(leftL, relL, rightL),
+                CompareFloat64(leftR, relR, rightR)
+              ) =>
+            val c1 = Order[Expr[A]].compare(leftL, leftR)
+            if (c1 != 0) c1
+            else {
+              val c2 = Order[CompareRel].compare(relL, relR)
+              if (c2 != 0) c2
+              else Order[Expr[A]].compare(rightL, rightR)
+            }
 
           case (EqualsNat(exprL, natL), EqualsNat(exprR, natR)) =>
             val c1 = Order[Expr[A]].compare(exprL, exprR)
@@ -3444,10 +3669,17 @@ object Matchless {
       @annotation.tailrec
       def loopBool(boolExpr: BoolExpr[A]): Boolean =
         boolExpr match {
-          case EqualsLit(expr, _) =>
+          case CompareLit(expr, _, _) =>
             Expr.referencesBindable(expr, target)
-          case LtEqLit(expr, _) =>
-            Expr.referencesBindable(expr, target)
+          case CompareInt(left, _, right) =>
+            Expr.referencesBindable(left, target) ||
+              Expr.referencesBindable(right, target)
+          case CompareInt64(left, _, right) =>
+            Expr.referencesBindable(left, target) ||
+              Expr.referencesBindable(right, target)
+          case CompareFloat64(left, _, right) =>
+            Expr.referencesBindable(left, target) ||
+              Expr.referencesBindable(right, target)
           case EqualsNat(expr, _) =>
             Expr.referencesBindable(expr, target)
           case And(left, right) =>
@@ -3482,10 +3714,17 @@ object Matchless {
       @annotation.tailrec
       def loopBool(boolExpr: BoolExpr[A]): Boolean =
         boolExpr match {
-          case EqualsLit(expr, _) =>
+          case CompareLit(expr, _, _) =>
             Expr.referencesLocalAnon(expr, target)
-          case LtEqLit(expr, _) =>
-            Expr.referencesLocalAnon(expr, target)
+          case CompareInt(left, _, right) =>
+            Expr.referencesLocalAnon(left, target) ||
+              Expr.referencesLocalAnon(right, target)
+          case CompareInt64(left, _, right) =>
+            Expr.referencesLocalAnon(left, target) ||
+              Expr.referencesLocalAnon(right, target)
+          case CompareFloat64(left, _, right) =>
+            Expr.referencesLocalAnon(left, target) ||
+              Expr.referencesLocalAnon(right, target)
           case EqualsNat(expr, _) =>
             Expr.referencesLocalAnon(expr, target)
           case And(left, right) =>
@@ -3525,8 +3764,48 @@ object Matchless {
       }
   }
   // returns 1 if it does, else 0
-  case class EqualsLit[A](expr: CheapExpr[A], lit: Lit) extends BoolExpr[A]
-  case class LtEqLit[A](expr: CheapExpr[A], lit: Lit) extends BoolExpr[A]
+  case class CompareLit[A](expr: CheapExpr[A], rel: CompareRel, lit: Lit)
+      extends BoolExpr[A]
+  case class CompareInt[A](
+      left: CheapExpr[A],
+      rel: CompareRel,
+      right: CheapExpr[A]
+  ) extends BoolExpr[A]
+  case class CompareInt64[A](
+      left: CheapExpr[A],
+      rel: CompareRel,
+      right: CheapExpr[A]
+  ) extends BoolExpr[A]
+  case class CompareFloat64[A](
+      left: CheapExpr[A],
+      rel: CompareRel,
+      right: CheapExpr[A]
+  ) extends BoolExpr[A]
+  object EqualsLit {
+    def apply[A](expr: CheapExpr[A], lit: Lit): BoolExpr[A] =
+      CompareLit(expr, CompareRel.Eq, lit)
+
+    def unapply[A](boolExpr: BoolExpr[A]): Option[(CheapExpr[A], Lit)] =
+      boolExpr match {
+        case CompareLit(expr, CompareRel.Eq, lit) =>
+          Some((expr, lit))
+        case _ =>
+          None
+      }
+  }
+
+  object LtEqLit {
+    def apply[A](expr: CheapExpr[A], lit: Lit): BoolExpr[A] =
+      CompareLit(expr, CompareRel.Lte, lit)
+
+    def unapply[A](boolExpr: BoolExpr[A]): Option[(CheapExpr[A], Lit)] =
+      boolExpr match {
+        case CompareLit(expr, CompareRel.Lte, lit) =>
+          Some((expr, lit))
+        case _ =>
+          None
+      }
+  }
   case class EqualsNat[A](expr: CheapExpr[A], nat: DataRepr.Nat)
       extends BoolExpr[A]
   // 1 if both are > 0
@@ -3591,8 +3870,10 @@ object Matchless {
     bx match {
       case SetMut(_, _) => true
       case TrueConst | CheckVariant(_, _, _, _) | CheckVariantSet(_, _, _, _) |
-          EqualsLit(_, _) |
-          LtEqLit(_, _) |
+          CompareLit(_, _, _) |
+          CompareInt(_, _, _) |
+          CompareInt64(_, _, _) |
+          CompareFloat64(_, _, _) |
           EqualsNat(_, _) =>
         false
       case And(b1, b2)      => hasSideEffect(b1) || hasSideEffect(b2)
@@ -4096,7 +4377,7 @@ object Matchless {
                   onMatch,
                   onMiss
                 )
-              } yield If(EqualsLit(left, emptyStringLit), matchedExpr, missExpr),
+              } yield If(CompareLit(left, CompareRel.Eq, emptyStringLit), matchedExpr, missExpr),
             onMiss
           )
         case (charPart: StrPart.CharPart) :: tail =>
@@ -4246,7 +4527,7 @@ object Matchless {
       } yield {
         val loopEffect =
           If(
-            EqualsLit(currentMut, emptyStringLit),
+            CompareLit(currentMut, CompareRel.Eq, emptyStringLit),
             stopStringSearchExpr(state),
             effect
           )
@@ -4447,7 +4728,7 @@ object Matchless {
                   If(successCheck, matched, advance)
                 case None    =>
                   If(
-                    EqualsLit(remainder, emptyStringLit),
+                    CompareLit(remainder, CompareRel.Eq, emptyStringLit),
                     If(successCheck, matched, advance),
                     advance
                   )
@@ -4458,7 +4739,7 @@ object Matchless {
       } yield {
         val loopEffect =
           If(
-            EqualsLit(currentMut, emptyStringLit),
+            CompareLit(currentMut, CompareRel.Eq, emptyStringLit),
             stopStringSearchExpr(state),
             effect
           )
@@ -4557,7 +4838,7 @@ object Matchless {
                       If(successCheck, matched, onCandidateMiss)
                     case None    =>
                       If(
-                        EqualsLit(remainder, emptyStringLit),
+                        CompareLit(remainder, CompareRel.Eq, emptyStringLit),
                         If(successCheck, matched, onCandidateMiss),
                         onCandidateMiss
                       )
@@ -4681,7 +4962,7 @@ object Matchless {
 
         val effect =
           If(
-            EqualsLit(currentMut, emptyStringLit),
+            CompareLit(currentMut, CompareRel.Eq, emptyStringLit),
             onEmpty,
             If(check, onMatch, advance)
           )
@@ -4793,7 +5074,7 @@ object Matchless {
         val onEmpty = setAll((runMut, FalseExpr) :: Nil, UnitExpr)
         val effect =
           If(
-            EqualsLit(currentMut, emptyStringLit),
+            CompareLit(currentMut, CompareRel.Eq, emptyStringLit),
             onEmpty,
             stepExpr
           )
@@ -4824,7 +5105,7 @@ object Matchless {
     ): F[BoolExpr[A]] =
       parts match {
         case Nil =>
-          Monad[F].pure(EqualsLit(arg, emptyStringLit))
+          Monad[F].pure(CompareLit(arg, CompareRel.Eq, emptyStringLit))
         case StrPart.LitStr(expect) :: tail =>
           withSomeTuple2(
             call2(ctx.from, partitionStringName, arg, Literal(Lit.Str(expect))),
@@ -4832,7 +5113,7 @@ object Matchless {
           ) { (left, right) =>
             matchStringParts(right, tail, bindTargets, nextBind, ctx).map {
               rest =>
-                EqualsLit(left, emptyStringLit) && rest
+                CompareLit(left, CompareRel.Eq, emptyStringLit) && rest
             }
           }
         case (charPart: StrPart.CharPart) :: tail =>
@@ -5177,6 +5458,226 @@ object Matchless {
           }
       }
 
+    enum BuiltinCompareDomain derives CanEqual {
+      case IntDomain, Int64Domain, Float64Domain
+    }
+
+    val int64PackageName = PackageName.parts("Bosatsu", "Num", "Int64")
+    val eqIntName = Identifier.Name("eq_Int")
+    val cmpIntName = Identifier.Name("cmp_Int")
+    val eqFloat64Name = Identifier.Name("eq_Float64")
+    val cmpFloat64Name = Identifier.Name("cmp_Float64")
+    val eqInt64Name = Identifier.Name("eq_Int64")
+    val cmpInt64Name = Identifier.Name("cmp_Int64")
+    val intToInt64Name = Identifier.Name("int_to_Int64")
+    val intLowBitsToInt64Name = Identifier.Name("int_low_bits_to_Int64")
+    val someConstructor = Constructor("Some")
+    val noneConstructor = Constructor("None")
+
+    lazy val optionSomeData: (Int, Int, List[Int]) =
+      variantOf(PackageName.PredefName, someConstructor) match {
+        case Some(DataRepr.Enum(variant, arity, famArities)) =>
+          (variant, arity, famArities)
+        case other =>
+          // $COVERAGE-OFF$
+          throw new IllegalStateException(
+            s"expected Bosatsu/Predef.Some to be an enum, found: $other"
+          )
+        // $COVERAGE-ON$
+      }
+
+    lazy val optionNoneExpr: Expr[B] =
+      variantOf(PackageName.PredefName, noneConstructor) match {
+        case Some(DataRepr.Enum(variant, arity, famArities)) =>
+          MakeEnum(variant, arity, famArities)
+        case other =>
+          // $COVERAGE-OFF$
+          throw new IllegalStateException(
+            s"expected Bosatsu/Predef.None to be an enum, found: $other"
+          )
+        // $COVERAGE-ON$
+      }
+
+    def optionSomeExpr(value: Expr[B]): Expr[B] = {
+      val (variant, arity, famArities) = optionSomeData
+      applyArgs(MakeEnum(variant, arity, famArities), NonEmptyList.one(value))
+    }
+
+    def eqBuiltinDomain(
+        pack: PackageName,
+        fnName: Bindable
+    ): Option[BuiltinCompareDomain] =
+      if ((pack == PackageName.PredefName) && (fnName == eqIntName))
+        Some(BuiltinCompareDomain.IntDomain)
+      else if ((pack == PackageName.PredefName) && (fnName == eqFloat64Name))
+        Some(BuiltinCompareDomain.Float64Domain)
+      else if ((pack == int64PackageName) && (fnName == eqInt64Name))
+        Some(BuiltinCompareDomain.Int64Domain)
+      else None
+
+    def cmpBuiltinDomain(
+        pack: PackageName,
+        fnName: Bindable
+    ): Option[BuiltinCompareDomain] =
+      if ((pack == PackageName.PredefName) && (fnName == cmpIntName))
+        Some(BuiltinCompareDomain.IntDomain)
+      else if ((pack == PackageName.PredefName) && (fnName == cmpFloat64Name))
+        Some(BuiltinCompareDomain.Float64Domain)
+      else if ((pack == int64PackageName) && (fnName == cmpInt64Name))
+        Some(BuiltinCompareDomain.Int64Domain)
+      else None
+
+    def comparePredicate(
+        domain: BuiltinCompareDomain,
+        left: CheapExpr[B],
+        rel: CompareRel,
+        right: CheapExpr[B]
+    ): BoolExpr[B] =
+      domain match {
+        case BuiltinCompareDomain.IntDomain =>
+          CompareInt(left, rel, right)
+        case BuiltinCompareDomain.Int64Domain =>
+          CompareInt64(left, rel, right)
+        case BuiltinCompareDomain.Float64Domain =>
+          CompareFloat64(left, rel, right)
+      }
+
+    def memoizeBinaryExpr(
+        left: Expr[B],
+        right: Expr[B]
+    )(
+        build: (CheapExpr[B], CheapExpr[B]) => Expr[B]
+    ): F[Expr[B]] =
+      maybeMemoWith(left, makeAnon) { leftCheap =>
+        maybeMemoWith(right, makeAnon) { rightCheap =>
+          Monad[F].pure(build(leftCheap, rightCheap))
+        } { (rightTmp, rightExpr, body) =>
+          Let(rightTmp, rightExpr, body)
+        }
+      } { (leftTmp, leftExpr, body) =>
+        Let(leftTmp, leftExpr, body)
+      }
+
+    def lowerBooleanCompare(
+        domain: BuiltinCompareDomain,
+        left: Expr[B],
+        rel: CompareRel,
+        right: Expr[B]
+    ): F[Expr[B]] =
+      memoizeBinaryExpr(left, right) { (leftCheap, rightCheap) =>
+        If(comparePredicate(domain, leftCheap, rel, rightCheap), TrueExpr, FalseExpr)
+      }
+
+    def lowerConstantBoolWithOperands(
+        left: Expr[B],
+        right: Expr[B],
+        value: Boolean
+    ): F[Expr[B]] =
+      memoizeBinaryExpr(left, right) { (_, _) =>
+        if (value) TrueExpr else FalseExpr
+      }
+
+    val comparisonFamArities = 0 :: 0 :: 0 :: Nil
+    val comparisonTrueVariants = Set(0, 1, 2)
+
+    def comparisonObservation(
+        trueVariants: Set[Int]
+    ): Either[Boolean, CompareRel] =
+      if (trueVariants.isEmpty) Left(false)
+      else if (trueVariants == Set(0)) Right(CompareRel.Lt)
+      else if (trueVariants == Set(0, 1)) Right(CompareRel.Lte)
+      else if (trueVariants == Set(1)) Right(CompareRel.Eq)
+      else if (trueVariants == Set(1, 2)) Right(CompareRel.Gte)
+      else if (trueVariants == Set(2)) Right(CompareRel.Gt)
+      else if (trueVariants == Set(0, 2)) Right(CompareRel.Ne)
+      else if (trueVariants == comparisonTrueVariants) Left(true)
+      else {
+        // total boolean matches over Comparison only have these subsets
+        // $COVERAGE-OFF$
+        throw new IllegalStateException(
+          s"unexpected Comparison observation: $trueVariants"
+        )
+        // $COVERAGE-ON$
+      }
+
+    def comparisonObservationFor(
+        selector: CheapExpr[B],
+        expr: Expr[B]
+    ): Option[Either[Boolean, CompareRel]] =
+      collectTrueVariants(
+        expr,
+        comparisonTrueVariants,
+        (selector, 0, comparisonFamArities)
+      ).map(comparisonObservation)
+
+    def cmpBuiltinArgs(
+        expr: Expr[B]
+    ): Option[(BuiltinCompareDomain, Expr[B], Expr[B])] =
+      expr match {
+        case App(Global(_, pack, fnName), NonEmptyList(left, right :: Nil)) =>
+          cmpBuiltinDomain(pack, fnName).map((_, left, right))
+        case _ =>
+          None
+      }
+
+    def maybeLowerComparisonObservationLet(
+        arg: Either[LocalAnon, Bindable],
+        value: Expr[B],
+        in: Expr[B]
+    ): Option[F[Expr[B]]] = {
+      val selector: CheapExpr[B] =
+        arg match {
+          case Left(localAnon) => localAnon
+          case Right(name)     => Local(name)
+        }
+
+      for {
+        (domain, left, right) <- cmpBuiltinArgs(value)
+        observation <- comparisonObservationFor(selector, in)
+      } yield {
+        observation match {
+          case Left(boolValue) =>
+            lowerConstantBoolWithOperands(left, right, boolValue)
+          case Right(rel)      =>
+            lowerBooleanCompare(domain, left, rel, right)
+        }
+      }
+    }
+
+    def maybeLiteralIntValue(expr: TypedExpr[A]): Option[java.math.BigInteger] =
+      expr match {
+        case TypedExpr.Literal(Lit.Integer(value), _, _) =>
+          Some(value)
+        case _ =>
+          None
+      }
+
+    def maybeLiteralInt64App(
+        fn: TypedExpr[A],
+        args: List[TypedExpr[A]]
+    ): Option[Expr[B]] =
+      (fn, args) match {
+        case (
+              TypedExpr.Global(pack, fnName, _, _),
+              literalArg :: Nil
+            ) if (pack == int64PackageName) && (fnName == intLowBitsToInt64Name) =>
+          maybeLiteralIntValue(literalArg).map(value => LitInt64(value.longValue))
+
+        case (
+              TypedExpr.Global(pack, fnName, _, _),
+              literalArg :: Nil
+            ) if (pack == int64PackageName) && (fnName == intToInt64Name) =>
+          maybeLiteralIntValue(literalArg).map { value =>
+            try optionSomeExpr(LitInt64(value.longValueExact()))
+            catch {
+              case _: ArithmeticException => optionNoneExpr
+            }
+          }
+
+        case _ =>
+          None
+      }
+
     case class LambdaState(
         name: Option[Bindable],
         slots: Map[Bindable, Expr[B]]
@@ -5224,10 +5725,26 @@ object Matchless {
         case SetMut(mut, e) => SetMut(mut, substituteLocals(m, e))
         case And(b1, b2)    =>
           And(substituteLocalsBool(m, b1), substituteLocalsBool(m, b2))
-        case EqualsLit(x, l) =>
-          EqualsLit(substituteLocalsCheap(m, x), l)
-        case LtEqLit(x, l) =>
-          LtEqLit(substituteLocalsCheap(m, x), l)
+        case CompareLit(x, rel, l) =>
+          CompareLit(substituteLocalsCheap(m, x), rel, l)
+        case CompareInt(left, rel, right) =>
+          CompareInt(
+            substituteLocalsCheap(m, left),
+            rel,
+            substituteLocalsCheap(m, right)
+          )
+        case CompareInt64(left, rel, right) =>
+          CompareInt64(
+            substituteLocalsCheap(m, left),
+            rel,
+            substituteLocalsCheap(m, right)
+          )
+        case CompareFloat64(left, rel, right) =>
+          CompareFloat64(
+            substituteLocalsCheap(m, left),
+            rel,
+            substituteLocalsCheap(m, right)
+          )
         case EqualsNat(x, n) =>
           EqualsNat(substituteLocalsCheap(m, x), n)
         case TrueConst                           => TrueConst
@@ -5298,7 +5815,7 @@ object Matchless {
         case WhileExpr(c, ef, r) =>
           WhileExpr(substituteLocalsBool(m, c), substituteLocals(m, ef), r)
         case ClosureSlot(_) | Global(_, _, _) | LocalAnon(_) | LocalAnonMut(_) |
-            MakeEnum(_, _, _) | MakeStruct(_) | SuccNat | Literal(_) |
+            MakeEnum(_, _, _) | MakeStruct(_) | SuccNat | Literal(_) | LitInt64(_) |
             ZeroNat =>
           e
       }
@@ -5399,7 +5916,7 @@ object Matchless {
           // the rest cannot have a call in tail position
           case App(_, _) | ClosureSlot(_) | GetEnumElement(_, _, _, _) |
               GetStructElement(_, _, _) | Global(_, _, _) | Lambda(_, _, _, _) |
-              Literal(_) | Local(_) | LocalAnon(_) | LocalAnonMut(_) |
+              Literal(_) | LitInt64(_) | Local(_) | LocalAnon(_) | LocalAnonMut(_) |
               MakeEnum(_, _, _) | MakeStruct(_) | PrevNat(_) | SuccNat |
               WhileExpr(_, _, _) | ZeroNat =>
             None
@@ -5700,25 +6217,55 @@ object Matchless {
           Monad[F].pure(slots(bind))
         case app @ TypedExpr.App(fn, as, _, _) =>
           val unnameSlots = slots.unname
-          TypedExpr.flattenApp2(app) match {
-            case Some((steps, last)) =>
-              val compiledStepsF =
-                steps.toList.foldLeftM(List.empty[(Expr[B], Expr[B])]) {
-                  case (acc, step) =>
-                    (loop(step.fn, unnameSlots), loop(step.arg, unnameSlots))
-                      .mapN { (fn1, arg1) =>
-                        (fn1, arg1) :: acc
-                      }
-                }
-              (compiledStepsF, loop(last, unnameSlots)).mapN {
-                (compiledRev, lastExpr) =>
-                  compiledRev.foldLeft(lastExpr) { case (rhsExpr, (fnExpr, argExpr)) =>
-                    applyArgs(fnExpr, NonEmptyList.of(argExpr, rhsExpr))
+          def fallbackApp: F[Expr[B]] =
+            TypedExpr.flattenApp2(app) match {
+              case Some((steps, last)) =>
+                val compiledStepsF =
+                  steps.toList.foldLeftM(List.empty[(Expr[B], Expr[B])]) {
+                    case (acc, step) =>
+                      (loop(step.fn, unnameSlots), loop(step.arg, unnameSlots))
+                        .mapN { (fn1, arg1) =>
+                          (fn1, arg1) :: acc
+                        }
                   }
-              }
+                (compiledStepsF, loop(last, unnameSlots)).mapN {
+                  (compiledRev, lastExpr) =>
+                    compiledRev.foldLeft(lastExpr) { case (rhsExpr, (fnExpr, argExpr)) =>
+                      applyArgs(fnExpr, NonEmptyList.of(argExpr, rhsExpr))
+                    }
+                }
+              case None =>
+                (loop(fn, unnameSlots), as.traverse(loop(_, unnameSlots)))
+                  .mapN(applyArgs(_, _))
+            }
+
+          maybeLiteralInt64App(fn, as.toList) match {
+            case Some(expr) =>
+              Monad[F].pure(expr)
             case None =>
-              (loop(fn, unnameSlots), as.traverse(loop(_, unnameSlots)))
-                .mapN(applyArgs(_, _))
+              (fn, as) match {
+                case (
+                      TypedExpr.Global(pack, fnName: Bindable, _, _),
+                      NonEmptyList(left, right :: Nil)
+                    ) =>
+                  eqBuiltinDomain(pack, fnName) match {
+                    case Some(domain) =>
+                      (loop(left, unnameSlots), loop(right, unnameSlots))
+                        .tupled
+                        .flatMap { case (leftExpr, rightExpr) =>
+                          lowerBooleanCompare(
+                            domain,
+                            leftExpr,
+                            CompareRel.Eq,
+                            rightExpr
+                          )
+                        }
+                    case None =>
+                      fallbackApp
+                  }
+                case _ =>
+                  fallbackApp
+              }
           }
         case TypedExpr.Loop(args, body, _) =>
           val avoid: Set[Bindable] =
@@ -5747,9 +6294,10 @@ object Matchless {
             loopLetVal(arg, rhs, RecursionKind.NonRecursive, slots.unname)
               .map(v => (arg, v))
           }
-          (bindsF, loop(tail, slots)).mapN { (binds, tailExpr) =>
-            binds.reverseIterator.foldLeft(tailExpr) { case (acc, (arg, value)) =>
-              Let(arg, value, acc)
+          (bindsF, loop(tail, slots)).tupled.flatMap { case (binds, tailExpr) =>
+            binds.reverse.foldLeftM(tailExpr) { case (acc, (arg, value)) =>
+              maybeLowerComparisonObservationLet(Right(arg), value, acc)
+                .getOrElse(Monad[F].pure(Let(arg, value, acc)))
             }
           }
         case TypedExpr.Recur(_, _, _) =>
@@ -6483,7 +7031,7 @@ object Matchless {
         case Pattern.Literal(lit) =>
           val cond =
             if (mustMatch) TrueConst
-            else EqualsLit(arg, lit)
+            else CompareLit(arg, CompareRel.Eq, lit)
           finish(Monad[F].pure(NonEmptyList((Nil, cond, Nil), Nil)))
         case Pattern.Var(v) =>
           finish(Monad[F].pure(
@@ -7408,6 +7956,16 @@ object Matchless {
         )
     }
 
+    def directGuardBoolExpr(expr: Expr[B]): Option[BoolExpr[B]] =
+      expr match {
+        case Let(arg, value, in) =>
+          directGuardBoolExpr(in).map(LetBool(arg, value, _))
+        case If(cond, TrueExpr, FalseExpr) =>
+          Some(cond)
+        case _ =>
+          None
+      }
+
     def selectorGuardToBoolExpr(expr: Expr[B]): Option[BoolExpr[B]] =
       expr match {
         case Let(arg, value, in) =>
@@ -7438,7 +7996,8 @@ object Matchless {
       }
 
     def guardToBoolExpr(guardExpr: Expr[B]): F[BoolExpr[B]] =
-      selectorGuardToBoolExpr(guardExpr) match {
+      directGuardBoolExpr(guardExpr)
+        .orElse(selectorGuardToBoolExpr(guardExpr)) match {
         case Some(fastPath) =>
           Monad[F].pure(fastPath)
         case None           =>
@@ -7696,7 +8255,7 @@ object Matchless {
                         minimizeSpecializedRows(sig, rows, colIdx, 0)
                       val newOccs = occs.patch(colIdx, Nil, 1)
                       val cond =
-                        if (caseMustMatch) TrueConst else EqualsLit(occ, lit)
+                        if (caseMustMatch) TrueConst else CompareLit(occ, CompareRel.Eq, lit)
                       Monad[F].pure((cond, Nil, newRows, newOccs))
                     case ZeroSig =>
                       val (newRows, _) =
@@ -7875,14 +8434,14 @@ object Matchless {
                     if (lits.isEmpty) fallback
                     else if (lits.length == 1) {
                       val (lit, thenExpr) = lits.head
-                      If(EqualsLit(occ, lit), thenExpr, fallback)
+                      If(CompareLit(occ, CompareRel.Eq, lit), thenExpr, fallback)
                     } else {
                       // Keep the left branch as all literals <= pivot.
                       val leftSize = (lits.length + 1) / 2
                       val pivot = lits(leftSize - 1)._1
                       val leftTree = buildTree(lits.take(leftSize), fallback)
                       val rightTree = buildTree(lits.drop(leftSize), fallback)
-                      If(LtEqLit(occ, pivot), leftTree, rightTree)
+                      If(CompareLit(occ, CompareRel.Lte, pivot), leftTree, rightTree)
                     }
 
                   (sortedLits.traverse(compileLiteralCase), fallbackExpr).mapN {
@@ -8011,10 +8570,14 @@ object Matchless {
 
       def loopBool(b: BoolExpr[B]): Int =
         b match {
-          case EqualsLit(expr, _) =>
+          case CompareLit(expr, _, _) =>
             1 + loopExpr(expr)
-          case LtEqLit(expr, _) =>
-            1 + loopExpr(expr)
+          case CompareInt(left, _, right) =>
+            1 + loopExpr(left) + loopExpr(right)
+          case CompareInt64(left, _, right) =>
+            1 + loopExpr(left) + loopExpr(right)
+          case CompareFloat64(left, _, right) =>
+            1 + loopExpr(left) + loopExpr(right)
           case EqualsNat(expr, _) =>
             1 + loopExpr(expr)
           case And(left, right) =>
@@ -8318,6 +8881,95 @@ object Matchless {
         }
       }
 
+      def comparisonSelectorBranches(
+          selectorExpr: Expr[B],
+          bs: NonEmptyList[MatchBranch]
+      ): Option[F[Expr[B]]] = {
+        val ltPat: Pattern[(PackageName, Constructor), Type] =
+          Pattern.PositionalStruct(
+            (PackageName.PredefName, Constructor("LT")),
+            Nil
+          )
+        val eqPat: Pattern[(PackageName, Constructor), Type] =
+          Pattern.PositionalStruct(
+            (PackageName.PredefName, Constructor("EQ")),
+            Nil
+          )
+        val gtPat: Pattern[(PackageName, Constructor), Type] =
+          Pattern.PositionalStruct(
+            (PackageName.PredefName, Constructor("GT")),
+            Nil
+          )
+
+        def normalizedNoNames(
+            p: Pattern[(PackageName, Constructor), Type]
+        ): Option[Pattern[(PackageName, Constructor), Type]] = {
+          val p1 = normalizePattern(p)
+          if (p1.names.isEmpty) Some(p1)
+          else None
+        }
+
+        def patternVariants(
+            p: Pattern[(PackageName, Constructor), Type]
+        ): Option[Set[Int]] =
+          p match {
+            case Pattern.WildCard =>
+              Some(comparisonTrueVariants)
+            case `ltPat` =>
+              Some(Set(0))
+            case `eqPat` =>
+              Some(Set(1))
+            case `gtPat` =>
+              Some(Set(2))
+            case Pattern.Union(head, tail) =>
+              (head :: tail.toList).traverse(patternVariants).map(_.foldLeft(Set.empty[Int])(_ union _))
+            case _ =>
+              None
+          }
+
+        def literalBoolValue(expr: Expr[B]): Option[Boolean] =
+          expr match {
+            case TrueExpr  => Some(true)
+            case FalseExpr => Some(false)
+            case _         => None
+          }
+
+        val trueVariantsOpt =
+          bs.toList
+            .foldLeft(Option((comparisonTrueVariants, Set.empty[Int]))) {
+              case (accOpt, MatchBranch(pattern, None, rhs)) =>
+                for {
+                  acc <- accOpt
+                  (remaining, trueVariants) = acc
+                  normalized <- normalizedNoNames(pattern)
+                  variants <- patternVariants(normalized)
+                  branchValue <- literalBoolValue(rhs)
+                } yield {
+                  val covered = remaining intersect variants
+                  val nextTrueVariants =
+                    if (branchValue) trueVariants union covered else trueVariants
+                  (remaining diff covered, nextTrueVariants)
+                }
+              case _ =>
+                None
+            }
+            .collect { case (remaining, trueVariants) if remaining.isEmpty =>
+              trueVariants
+            }
+
+        for {
+          trueVariants <- trueVariantsOpt
+          (domain, left, right) <- cmpBuiltinArgs(selectorExpr)
+        } yield {
+          comparisonObservation(trueVariants) match {
+            case Left(value) =>
+              lowerConstantBoolWithOperands(left, right, value)
+            case Right(rel)  =>
+              lowerBooleanCompare(domain, left, rel, right)
+          }
+        }
+      }
+
       def maybeMatrix(
           arg: CheapExpr[B],
           branches: NonEmptyList[MatchBranch],
@@ -8360,19 +9012,22 @@ object Matchless {
       }
 
       val maybeBoolBranches = boolSelectorBranches(branches)
+      val maybeComparisonBranches = comparisonSelectorBranches(arg, branches)
 
       def compileWithoutInlining: F[Expr[B]] =
         maybeBoolBranches match {
           case Some((ifTrue, ifFalse)) =>
             guardToBoolExpr(arg).map(If(_, ifTrue, ifFalse))
-          case None                    =>
-            maybeMemo(arg, tmp) { (arg: CheapExpr[B]) =>
-              compileWithCheapArg(arg, branches, None)
+          case None =>
+            maybeComparisonBranches.getOrElse {
+              maybeMemo(arg, tmp) { (arg: CheapExpr[B]) =>
+                compileWithCheapArg(arg, branches, None)
+              }
             }
         }
 
       // phase-1 policy: if multiple branches bind the whole root, keep eager root allocation
-      if (wholeRootBindBranches > 1 || maybeBoolBranches.nonEmpty)
+      if (wholeRootBindBranches > 1 || maybeBoolBranches.nonEmpty || maybeComparisonBranches.nonEmpty)
         compileWithoutInlining
       else {
         prepareInlinedStructRoot(arg).flatMap {

--- a/core/src/main/scala/dev/bosatsu/MatchlessGlobalInlining.scala
+++ b/core/src/main/scala/dev/bosatsu/MatchlessGlobalInlining.scala
@@ -242,10 +242,14 @@ object MatchlessGlobalInlining {
               loop(ge.arg :: tail, acc)
             case gs: Matchless.GetStructElement[?] =>
               loop(gs.arg :: tail, acc)
-            case Matchless.EqualsLit(arg, _) =>
+            case Matchless.CompareLit(arg, _, _) =>
               loop(arg :: tail, acc)
-            case Matchless.LtEqLit(arg, _) =>
-              loop(arg :: tail, acc)
+            case Matchless.CompareInt(left, _, right) =>
+              loop(left :: right :: tail, acc)
+            case Matchless.CompareInt64(left, _, right) =>
+              loop(left :: right :: tail, acc)
+            case Matchless.CompareFloat64(left, _, right) =>
+              loop(left :: right :: tail, acc)
             case Matchless.EqualsNat(arg, _) =>
               loop(arg :: tail, acc)
             case Matchless.And(left, right) =>
@@ -261,7 +265,7 @@ object MatchlessGlobalInlining {
             case Matchless.LetMutBool(_, in) =>
               loop(in :: tail, acc)
             case Matchless.Local(_) | Matchless.ClosureSlot(_) | Matchless.LocalAnon(_) |
-                Matchless.LocalAnonMut(_) | Matchless.Literal(_) |
+                Matchless.LocalAnonMut(_) | Matchless.Literal(_) | Matchless.LitInt64(_) |
                 Matchless.MakeEnum(_, _, _) | Matchless.MakeStruct(_) |
                 _: Matchless.SuccNat.type | _: Matchless.ZeroNat.type |
                 _: Matchless.TrueConst.type =>
@@ -287,7 +291,7 @@ object MatchlessGlobalInlining {
 
     def cheapReferenceValue(value: Expr[K]): Option[Matchless.CheapExpr[K]] =
       value match {
-        case lit @ Matchless.Literal(_) =>
+        case lit @ (Matchless.Literal(_) | Matchless.LitInt64(_)) =>
           Some(lit)
         case global @ Matchless.Global(_, _, _) =>
           Some(global)
@@ -339,7 +343,7 @@ object MatchlessGlobalInlining {
               case _ =>
                 None
             }
-        case lit @ Matchless.Literal(_) =>
+        case lit @ (Matchless.Literal(_) | Matchless.LitInt64(_)) =>
           Some(lit)
         case enumExpr @ Matchless.MakeEnum(_, 0, _) =>
           Some(enumExpr)
@@ -459,7 +463,7 @@ object MatchlessGlobalInlining {
           knownSummaryValue(rewritten, Set.empty).fold(rewritten: Expr[K])(loop)
         case Matchless.Local(_) | Matchless.ClosureSlot(_) |
             Matchless.LocalAnon(_) | Matchless.LocalAnonMut(_) |
-            Matchless.Literal(_) | Matchless.MakeEnum(_, _, _) |
+            Matchless.Literal(_) | Matchless.LitInt64(_) | Matchless.MakeEnum(_, _, _) |
             Matchless.MakeStruct(_) | Matchless.SuccNat | Matchless.ZeroNat =>
           ex
       }
@@ -492,10 +496,14 @@ object MatchlessGlobalInlining {
 
     def loopBool(ex: Matchless.BoolExpr[K]): Matchless.BoolExpr[K] =
       ex match {
-        case Matchless.EqualsLit(arg, lit) =>
-          Matchless.EqualsLit(loopCheap(arg), lit)
-        case Matchless.LtEqLit(arg, lit) =>
-          Matchless.LtEqLit(loopCheap(arg), lit)
+        case Matchless.CompareLit(arg, rel, lit) =>
+          Matchless.CompareLit(loopCheap(arg), rel, lit)
+        case Matchless.CompareInt(left, rel, right) =>
+          Matchless.CompareInt(loopCheap(left), rel, loopCheap(right))
+        case Matchless.CompareInt64(left, rel, right) =>
+          Matchless.CompareInt64(loopCheap(left), rel, loopCheap(right))
+        case Matchless.CompareFloat64(left, rel, right) =>
+          Matchless.CompareFloat64(loopCheap(left), rel, loopCheap(right))
         case Matchless.EqualsNat(arg, nat) =>
           Matchless.EqualsNat(loopCheap(arg), nat)
         case Matchless.And(left, right) =>
@@ -666,6 +674,7 @@ object MatchlessGlobalInlining {
   private def isKnownArgumentValue[A](expr: Expr[A]): Boolean =
     expr match {
       case Matchless.Literal(_) |
+          Matchless.LitInt64(_) |
           Matchless.MakeEnum(_, 0, _) |
           Matchless.MakeStruct(0) |
           Matchless.ZeroNat |
@@ -759,7 +768,7 @@ object MatchlessGlobalInlining {
   ): Option[InlineSummary[K]] = {
     def knownValue(ex: Expr[K]): Option[Expr[K]] =
       ex match {
-        case lit @ Matchless.Literal(_) =>
+        case lit @ (Matchless.Literal(_) | Matchless.LitInt64(_)) =>
           Some(lit)
         case global @ Matchless.Global(_, _, _) =>
           Some(global)
@@ -873,7 +882,7 @@ object MatchlessGlobalInlining {
         case gs: Matchless.GetStructElement[?] =>
           loopExpr(gs.arg, boundMuts)
         case Matchless.Local(_) | Matchless.Global(_, _, _) | Matchless.ClosureSlot(_) |
-            Matchless.LocalAnon(_) | Matchless.Literal(_) |
+            Matchless.LocalAnon(_) | Matchless.Literal(_) | Matchless.LitInt64(_) |
             Matchless.MakeEnum(_, _, _) | Matchless.MakeStruct(_) |
             Matchless.SuccNat | Matchless.ZeroNat =>
           Set.empty
@@ -884,10 +893,14 @@ object MatchlessGlobalInlining {
         boundMuts: Set[Long]
     ): Set[Long] =
       ex match {
-        case Matchless.EqualsLit(expr, _) =>
+        case Matchless.CompareLit(expr, _, _) =>
           loopExpr(expr, boundMuts)
-        case Matchless.LtEqLit(expr, _) =>
-          loopExpr(expr, boundMuts)
+        case Matchless.CompareInt(left, _, right) =>
+          loopExpr(left, boundMuts) ++ loopExpr(right, boundMuts)
+        case Matchless.CompareInt64(left, _, right) =>
+          loopExpr(left, boundMuts) ++ loopExpr(right, boundMuts)
+        case Matchless.CompareFloat64(left, _, right) =>
+          loopExpr(left, boundMuts) ++ loopExpr(right, boundMuts)
         case Matchless.EqualsNat(expr, _) =>
           loopExpr(expr, boundMuts)
         case Matchless.And(left, right) =>

--- a/core/src/main/scala/dev/bosatsu/MatchlessToValue.scala
+++ b/core/src/main/scala/dev/bosatsu/MatchlessToValue.scala
@@ -293,7 +293,7 @@ object MatchlessToValue {
           case rhs: Lit.StringMatchResult =>
             left match {
               case s: String =>
-                Matchless.compareRelHolds(rel, s.compareTo(rhs.asStr))
+                Matchless.compareRelHolds(rel, StringUtil.codePointCompare(s, rhs.asStr))
               case _ =>
                 false
             }

--- a/core/src/main/scala/dev/bosatsu/MatchlessToValue.scala
+++ b/core/src/main/scala/dev/bosatsu/MatchlessToValue.scala
@@ -280,6 +280,16 @@ object MatchlessToValue {
         right match {
           case Lit.Integer(value) =>
             compareIntValues(left, rel, BInt.fromBigInteger(value))
+          case rhs: Lit.Chr =>
+            left match {
+              case s: String if s.codePointCount(0, s.length) == 1 =>
+                Matchless.compareRelHolds(
+                  rel,
+                  Integer.compare(s.codePointAt(0), rhs.toCodePoint)
+                )
+              case _ =>
+                false
+            }
           case rhs: Lit.StringMatchResult =>
             left match {
               case s: String =>

--- a/core/src/main/scala/dev/bosatsu/MatchlessToValue.scala
+++ b/core/src/main/scala/dev/bosatsu/MatchlessToValue.scala
@@ -3,7 +3,7 @@ package dev.bosatsu
 import cats.{Eval, Functor, Applicative}
 import cats.data.NonEmptyList
 import cats.evidence.Is
-import java.math.BigInteger
+import cats.syntax.all.*
 import scala.collection.immutable.LongMap
 import dev.bosatsu.BosatsuInt as BInt
 
@@ -245,71 +245,89 @@ object MatchlessToValue {
     }
 
     class Env[F](resolve: (F, PackageName, Identifier) => Eval[Value]) {
-      private def valueEquals(left: Any, right: Any): Boolean =
+      private def compareIntValues(
+          left: Any,
+          rel: CompareRel,
+          right: Any
+      ): Boolean =
         (left, right) match {
-          case (BInt(li), ri: BigInteger) =>
-            li.toBigInteger == ri
-          case (li: BigInteger, BInt(ri)) =>
-            li == ri.toBigInteger
+          case (BInt(lhs), BInt(rhs)) =>
+            Matchless.compareRelHolds(rel, lhs.compare(rhs))
           case _ =>
-            java.util.Objects.equals(
-              left.asInstanceOf[AnyRef],
-              right.asInstanceOf[AnyRef]
-            )
+            false
         }
 
-      private def valueToCodePoint(value: Any): Option[Int] =
-        value match {
-          case s: String if s.nonEmpty => Some(s.codePointAt(0))
-          case _                       => None
+      private def compareInt64Values(
+          left: Any,
+          rel: CompareRel,
+          right: Any
+      ): Boolean =
+        (left, right) match {
+          case (lhs: java.lang.Long, rhs: java.lang.Long) =>
+            Matchless.compareRelHolds(
+              rel,
+              java.lang.Long.compare(lhs.longValue, rhs.longValue)
+            )
+          case _ =>
+            false
+        }
+
+      private def compareLiteralValue(
+          left: Any,
+          rel: CompareRel,
+          right: Lit
+      ): Boolean =
+        right match {
+          case Lit.Integer(value) =>
+            compareIntValues(left, rel, BInt.fromBigInteger(value))
+          case rhs: Lit.StringMatchResult =>
+            left match {
+              case s: String =>
+                Matchless.compareRelHolds(rel, s.compareTo(rhs.asStr))
+              case _ =>
+                false
+            }
+          case rhs: Lit.Float64 =>
+            left match {
+              case d: java.lang.Double =>
+                Matchless.compareFloat64Values(d.doubleValue, rel, rhs.toDouble)
+              case _ =>
+                false
+            }
         }
 
       // evaluating boolExpr can mutate an existing value in muts
       private def boolExpr(ix: BoolExpr[F]): Scoped[Boolean] =
         ix match {
-          case EqualsLit(expr, lit) =>
+          case CompareLit(expr, rel, lit) =>
             loop(expr).map { e =>
-              val external = e.asExternal.toAny
-              lit match {
-                case lf: Lit.Float64 =>
-                  external match {
-                    case d: java.lang.Double =>
-                      val left = lf.toDouble
-                      val right = d.doubleValue
-                      // Float literal matching follows numeric equality:
-                      // -0.0 == 0.0 and NaN matches NaN.
-                      (left == right) || (java.lang.Double.isNaN(
-                        left
-                      ) && java.lang.Double.isNaN(right))
-                    case _ =>
-                      // $COVERAGE-OFF$
-                      false
-                    // $COVERAGE-ON$
-                  }
+              compareLiteralValue(e.asExternal.toAny, rel, lit)
+            }
+          case CompareInt(left, rel, right) =>
+            (loop(left), loop(right)).mapN { (lhs, rhs) =>
+              compareIntValues(lhs.asExternal.toAny, rel, rhs.asExternal.toAny)
+            }
+          case CompareInt64(left, rel, right) =>
+            (loop(left), loop(right)).mapN { (lhs, rhs) =>
+              compareInt64Values(
+                lhs.asExternal.toAny,
+                rel,
+                rhs.asExternal.toAny
+              )
+            }
+          case CompareFloat64(left, rel, right) =>
+            (loop(left), loop(right)).mapN { (lhs, rhs) =>
+              (lhs.asExternal.toAny, rhs.asExternal.toAny) match {
+                case (ld: java.lang.Double, rd: java.lang.Double) =>
+                  Matchless.compareFloat64Values(
+                    ld.doubleValue,
+                    rel,
+                    rd.doubleValue
+                  )
                 case _ =>
-                  valueEquals(external, lit.unboxToAny)
+                  false
               }
             }
-
-          case LtEqLit(expr, Lit.Integer(i)) =>
-            val rhs = BInt.fromBigInteger(i)
-            loop(expr).map { e =>
-              e.asExternal.toAny match {
-                case BInt(lhs) => lhs.compare(rhs) <= 0
-                case _         => false
-              }
-            }
-          case LtEqLit(expr, c: Lit.Chr) =>
-            val rhsCodePoint = c.toCodePoint
-            loop(expr).map { e =>
-              valueToCodePoint(e.asExternal.toAny).exists(_ <= rhsCodePoint)
-            }
-          case LtEqLit(_, lit) =>
-            // $COVERAGE-OFF$
-            throw new IllegalStateException(
-              s"unexpected LtEqLit literal: $lit"
-            )
-          // $COVERAGE-ON$
 
           case EqualsNat(nat, zeroOrSucc) =>
             val natF = loop(nat)
@@ -484,6 +502,8 @@ object MatchlessToValue {
             }
           case Literal(lit) =>
             Static(Value.fromLit(lit))
+          case LitInt64(value) =>
+            Static(ExternalValue(PredefImpl.Int64Value(value)))
           case If(cond, thenExpr, elseExpr) =>
             val condF = boolExpr(cond)
             // compile each branch at most once, and only if needed

--- a/core/src/main/scala/dev/bosatsu/codegen/clang/ClangGen.scala
+++ b/core/src/main/scala/dev/bosatsu/codegen/clang/ClangGen.scala
@@ -410,71 +410,179 @@ class ClangGen[K](ns: CompilationNamespace[K]) {
               }
         }
       // The type of this value must be a C _Bool
+      def compareRelBinOp(rel: Matchless.CompareRel): Code.BinOp =
+        rel match {
+          case Matchless.CompareRel.Eq  => Code.BinOp.Eq
+          case Matchless.CompareRel.Ne  => Code.BinOp.NotEq
+          case Matchless.CompareRel.Lt  => Code.BinOp.Lt
+          case Matchless.CompareRel.Lte => Code.BinOp.LtEq
+          case Matchless.CompareRel.Gt  => Code.BinOp.Gt
+          case Matchless.CompareRel.Gte => Code.BinOp.GtEq
+        }
+
+      def compareCmpResult(
+          cmp: Code.Expression,
+          rel: Matchless.CompareRel
+      ): Code.Expression =
+        cmp.bin(compareRelBinOp(rel), Code.IntLiteral.Zero)
+
+      def charCodePoint(expr: Code.Expression): Code.Expression =
+        Code.Ident("bsts_char_code_point_from_value")(expr)
+
+      def compareIntExpr(
+          left: Code.Expression,
+          rel: Matchless.CompareRel,
+          right: Code.ValueLike
+      ): T[Code.ValueLike] =
+        rel match {
+          case Matchless.CompareRel.Eq | Matchless.CompareRel.Ne =>
+            Code.ValueLike
+              .applyArgs(
+                Code.Ident("bsts_integer_equals"),
+                NonEmptyList(left, right :: Nil)
+              )(newLocalName)
+              .map {
+                case expr: Code.Expression
+                    if rel == Matchless.CompareRel.Ne =>
+                  !expr
+                case other =>
+                  other
+              }
+          case _ =>
+            Code.ValueLike
+              .applyArgs(
+                Code.Ident("bsts_integer_cmp"),
+                NonEmptyList(left, right :: Nil)
+              )(newLocalName)
+              .flatMap(_.onExpr(cmp => pv(compareCmpResult(cmp, rel)))(newLocalName))
+        }
+
+      def compareIntZeroExpr(
+          left: Code.Expression,
+          rel: Matchless.CompareRel
+      ): T[Code.ValueLike] =
+        Code.ValueLike
+          .applyArgs(
+            Code.Ident("bsts_integer_cmp_zero"),
+            NonEmptyList.one(left)
+          )(newLocalName)
+          .flatMap(_.onExpr(cmp => pv(compareCmpResult(cmp, rel)))(newLocalName))
+
+      def compareInt64Expr(
+          left: Code.Expression,
+          rel: Matchless.CompareRel,
+          right: Code.Expression
+      ): T[Code.ValueLike] = {
+        val lhs = Code.Ident("bsts_int64_to_int64")(left)
+        val rhs = Code.Ident("bsts_int64_to_int64")(right)
+        pv(lhs.bin(compareRelBinOp(rel), rhs))
+      }
+
+      def compareFloat64Expr(
+          left: Code.Expression,
+          rel: Matchless.CompareRel,
+          right: Code.ValueLike
+      ): T[Code.ValueLike] =
+        rel match {
+          case Matchless.CompareRel.Eq | Matchless.CompareRel.Ne =>
+            Code.ValueLike
+              .applyArgs(
+                Code.Ident("bsts_float64_equals"),
+                NonEmptyList(left, right :: Nil)
+              )(newLocalName)
+              .map {
+                case expr: Code.Expression
+                    if rel == Matchless.CompareRel.Ne =>
+                  !expr
+                case other =>
+                  other
+              }
+          case _ =>
+            Code.ValueLike
+              .applyArgs(
+                Code.Ident("bsts_float64_cmp_total"),
+                NonEmptyList(left, right :: Nil)
+              )(newLocalName)
+              .flatMap(_.onExpr(cmp => pv(compareCmpResult(cmp, rel)))(newLocalName))
+        }
+
       def boolToValue(boolExpr: BoolExpr[K]): T[Code.ValueLike] =
         boolExpr match {
-          case EqualsLit(expr, lit) =>
+          case CompareLit(expr, rel, lit) =>
             innerToValue(expr).flatMap { vl =>
               lit match {
-                case c @ Lit.Chr(_) =>
-                  vl.onExpr(e => pv(equalsChar(e, c.toCodePoint)))(newLocalName)
+                case c: Lit.Chr =>
+                  vl.onExpr { e =>
+                    pv(charCodePoint(e).bin(compareRelBinOp(rel), Code.IntLiteral(c.toCodePoint)))
+                  }(newLocalName)
                 case Lit.Str(_) =>
                   vl.onExpr { e =>
                     literal(lit).flatMap { litStr =>
-                      Code.ValueLike.applyArgs(
-                        Code.Ident("bsts_string_equals"),
-                        NonEmptyList(e, litStr :: Nil)
-                      )(newLocalName)
+                      rel match {
+                        case Matchless.CompareRel.Eq | Matchless.CompareRel.Ne =>
+                          Code.ValueLike
+                            .applyArgs(
+                              Code.Ident("bsts_string_equals"),
+                              NonEmptyList(e, litStr :: Nil)
+                            )(newLocalName)
+                            .map {
+                              case expr: Code.Expression
+                                  if rel == Matchless.CompareRel.Ne =>
+                                !expr
+                              case other =>
+                                other
+                            }
+                        case _ =>
+                          Code.ValueLike
+                            .applyArgs(
+                              Code.Ident("bsts_string_cmp"),
+                              NonEmptyList(e, litStr :: Nil)
+                            )(newLocalName)
+                            .flatMap(
+                              _.onExpr(cmp => pv(compareCmpResult(cmp, rel)))(newLocalName)
+                            )
+                      }
                     }
                   }(newLocalName)
                 case Lit.Integer(_) =>
                   vl.onExpr { e =>
                     literal(lit).flatMap { litStr =>
-                      Code.ValueLike.applyArgs(
-                        Code.Ident("bsts_integer_equals"),
-                        NonEmptyList(e, litStr :: Nil)
-                      )(newLocalName)
+                      compareIntExpr(e, rel, litStr)
                     }
                   }(newLocalName)
                 case _: Lit.Float64 =>
                   vl.onExpr { e =>
                     literal(lit).flatMap { litFloat =>
-                      Code.ValueLike.applyArgs(
-                        Code.Ident("bsts_float64_equals"),
-                        NonEmptyList(e, litFloat :: Nil)
-                      )(newLocalName)
+                      compareFloat64Expr(e, rel, litFloat)
                     }
                   }(newLocalName)
               }
             }
-          case LtEqLit(expr, lit) =>
-            innerToValue(expr).flatMap { vl =>
-              lit match {
-                case Lit.Integer(_) =>
-                  vl.onExpr { e =>
-                    literal(lit).flatMap { litInt =>
-                      Code.ValueLike
-                        .applyArgs(
-                          Code.Ident("bsts_integer_cmp"),
-                          NonEmptyList(e, litInt :: Nil)
-                        )(newLocalName)
-                        .flatMap {
-                          _.onExpr(cmp =>
-                            pv(cmp.bin(Code.BinOp.LtEq, Code.IntLiteral.Zero))
-                          )(newLocalName)
-                        }
-                    }
-                  }(newLocalName)
-                case c: Lit.Chr =>
-                  vl.onExpr(e => pv(lessThanOrEqualChar(e, c.toCodePoint)))(
-                    newLocalName
-                  )
-                case _ =>
-                  // $COVERAGE-OFF$
-                  throw new IllegalStateException(
-                    s"LtEqLit only supports Int and Char literals, found: $lit"
-                  )
-                // $COVERAGE-ON$
-              }
+          case CompareInt(left, rel, right) =>
+            (innerToValue(left), innerToValue(right)).flatMapN { (lv, rv) =>
+              lv.onExpr { leftExpr =>
+                rv.onExpr {
+                  case Code.Apply(
+                        Code.Ident("bsts_integer_from_int"),
+                        Code.IntLiteral(0) :: Nil
+                      ) =>
+                    compareIntZeroExpr(leftExpr, rel)
+                  case rightExpr =>
+                    compareIntExpr(leftExpr, rel, rightExpr)
+                }(newLocalName)
+              }(newLocalName)
+            }
+          case CompareInt64(left, rel, right) =>
+            (innerToValue(left), innerToValue(right)).flatMapN { (lv, rv) =>
+              lv.onExpr(leftExpr => rv.onExpr(compareInt64Expr(leftExpr, rel, _))(newLocalName))(
+                newLocalName
+              )
+            }
+          case CompareFloat64(left, rel, right) =>
+            (innerToValue(left), innerToValue(right)).flatMapN { (lv, rv) =>
+              lv.onExpr(leftExpr => rv.onExpr(compareFloat64Expr(leftExpr, rel, _))(newLocalName))(
+                newLocalName
+              )
             }
           case EqualsNat(expr, nat) =>
             val fn = nat match {
@@ -881,6 +989,7 @@ class ClangGen[K](ns: CompilationNamespace[K]) {
               } yield decl +: res
             }
           case Literal(lit)                 => literal(lit)
+          case LitInt64(value)              => pv(int64LiteralExpr(value))
           case If(cond, thenExpr, elseExpr) =>
             (boolToValue(cond), innerToValue(thenExpr), innerToValue(elseExpr))
               .flatMapN { (c, thenC, elseC) =>

--- a/core/src/main/scala/dev/bosatsu/codegen/python/PythonGen.scala
+++ b/core/src/main/scala/dev/bosatsu/codegen/python/PythonGen.scala
@@ -3165,6 +3165,47 @@ object PythonGen {
         ns: CompilationNamespace[K]
     ) {
       private type InlineSlots = Option[Vector[Expression]]
+      private val int64Package = PackageName.parts("Bosatsu", "Num", "Int64")
+
+      private def mathModule: Env[Code.Ident] =
+        Env.importLiteral(NonEmptyList.one(Code.Ident("math")))
+
+      private def progExtModule: Env[Code.Ident] =
+        Env.importLiteral(NonEmptyList.one(Code.Ident("ProgExt")))
+
+      // Prefer the package-level external remap so Jython tests and any
+      // alternate Int64 runtime shims stay in sync with normal codegen.
+      private def applyExternalFn(
+          value: ValueLike,
+          arg: Code.Expression
+      ): Env[Code.Expression] =
+        Env
+          .onLastM(value)(fn => Env.pure[Code.ValueLike](fn(arg)))
+          .map {
+            case expr: Code.Expression => expr
+            case other =>
+              // $COVERAGE-OFF$
+              throw new IllegalStateException(
+                s"expected external application to stay expression-shaped, found: $other"
+              )
+            // $COVERAGE-ON$
+          }
+
+      private def boxInt64(expr: Code.Expression): Env[Code.Expression] =
+        remap(int64Package, Identifier.Name("int_low_bits_to_Int64")).flatMap {
+          case Some(vl) =>
+            applyExternalFn(vl, expr)
+          case None =>
+            progExtModule.map(_.dot(Code.Ident("_BosatsuInt64"))(expr))
+        }
+
+      private def unboxInt64(expr: Code.Expression): Env[Code.Expression] =
+        remap(int64Package, Identifier.Name("int64_to_Int")).flatMap {
+          case Some(vl) =>
+            applyExternalFn(vl, expr)
+          case None =>
+            progExtModule.map(_.dot(Code.Ident("int64_to_Int"))(expr))
+        }
 
       /*
        * enums with no fields are integers
@@ -3227,38 +3268,101 @@ object PythonGen {
           slotName: Option[Code.Ident],
           inlineSlots: InlineSlots
       ): Env[ValueLike] =
-        ix match {
-          case EqualsLit(expr, lit: dev.bosatsu.Lit.Float64) =>
-            val literal = Code.litToExpr(lit)
-            if (java.lang.Double.isNaN(lit.toDouble)) {
-              Env.importLiteral(NonEmptyList.one(Code.Ident("math"))).flatMap {
-                math =>
-                  loop(expr, slotName, inlineSlots)
-                    .flatMap(
-                      Env.onLast(_)(ex => math.dot(Code.Ident("isnan"))(ex))
-                    )
-              }
-            } else {
-              loop(expr, slotName, inlineSlots)
-                .flatMap(Env.onLast(_)(ex => ex =:= literal))
+        def compareRelExpr(
+            left: Code.Expression,
+            rel: Matchless.CompareRel,
+            right: Code.Expression
+        ): Code.Expression =
+          rel match {
+            case Matchless.CompareRel.Eq  => left =:= right
+            case Matchless.CompareRel.Ne  => left =!= right
+            case Matchless.CompareRel.Lt  => left :< right
+            case Matchless.CompareRel.Lte => !(right :< left)
+            case Matchless.CompareRel.Gt  => left :> right
+            case Matchless.CompareRel.Gte => !(left :< right)
+          }
+
+        def floatCmpExpr(
+            left: Code.Expression,
+            right: Code.Expression
+        ): Env[Code.Expression] =
+          mathModule.map { math =>
+            val leftNaN = math.dot(Code.Ident("isnan"))(left)
+            val rightNaN = math.dot(Code.Ident("isnan"))(right)
+            val neitherNaN = Code
+              .Ternary(
+                0,
+                left :< right,
+                Code.Ternary(1, left =:= right, 2)
+              )
+              .simplify
+            Code
+              .Ternary(
+                Code.Ternary(1, rightNaN, 0),
+                leftNaN,
+                Code.Ternary(2, rightNaN, neitherNaN)
+              )
+              .simplify
+          }
+
+        def compareFloatExpr(
+            left: Code.Expression,
+            rel: Matchless.CompareRel,
+            right: Code.Expression
+        ): Env[Code.Expression] =
+          floatCmpExpr(left, right).map { cmp =>
+            rel match {
+              case Matchless.CompareRel.Eq  => cmp =:= 1
+              case Matchless.CompareRel.Ne  => cmp =!= 1
+              case Matchless.CompareRel.Lt  => cmp =:= 0
+              case Matchless.CompareRel.Lte => cmp =!= 2
+              case Matchless.CompareRel.Gt  => cmp =:= 2
+              case Matchless.CompareRel.Gte => cmp =!= 0
             }
-          case EqualsLit(expr, lit) =>
+          }
+
+        ix match {
+          case CompareLit(expr, rel, lit: dev.bosatsu.Lit.Float64) =>
             val literal = Code.litToExpr(lit)
             loop(expr, slotName, inlineSlots)
-              .flatMap(Env.onLast(_)(ex => ex =:= literal))
-          case LtEqLit(expr, lit) =>
-            lit match {
-              case Lit.Integer(_) | Lit.Chr(_) =>
-                val literal = Code.litToExpr(lit)
-                loop(expr, slotName, inlineSlots)
-                  .flatMap(Env.onLast(_)(ex => !(literal :< ex)))
-              case _ =>
-                // $COVERAGE-OFF$
-                throw new IllegalStateException(
-                  s"LtEqLit only supports Int and Char literals, found: $lit"
-                )
-              // $COVERAGE-ON$
-            }
+              .flatMap(Env.onLastM(_)(ex => compareFloatExpr(ex, rel, literal)))
+          case CompareLit(expr, rel, lit) =>
+            val literal = Code.litToExpr(lit)
+            loop(expr, slotName, inlineSlots)
+              .flatMap(Env.onLast(_)(ex => compareRelExpr(ex, rel, literal)))
+          case CompareInt(left, rel, right) =>
+            (loop(left, slotName, inlineSlots), loop(right, slotName, inlineSlots))
+              .flatMapN(Env.onLast2(_, _)(compareRelExpr(_, rel, _)))
+          case CompareInt64(left, rel, right) =>
+            (loop(left, slotName, inlineSlots), loop(right, slotName, inlineSlots))
+              .flatMapN { (leftValue, rightValue) =>
+                Env.onLastsM(leftValue :: rightValue :: Nil) {
+                  case leftExpr :: rightExpr :: Nil =>
+                    (unboxInt64(leftExpr), unboxInt64(rightExpr)).mapN {
+                      compareRelExpr(_, rel, _)
+                    }
+                  case other =>
+                    // $COVERAGE-OFF$
+                    throw new IllegalStateException(
+                      s"expected two Int64 operands, found: $other"
+                    )
+                  // $COVERAGE-ON$
+                }
+              }
+          case CompareFloat64(left, rel, right) =>
+            (loop(left, slotName, inlineSlots), loop(right, slotName, inlineSlots))
+              .flatMapN { (leftValue, rightValue) =>
+                Env.onLastsM(leftValue :: rightValue :: Nil) {
+                  case leftExpr :: rightExpr :: Nil =>
+                    compareFloatExpr(leftExpr, rel, rightExpr)
+                  case other =>
+                    // $COVERAGE-OFF$
+                    throw new IllegalStateException(
+                      s"expected two Float64 operands, found: $other"
+                    )
+                  // $COVERAGE-ON$
+                }
+              }
           case EqualsNat(nat, zeroOrSucc) =>
             val natF = loop(nat, slotName, inlineSlots)
 
@@ -3625,6 +3729,8 @@ object PythonGen {
             // there is no need to
             loop(in, slotName, inlineSlots)
           case Literal(lit)         => Env.pure(Code.litToExpr(lit))
+          case LitInt64(value)      =>
+            boxInt64(Code.PyInt(java.math.BigInteger.valueOf(value)))
           case ifExpr @ If(_, _, _) =>
             val (ifs, last) = ifExpr.flatten
 

--- a/core/src/main/scala/dev/bosatsu/codegen/python/PythonGen.scala
+++ b/core/src/main/scala/dev/bosatsu/codegen/python/PythonGen.scala
@@ -857,7 +857,7 @@ object PythonGen {
         }
       }
 
-      private val cmpStringFn: List[ValueLike] => Env[ValueLike] = { input =>
+      private[Impl] val cmpStringFn: List[ValueLike] => Env[ValueLike] = { input =>
         Env.ensureHelper(pyStringCmpHelperKey)(buildPyStringCmpHelper)
           .flatMap { helperName =>
             Env.onLast2(input.head, input.tail.head) { (arg0, arg1) =>
@@ -3282,6 +3282,19 @@ object PythonGen {
             case Matchless.CompareRel.Gte => !(left :< right)
           }
 
+        def compareCmpExpr(
+            cmp: Code.Expression,
+            rel: Matchless.CompareRel
+        ): Code.Expression =
+          rel match {
+            case Matchless.CompareRel.Eq  => cmp =:= 1
+            case Matchless.CompareRel.Ne  => cmp =!= 1
+            case Matchless.CompareRel.Lt  => cmp =:= 0
+            case Matchless.CompareRel.Lte => cmp =!= 2
+            case Matchless.CompareRel.Gt  => cmp =:= 2
+            case Matchless.CompareRel.Gte => cmp =!= 0
+          }
+
         def floatCmpExpr(
             left: Code.Expression,
             right: Code.Expression
@@ -3310,18 +3323,40 @@ object PythonGen {
             rel: Matchless.CompareRel,
             right: Code.Expression
         ): Env[Code.Expression] =
-          floatCmpExpr(left, right).map { cmp =>
-            rel match {
-              case Matchless.CompareRel.Eq  => cmp =:= 1
-              case Matchless.CompareRel.Ne  => cmp =!= 1
-              case Matchless.CompareRel.Lt  => cmp =:= 0
-              case Matchless.CompareRel.Lte => cmp =!= 2
-              case Matchless.CompareRel.Gt  => cmp =:= 2
-              case Matchless.CompareRel.Gte => cmp =!= 0
+          floatCmpExpr(left, right).map(compareCmpExpr(_, rel))
+
+        def compareStringExpr(
+            left: Code.Expression,
+            rel: Matchless.CompareRel,
+            right: Code.Expression
+        ): Env[Code.Expression] =
+          PredefExternal
+            .cmpStringFn(left :: right :: Nil)
+            .flatMap(Env.onLast(_)(compareCmpExpr(_, rel)))
+            .map {
+              case expr: Code.Expression => expr
+              case other =>
+                // $COVERAGE-OFF$
+                throw new IllegalStateException(
+                  s"expected string comparison to stay expression-shaped, found: $other"
+                )
+              // $COVERAGE-ON$
             }
-          }
 
         ix match {
+          case CompareLit(expr, rel, lit: dev.bosatsu.Lit.Str) =>
+            val literal = Code.litToExpr(lit)
+            loop(expr, slotName, inlineSlots)
+              .flatMap(
+                Env.onLastM(_)(ex =>
+                  if (
+                    lit.toStr.isEmpty ||
+                    rel == Matchless.CompareRel.Eq ||
+                    rel == Matchless.CompareRel.Ne
+                  ) Env.pure(compareRelExpr(ex, rel, literal))
+                  else compareStringExpr(ex, rel, literal)
+                )
+              )
           case CompareLit(expr, rel, lit: dev.bosatsu.Lit.Float64) =>
             val literal = Code.litToExpr(lit)
             loop(expr, slotName, inlineSlots)

--- a/core/src/main/scala/dev/bosatsu/tool/ShowEdn.scala
+++ b/core/src/main/scala/dev/bosatsu/tool/ShowEdn.scala
@@ -1683,6 +1683,16 @@ object ShowEdn {
       case DataRepr.SuccNat => sym("succ-nat")
     }
 
+  private def encodeCompareRel(rel: Matchless.CompareRel): Edn =
+    rel match {
+      case Matchless.CompareRel.Eq  => sym("eq")
+      case Matchless.CompareRel.Ne  => sym("ne")
+      case Matchless.CompareRel.Lt  => sym("lt")
+      case Matchless.CompareRel.Lte => sym("lte")
+      case Matchless.CompareRel.Gt  => sym("gt")
+      case Matchless.CompareRel.Gte => sym("gte")
+    }
+
   private def encodeMatchlessCheapExpr(
       expr: Matchless.CheapExpr[?],
       quotePackageNames: Boolean
@@ -1694,17 +1704,41 @@ object ShowEdn {
       quotePackageNames: Boolean
   ): Edn =
     expr match {
-      case Matchless.EqualsLit(arg, lit) =>
+      case Matchless.CompareLit(arg, rel, lit) =>
         EList(
           List(
-            sym("equals-lit"),
+            sym("compare-lit"),
             encodeMatchlessCheapExpr(arg, quotePackageNames),
+            encodeCompareRel(rel),
             encodeLit(lit)
           )
         )
-      case Matchless.LtEqLit(arg, lit)   =>
+      case Matchless.CompareInt(left, rel, right) =>
         EList(
-          List(sym("lte-lit"), encodeMatchlessCheapExpr(arg, quotePackageNames), encodeLit(lit))
+          List(
+            sym("compare-int"),
+            encodeMatchlessCheapExpr(left, quotePackageNames),
+            encodeCompareRel(rel),
+            encodeMatchlessCheapExpr(right, quotePackageNames)
+          )
+        )
+      case Matchless.CompareInt64(left, rel, right) =>
+        EList(
+          List(
+            sym("compare-int64"),
+            encodeMatchlessCheapExpr(left, quotePackageNames),
+            encodeCompareRel(rel),
+            encodeMatchlessCheapExpr(right, quotePackageNames)
+          )
+        )
+      case Matchless.CompareFloat64(left, rel, right) =>
+        EList(
+          List(
+            sym("compare-float64"),
+            encodeMatchlessCheapExpr(left, quotePackageNames),
+            encodeCompareRel(rel),
+            encodeMatchlessCheapExpr(right, quotePackageNames)
+          )
         )
       case Matchless.EqualsNat(arg, nat) =>
         EList(
@@ -1897,6 +1931,8 @@ object ShowEdn {
         )
       case Matchless.Literal(lit) =>
         EList(List(sym("lit"), encodeLit(lit)))
+      case Matchless.LitInt64(value) =>
+        EList(List(sym("lit-int64"), sym(value.toString)))
       case Matchless.MakeEnum(1, 0, 0 :: 0 :: Nil) =>
         EBool(true)
       case Matchless.MakeEnum(0, 0, 0 :: 0 :: Nil) =>

--- a/core/src/test/scala/dev/bosatsu/EvaluationTest.scala
+++ b/core/src/test/scala/dev/bosatsu/EvaluationTest.scala
@@ -590,6 +590,72 @@ test = TestSuite("int64-eval", [
     )
   }
 
+  test("comparison observations preserve semantics across Int, Float64, and Int64") {
+    val float64Pack = Predef.loadFileInCompile("test_workspace/Float64.bosatsu")
+    val int64Pack = Predef.loadFileInCompile("test_workspace/Int64.bosatsu")
+
+    runBosatsuTest(
+      List(
+        float64Pack,
+        int64Pack,
+        """
+package Foo
+
+from Bosatsu/Num/Int64 import (
+  cmp_Int64,
+  eq_Int64,
+  int_low_bits_to_Int64,
+  int_to_Int64,
+)
+
+nan0 = divf(0.0, 0.0)
+
+def let_cmp():
+  cmp = cmp_Int(add(1, 2), sub(10, 7))
+  match cmp:
+    case LT | EQ: True
+    case GT: False
+
+test = TestSuite("comparison-lowering", [
+  Assertion(cmp_Int(-1, 0) matches LT | EQ, "int <= 0"),
+  Assertion(cmp_Int(7, 7) matches GT | EQ, "int >= dynamic"),
+  Assertion(
+    (
+      match cmp_Int(4, 5):
+        case LT: True
+        case GT: True
+        case _: False
+    ),
+    "explicit bool match"
+  ),
+  Assertion(eq_Int(0, 0), "eq_Int"),
+  Assertion(let_cmp(), "let-bound cmp observation"),
+  Assertion(eq_Float64(nan0, .NaN), "float equality keeps NaN behavior"),
+  Assertion(cmp_Float64(-0.0, 0.0) matches EQ, "float signed zero"),
+  Assertion(
+    eq_Int64(int_low_bits_to_Int64(-1), int_low_bits_to_Int64(-1)),
+    "Int64 equality"
+  ),
+  Assertion(
+    cmp_Int64(int_low_bits_to_Int64(-1), int_low_bits_to_Int64(0)) matches LT | EQ,
+    "Int64 comparison"
+  ),
+  Assertion(
+    (
+      match int_to_Int64(9223372036854775808):
+        case None: True
+        case Some(_): False
+    ),
+    "Int64 literal conversion fallback"
+  ),
+])
+"""
+      ),
+      "Foo",
+      10
+    )
+  }
+
   test("use range") {
     evalTest(
       List("""

--- a/core/src/test/scala/dev/bosatsu/Issue1633Test.scala
+++ b/core/src/test/scala/dev/bosatsu/Issue1633Test.scala
@@ -108,10 +108,6 @@ main = parse_value(" null")
           loopExpr(left) || loopExpr(right)
         case Matchless.CompareFloat64(left, _, right) =>
           loopExpr(left) || loopExpr(right)
-        case Matchless.EqualsLit(expr, _) =>
-          loopExpr(expr)
-        case Matchless.LtEqLit(expr, _) =>
-          loopExpr(expr)
         case Matchless.EqualsNat(expr, _) =>
           loopExpr(expr)
         case Matchless.And(left, right) =>

--- a/core/src/test/scala/dev/bosatsu/Issue1633Test.scala
+++ b/core/src/test/scala/dev/bosatsu/Issue1633Test.scala
@@ -1,9 +1,7 @@
 package dev.bosatsu
 
 import cats.Order
-import scala.annotation.nowarn
 
-@nowarn("msg=match may not be exhaustive")
 class Issue1633Test extends munit.FunSuite with ParTest {
   private val reproSource = """
 package MyLib/ReproMin8
@@ -94,6 +92,7 @@ main = parse_value(" null")
         case Matchless.Local(_) | Matchless.Global(_, _, _) |
             Matchless.ClosureSlot(_) | Matchless.LocalAnon(_) |
             Matchless.LocalAnonMut(_) | Matchless.Literal(_) |
+            Matchless.LitInt64(_) |
             Matchless.MakeEnum(_, _, _) | Matchless.MakeStruct(_) |
             Matchless.ZeroNat | Matchless.SuccNat =>
           false
@@ -101,6 +100,14 @@ main = parse_value(" null")
 
     def loopBool(b: Matchless.BoolExpr[A]): Boolean =
       b match {
+        case Matchless.CompareLit(expr, _, _) =>
+          loopExpr(expr)
+        case Matchless.CompareInt(left, _, right) =>
+          loopExpr(left) || loopExpr(right)
+        case Matchless.CompareInt64(left, _, right) =>
+          loopExpr(left) || loopExpr(right)
+        case Matchless.CompareFloat64(left, _, right) =>
+          loopExpr(left) || loopExpr(right)
         case Matchless.EqualsLit(expr, _) =>
           loopExpr(expr)
         case Matchless.LtEqLit(expr, _) =>

--- a/core/src/test/scala/dev/bosatsu/Issue1633Test.scala
+++ b/core/src/test/scala/dev/bosatsu/Issue1633Test.scala
@@ -1,7 +1,9 @@
 package dev.bosatsu
 
 import cats.Order
+import scala.annotation.nowarn
 
+@nowarn("msg=match may not be exhaustive")
 class Issue1633Test extends munit.FunSuite with ParTest {
   private val reproSource = """
 package MyLib/ReproMin8

--- a/core/src/test/scala/dev/bosatsu/MatchlessInterfaceTest.scala
+++ b/core/src/test/scala/dev/bosatsu/MatchlessInterfaceTest.scala
@@ -4,7 +4,9 @@ import cats.Order
 import cats.data.NonEmptyList
 import dev.bosatsu.IorMethods.IorExtension
 import dev.bosatsu.codegen.CompilationSource
+import scala.annotation.nowarn
 
+@nowarn("msg=match may not be exhaustive")
 class MatchlessInterfaceTest extends munit.FunSuite {
 
   private def typeCheck(

--- a/core/src/test/scala/dev/bosatsu/MatchlessInterfaceTest.scala
+++ b/core/src/test/scala/dev/bosatsu/MatchlessInterfaceTest.scala
@@ -77,10 +77,6 @@ class MatchlessInterfaceTest extends munit.FunSuite {
         containsGlobal(left, pack, name) || containsGlobal(right, pack, name)
       case Matchless.CompareFloat64(left, _, right) =>
         containsGlobal(left, pack, name) || containsGlobal(right, pack, name)
-      case Matchless.EqualsLit(arg, _) =>
-        containsGlobal(arg, pack, name)
-      case Matchless.LtEqLit(arg, _) =>
-        containsGlobal(arg, pack, name)
       case Matchless.EqualsNat(arg, _) =>
         containsGlobal(arg, pack, name)
       case Matchless.And(left, right) =>

--- a/core/src/test/scala/dev/bosatsu/MatchlessInterfaceTest.scala
+++ b/core/src/test/scala/dev/bosatsu/MatchlessInterfaceTest.scala
@@ -4,9 +4,7 @@ import cats.Order
 import cats.data.NonEmptyList
 import dev.bosatsu.IorMethods.IorExtension
 import dev.bosatsu.codegen.CompilationSource
-import scala.annotation.nowarn
 
-@nowarn("msg=match may not be exhaustive")
 class MatchlessInterfaceTest extends munit.FunSuite {
 
   private def typeCheck(
@@ -71,6 +69,14 @@ class MatchlessInterfaceTest extends munit.FunSuite {
       name: Identifier.Bindable
   ): Boolean =
     boolExpr match {
+      case Matchless.CompareLit(arg, _, _) =>
+        containsGlobal(arg, pack, name)
+      case Matchless.CompareInt(left, _, right) =>
+        containsGlobal(left, pack, name) || containsGlobal(right, pack, name)
+      case Matchless.CompareInt64(left, _, right) =>
+        containsGlobal(left, pack, name) || containsGlobal(right, pack, name)
+      case Matchless.CompareFloat64(left, _, right) =>
+        containsGlobal(left, pack, name) || containsGlobal(right, pack, name)
       case Matchless.EqualsLit(arg, _) =>
         containsGlobal(arg, pack, name)
       case Matchless.LtEqLit(arg, _) =>

--- a/core/src/test/scala/dev/bosatsu/MatchlessRegressionTest.scala
+++ b/core/src/test/scala/dev/bosatsu/MatchlessRegressionTest.scala
@@ -5,7 +5,9 @@ import cats.data.NonEmptyList
 import dev.bosatsu.rankn.DataRepr
 import dev.bosatsu.rankn.Type
 import java.math.BigInteger
+import scala.annotation.nowarn
 
+@nowarn("msg=match may not be exhaustive")
 class MatchlessRegressionTest extends munit.FunSuite {
   private def nestedLetMut(depth: Int): Matchless.Expr[Unit] =
     (0 until depth).foldLeft[Matchless.Expr[Unit]](Matchless.MakeStruct(0)) {
@@ -256,6 +258,84 @@ class MatchlessRegressionTest extends munit.FunSuite {
     loopExpr(expr, Set.empty)
   }
 
+  private def collectBoolExprs(
+      expr: Matchless.Expr[Unit]
+  ): List[Matchless.BoolExpr[Unit]] = {
+    def loopCheap(cheap: Matchless.CheapExpr[Unit]): List[Matchless.BoolExpr[Unit]] =
+      cheap match {
+        case Matchless.GetEnumElement(arg, _, _, _) =>
+          loopCheap(arg)
+        case Matchless.GetStructElement(arg, _, _) =>
+          loopCheap(arg)
+        case Matchless.Local(_) | Matchless.Global(_, _, _) |
+            Matchless.ClosureSlot(_) | Matchless.LocalAnon(_) |
+            Matchless.LocalAnonMut(_) | Matchless.Literal(_) |
+            Matchless.LitInt64(_) =>
+          Nil
+      }
+
+    def loopBool(boolExpr: Matchless.BoolExpr[Unit]): List[Matchless.BoolExpr[Unit]] = {
+      val nested =
+        boolExpr match {
+          case Matchless.CompareLit(expr, _, _) =>
+            loopCheap(expr)
+          case Matchless.CompareInt(left, _, right) =>
+            loopCheap(left) ++ loopCheap(right)
+          case Matchless.CompareInt64(left, _, right) =>
+            loopCheap(left) ++ loopCheap(right)
+          case Matchless.CompareFloat64(left, _, right) =>
+            loopCheap(left) ++ loopCheap(right)
+          case Matchless.EqualsNat(expr, _) =>
+            loopCheap(expr)
+          case Matchless.And(left, right) =>
+            loopBool(left) ++ loopBool(right)
+          case Matchless.CheckVariant(expr, _, _, _) =>
+            loopCheap(expr)
+          case Matchless.CheckVariantSet(expr, _, _, _) =>
+            loopCheap(expr)
+          case Matchless.SetMut(_, expr) =>
+            loopExpr(expr)
+          case Matchless.LetBool(_, value, in) =>
+            loopExpr(value) ++ loopBool(in)
+          case Matchless.LetMutBool(_, in) =>
+            loopBool(in)
+          case Matchless.TrueConst =>
+            Nil
+        }
+
+      boolExpr :: nested
+    }
+
+    def loopExpr(e: Matchless.Expr[Unit]): List[Matchless.BoolExpr[Unit]] =
+      e match {
+        case Matchless.Lambda(captures, _, _, body) =>
+          captures.toList.flatMap(loopExpr) ++ loopExpr(body)
+        case Matchless.WhileExpr(cond, effectExpr, _) =>
+          loopBool(cond) ++ loopExpr(effectExpr)
+        case Matchless.App(fn, args) =>
+          loopExpr(fn) ++ args.toList.flatMap(loopExpr)
+        case Matchless.Let(_, value, in) =>
+          loopExpr(value) ++ loopExpr(in)
+        case Matchless.LetMut(_, in) =>
+          loopExpr(in)
+        case Matchless.If(cond, thenExpr, elseExpr) =>
+          loopBool(cond) ++ loopExpr(thenExpr) ++ loopExpr(elseExpr)
+        case Matchless.SwitchVariant(on, _, cases, default) =>
+          loopCheap(on) ++ cases.toList.flatMap { case (_, branch) =>
+            loopExpr(branch)
+          } ++ default.toList.flatMap(loopExpr)
+        case Matchless.Always(cond, thenExpr) =>
+          loopBool(cond) ++ loopExpr(thenExpr)
+        case Matchless.PrevNat(of) =>
+          loopExpr(of)
+        case Matchless.MakeEnum(_, _, _) | Matchless.MakeStruct(_) |
+            Matchless.ZeroNat | Matchless.SuccNat | (_: Matchless.CheapExpr[Unit]) =>
+          Nil
+      }
+
+    loopExpr(expr)
+  }
+
   test("polymorphic recursion lowers to while in Matchless without self-calls") {
     TestUtils.checkMatchless("""
 struct Box[a](box: a)
@@ -402,7 +482,7 @@ def branch_blowup(args: L) -> Nat:
 
     val evaluated =
       MatchlessToValue
-        .traverse(evalExprs)((_, _, _) => Eval.now(Value.UnitValue))
+        .traverse[Vector, Unit](evalExprs)((_, _, _) => Eval.now(Value.UnitValue))
         .map(_.value)
     assertEquals(evaluated, Vector(Value.VInt(1), Value.VInt(0)))
   }
@@ -450,12 +530,84 @@ def branch_blowup(args: L) -> Nat:
 
     val evaluated =
       MatchlessToValue
-        .traverse(evalExprs)((_, _, _) => Eval.now(Value.UnitValue))
+        .traverse[Vector, Unit](evalExprs)((_, _, _) => Eval.now(Value.UnitValue))
         .map(_.value)
     assertEquals(
       evaluated,
       Vector(Value.VInt(1), Value.VInt(0), Value.VInt(1), Value.VInt(0))
     )
+  }
+
+  test("let-bound cmp_Int boolean observations lower to CompareInt") {
+    TestUtils.checkMatchless("""
+def observe(i, j):
+  cmp = cmp_Int(i, j)
+  match cmp:
+    case LT | EQ: True
+    case GT: False
+
+main = observe
+""") { binds =>
+      val byName = binds(TestUtils.testPackage).toMap
+      val expr = byName(Identifier.Name("observe"))
+      val bools = collectBoolExprs(expr)
+      val comparisonFamArities = 0 :: 0 :: 0 :: Nil
+
+      assert(
+        bools.exists {
+          case Matchless.CompareInt(_, Matchless.CompareRel.Lte, _) => true
+          case _                                                    => false
+        },
+        expr.toString
+      )
+      assert(
+        !bools.exists {
+          case Matchless.CheckVariant(_, _, _, famArities) =>
+            famArities == comparisonFamArities
+          case Matchless.CheckVariantSet(_, _, _, famArities) =>
+            famArities == comparisonFamArities
+          case _ =>
+            false
+        },
+        expr.toString
+      )
+    }
+  }
+
+  test("let-bound cmp_Int observations memoize non-cheap operands once") {
+    TestUtils.checkMatchless("""
+def observe(i, j):
+  cmp = cmp_Int(add(i, 1), sub(j, 2))
+  match cmp:
+    case LT: True
+    case GT: True
+    case _: False
+
+main = observe
+""") { binds =>
+      val byName = binds(TestUtils.testPackage).toMap
+      val expr = byName(Identifier.Name("observe"))
+      val compare =
+        collectBoolExprs(expr).collectFirst {
+          case c @ Matchless.CompareInt(_, Matchless.CompareRel.Ne, _) => c
+        }
+
+      def isMemoizedOperand(
+          cheap: Matchless.CheapExpr[Unit]
+      ): Boolean =
+        cheap match {
+          case Matchless.Local(_) | Matchless.LocalAnon(_) => true
+          case _                                           => false
+        }
+
+      compare match {
+        case Some(Matchless.CompareInt(left, _, right)) =>
+          assert(isMemoizedOperand(left), expr.toString)
+          assert(isMemoizedOperand(right), expr.toString)
+        case _ =>
+          fail(expr.toString)
+      }
+    }
   }
 
   Platform.onJvm(
@@ -525,7 +677,7 @@ def branch_blowup(args: L) -> Nat:
 
     val evaluated =
       MatchlessToValue
-        .traverse(evalExprs)((_, _, _) => Eval.now(Value.UnitValue))
+        .traverse[Vector, Unit](evalExprs)((_, _, _) => Eval.now(Value.UnitValue))
         .map(_.value)
     assertEquals(
       evaluated,

--- a/core/src/test/scala/dev/bosatsu/MatchlessRegressionTest.scala
+++ b/core/src/test/scala/dev/bosatsu/MatchlessRegressionTest.scala
@@ -5,9 +5,7 @@ import cats.data.NonEmptyList
 import dev.bosatsu.rankn.DataRepr
 import dev.bosatsu.rankn.Type
 import java.math.BigInteger
-import scala.annotation.nowarn
 
-@nowarn("msg=match may not be exhaustive")
 class MatchlessRegressionTest extends munit.FunSuite {
   private def nestedLetMut(depth: Int): Matchless.Expr[Unit] =
     (0 until depth).foldLeft[Matchless.Expr[Unit]](Matchless.MakeStruct(0)) {
@@ -149,6 +147,14 @@ class MatchlessRegressionTest extends munit.FunSuite {
 
   private def countBoolWhileExprs(b: Matchless.BoolExpr[Unit]): Int =
     b match {
+      case Matchless.CompareLit(expr, _, _) =>
+        countWhileExprs(expr)
+      case Matchless.CompareInt(left, _, right) =>
+        countWhileExprs(left) + countWhileExprs(right)
+      case Matchless.CompareInt64(left, _, right) =>
+        countWhileExprs(left) + countWhileExprs(right)
+      case Matchless.CompareFloat64(left, _, right) =>
+        countWhileExprs(left) + countWhileExprs(right)
       case Matchless.EqualsLit(expr, _) =>
         countWhileExprs(expr)
       case Matchless.LtEqLit(expr, _) =>
@@ -177,6 +183,14 @@ class MatchlessRegressionTest extends munit.FunSuite {
         activeRecNames: Set[Identifier.Bindable]
     ): Int =
       b match {
+        case Matchless.CompareLit(expr, _, _) =>
+          loopExpr(expr, activeRecNames)
+        case Matchless.CompareInt(left, _, right) =>
+          loopExpr(left, activeRecNames) + loopExpr(right, activeRecNames)
+        case Matchless.CompareInt64(left, _, right) =>
+          loopExpr(left, activeRecNames) + loopExpr(right, activeRecNames)
+        case Matchless.CompareFloat64(left, _, right) =>
+          loopExpr(left, activeRecNames) + loopExpr(right, activeRecNames)
         case Matchless.EqualsLit(expr, _) =>
           loopExpr(expr, activeRecNames)
         case Matchless.LtEqLit(expr, _) =>
@@ -250,6 +264,7 @@ class MatchlessRegressionTest extends munit.FunSuite {
         case Matchless.Local(_) | Matchless.Global(_, _, _) |
             Matchless.ClosureSlot(_) | Matchless.LocalAnon(_) |
             Matchless.LocalAnonMut(_) | Matchless.Literal(_) |
+            Matchless.LitInt64(_) |
             Matchless.MakeEnum(_, _, _) | Matchless.MakeStruct(_) |
             Matchless.ZeroNat | Matchless.SuccNat =>
           0
@@ -285,6 +300,10 @@ class MatchlessRegressionTest extends munit.FunSuite {
             loopCheap(left) ++ loopCheap(right)
           case Matchless.CompareFloat64(left, _, right) =>
             loopCheap(left) ++ loopCheap(right)
+          case Matchless.EqualsLit(expr, _) =>
+            loopCheap(expr)
+          case Matchless.LtEqLit(expr, _) =>
+            loopCheap(expr)
           case Matchless.EqualsNat(expr, _) =>
             loopCheap(expr)
           case Matchless.And(left, right) =>

--- a/core/src/test/scala/dev/bosatsu/MatchlessRegressionTest.scala
+++ b/core/src/test/scala/dev/bosatsu/MatchlessRegressionTest.scala
@@ -155,10 +155,6 @@ class MatchlessRegressionTest extends munit.FunSuite {
         countWhileExprs(left) + countWhileExprs(right)
       case Matchless.CompareFloat64(left, _, right) =>
         countWhileExprs(left) + countWhileExprs(right)
-      case Matchless.EqualsLit(expr, _) =>
-        countWhileExprs(expr)
-      case Matchless.LtEqLit(expr, _) =>
-        countWhileExprs(expr)
       case Matchless.EqualsNat(expr, _) =>
         countWhileExprs(expr)
       case Matchless.And(left, right) =>
@@ -191,10 +187,6 @@ class MatchlessRegressionTest extends munit.FunSuite {
           loopExpr(left, activeRecNames) + loopExpr(right, activeRecNames)
         case Matchless.CompareFloat64(left, _, right) =>
           loopExpr(left, activeRecNames) + loopExpr(right, activeRecNames)
-        case Matchless.EqualsLit(expr, _) =>
-          loopExpr(expr, activeRecNames)
-        case Matchless.LtEqLit(expr, _) =>
-          loopExpr(expr, activeRecNames)
         case Matchless.EqualsNat(expr, _) =>
           loopExpr(expr, activeRecNames)
         case Matchless.And(left, right) =>
@@ -300,10 +292,6 @@ class MatchlessRegressionTest extends munit.FunSuite {
             loopCheap(left) ++ loopCheap(right)
           case Matchless.CompareFloat64(left, _, right) =>
             loopCheap(left) ++ loopCheap(right)
-          case Matchless.EqualsLit(expr, _) =>
-            loopCheap(expr)
-          case Matchless.LtEqLit(expr, _) =>
-            loopCheap(expr)
           case Matchless.EqualsNat(expr, _) =>
             loopCheap(expr)
           case Matchless.And(left, right) =>

--- a/core/src/test/scala/dev/bosatsu/MatchlessTests.scala
+++ b/core/src/test/scala/dev/bosatsu/MatchlessTests.scala
@@ -11,8 +11,10 @@ import Identifier.{Bindable, Constructor}
 import rankn.DataRepr
 
 import scala.collection.immutable.SortedMap
+import scala.annotation.nowarn
 import scala.util.Try
 
+@nowarn("msg=match may not be exhaustive")
 class MatchlessTest extends munit.ScalaCheckSuite {
   given Order[Unit] = Order.fromOrdering
 
@@ -24,6 +26,8 @@ class MatchlessTest extends munit.ScalaCheckSuite {
     if (Platform.isScalaJvm) 6 else 4
   private val maxMatchlessPackageCount =
     if (Platform.isScalaJvm) 3 else 2
+  private val int64Pack =
+    Predef.loadFileInCompile("test_workspace/Int64.bosatsu")
 
   private def boundedMatchlessGen[A](maxSize: Int)(gen: => Gen[A]): Gen[A] =
     Gen.sized { size =>
@@ -267,6 +271,21 @@ class MatchlessTest extends munit.ScalaCheckSuite {
 
   private def intLit(i: Int): TypedExpr[Unit] =
     TypedExpr.Literal(Lit.fromInt(i), rankn.Type.IntType, ())
+
+  private def evalExpr(expr: Matchless.Expr[Unit]): Value =
+    MatchlessToValue
+      .traverse[Vector, Unit](Vector(expr))((_, _, _) => Eval.now(Value.UnitValue))
+      .head
+      .value
+
+  private def evalBoolExpr(boolExpr: Matchless.BoolExpr[Unit]): Boolean =
+    evalExpr(
+      Matchless.If(
+        boolExpr,
+        Matchless.Literal(Lit(1)),
+        Matchless.Literal(Lit(0))
+      )
+    ) == Value.VInt(1)
 
   private def pairCtorType(
       leftType: rankn.Type,
@@ -6404,6 +6423,153 @@ ${tmpLines}
           enableGlobalInlining = true
         ),
         namespace.compiled
+      )
+    }
+  }
+
+  test("CompareInt predicates agree with integer relation semantics") {
+    val compareRels = List(
+      Matchless.CompareRel.Eq,
+      Matchless.CompareRel.Ne,
+      Matchless.CompareRel.Lt,
+      Matchless.CompareRel.Lte,
+      Matchless.CompareRel.Gt,
+      Matchless.CompareRel.Gte
+    )
+
+    forAll(
+      Arbitrary.arbitrary[Int],
+      Arbitrary.arbitrary[Int],
+      Gen.oneOf(compareRels)
+    ) { (left, right, rel) =>
+      val predicate =
+        Matchless.CompareInt(
+          Matchless.Literal(Lit.fromInt(left)),
+          rel,
+          Matchless.Literal(Lit.fromInt(right))
+        )
+
+      assertEquals(
+        evalBoolExpr(predicate),
+        Matchless.compareRelHolds(rel, Integer.compare(left, right))
+      )
+    }
+  }
+
+  test("CompareInt64 predicates agree with signed Long relation semantics") {
+    val compareRels = List(
+      Matchless.CompareRel.Eq,
+      Matchless.CompareRel.Ne,
+      Matchless.CompareRel.Lt,
+      Matchless.CompareRel.Lte,
+      Matchless.CompareRel.Gt,
+      Matchless.CompareRel.Gte
+    )
+
+    forAll(
+      Arbitrary.arbitrary[Long],
+      Arbitrary.arbitrary[Long],
+      Gen.oneOf(compareRels)
+    ) { (left, right, rel) =>
+      val predicate =
+        Matchless.CompareInt64(
+          Matchless.LitInt64(left),
+          rel,
+          Matchless.LitInt64(right)
+        )
+
+      assertEquals(
+        evalBoolExpr(predicate),
+        Matchless.compareRelHolds(rel, java.lang.Long.compare(left, right))
+      )
+    }
+  }
+
+  test("CompareFloat64 predicates agree with total-order Float64 semantics") {
+    val compareRels = List(
+      Matchless.CompareRel.Eq,
+      Matchless.CompareRel.Ne,
+      Matchless.CompareRel.Lt,
+      Matchless.CompareRel.Lte,
+      Matchless.CompareRel.Gt,
+      Matchless.CompareRel.Gte
+    )
+    val rawBitsGen: Gen[Long] =
+      Gen.frequency(
+        (8, Arbitrary.arbitrary[Long]),
+        (1, Gen.const(java.lang.Double.doubleToRawLongBits(Double.NaN))),
+        (
+          1,
+          Gen.const(
+            java.lang.Double.doubleToRawLongBits(
+              java.lang.Double.POSITIVE_INFINITY
+            )
+          )
+        ),
+        (
+          1,
+          Gen.const(
+            java.lang.Double.doubleToRawLongBits(
+              java.lang.Double.NEGATIVE_INFINITY
+            )
+          )
+        ),
+        (1, Gen.const(java.lang.Double.doubleToRawLongBits(0.0d))),
+        (1, Gen.const(java.lang.Double.doubleToRawLongBits(-0.0d)))
+      )
+
+    forAll(rawBitsGen, rawBitsGen, Gen.oneOf(compareRels)) {
+      (leftBits: Long, rightBits: Long, rel) =>
+        val left = java.lang.Double.longBitsToDouble(leftBits)
+        val right = java.lang.Double.longBitsToDouble(rightBits)
+        val predicate =
+          Matchless.CompareFloat64(
+            Matchless.Literal(Lit.Float64.fromRawLongBits(leftBits)),
+            rel,
+            Matchless.Literal(Lit.Float64.fromRawLongBits(rightBits))
+          )
+
+        assertEquals(
+          evalBoolExpr(predicate),
+          Matchless.compareRelHolds(rel, PredefImpl.compareFloat64Total(left, right))
+        )
+    }
+  }
+
+  test("literal Int64 conversions lower to LitInt64 and direct Option constructors") {
+    val src =
+      """package Test
+        |
+        |from Bosatsu/Num/Int64 import int_low_bits_to_Int64, int_to_Int64
+        |
+        |low_bits = int_low_bits_to_Int64(18446744073709551615)
+        |safe = int_to_Int64(-9223372036854775808)
+        |too_big = int_to_Int64(9223372036854775808)
+        |main = (low_bits, safe, too_big)
+        |""".stripMargin
+
+    Par.withEC {
+      TestUtils.testInferred(
+        List(int64Pack, src),
+        "Test", { (pm, packName) =>
+          val compiled =
+            MatchlessFromTypedExpr.compile(
+              (),
+              pm,
+              Matchless.LocalPassOptions.Default
+            )
+          val byName = compiled(packName).toMap
+          val lowBits = byName(Identifier.Name("low_bits"))
+          val safe = byName(Identifier.Name("safe"))
+          val tooBig = byName(Identifier.Name("too_big"))
+
+          assertEquals(lowBits, Matchless.LitInt64(-1L))
+          assert(safe.toString.contains("LitInt64(-9223372036854775808)"), safe.toString)
+          assert(
+            !tooBig.toString.contains("int__to__Int64"),
+            tooBig.toString
+          )
+        }
       )
     }
   }

--- a/core/src/test/scala/dev/bosatsu/MatchlessTests.scala
+++ b/core/src/test/scala/dev/bosatsu/MatchlessTests.scala
@@ -11,10 +11,8 @@ import Identifier.{Bindable, Constructor}
 import rankn.DataRepr
 
 import scala.collection.immutable.SortedMap
-import scala.annotation.nowarn
 import scala.util.Try
 
-@nowarn("msg=match may not be exhaustive")
 class MatchlessTest extends munit.ScalaCheckSuite {
   given Order[Unit] = Order.fromOrdering
 
@@ -184,6 +182,14 @@ class MatchlessTest extends munit.ScalaCheckSuite {
 
     def loopBool(b: Matchless.BoolExpr[Unit]): List[Matchless.SwitchVariant[Unit]] =
       b match {
+        case Matchless.CompareLit(e, _, _) =>
+          loopExpr(e)
+        case Matchless.CompareInt(left, _, right) =>
+          loopExpr(left) ++ loopExpr(right)
+        case Matchless.CompareInt64(left, _, right) =>
+          loopExpr(left) ++ loopExpr(right)
+        case Matchless.CompareFloat64(left, _, right) =>
+          loopExpr(left) ++ loopExpr(right)
         case Matchless.EqualsLit(e, _) =>
           loopExpr(e)
         case Matchless.LtEqLit(e, _) =>
@@ -444,6 +450,14 @@ class MatchlessTest extends munit.ScalaCheckSuite {
 
     def loopBool(ex: Matchless.BoolExpr[Unit]): Boolean =
       ex match {
+        case Matchless.CompareLit(arg, _, _) =>
+          loopExpr(arg)
+        case Matchless.CompareInt(left, _, right) =>
+          loopExpr(left) || loopExpr(right)
+        case Matchless.CompareInt64(left, _, right) =>
+          loopExpr(left) || loopExpr(right)
+        case Matchless.CompareFloat64(left, _, right) =>
+          loopExpr(left) || loopExpr(right)
         case Matchless.EqualsLit(arg, _) =>
           loopExpr(arg)
         case Matchless.LtEqLit(arg, _) =>
@@ -504,6 +518,14 @@ class MatchlessTest extends munit.ScalaCheckSuite {
 
     def loopBool(ex: Matchless.BoolExpr[Unit]): Int =
       ex match {
+        case Matchless.CompareLit(arg, _, _) =>
+          loopExpr(arg)
+        case Matchless.CompareInt(left, _, right) =>
+          loopExpr(left) + loopExpr(right)
+        case Matchless.CompareInt64(left, _, right) =>
+          loopExpr(left) + loopExpr(right)
+        case Matchless.CompareFloat64(left, _, right) =>
+          loopExpr(left) + loopExpr(right)
         case Matchless.EqualsLit(arg, _) =>
           loopExpr(arg)
         case Matchless.LtEqLit(arg, _) =>
@@ -564,6 +586,14 @@ class MatchlessTest extends munit.ScalaCheckSuite {
 
     def loopBool(ex: Matchless.BoolExpr[Unit]): Int =
       ex match {
+        case Matchless.CompareLit(arg, _, _) =>
+          loopExpr(arg)
+        case Matchless.CompareInt(left, _, right) =>
+          loopExpr(left) + loopExpr(right)
+        case Matchless.CompareInt64(left, _, right) =>
+          loopExpr(left) + loopExpr(right)
+        case Matchless.CompareFloat64(left, _, right) =>
+          loopExpr(left) + loopExpr(right)
         case Matchless.EqualsLit(arg, _) =>
           loopExpr(arg)
         case Matchless.LtEqLit(arg, _) =>
@@ -713,13 +743,25 @@ class MatchlessTest extends munit.ScalaCheckSuite {
           loopCheap(arg)
         case Matchless.Local(_) | Matchless.Global(_, _, _) |
             Matchless.LocalAnon(_) | Matchless.LocalAnonMut(_) |
-            Matchless.ClosureSlot(_) | Matchless.Literal(_) =>
+            Matchless.ClosureSlot(_) | Matchless.Literal(_) |
+            Matchless.LitInt64(_) =>
           ()
       }
     }
 
     def loopBool(b: Matchless.BoolExpr[Unit]): Unit =
       b match {
+        case Matchless.CompareLit(e, _, _) =>
+          loopCheap(e)
+        case Matchless.CompareInt(left, _, right) =>
+          loopCheap(left)
+          loopCheap(right)
+        case Matchless.CompareInt64(left, _, right) =>
+          loopCheap(left)
+          loopCheap(right)
+        case Matchless.CompareFloat64(left, _, right) =>
+          loopCheap(left)
+          loopCheap(right)
         case Matchless.EqualsLit(e, _) =>
           loopCheap(e)
         case Matchless.LtEqLit(e, _) =>
@@ -823,6 +865,14 @@ class MatchlessTest extends munit.ScalaCheckSuite {
         boolFn: Matchless.BoolExpr[Unit] => Boolean
     ): Boolean =
       b match {
+        case Matchless.CompareLit(e, _, _) =>
+          exprFn(e)
+        case Matchless.CompareInt(left, _, right) =>
+          exprFn(left) || exprFn(right)
+        case Matchless.CompareInt64(left, _, right) =>
+          exprFn(left) || exprFn(right)
+        case Matchless.CompareFloat64(left, _, right) =>
+          exprFn(left) || exprFn(right)
         case Matchless.EqualsLit(e, _) =>
           exprFn(e)
         case Matchless.LtEqLit(e, _) =>
@@ -914,6 +964,7 @@ class MatchlessTest extends munit.ScalaCheckSuite {
           withinWhileExpr(gs.arg)
         case Matchless.Local(_) | Matchless.Global(_, _, _) | Matchless.ClosureSlot(_) |
             Matchless.LocalAnon(_) | Matchless.LocalAnonMut(_) | Matchless.Literal(_) |
+            Matchless.LitInt64(_) |
             Matchless.MakeEnum(_, _, _) | Matchless.MakeStruct(_) | Matchless.ZeroNat |
             Matchless.SuccNat =>
           0
@@ -921,6 +972,14 @@ class MatchlessTest extends munit.ScalaCheckSuite {
 
     def withinWhileBool(b: Matchless.BoolExpr[Unit]): Int =
       b match {
+        case Matchless.CompareLit(e, _, _) =>
+          withinWhileExpr(e)
+        case Matchless.CompareInt(left, _, right) =>
+          withinWhileExpr(left) + withinWhileExpr(right)
+        case Matchless.CompareInt64(left, _, right) =>
+          withinWhileExpr(left) + withinWhileExpr(right)
+        case Matchless.CompareFloat64(left, _, right) =>
+          withinWhileExpr(left) + withinWhileExpr(right)
         case Matchless.EqualsLit(e, _) =>
           withinWhileExpr(e)
         case Matchless.LtEqLit(e, _) =>
@@ -947,6 +1006,14 @@ class MatchlessTest extends munit.ScalaCheckSuite {
 
     def findWhilesBool(b: Matchless.BoolExpr[Unit]): Int =
       b match {
+        case Matchless.CompareLit(e, _, _) =>
+          findWhiles(e)
+        case Matchless.CompareInt(left, _, right) =>
+          findWhiles(left) + findWhiles(right)
+        case Matchless.CompareInt64(left, _, right) =>
+          findWhiles(left) + findWhiles(right)
+        case Matchless.CompareFloat64(left, _, right) =>
+          findWhiles(left) + findWhiles(right)
         case Matchless.EqualsLit(e, _) =>
           findWhiles(e)
         case Matchless.LtEqLit(e, _) =>
@@ -997,6 +1064,7 @@ class MatchlessTest extends munit.ScalaCheckSuite {
           findWhiles(gs.arg)
         case Matchless.Local(_) | Matchless.Global(_, _, _) | Matchless.ClosureSlot(_) |
             Matchless.LocalAnon(_) | Matchless.LocalAnonMut(_) | Matchless.Literal(_) |
+            Matchless.LitInt64(_) |
             Matchless.MakeEnum(_, _, _) | Matchless.MakeStruct(_) | Matchless.ZeroNat |
             Matchless.SuccNat =>
           0
@@ -1037,12 +1105,21 @@ class MatchlessTest extends munit.ScalaCheckSuite {
           loopCheap(arg)
         case Matchless.Local(_) | Matchless.Global(_, _, _) |
             Matchless.LocalAnon(_) | Matchless.LocalAnonMut(_) |
-            Matchless.ClosureSlot(_) | Matchless.Literal(_) =>
+            Matchless.ClosureSlot(_) | Matchless.Literal(_) |
+            Matchless.LitInt64(_) =>
           0
       }
 
     def loopBool(b: Matchless.BoolExpr[Unit]): Int =
       b match {
+        case Matchless.CompareLit(e, _, _) =>
+          loopCheap(e)
+        case Matchless.CompareInt(left, _, right) =>
+          loopCheap(left) + loopCheap(right)
+        case Matchless.CompareInt64(left, _, right) =>
+          loopCheap(left) + loopCheap(right)
+        case Matchless.CompareFloat64(left, _, right) =>
+          loopCheap(left) + loopCheap(right)
         case Matchless.EqualsLit(e, _) =>
           loopCheap(e)
         case Matchless.LtEqLit(e, _) =>
@@ -1112,7 +1189,8 @@ class MatchlessTest extends munit.ScalaCheckSuite {
           loopCheap(arg, inConditionalBranch)
         case Matchless.Local(_) | Matchless.Global(_, _, _) |
             Matchless.LocalAnon(_) | Matchless.LocalAnonMut(_) |
-            Matchless.ClosureSlot(_) | Matchless.Literal(_) =>
+            Matchless.ClosureSlot(_) | Matchless.Literal(_) |
+            Matchless.LitInt64(_) =>
           false
       }
 
@@ -1121,6 +1199,14 @@ class MatchlessTest extends munit.ScalaCheckSuite {
         inConditionalBranch: Boolean
     ): Boolean =
       b match {
+        case Matchless.CompareLit(e, _, _) =>
+          loopCheap(e, inConditionalBranch)
+        case Matchless.CompareInt(left, _, right) =>
+          loopCheap(left, inConditionalBranch) || loopCheap(right, inConditionalBranch)
+        case Matchless.CompareInt64(left, _, right) =>
+          loopCheap(left, inConditionalBranch) || loopCheap(right, inConditionalBranch)
+        case Matchless.CompareFloat64(left, _, right) =>
+          loopCheap(left, inConditionalBranch) || loopCheap(right, inConditionalBranch)
         case Matchless.EqualsLit(e, _) =>
           loopCheap(e, inConditionalBranch)
         case Matchless.LtEqLit(e, _) =>
@@ -1215,12 +1301,21 @@ class MatchlessTest extends munit.ScalaCheckSuite {
           loopCheap(arg)
         case Matchless.Local(_) | Matchless.Global(_, _, _) |
             Matchless.LocalAnon(_) | Matchless.LocalAnonMut(_) |
-            Matchless.ClosureSlot(_) | Matchless.Literal(_) =>
+            Matchless.ClosureSlot(_) | Matchless.Literal(_) |
+            Matchless.LitInt64(_) =>
           0
       }
 
     def loopBool(b: Matchless.BoolExpr[Unit]): Int =
       b match {
+        case Matchless.CompareLit(e, _, _) =>
+          loopCheap(e)
+        case Matchless.CompareInt(left, _, right) =>
+          loopCheap(left) + loopCheap(right)
+        case Matchless.CompareInt64(left, _, right) =>
+          loopCheap(left) + loopCheap(right)
+        case Matchless.CompareFloat64(left, _, right) =>
+          loopCheap(left) + loopCheap(right)
         case Matchless.EqualsLit(e, _) =>
           loopCheap(e)
         case Matchless.LtEqLit(e, _) =>
@@ -1615,12 +1710,21 @@ main = select
             loopCheap(arg)
           case Matchless.Local(_) | Matchless.Global(_, _, _) |
               Matchless.LocalAnon(_) | Matchless.LocalAnonMut(_) |
-              Matchless.ClosureSlot(_) | Matchless.Literal(_) =>
+              Matchless.ClosureSlot(_) | Matchless.Literal(_) |
+              Matchless.LitInt64(_) =>
             0
         }
 
       def loopBool(b: Matchless.BoolExpr[Unit]): Int =
         b match {
+          case Matchless.CompareLit(e, _, _) =>
+            loopCheap(e)
+          case Matchless.CompareInt(left, _, right) =>
+            loopCheap(left) + loopCheap(right)
+          case Matchless.CompareInt64(left, _, right) =>
+            loopCheap(left) + loopCheap(right)
+          case Matchless.CompareFloat64(left, _, right) =>
+            loopCheap(left) + loopCheap(right)
           case Matchless.EqualsLit(e, _) =>
             loopCheap(e)
           case Matchless.LtEqLit(e, _) =>
@@ -2294,6 +2398,17 @@ main = (cmp_guard, enum_guard)
 
       def checkBool(boolExpr: Matchless.BoolExpr[Unit]): Unit =
         boolExpr match {
+          case Matchless.CompareLit(e, _, _) =>
+            requireSubset(e)
+          case Matchless.CompareInt(left, _, right) =>
+            requireSubset(left)
+            requireSubset(right)
+          case Matchless.CompareInt64(left, _, right) =>
+            requireSubset(left)
+            requireSubset(right)
+          case Matchless.CompareFloat64(left, _, right) =>
+            requireSubset(left)
+            requireSubset(right)
           case Matchless.EqualsLit(e, _) =>
             requireSubset(e)
           case Matchless.LtEqLit(e, _) =>
@@ -3152,12 +3267,21 @@ main = (cmp_guard, enum_guard)
           }
         case Matchless.Local(_) | Matchless.Global(_, _, _) |
             Matchless.LocalAnon(_) | Matchless.LocalAnonMut(_) |
-            Matchless.ClosureSlot(_) | Matchless.Literal(_) =>
+            Matchless.ClosureSlot(_) | Matchless.Literal(_) |
+            Matchless.LitInt64(_) =>
           false
       }
 
     def hasNestedProjectionBool(b: Matchless.BoolExpr[Unit]): Boolean =
       b match {
+        case Matchless.CompareLit(e, _, _) =>
+          hasNestedProjectionCheap(e)
+        case Matchless.CompareInt(left, _, right) =>
+          hasNestedProjectionCheap(left) || hasNestedProjectionCheap(right)
+        case Matchless.CompareInt64(left, _, right) =>
+          hasNestedProjectionCheap(left) || hasNestedProjectionCheap(right)
+        case Matchless.CompareFloat64(left, _, right) =>
+          hasNestedProjectionCheap(left) || hasNestedProjectionCheap(right)
         case Matchless.EqualsLit(e, _) =>
           hasNestedProjectionCheap(e)
         case Matchless.LtEqLit(e, _) =>
@@ -6533,6 +6657,66 @@ ${tmpLines}
           evalBoolExpr(predicate),
           Matchless.compareRelHolds(rel, PredefImpl.compareFloat64Total(left, right))
         )
+    }
+  }
+
+  test("CompareLit Char predicates agree with code point relation semantics") {
+    val compareRels = List(
+      Matchless.CompareRel.Eq,
+      Matchless.CompareRel.Ne,
+      Matchless.CompareRel.Lt,
+      Matchless.CompareRel.Lte,
+      Matchless.CompareRel.Gt,
+      Matchless.CompareRel.Gte
+    )
+
+    forAll(
+      Arbitrary.arbitrary[Char],
+      Arbitrary.arbitrary[Char],
+      Gen.oneOf(compareRels)
+    ) { (left, right, rel) =>
+      val leftLit = Lit.fromCodePoint(left.toInt)
+      val rightLit = Lit.fromCodePoint(right.toInt)
+      val expected =
+        Matchless.compareRelHolds(rel, Integer.compare(left.toInt, right.toInt))
+
+      assertEquals(
+        Matchless.compareLiteralValues(leftLit, rel, rightLit),
+        Some(expected)
+      )
+
+      val predicate =
+        Matchless.CompareLit(
+          Matchless.Literal(leftLit),
+          rel,
+          rightLit
+        )
+
+      assertEquals(evalBoolExpr(predicate), expected)
+    }
+  }
+
+  test("comparisonObservation matches Comparison constructor subset semantics") {
+    val observationGen =
+      Gen.oneOf(Matchless.comparisonTrueVariants.subsets.map(_.toSet).toList)
+
+    forAll(observationGen, Arbitrary.arbitrary[Int], Arbitrary.arbitrary[Int]) {
+      (trueVariants, left, right) =>
+        val cmp = Integer.compare(left, right)
+        val activeVariant =
+          if (cmp < 0) 0
+          else if (cmp == 0) 1
+          else 2
+        val expected = trueVariants(activeVariant)
+        val observed =
+          Matchless.comparisonObservation(trueVariants) match {
+            case Left(value) =>
+              value
+            case Right(rel)  =>
+              Matchless.compareRelHolds(rel, cmp)
+          }
+
+        assertEquals(observed, expected)
     }
   }
 

--- a/core/src/test/scala/dev/bosatsu/MatchlessTests.scala
+++ b/core/src/test/scala/dev/bosatsu/MatchlessTests.scala
@@ -6640,6 +6640,38 @@ ${tmpLines}
     }
   }
 
+  test("CompareLit String predicates use Bosatsu code point ordering for astral Unicode") {
+    val left = Lit.Str("\uE000")
+    val right = Lit.Str(new String(Character.toChars(0x10000)))
+    val compareRels = List(
+      Matchless.CompareRel.Eq -> false,
+      Matchless.CompareRel.Ne -> true,
+      Matchless.CompareRel.Lt -> true,
+      Matchless.CompareRel.Lte -> true,
+      Matchless.CompareRel.Gt -> false,
+      Matchless.CompareRel.Gte -> false
+    )
+
+    assert(StringUtil.codePointCompare(left.asStr, right.asStr) < 0)
+    assert(left.asStr.compareTo(right.asStr) > 0)
+
+    compareRels.foreach { case (rel, expected) =>
+      assertEquals(
+        Matchless.compareLiteralValues(left, rel, right),
+        Some(expected)
+      )
+
+      val predicate =
+        Matchless.CompareLit(
+          Matchless.Literal(left),
+          rel,
+          right
+        )
+
+      assertEquals(evalBoolExpr(predicate), expected)
+    }
+  }
+
   test("comparisonObservation matches Comparison constructor subset semantics") {
     val observationGen =
       Gen.oneOf(Matchless.comparisonTrueVariants.subsets.map(_.toSet).toList)

--- a/core/src/test/scala/dev/bosatsu/MatchlessTests.scala
+++ b/core/src/test/scala/dev/bosatsu/MatchlessTests.scala
@@ -190,10 +190,6 @@ class MatchlessTest extends munit.ScalaCheckSuite {
           loopExpr(left) ++ loopExpr(right)
         case Matchless.CompareFloat64(left, _, right) =>
           loopExpr(left) ++ loopExpr(right)
-        case Matchless.EqualsLit(e, _) =>
-          loopExpr(e)
-        case Matchless.LtEqLit(e, _) =>
-          loopExpr(e)
         case Matchless.EqualsNat(e, _) =>
           loopExpr(e)
         case Matchless.And(l, r) =>
@@ -458,10 +454,6 @@ class MatchlessTest extends munit.ScalaCheckSuite {
           loopExpr(left) || loopExpr(right)
         case Matchless.CompareFloat64(left, _, right) =>
           loopExpr(left) || loopExpr(right)
-        case Matchless.EqualsLit(arg, _) =>
-          loopExpr(arg)
-        case Matchless.LtEqLit(arg, _) =>
-          loopExpr(arg)
         case Matchless.EqualsNat(arg, _) =>
           loopExpr(arg)
         case Matchless.And(left, right) =>
@@ -526,10 +518,6 @@ class MatchlessTest extends munit.ScalaCheckSuite {
           loopExpr(left) + loopExpr(right)
         case Matchless.CompareFloat64(left, _, right) =>
           loopExpr(left) + loopExpr(right)
-        case Matchless.EqualsLit(arg, _) =>
-          loopExpr(arg)
-        case Matchless.LtEqLit(arg, _) =>
-          loopExpr(arg)
         case Matchless.EqualsNat(arg, _) =>
           loopExpr(arg)
         case Matchless.And(left, right) =>
@@ -594,10 +582,6 @@ class MatchlessTest extends munit.ScalaCheckSuite {
           loopExpr(left) + loopExpr(right)
         case Matchless.CompareFloat64(left, _, right) =>
           loopExpr(left) + loopExpr(right)
-        case Matchless.EqualsLit(arg, _) =>
-          loopExpr(arg)
-        case Matchless.LtEqLit(arg, _) =>
-          loopExpr(arg)
         case Matchless.EqualsNat(arg, _) =>
           loopExpr(arg)
         case Matchless.And(left, right) =>
@@ -762,10 +746,6 @@ class MatchlessTest extends munit.ScalaCheckSuite {
         case Matchless.CompareFloat64(left, _, right) =>
           loopCheap(left)
           loopCheap(right)
-        case Matchless.EqualsLit(e, _) =>
-          loopCheap(e)
-        case Matchless.LtEqLit(e, _) =>
-          loopCheap(e)
         case Matchless.EqualsNat(e, _) =>
           loopCheap(e)
         case Matchless.And(l, r) =>
@@ -873,10 +853,6 @@ class MatchlessTest extends munit.ScalaCheckSuite {
           exprFn(left) || exprFn(right)
         case Matchless.CompareFloat64(left, _, right) =>
           exprFn(left) || exprFn(right)
-        case Matchless.EqualsLit(e, _) =>
-          exprFn(e)
-        case Matchless.LtEqLit(e, _) =>
-          exprFn(e)
         case Matchless.EqualsNat(e, _) =>
           exprFn(e)
         case Matchless.And(l, r) =>
@@ -980,10 +956,6 @@ class MatchlessTest extends munit.ScalaCheckSuite {
           withinWhileExpr(left) + withinWhileExpr(right)
         case Matchless.CompareFloat64(left, _, right) =>
           withinWhileExpr(left) + withinWhileExpr(right)
-        case Matchless.EqualsLit(e, _) =>
-          withinWhileExpr(e)
-        case Matchless.LtEqLit(e, _) =>
-          withinWhileExpr(e)
         case Matchless.EqualsNat(e, _) =>
           withinWhileExpr(e)
         case Matchless.And(l, r) =>
@@ -1014,10 +986,6 @@ class MatchlessTest extends munit.ScalaCheckSuite {
           findWhiles(left) + findWhiles(right)
         case Matchless.CompareFloat64(left, _, right) =>
           findWhiles(left) + findWhiles(right)
-        case Matchless.EqualsLit(e, _) =>
-          findWhiles(e)
-        case Matchless.LtEqLit(e, _) =>
-          findWhiles(e)
         case Matchless.EqualsNat(e, _) =>
           findWhiles(e)
         case Matchless.And(l, r) =>
@@ -1120,10 +1088,6 @@ class MatchlessTest extends munit.ScalaCheckSuite {
           loopCheap(left) + loopCheap(right)
         case Matchless.CompareFloat64(left, _, right) =>
           loopCheap(left) + loopCheap(right)
-        case Matchless.EqualsLit(e, _) =>
-          loopCheap(e)
-        case Matchless.LtEqLit(e, _) =>
-          loopCheap(e)
         case Matchless.EqualsNat(e, _) =>
           loopCheap(e)
         case Matchless.And(l, r) =>
@@ -1207,10 +1171,6 @@ class MatchlessTest extends munit.ScalaCheckSuite {
           loopCheap(left, inConditionalBranch) || loopCheap(right, inConditionalBranch)
         case Matchless.CompareFloat64(left, _, right) =>
           loopCheap(left, inConditionalBranch) || loopCheap(right, inConditionalBranch)
-        case Matchless.EqualsLit(e, _) =>
-          loopCheap(e, inConditionalBranch)
-        case Matchless.LtEqLit(e, _) =>
-          loopCheap(e, inConditionalBranch)
         case Matchless.EqualsNat(e, _) =>
           loopCheap(e, inConditionalBranch)
         case Matchless.And(l, r) =>
@@ -1316,10 +1276,6 @@ class MatchlessTest extends munit.ScalaCheckSuite {
           loopCheap(left) + loopCheap(right)
         case Matchless.CompareFloat64(left, _, right) =>
           loopCheap(left) + loopCheap(right)
-        case Matchless.EqualsLit(e, _) =>
-          loopCheap(e)
-        case Matchless.LtEqLit(e, _) =>
-          loopCheap(e)
         case Matchless.EqualsNat(e, _) =>
           loopCheap(e)
         case Matchless.And(l, r) =>
@@ -1725,10 +1681,6 @@ main = select
             loopCheap(left) + loopCheap(right)
           case Matchless.CompareFloat64(left, _, right) =>
             loopCheap(left) + loopCheap(right)
-          case Matchless.EqualsLit(e, _) =>
-            loopCheap(e)
-          case Matchless.LtEqLit(e, _) =>
-            loopCheap(e)
           case Matchless.EqualsNat(e, _) =>
             loopCheap(e)
           case Matchless.And(l, r) =>
@@ -2409,10 +2361,6 @@ main = (cmp_guard, enum_guard)
           case Matchless.CompareFloat64(left, _, right) =>
             requireSubset(left)
             requireSubset(right)
-          case Matchless.EqualsLit(e, _) =>
-            requireSubset(e)
-          case Matchless.LtEqLit(e, _) =>
-            requireSubset(e)
           case Matchless.EqualsNat(e, _) =>
             requireSubset(e)
           case Matchless.And(l, r) =>
@@ -3282,10 +3230,6 @@ main = (cmp_guard, enum_guard)
           hasNestedProjectionCheap(left) || hasNestedProjectionCheap(right)
         case Matchless.CompareFloat64(left, _, right) =>
           hasNestedProjectionCheap(left) || hasNestedProjectionCheap(right)
-        case Matchless.EqualsLit(e, _) =>
-          hasNestedProjectionCheap(e)
-        case Matchless.LtEqLit(e, _) =>
-          hasNestedProjectionCheap(e)
         case Matchless.EqualsNat(e, _) =>
           hasNestedProjectionCheap(e)
         case Matchless.And(l, r) =>

--- a/core/src/test/scala/dev/bosatsu/MatchlessTests.scala
+++ b/core/src/test/scala/dev/bosatsu/MatchlessTests.scala
@@ -3503,8 +3503,8 @@ def small_spaces(rem):
       val expr = byName(Identifier.Name("small_spaces"))
       assertEquals(
         exprBoolSubexpressions(expr).exists {
-          case Matchless.LtEqLit(_, _) => true
-          case _                       => false
+          case Matchless.CompareLit(_, Matchless.CompareRel.Lte, _) => true
+          case _                                                    => false
         },
         true,
         expr.toString
@@ -3551,8 +3551,8 @@ def classify_char(ch):
       val expr = byName(Identifier.Name("classify_char"))
       assertEquals(
         exprBoolSubexpressions(expr).exists {
-          case Matchless.LtEqLit(_, _) => true
-          case _                       => false
+          case Matchless.CompareLit(_, Matchless.CompareRel.Lte, _) => true
+          case _                                                    => false
         },
         true,
         expr.toString
@@ -3603,8 +3603,8 @@ def classify_small(n):
       val expr = byName(Identifier.Name("classify_small"))
       assertEquals(
         exprBoolSubexpressions(expr).exists {
-          case Matchless.LtEqLit(_, _) => true
-          case _                       => false
+          case Matchless.CompareLit(_, Matchless.CompareRel.Lte, _) => true
+          case _                                                    => false
         },
         false,
         expr.toString

--- a/core/src/test/scala/dev/bosatsu/ToolAndLibCommandTest.scala
+++ b/core/src/test/scala/dev/bosatsu/ToolAndLibCommandTest.scala
@@ -22,10 +22,8 @@ import java.io.{ByteArrayInputStream, InputStream}
 import java.nio.charset.StandardCharsets
 import munit.FunSuite
 import org.typelevel.paiges.Doc
-import scala.annotation.nowarn
 import scala.collection.immutable.SortedMap
 
-@nowarn("msg=match may not be exhaustive")
 class ToolAndLibCommandTest extends FunSuite {
   private type ErrorOr[A] = Either[Throwable, A]
   private type StateIO[A] = MemoryMain.StateF[ErrorOr][A]
@@ -1014,6 +1012,14 @@ class ToolAndLibCommandTest extends FunSuite {
 
     def loopBool(ex: Matchless.BoolExpr[?]): Boolean =
       ex match {
+        case Matchless.CompareLit(arg, _, _) =>
+          loopExpr(arg)
+        case Matchless.CompareInt(left, _, right) =>
+          loopExpr(left) || loopExpr(right)
+        case Matchless.CompareInt64(left, _, right) =>
+          loopExpr(left) || loopExpr(right)
+        case Matchless.CompareFloat64(left, _, right) =>
+          loopExpr(left) || loopExpr(right)
         case Matchless.EqualsLit(arg, _) =>
           loopExpr(arg)
         case Matchless.LtEqLit(arg, _) =>

--- a/core/src/test/scala/dev/bosatsu/ToolAndLibCommandTest.scala
+++ b/core/src/test/scala/dev/bosatsu/ToolAndLibCommandTest.scala
@@ -22,8 +22,10 @@ import java.io.{ByteArrayInputStream, InputStream}
 import java.nio.charset.StandardCharsets
 import munit.FunSuite
 import org.typelevel.paiges.Doc
+import scala.annotation.nowarn
 import scala.collection.immutable.SortedMap
 
+@nowarn("msg=match may not be exhaustive")
 class ToolAndLibCommandTest extends FunSuite {
   private type ErrorOr[A] = Either[Throwable, A]
   private type StateIO[A] = MemoryMain.StateF[ErrorOr][A]

--- a/core/src/test/scala/dev/bosatsu/ToolAndLibCommandTest.scala
+++ b/core/src/test/scala/dev/bosatsu/ToolAndLibCommandTest.scala
@@ -1020,10 +1020,6 @@ class ToolAndLibCommandTest extends FunSuite {
           loopExpr(left) || loopExpr(right)
         case Matchless.CompareFloat64(left, _, right) =>
           loopExpr(left) || loopExpr(right)
-        case Matchless.EqualsLit(arg, _) =>
-          loopExpr(arg)
-        case Matchless.LtEqLit(arg, _) =>
-          loopExpr(arg)
         case Matchless.EqualsNat(arg, _) =>
           loopExpr(arg)
         case Matchless.And(left, right) =>

--- a/core/src/test/scala/dev/bosatsu/codegen/clang/ClangGenTest.scala
+++ b/core/src/test/scala/dev/bosatsu/codegen/clang/ClangGenTest.scala
@@ -297,7 +297,7 @@ main = has_two
         val hasTwo = extractCFunction(rendered, "_l_has__two(BValue")
 
         val loopPattern =
-          """(?s)while \(__bsts_l_cond\d+\) \{\s*BValue __bsts_b_x\d+ = get_enum_index\(__bsts_a_\d+, 0\);\s*BValue __bsts_a_\d+ = alloc_enum0\(bsts_integer_equals\(__bsts_b_x\d+,\s*bsts_integer_from_int\(2\)\)\);\s*if \(get_variant_value\(__bsts_a_\d+\) == 1\) \{\s*__bsts_a_\d+ = alloc_enum0\(0\);\s*__bsts_a_\d+ = alloc_enum0\(1\);\s*\}\s*else if \(get_variant\(__bsts_a_\d+\) == 1\) \{\s*__bsts_a_\d+ = __bsts_a_\d+;\s*__bsts_a_\d+ = get_enum_index\(__bsts_a_\d+, 1\);""".r
+          """(?s)while \(__bsts_l_cond\d+\) \{\s*BValue __bsts_b_x\d+ = get_enum_index\(__bsts_a_\d+, 0\);\s*if \(bsts_integer_equals\(__bsts_b_x\d+,\s*bsts_integer_from_int\(2\)\)\) \{\s*__bsts_a_\d+ = alloc_enum0\(0\);\s*__bsts_a_\d+ = alloc_enum0\(1\);\s*\}\s*else if \(get_variant\(__bsts_a_\d+\) == 1\) \{\s*__bsts_a_\d+ = __bsts_a_\d+;\s*__bsts_a_\d+ = get_enum_index\(__bsts_a_\d+, 1\);""".r
 
         assert(loopPattern.findFirstIn(hasTwo).nonEmpty, hasTwo)
         assertEquals(deadCTemps(hasTwo), Set.empty, hasTwo)
@@ -1277,14 +1277,17 @@ main = is_one
     }
   }
 
-  test("eq_Float64 lowers to the direct predef helper") {
+  test("eq_Float64 applications lower to the direct float equality helper") {
     TestUtils.checkPackageMap("""
-main = eq_Float64
+def same(a, b):
+  1 if eq_Float64(a, b) else 0
+
+main = same
 """) { pm =>
       val renderedE = Par.withEC {
         ClangGen(pm).renderMain(
           TestUtils.testPackage,
-          Identifier.Name("main"),
+          Identifier.Name("same"),
           Code.Ident("run_main")
         )
       }
@@ -1292,9 +1295,114 @@ main = eq_Float64
         case Left(err) =>
           fail(err.toString)
         case Right(doc) =>
-          val rendered = doc.render(80)
-          assert(rendered.contains("___bsts_g_Bosatsu_l_Predef_l_eq__Float64"))
+          val rendered = doc.render(120)
+          val same = extractCFunction(rendered, "_l_same(BValue")
+          assert(same.contains("bsts_float64_equals"), same)
+          assert(!same.contains("get_variant("), same)
       }
+    }
+  }
+
+  test("numeric comparison observations avoid Comparison tag inspection in C") {
+    val pm = typeCheckPackages(
+      List(
+        float64Pack,
+        int64Pack,
+        """package Test
+          |
+          |from Bosatsu/Num/Int64 import eq_Int64, cmp_Int64
+          |
+          |def lte_zero(x):
+          |  cmp_Int(x, 0) matches LT | EQ
+          |
+          |def gte(x, y):
+          |  cmp_Int(x, y) matches GT | EQ
+          |
+          |def neq(x, y):
+          |  match cmp_Int(x, y):
+          |    case LT: True
+          |    case GT: True
+          |    case _: False
+          |
+          |def same_float(x, y):
+          |  1 if eq_Float64(x, y) else 0
+          |
+          |def neq_float(x, y):
+          |  cmp_Float64(x, y) matches LT | GT
+          |
+          |def same_i64(x, y):
+          |  1 if eq_Int64(x, y) else 0
+          |
+          |def gte_i64(x, y):
+          |  cmp_Int64(x, y) matches GT | EQ
+          |
+          |main = (
+          |  lte_zero,
+          |  gte,
+          |  neq,
+          |  same_float,
+          |  neq_float,
+          |  same_i64,
+          |  gte_i64,
+          |)
+          |""".stripMargin
+      )
+    )
+
+    val renderedE = Par.withEC {
+      ClangGen(pm).renderMain(
+        PackageName.parse("Test").get,
+        Identifier.Name("main"),
+        Code.Ident("run_main")
+      )
+    }
+
+    renderedE match {
+      case Left(err) =>
+        fail(err.toString)
+      case Right(doc) =>
+        val rendered = doc.render(120)
+
+        val lteZero = extractCFunction(rendered, "_l_lte__zero(BValue")
+        assert(lteZero.contains("bsts_integer_cmp_zero"), lteZero)
+        assert(!lteZero.contains("get_variant("), lteZero)
+
+        val gte = extractCFunction(rendered, "_l_gte(BValue")
+        assert(gte.contains("bsts_integer_cmp"), gte)
+        assert(gte.contains(">= 0"), gte)
+        assert(!gte.contains("get_variant("), gte)
+
+        val neq = extractCFunction(rendered, "_l_neq(BValue")
+        assert(
+          neq.contains("bsts_integer_equals") || neq.contains("bsts_integer_cmp"),
+          neq
+        )
+        assert(!neq.contains("get_variant("), neq)
+
+        val sameFloat = extractCFunction(rendered, "_l_same__float(BValue")
+        assert(sameFloat.contains("bsts_float64_equals"), sameFloat)
+        assert(!sameFloat.contains("get_variant("), sameFloat)
+
+        val neqFloat = extractCFunction(rendered, "_l_neq__float(BValue")
+        assert(neqFloat.contains("bsts_float64_equals"), neqFloat)
+        assert(
+          neqFloat.contains("!") || neqFloat.contains("== 0"),
+          neqFloat
+        )
+        assert(!neqFloat.contains("get_variant("), neqFloat)
+
+        val sameI64 = extractCFunction(rendered, "_l_same__i64(BValue")
+        assert(sameI64.contains("bsts_int64_to_int64"), sameI64)
+        assert(
+          sameI64.contains("==") || sameI64.contains("!bsts_int64_to_int64"),
+          sameI64
+        )
+        assert(!sameI64.contains("get_variant("), sameI64)
+
+        val gteI64 = extractCFunction(rendered, "_l_gte__i64(BValue")
+        assert(gteI64.contains("bsts_int64_to_int64"), gteI64)
+        assert(gteI64.contains(">="), gteI64)
+        assert(!gteI64.contains("get_variant("), gteI64)
     }
   }
 

--- a/core/src/test/scala/dev/bosatsu/codegen/python/PythonGenTest.scala
+++ b/core/src/test/scala/dev/bosatsu/codegen/python/PythonGenTest.scala
@@ -607,6 +607,39 @@ main = compare_three
     }
   }
 
+  test("CompareLit string predicates keep the Python string helper") {
+    val astral = new String(Character.toChars(0x10000))
+    val pm = typeCheckPackage(s"""package Test
+from Bosatsu/Predef import cmp_String
+
+def before_astral(s):
+  cmp_String(s, "$astral") matches LT
+
+main = before_astral
+""")
+
+    Par.withEC {
+      val rendered = PythonGen.renderSource(pm, Map.empty, Map.empty)
+      val code = rendered(())(TestUtils.testPackage)
+        ._2
+        .render(120)
+      val beforeAstral =
+        normalizeGeneratedTemps(extractPythonDef(code, "before_astral"))
+
+      assertEquals(
+        "u\"\\\\ue000\" < u\"\\\\U00010000\"".r.findAllMatchIn(code).length,
+        1,
+        code
+      )
+      assert(!beforeAstral.contains("< u\"\\U00010000\""), beforeAstral)
+      assert(!beforeAstral.contains("""cmp_String"""), beforeAstral)
+      assert(
+        beforeAstral.contains("== 0") || beforeAstral.contains("0 =="),
+        beforeAstral
+      )
+    }
+  }
+
   test("CheckVariantSet guards compile to direct Python membership comparisons") {
     val famArities = 0 :: 0 :: 0 :: 0 :: 0 :: Nil
     val arg = Identifier.Name("v")

--- a/core/src/test/scala/dev/bosatsu/codegen/python/PythonGenTest.scala
+++ b/core/src/test/scala/dev/bosatsu/codegen/python/PythonGenTest.scala
@@ -15,6 +15,7 @@ import dev.bosatsu.{
   PackageName,
   Par,
   Parser,
+  Predef,
   TestUtils
 }
 import dev.bosatsu.codegen.CompilationNamespace
@@ -28,6 +29,10 @@ class PythonGenTest extends munit.ScalaCheckSuite {
   // PropertyCheckConfiguration(minSuccessful = 500)
 
   val PythonName = "[_A-Za-z][_A-Za-z0-9]*".r.pattern
+  private val float64Pack =
+    Predef.loadFileInCompile("test_workspace/Float64.bosatsu")
+  private val int64Pack =
+    Predef.loadFileInCompile("test_workspace/Int64.bosatsu")
 
   private def normalizeGeneratedTemps(code: String): String = {
     val tempName = "___[A-Za-z]\\d+".r
@@ -91,6 +96,20 @@ class PythonGenTest extends munit.ScalaCheckSuite {
     Par.noParallelism {
       PackageMap
         .typeCheckParsed(nel, ifaces, "<predef>", CompileOptions.Default)
+        .strictToValidated
+        .fold(errs => fail(errs.toList.mkString("\n")), identity)
+    }
+  }
+
+  private def typeCheckPackages(srcs: List[String]): PackageMap.Typed[Any] = {
+    val parsed = srcs.zipWithIndex.map { case (src, idx) =>
+      val pack = Parser.unsafeParse(Package.parser, src)
+      ((s"test$idx", LocationMap(src)), pack)
+    }
+    val nel = NonEmptyList.fromListUnsafe(parsed)
+    Par.noParallelism {
+      PackageMap
+        .typeCheckParsed(nel, Nil, "<predef>", CompileOptions.Default)
         .strictToValidated
         .fold(errs => fail(errs.toList.mkString("\n")), identity)
     }
@@ -189,18 +208,117 @@ main = has_two
       val code = doc.render(120)
       val hasTwo = normalizeGeneratedTemps(extractPythonDef(code, "has_two"))
       assert(hasTwo.contains("while ___v4:"), hasTwo)
-      assert(hasTwo.contains("if (___v2[1] == 2) == 1:"), hasTwo)
+      assert(hasTwo.contains("if ___v2[1] == 2:"), hasTwo)
       assert(hasTwo.contains("elif ___v3[0] == 1:"), hasTwo)
       assert(hasTwo.contains("___v3 = ___v3[2]"), hasTwo)
 
       val whileIdx = hasTwo.indexOf("while ___v4:")
-      val guardIdx = hasTwo.indexOf("if (___v2[1] == 2) == 1:")
+      val guardIdx = hasTwo.indexOf("if ___v2[1] == 2:")
       val advanceIdx = hasTwo.indexOf("___v3 = ___v3[2]")
 
       assert(whileIdx >= 0, hasTwo)
       assert(guardIdx > whileIdx, hasTwo)
       assert(advanceIdx > guardIdx, hasTwo)
       assertEquals(deadPythonTemps(hasTwo), Set.empty, hasTwo)
+    }
+  }
+
+  test("numeric comparison observations lower to direct Python comparisons") {
+    val pm = typeCheckPackages(
+      List(
+        float64Pack,
+        int64Pack,
+        """package Test
+          |
+          |from Bosatsu/Num/Int64 import eq_Int64, cmp_Int64
+          |
+          |def lte_zero(x):
+          |  cmp_Int(x, 0) matches LT | EQ
+          |
+          |def gte(x, y):
+          |  cmp_Int(x, y) matches GT | EQ
+          |
+          |def neq(x, y):
+          |  match cmp_Int(x, y):
+          |    case LT: True
+          |    case GT: True
+          |    case _: False
+          |
+          |def same_float(x, y):
+          |  1 if eq_Float64(x, y) else 0
+          |
+          |def neq_float(x, y):
+          |  cmp_Float64(x, y) matches LT | GT
+          |
+          |def same_i64(x, y):
+          |  1 if eq_Int64(x, y) else 0
+          |
+          |def gte_i64(x, y):
+          |  cmp_Int64(x, y) matches GT | EQ
+          |
+          |main = (
+          |  lte_zero,
+          |  gte,
+          |  neq,
+          |  same_float,
+          |  neq_float,
+          |  same_i64,
+          |  gte_i64,
+          |)
+          |""".stripMargin
+      )
+    )
+
+    Par.withEC {
+      val rendered = PythonGen.renderSource(pm, Map.empty, Map.empty)
+      val doc = rendered(())(PackageName.parse("Test").get)._2
+      val code = doc.render(120)
+
+      val lteZero = normalizeGeneratedTemps(extractPythonDef(code, "lte_zero"))
+      assert(
+        lteZero.contains("return not (0 < ___") || lteZero.contains(" <= 0"),
+        lteZero
+      )
+      assert(!lteZero.contains("cmp_Int"), lteZero)
+
+      val gte = normalizeGeneratedTemps(extractPythonDef(code, "gte"))
+      assert(
+        gte.contains("return not (___") || gte.contains(" >= ___"),
+        gte
+      )
+      assert(!gte.contains("cmp_Int"), gte)
+
+      val neq = normalizeGeneratedTemps(extractPythonDef(code, "neq"))
+      assert(
+        neq.contains(" != ___") || neq.contains("return not (___"),
+        neq
+      )
+      assert(!neq.contains("cmp_Int"), neq)
+
+      val sameFloat =
+        normalizeGeneratedTemps(extractPythonDef(code, "same_float"))
+      assert(sameFloat.contains("isnan"), sameFloat)
+      assert(sameFloat.contains("== 1") || sameFloat.contains(" else "), sameFloat)
+      assert(!sameFloat.contains("eq_Float64"), sameFloat)
+      assert(!sameFloat.contains("cmp_Float64"), sameFloat)
+
+      val neqFloat =
+        normalizeGeneratedTemps(extractPythonDef(code, "neq_float"))
+      assert(neqFloat.contains("isnan"), neqFloat)
+      assert(!neqFloat.contains("cmp_Float64"), neqFloat)
+
+      val sameI64 = normalizeGeneratedTemps(extractPythonDef(code, "same_i64"))
+      assert(sameI64.contains("int64_to_Int"), sameI64)
+      assert(sameI64.contains("=="), sameI64)
+      assert(!sameI64.contains("eq_Int64"), sameI64)
+
+      val gteI64 = normalizeGeneratedTemps(extractPythonDef(code, "gte_i64"))
+      assert(gteI64.contains("int64_to_Int"), gteI64)
+      assert(
+        gteI64.contains(">=") || gteI64.contains("return not ("),
+        gteI64
+      )
+      assert(!gteI64.contains("cmp_Int64"), gteI64)
     }
   }
 


### PR DESCRIPTION
Implements the #2320 Matchless comparison lowering work and addresses the approval-blocking review fixes. `Matchless.compareLiteralValues` and `MatchlessToValue` now handle `Lit.Chr` explicitly, the Comparison-subset-to-relation mapping is centralized in `Matchless.comparisonObservation` and covered by a property test, and the five affected test suites now traverse `CompareLit`, `CompareInt`, `CompareInt64`, `CompareFloat64`, and `LitInt64` explicitly instead of suppressing exhaustiveness warnings. Verification passed with `sbt "coreJVM/test:compile"`, focused suites (`dev.bosatsu.MatchlessRegressionTest`, `dev.bosatsu.MatchlessInterfaceTest`, `dev.bosatsu.Issue1633Test`), and the required `scripts/test_basic.sh`.

Fixes #2320

Implements design doc: [docs/design/2320-improve-compilation-of-common-int-expressions.md](https://github.com/johnynek/bosatsu/blob/main/docs/design/2320-improve-compilation-of-common-int-expressions.md)

Design source PR: https://github.com/johnynek/bosatsu/pull/2321