### PR TITLE
Roadmap revision for #2340 (v2)

### DIFF
--- a/docs/roadmap/2340-add-basic-support-for-libuv-in-c-backend.graph.json
+++ b/docs/roadmap/2340-add-basic-support-for-libuv-in-c-backend.graph.json
@@ -104,7 +104,7 @@
       "title": "Implement libuv-backed process spawn and wait for C IO/Core"
     },
     {
-      "body_markdown": "Use the merged reference document from `design` and the implemented runtime, IO, and process work from `loop_core`, `async_resume`, `io_phase1`, `io_files`, and `process_stdio` as direct inputs. The worker may rely on the full libuv-backed C runtime behavior being present on the branch.\n\nTighten validation for the completed libuv integration. Update `scripts/test_c_sanitizers.sh`, `scripts/test_c_valgrind.sh`, `scripts/c_runtime_ci_env.py`, or adjacent tests only as needed to ensure vendored libuv link flags, `GC_THREADS`, and generated C binaries are exercised. Add regression coverage for Main and Test compatibility, async continuation after IO completion, recovered async errors, file IO, process wait, and GC/thread safety assumptions that can be tested locally.\n\nRun and document the practical verification set: relevant Scala unit tests for `dev.bosatsu.cruntime` and `dev.bosatsu.codegen.clang`, `scripts/test_c_sanitizers.sh`, and `scripts/test_c_valgrind.sh` when valgrind is installed. If valgrind is unavailable in the worker environment, leave the script updated and report that limitation in the PR.\n\nCompletion outcome: the roadmap closes with high-confidence tests and scripts covering libuv vendoring, runtime loop execution, async resume behavior, IO compatibility, and GC/libuv safety.",
+      "body_markdown": "Use the merged reference document from `design`, the implemented vendored libuv dependency pipeline from `vendored_libuv`, and the implemented runtime, IO, and process work from `loop_core`, `async_resume`, `io_phase1`, `io_files`, and `process_stdio` as direct inputs. The worker may rely on the full libuv-backed C runtime behavior being present on the branch and on the vendored libuv install/link metadata being present in the C runtime dependency pipeline.\n\nTighten validation for the completed libuv integration. Update `scripts/test_c_sanitizers.sh`, `scripts/test_c_valgrind.sh`, `scripts/c_runtime_ci_env.py`, or adjacent tests only as needed to ensure vendored libuv link flags, `GC_THREADS`, and generated C binaries are exercised. Add regression coverage for Main and Test compatibility, async continuation after IO completion, recovered async errors, file IO, process wait, and GC/thread safety assumptions that can be tested locally.\n\nRun and document the practical verification set: relevant Scala unit tests for `dev.bosatsu.cruntime` and `dev.bosatsu.codegen.clang`, `scripts/test_c_sanitizers.sh`, and `scripts/test_c_valgrind.sh` when valgrind is installed. If valgrind is unavailable in the worker environment, leave the script updated and report that limitation in the PR.\n\nCompletion outcome: the roadmap closes with high-confidence tests and scripts covering libuv vendoring, runtime loop execution, async resume behavior, IO compatibility, and GC/libuv safety.",
       "depends_on": [
         {
           "node_id": "async_resume",
@@ -129,10 +129,14 @@
         {
           "node_id": "process_stdio",
           "requires": "implemented"
+        },
+        {
+          "node_id": "vendored_libuv",
+          "requires": "implemented"
         }
       ],
       "kind": "small_job",
-      "node_id": "validation",
+      "node_id": "validation_with_vendored",
       "title": "Harden C backend libuv coverage and CI validation"
     },
     {
@@ -158,5 +162,5 @@
     "summary_markdown": "Add basic libuv support to the C backend without introducing new Bosatsu surface area. The completed roadmap should leave the C runtime building libuv as a vendored dependency alongside threadsafe bdwgc, running `Bosatsu/Prog::Main` and `ProgTest` values through a `uv_loop_t`, and preserving existing Main/Test behavior while moving current C IO externals onto libuv-backed runtime primitives where practical."
   },
   "roadmap_issue_number": 2340,
-  "version": 1
+  "version": 2
 }

--- a/docs/roadmap/2340-add-basic-support-for-libuv-in-c-backend.md
+++ b/docs/roadmap/2340-add-basic-support-for-libuv-in-c-backend.md
@@ -18,7 +18,7 @@ Add basic libuv support to the C backend without introducing new Bosatsu surface
 ## Metadata
 
 - Roadmap issue: `#2340`
-- Graph version: `1`
+- Graph version: `2`
 - Node count: `8`
 
 ## Dependency Overview
@@ -30,7 +30,7 @@ Add basic libuv support to the C backend without introducing new Bosatsu surface
 5. `io_phase1` (`small_job`): `async_resume` (`implemented`), `design` (`planned`), `loop_core` (`implemented`)
 6. `io_files` (`small_job`): `async_resume` (`implemented`), `design` (`planned`), `io_phase1` (`implemented`)
 7. `process_stdio` (`small_job`): `async_resume` (`implemented`), `design` (`planned`), `io_files` (`implemented`)
-8. `validation` (`small_job`): `async_resume` (`implemented`), `design` (`planned`), `io_files` (`implemented`), `io_phase1` (`implemented`), `loop_core` (`implemented`), `process_stdio` (`implemented`)
+8. `validation_with_vendored` (`small_job`): `async_resume` (`implemented`), `design` (`planned`), `io_files` (`implemented`), `io_phase1` (`implemented`), `loop_core` (`implemented`), `process_stdio` (`implemented`), `vendored_libuv` (`implemented`)
 
 ## Nodes
 
@@ -144,15 +144,15 @@ Add C backend tests for spawning a simple command, waiting for its exit code, pi
 
 Completion outcome: C backend process execution is no longer the known unsupported gap in IO/Core and is integrated with the libuv loop and handle model.
 
-### `validation`
+### `validation_with_vendored`
 
 - Kind: `small_job`
 - Title: Harden C backend libuv coverage and CI validation
-- Depends on: `async_resume` (`implemented`), `design` (`planned`), `io_files` (`implemented`), `io_phase1` (`implemented`), `loop_core` (`implemented`), `process_stdio` (`implemented`)
+- Depends on: `async_resume` (`implemented`), `design` (`planned`), `io_files` (`implemented`), `io_phase1` (`implemented`), `loop_core` (`implemented`), `process_stdio` (`implemented`), `vendored_libuv` (`implemented`)
 
 #### Body
 
-Use the merged reference document from `design` and the implemented runtime, IO, and process work from `loop_core`, `async_resume`, `io_phase1`, `io_files`, and `process_stdio` as direct inputs. The worker may rely on the full libuv-backed C runtime behavior being present on the branch.
+Use the merged reference document from `design`, the implemented vendored libuv dependency pipeline from `vendored_libuv`, and the implemented runtime, IO, and process work from `loop_core`, `async_resume`, `io_phase1`, `io_files`, and `process_stdio` as direct inputs. The worker may rely on the full libuv-backed C runtime behavior being present on the branch and on the vendored libuv install/link metadata being present in the C runtime dependency pipeline.
 
 Tighten validation for the completed libuv integration. Update `scripts/test_c_sanitizers.sh`, `scripts/test_c_valgrind.sh`, `scripts/c_runtime_ci_env.py`, or adjacent tests only as needed to ensure vendored libuv link flags, `GC_THREADS`, and generated C binaries are exercised. Add regression coverage for Main and Test compatibility, async continuation after IO completion, recovered async errors, file IO, process wait, and GC/thread safety assumptions that can be tested locally.
 


### PR DESCRIPTION
Automated same-roadmap revision.

- target graph version: `2`
- roadmap doc path: `docs/roadmap/2340-add-basic-support-for-libuv-in-c-backend.md`
- graph path: `docs/roadmap/2340-add-basic-support-for-libuv-in-c-backend.graph.json`
- summary: `io_files` is a sound next executable slice, but the pending validation node has a direct-handoff gap that should be fixed before more child work is issued.

The current ready frontier is `io_files`. Its direct inputs are satisfied: `design` has produced `docs/design/2342-document-the-libuv-c-runtime-integration-contract.md`, `async_resume` is implemented, and `io_phase1` is implemented. Repository inspection matches the planned slice: libuv is vendored, the Prog runtime has loop/suspend-resume infrastructure, time/sleep/env have moved onto libuv runtime plumbing, and file/directory operations remain the next migration area in `c_runtime/bosatsu_ext_Bosatsu_l_IO_l_Core.c`.

The graph still needs revision because the unstarted `validation` node explicitly needs the implemented vendored-libuv state to validate link flags, `GC_THREADS`, and generated C runtime install behavior, but it does not directly depend on `vendored_libuv`. Under the roadmap dependency handoff contract, relying on `loop_core` to transitively carry that satisfied state is not valid. This is a missing direct artifact/state handoff, not an unsafe `io_files` frontier. The revision preserves started nodes and the next two frontiers (`io_files`, then `process_stdio`) and replaces only the unstarted validation node with an equivalent node that directly receives `vendored_libuv` as implemented input.

Refs #2340